### PR TITLE
fix(preview): tool_usage block crashed when declared/actual arrays absent

### DIFF
--- a/packages/core/src/session/preview_template.html
+++ b/packages/core/src/session/preview_template.html
@@ -430,32 +430,43 @@ async function render(){
   }
 
   // ── TOOL USAGE ──
+  // Defensive destructure: R.tool_usage may be present (object exists)
+  // but its inner arrays (declared / actual / unauthorized) may be
+  // missing entirely when the user never ran `treeship declare` or
+  // when an older receipt format omitted the arrays. Direct access
+  // like tu.declared.length used to throw "Cannot read properties of
+  // undefined" and crash the entire preview render.
   const tu=R.tool_usage;
-  if(tu&&(tu.declared.length||tu.actual.length)){
-    h+='<section class="section" id="tools"><div class="section-head"><div class="section-title">Tool authorization</div><div class="section-sub">Declared vs actual tool usage. Unauthorized calls are flagged.</div></div>';
-    h+='<div class="card">';
-    if(tu.declared.length){
-      h+='<div style="padding:1rem 1.25rem;border-bottom:1px solid var(--border)"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--faint);margin-bottom:.4rem;font-family:var(--mono)">Authorized tools</div>';
-      h+='<div style="display:flex;flex-wrap:wrap;gap:.35rem">'+tu.declared.map(t=>'<span class="badge badge-ok">'+esc(t)+'</span>').join('')+'</div></div>';
-    }
-    if(tu.actual.length){
-      h+='<div style="padding:1rem 1.25rem;border-bottom:1px solid var(--border)"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--faint);margin-bottom:.4rem;font-family:var(--mono)">Actual usage</div>';
-      tu.actual.forEach(a=>{
-        const isAuth=!tu.declared.length||tu.declared.includes(a.tool_name);
-        h+='<div style="display:flex;align-items:center;gap:.75rem;padding:.3rem 0;font-size:.8rem">';
-        h+='<span class="badge '+(isAuth?'badge-info':'badge-risk')+'">'+esc(a.tool_name)+'</span>';
-        h+='<span class="mono faint">'+num(a.count)+' call'+(a.count!==1?'s':'')+'</span>';
-        if(!isAuth)h+='<span class="badge badge-risk">unauthorized</span>';
+  if(tu){
+    const declared=tu.declared||[];
+    const actual=tu.actual||[];
+    const unauthorized=tu.unauthorized||[];
+    if(declared.length||actual.length){
+      h+='<section class="section" id="tools"><div class="section-head"><div class="section-title">Tool authorization</div><div class="section-sub">Declared vs actual tool usage. Unauthorized calls are flagged.</div></div>';
+      h+='<div class="card">';
+      if(declared.length){
+        h+='<div style="padding:1rem 1.25rem;border-bottom:1px solid var(--border)"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--faint);margin-bottom:.4rem;font-family:var(--mono)">Authorized tools</div>';
+        h+='<div style="display:flex;flex-wrap:wrap;gap:.35rem">'+declared.map(t=>'<span class="badge badge-ok">'+esc(t)+'</span>').join('')+'</div></div>';
+      }
+      if(actual.length){
+        h+='<div style="padding:1rem 1.25rem;border-bottom:1px solid var(--border)"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--faint);margin-bottom:.4rem;font-family:var(--mono)">Actual usage</div>';
+        actual.forEach(a=>{
+          const isAuth=!declared.length||declared.includes(a.tool_name);
+          h+='<div style="display:flex;align-items:center;gap:.75rem;padding:.3rem 0;font-size:.8rem">';
+          h+='<span class="badge '+(isAuth?'badge-info':'badge-risk')+'">'+esc(a.tool_name)+'</span>';
+          h+='<span class="mono faint">'+num(a.count)+' call'+(a.count!==1?'s':'')+'</span>';
+          if(!isAuth)h+='<span class="badge badge-risk">unauthorized</span>';
+          h+='</div>';
+        });
         h+='</div>';
-      });
-      h+='</div>';
+      }
+      if(unauthorized.length){
+        h+='<div style="padding:1rem 1.25rem"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--risk);margin-bottom:.4rem;font-family:var(--mono)">Unauthorized tool calls</div>';
+        unauthorized.forEach(t=>{h+='<span class="badge badge-risk" style="margin-right:.35rem">'+esc(t)+'</span>'});
+        h+='</div>';
+      }
+      h+='</div></section>';
     }
-    if(tu.unauthorized.length){
-      h+='<div style="padding:1rem 1.25rem"><div style="font-size:.65rem;text-transform:uppercase;letter-spacing:.09em;color:var(--risk);margin-bottom:.4rem;font-family:var(--mono)">Unauthorized tool calls</div>';
-      tu.unauthorized.forEach(t=>{h+='<span class="badge badge-risk" style="margin-right:.35rem">'+esc(t)+'</span>'});
-      h+='</div>';
-    }
-    h+='</div></section>';
   }
 
   // ── SECURITY FINDINGS (with empty state) ──


### PR DESCRIPTION
## The bug
Reported by the same engineer who flagged the events-aggregation bug ([PR #8](https://github.com/zerkerlabs/treeship/pull/8)):
> Renderer crashes separately on \`tu.declared.length\` — patched-around but secondary.

## Cause
\`preview_template.html\` line 434:
\`\`\`js
const tu = R.tool_usage;
if (tu && (tu.declared.length || tu.actual.length)) { ... }
\`\`\`

The guard checks \`R.tool_usage\` exists, but **not that its inner arrays exist**. When the user never ran \`treeship declare\`, \`tool_usage\` is built with \`declared\` / \`actual\` / \`unauthorized\` either undefined or omitted, so \`tu.declared.length\` throws **"Cannot read properties of undefined"** and the entire preview render aborts.

Result: \`preview.html\` in the package is broken or empty for any session that didn't have an explicit tool declaration — which is most sessions.

## Fix
Defensive destructure at the top of the block:
\`\`\`js
const declared = tu.declared || [];
const actual = tu.actual || [];
const unauthorized = tu.unauthorized || [];
\`\`\`
Then use the locals everywhere instead of \`tu.x\`. Same logic, same output, but a missing array is now an empty array. The block renders nothing instead of crashing the whole page.

Also restructured into outer \`if(tu)\` + inner \`if(declared.length || actual.length)\` so the destructure runs once and both conditions are always safe.

## Test
JS validity verified by piping the snippet through \`node\` parse — the \`new Function(...)\` wrapper accepts it cleanly.

## Test plan
- [ ] CI: cargo build / test passes
- [ ] Manual: open \`preview.html\` from a session that has no \`treeship declare\` declaration; preview renders fully (no \`tu.declared\` crash)
- [ ] Manual: open \`preview.html\` from a session WITH a declaration; tool authorization section still renders correctly with declared / actual / unauthorized sub-blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)