### PR TITLE
feat(claude-code-plugin): emit agent.decision at session start

### DIFF
--- a/integrations/claude-code-plugin/scripts/session-start.sh
+++ b/integrations/claude-code-plugin/scripts/session-start.sh
@@ -40,6 +40,43 @@ SESSION_NAME="${PROJECT}-claude-code-${TIMESTAMP}"
 SESSION_START_ERR=$(treeship session start --name "$SESSION_NAME" 2>&1 >/dev/null) || SESSION_START_FAILED=1
 
 if [ -z "${SESSION_START_FAILED:-}" ]; then
+  # Emit one agent.decision event so the receipt records WHICH model
+  # Claude Code was running on. Without this, AgentNode.model stays
+  # null and the receipt page can't show "claude-opus-4-7" beside
+  # the agent name -- the central claim of a multi-model session
+  # receipt.
+  #
+  # Detection priority (best-effort, fail-open):
+  #   1. TREESHIP_MODEL env var      (most explicit)
+  #   2. ~/.claude/settings.json     (where the user picks /model)
+  #   3. fall back to "claude" generic
+  MODEL="${TREESHIP_MODEL:-}"
+  if [ -z "$MODEL" ] && [ -f "$HOME/.claude/settings.json" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      MODEL=$(jq -r '.model // empty' "$HOME/.claude/settings.json" 2>/dev/null)
+    elif command -v python3 >/dev/null 2>&1; then
+      MODEL=$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        print(json.load(f).get("model", "") or "")
+except Exception:
+    pass
+' "$HOME/.claude/settings.json" 2>/dev/null)
+    fi
+  fi
+  MODEL="${MODEL:-claude}"
+
+  # Provider for claude-code is always anthropic. For multi-vendor
+  # deployments (codex/kimi/etc) each integration has its own
+  # session-start hook with the right provider hardcoded.
+  treeship session event \
+    --type agent.decision \
+    --model "$MODEL" \
+    --provider anthropic \
+    --agent-name claude-code \
+    >/dev/null 2>&1 || true
+
   cat <<EOF
 {
   "additionalContext": "Treeship session started: $SESSION_NAME. Every tool call below will be recorded into a portable, signed receipt. The receipt is yours -- it stays in .treeship/sessions/ and only leaves this machine when you run \`treeship session report\`."


### PR DESCRIPTION
## Summary
The PostToolUse hook already streams \`agent.read_file\` / \`agent.wrote_file\` / \`agent.completed_process\` / \`agent.connected_network\` events to the active session. But none of them carry model info, so receipts could say "claude-code did X" without ever showing **which** Claude.

This PR closes that gap by having the SessionStart hook emit one \`agent.decision\` event right after starting the session, with the detected model and provider=anthropic.

Once that event lands, core's \`session/graph.rs\` aggregates it into \`AgentNode.model\` on the receipt, and the receipt page renders the provider-colored model pill ([treeship.dev PR #3](https://github.com/zerkerlabs/treeship.dev/pull/3)).

## Detection priority
1. \`\$TREESHIP_MODEL\` env var (most explicit, user-set)
2. \`~/.claude/settings.json\`'s \`.model\` field (where the user picks via /model)
3. Fallback: literal \"claude\" (we know it's anthropic, just don't know which)

## Why one event, not per-tool
AgentNode is keyed by \`agent_instance_id\` across the whole session, so a single decision event sets \`model\` for the entire claude-code agent's contribution. Subsequent action events don't lose the attribution.

## Stacked on
[PR #6](https://github.com/zerkerlabs/treeship/pull/6) — needs the \`treeship session event --model/--provider\` flags.

Without #6, the script will silently fail-open (the \`|| true\` on the treeship call) and the receipt will lack model attribution — same as today, no regression.

## Smoke test
\`\`\`
bash integrations/claude-code-plugin/scripts/session-start.sh </dev/null
treeship session close --headline "smoke"
treeship package inspect .treeship/sessions/ssn_X.treeship
\`\`\`
Output:
\`\`\`
agent graph
  claude-code (agent) depth=0 tools=0 [active] @host_X
    model: claude | provider: anthropic | tokens: 0↓ 0↑
\`\`\`

## Test plan
- [ ] User installs plugin, has \`~/.claude/settings.json\` with \`"model": "claude-opus-4-7"\` → receipt shows that model
- [ ] User has no settings.json → receipt shows \"claude\" fallback
- [ ] User sets \`TREESHIP_MODEL=claude-sonnet-4-6\` env → receipt shows that
- [ ] Plugin still fails-open if treeship binary is missing or session start fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)