### PR TITLE
fix(docs): copy-install button advertised the orphaned cargo crate

### DIFF
--- a/docs/components/copy-install.tsx
+++ b/docs/components/copy-install.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react';
 
 export function CopyInstall() {
   const [copied, setCopied] = useState(false);
-  const command = 'cargo install treeship-cli';
+  const command = 'curl -fsSL treeship.dev/install | sh';
 
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(command).then(() => {


### PR DESCRIPTION
## Summary
- The CopyInstall sidebar banner (rendered at the top of every docs page) was hardcoded to \`cargo install treeship-cli\` — the orphaned v0.4.0 crates.io package we explicitly tell users NOT to use in \`cli/otel.mdx\`.
- Commit 78755c5 cleaned up the markdown content but missed this React component, so the most prominent install CTA on docs.treeship.dev was still pointing at the broken path.
- Switched to \`curl -fsSL treeship.dev/install | sh\` to match every other install instruction in the docs.

## Test plan
- [ ] Vercel preview: confirm the install banner at the top of any docs page now shows the curl command
- [ ] Click the banner, paste — confirm it copied the curl command not the cargo command

🤖 Generated with [Claude Code](https://claude.com/claude-code)