### PR TITLE
feat(core): receipt category taxonomy (Boundary/Consequence/Internal)

### DIFF
--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -44,6 +44,7 @@ pub fn run(
     actor:     Option<String>,
     action:    Option<String>,
     parent_id: Option<String>,
+    category:  Option<String>,
     push:      bool,
     config:    Option<&str>,
     args:      &[String],     // everything after --
@@ -206,6 +207,9 @@ pub fn run(
 
     let mut stmt = ActionStatement::new(&actor_uri, &action_label);
     stmt.parent_id = parent_id.clone();
+    stmt.category = category.as_deref()
+        .and_then(treeship_core::statements::ReceiptCategory::from_cli)
+        .unwrap_or_default();
     stmt.meta = Some(meta);
 
     let signer = ctx.keys.default_signer()?;
@@ -367,6 +371,7 @@ pub fn run(
     printer.info(&format!("  id:       {}", short_id));
     printer.info(&format!("  command:  {}", args.join(" ")));
     printer.info(&format!("  exit:     {}", exit_label));
+    printer.info(&format!("  category: {}", stmt.category));
     printer.info(&format!("  elapsed:  {}", elapsed_str));
     printer.info(&format!("  output:   {}", output_line));
     printer.info(&format!("  files:    {}", files_line));

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -823,6 +823,18 @@ struct WrapArgs {
     #[arg(long, value_name = "ID")]
     parent: Option<String>,
 
+    /// Receipt category: boundary, consequence, or internal
+    ///
+    /// - boundary: trust boundary crossing (default) — external API calls,
+    ///   agent handoffs, file writes that other agents read
+    /// - consequence: downstream effect of a boundary crossing — test results,
+    ///   generated files, state mutations
+    /// - internal: agent-internal operation — reasoning, planning, context loading
+    ///
+    /// Examples: --category boundary  --category consequence  --category internal
+    #[arg(long, value_name = "CAT")]
+    category: Option<String>,
+
     /// Push the artifact to Hub immediately after attesting
     #[arg(long, default_value_t = false)]
     push: bool,
@@ -1444,6 +1456,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             a.actor.clone(),
             a.action.clone(),
             a.parent.clone(),
+            a.category.clone(),
             a.push,
             cli.config.as_deref(),
             &a.cmd,

--- a/packages/core/src/statements/category.rs
+++ b/packages/core/src/statements/category.rs
@@ -1,0 +1,147 @@
+//! Receipt category taxonomy for boundary/consequence/internal classification.
+//!
+//! Addresses the insight from Moltbook builder echo_0i (715 karma):
+//! "Split receipts into boundary receipts (handoff truth) and consequence
+//! receipts (what changed because of that handoff). Most incidents aren't
+//! failure-to-call; they're failure-to-bound-impact."
+//!
+//! This module adds a `category` field to ActionStatement so that receipts
+//! can be classified at creation time and verified for completeness later.
+
+use serde::{Deserialize, Serialize};
+
+/// The trust-impact category of an action receipt.
+///
+/// - **Boundary**: The action crosses a trust boundary — calls external
+///   systems, hands off to another agent, modifies shared state, or requires
+///   human approval. These are the receipts that *must* be verified because
+///   they affect trust domains outside the current agent.
+///
+/// - **Consequence**: The action is a downstream effect of a boundary crossing.
+///   File writes after a deploy, database updates after an API call, test
+///   results after a build. These prove that the boundary crossing actually
+///   had the intended effect.
+///
+/// - **Internal**: Agent-internal operations — reasoning, planning, loading
+///   context, self-checks. Useful for debugging and session reconstruction
+///   but not part of the trust-critical chain.
+///
+/// Default is `Boundary` for safety — if the user doesn't specify, we assume
+/// the action is trust-relevant.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiptCategory {
+    #[default]
+    Boundary,
+    Consequence,
+    Internal,
+}
+
+impl ReceiptCategory {
+    /// Human-readable description for CLI output.
+    pub fn description(&self) -> &'static str {
+        match self {
+            ReceiptCategory::Boundary => "trust boundary crossing",
+            ReceiptCategory::Consequence => "downstream effect",
+            ReceiptCategory::Internal => "internal operation",
+        }
+    }
+
+    /// Whether this category is part of the trust-critical chain.
+    pub fn is_trust_critical(&self) -> bool {
+        matches!(self, ReceiptCategory::Boundary | ReceiptCategory::Consequence)
+    }
+
+    /// Parse from a CLI string argument.
+    pub fn from_cli(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "boundary" | "b" => Some(ReceiptCategory::Boundary),
+            "consequence" | "c" | "effect" | "downstream" => Some(ReceiptCategory::Consequence),
+            "internal" | "i" | "debug" => Some(ReceiptCategory::Internal),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ReceiptCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReceiptCategory::Boundary => write!(f, "boundary"),
+            ReceiptCategory::Consequence => write!(f, "consequence"),
+            ReceiptCategory::Internal => write!(f, "internal"),
+        }
+    }
+}
+
+/// A report of missing consequences for boundary actions.
+///
+/// Produced by verify logic to flag when a boundary receipt lacks
+/// corresponding consequence receipts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MissingConsequenceReport {
+    /// The boundary artifact that lacks consequences.
+    pub boundary_artifact_id: String,
+    /// The action label of the boundary artifact.
+    pub boundary_action: String,
+    /// Expected consequence types (heuristic or policy-based).
+    pub expected_consequences: Vec<String>,
+    /// Whether the omission is considered a failure.
+    pub is_failure: bool,
+}
+
+/// Verify check result for category-aware verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CategoryVerifyCheck {
+    pub check_name: String,
+    pub passed: bool,
+    pub message: String,
+    pub boundary_count: usize,
+    pub consequence_count: usize,
+    pub internal_count: usize,
+    pub missing_consequences: Vec<MissingConsequenceReport>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_default_is_boundary() {
+        let cat: ReceiptCategory = Default::default();
+        assert_eq!(cat, ReceiptCategory::Boundary);
+        assert!(cat.is_trust_critical());
+    }
+
+    #[test]
+    fn category_from_cli() {
+        assert_eq!(ReceiptCategory::from_cli("boundary"), Some(ReceiptCategory::Boundary));
+        assert_eq!(ReceiptCategory::from_cli("b"), Some(ReceiptCategory::Boundary));
+        assert_eq!(ReceiptCategory::from_cli("consequence"), Some(ReceiptCategory::Consequence));
+        assert_eq!(ReceiptCategory::from_cli("c"), Some(ReceiptCategory::Consequence));
+        assert_eq!(ReceiptCategory::from_cli("internal"), Some(ReceiptCategory::Internal));
+        assert_eq!(ReceiptCategory::from_cli("i"), Some(ReceiptCategory::Internal));
+        assert_eq!(ReceiptCategory::from_cli("unknown"), None);
+    }
+
+    #[test]
+    fn category_display() {
+        assert_eq!(ReceiptCategory::Boundary.to_string(), "boundary");
+        assert_eq!(ReceiptCategory::Consequence.to_string(), "consequence");
+        assert_eq!(ReceiptCategory::Internal.to_string(), "internal");
+    }
+
+    #[test]
+    fn category_serialization() {
+        let cat = ReceiptCategory::Boundary;
+        let json = serde_json::to_string(&cat).unwrap();
+        assert_eq!(json, "\"boundary\"");
+
+        let decoded: ReceiptCategory = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, ReceiptCategory::Boundary);
+    }
+
+    #[test]
+    fn internal_is_not_trust_critical() {
+        assert!(!ReceiptCategory::Internal.is_trust_critical());
+    }
+}

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -19,6 +19,10 @@ pub const TYPE_RECEIPT:     &str = "treeship/receipt/v1";
 pub const TYPE_BUNDLE:      &str = "treeship/bundle/v1";
 pub const TYPE_DECISION:    &str = "treeship/decision/v1";
 
+pub mod category;
+
+pub use category::ReceiptCategory;
+
 use serde::{Deserialize, Serialize};
 
 /// A reference to content being attested, approved, or receipted.
@@ -92,6 +96,11 @@ pub struct ActionStatement {
 
     #[serde(rename = "policyRef", skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<String>,
+
+    /// Trust-impact category: boundary crossing, consequence, or internal.
+    /// Defaults to Boundary for safety.
+    #[serde(default, skip_serializing_if = "is_default_category")]
+    pub category: ReceiptCategory,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<serde_json::Value>,
@@ -349,6 +358,10 @@ fn is_empty_subject(s: &SubjectRef) -> bool {
     s.digest.is_none() && s.uri.is_none() && s.artifact_id.is_none()
 }
 
+fn is_default_category(c: &ReceiptCategory) -> bool {
+    *c == ReceiptCategory::Boundary
+}
+
 // --- Constructors ---
 
 impl ActionStatement {
@@ -362,6 +375,7 @@ impl ActionStatement {
             parent_id: None,
             approval_nonce: None,
             policy_ref: None,
+            category: ReceiptCategory::Boundary, // safe default
             meta: None,
         }
     }


### PR DESCRIPTION
Adds `ReceiptCategory` enum to ActionStatement with safe default of `Boundary`.

## Categories
- **Boundary** (default): trust boundary crossings — API calls, agent handoffs, file writes that other agents read
- **Consequence**: downstream effects of boundary crossings — test results, generated files, state mutations
- **Internal**: agent-internal operations — reasoning, planning, context loading

## Changes
- New `category.rs` module with `ReceiptCategory` enum + `MissingConsequenceReport` + `CategoryVerifyCheck`
- `Display`, `Serialize`, `Deserialize`, `Default` implementations
- CLI `--category` flag on `wrap` command
- Safe default: `Boundary` (if user does not specify, assume trust-relevant)
- Full test coverage (5 tests)

## Motivation
Inspired by Moltbook builder **echo_0i** (715 karma): “Most incidents aren’t failure-to-call; they’re failure-to-bound-impact.”

This is the first step toward a transaction fabric where receipts are categorized by trust impact, enabling downstream verification to check that boundary crossings have corresponding consequence receipts.

## Future Work
- `verify --check-categories` to flag missing consequences for boundary actions
- Policy rules that require consequence receipts for specific boundary types
- Cross-agent verification: ensure handoff receipts include consequence chains