### PR TITLE
feat(add): detect Codex CLI and install MCP block in config.toml

### DIFF
--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,44 @@
+# Treeship + Codex CLI
+
+Codex CLI talks to MCP servers via TOML config in `~/.codex/config.toml`. The same [`@treeship/mcp`](../../bridges/mcp/) bridge that powers the Claude Code and Cursor integrations works here too: every MCP `callTool` is attested and appears in the session timeline when a Treeship session is active.
+
+## Method 1: CLI (recommended)
+
+From a project with `treeship init` already run:
+
+```bash
+curl -fsSL treeship.dev/install | sh
+treeship init
+treeship add codex
+# or: treeship add   # configures every detected agent, including Codex
+```
+
+This appends a `[mcp_servers.treeship]` block to `~/.codex/config.toml` (creating the file and parent dirs if needed). The actor URI is `agent://codex` so receipts identify Codex as the tool caller.
+
+**Restart Codex** so it reloads MCP settings.
+
+`treeship add` also drops `./TREESHIP.md` in the project (once) with the trust and capture details — read that before enabling the server.
+
+## Method 2: Copy the template
+
+If you prefer to edit config by hand, append the contents of `config.toml` in this directory to your existing `~/.codex/config.toml`.
+
+## Prerequisites
+
+- [Codex CLI](https://github.com/openai/codex) installed (so `~/.codex/` exists — run `codex` once if the folder is missing).
+- `treeship` CLI on `PATH` and Node/npx for `npx -y @treeship/mcp`.
+- A Treeship project: `treeship init` in the repo you open in Codex.
+
+## What gets captured
+
+Every Codex tool call routed through MCP produces:
+
+- A signed **intent attestation** before the call (action label, args digest, no raw arguments).
+- A signed **result receipt** after the call (tool name, elapsed time, exit code, output digest, no raw output).
+- A **session event** in the timeline so the receipt page renders Codex's contribution alongside other agents in the session.
+
+Codex's built-in tools that don't go through MCP (file reads/writes, shell exec) are not currently captured by this integration. For full per-tool coverage of Codex's built-ins, we'd need a hook story analogous to the [Claude Code plugin](../claude-code-plugin/) — which Codex does not yet expose.
+
+## Provider attribution
+
+Receipts identify the actor as `agent://codex` and (once `treeship session event --type agent.decision --provider openai --model <name>` is emitted at session start) display the OpenAI model name on the agent card. See the [Claude Code plugin's session-start hook](../claude-code-plugin/scripts/session-start.sh) for the pattern; an equivalent hook for Codex can land once Codex CLI exposes a session-start trigger.

--- a/integrations/codex/config.toml
+++ b/integrations/codex/config.toml
@@ -1,0 +1,14 @@
+# Treeship MCP server config for Codex CLI.
+#
+# Append this block to ~/.codex/config.toml (or run `treeship add codex`
+# which does it for you, idempotently).
+#
+# Restart Codex so it reloads MCP settings.
+
+[mcp_servers.treeship]
+command = "npx"
+args = ["-y", "@treeship/mcp"]
+
+[mcp_servers.treeship.env]
+TREESHIP_ACTOR = "agent://codex"
+TREESHIP_HUB_ENDPOINT = "https://api.treeship.dev"

--- a/packages/cli/src/commands/add.rs
+++ b/packages/cli/src/commands/add.rs
@@ -85,6 +85,19 @@ fn detect_agents() -> Vec<DetectedAgent> {
         });
     }
 
+    // Codex CLI: ~/.codex/config.toml
+    // OpenAI's Codex CLI uses TOML for config, so the install path is a
+    // text-append into config.toml rather than a JSON merge.
+    let codex_dir = h.join(".codex");
+    if codex_dir.is_dir() {
+        agents.push(DetectedAgent {
+            name: "codex",
+            display: "Codex CLI",
+            method: "MCP server (~/.codex/config.toml)",
+            config_path: codex_dir.join("config.toml"),
+        });
+    }
+
     agents
 }
 
@@ -239,8 +252,89 @@ fn install_agent(agent: &DetectedAgent, dry_run: bool, printer: &Printer) -> Res
     match agent.name {
         "claude-code" | "cursor" | "cline" => install_mcp_config(agent, dry_run, printer),
         "hermes" | "openclaw" => install_skill(agent, dry_run, printer),
+        "codex" => install_codex_mcp_config(agent, dry_run, printer),
         _ => Err(format!("unknown agent: {}", agent.name).into()),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Codex CLI MCP config (TOML-based)
+//
+// Codex stores MCP servers as TOML tables in ~/.codex/config.toml, not JSON,
+// so the JSON-based install_mcp_config above doesn't fit. We append a fresh
+// [mcp_servers.treeship] block instead of round-tripping the whole file
+// through a TOML library -- that preserves the user's existing comments and
+// formatting and avoids pulling toml_edit into the CLI for one feature.
+//
+// Idempotent via a pre-write substring check on the destination block name.
+// ---------------------------------------------------------------------------
+
+const CODEX_MCP_BLOCK: &str = r#"
+
+[mcp_servers.treeship]
+command = "npx"
+args = ["-y", "@treeship/mcp"]
+
+[mcp_servers.treeship.env]
+TREESHIP_ACTOR = "agent://codex"
+TREESHIP_HUB_ENDPOINT = "https://api.treeship.dev"
+"#;
+
+fn install_codex_mcp_config(
+    agent: &DetectedAgent,
+    dry_run: bool,
+    printer: &Printer,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let config_path = &agent.config_path;
+
+    if !is_safe_path(config_path) {
+        printer.warn(
+            &format!("  {} config path contains a symlink, skipping for safety", agent.display),
+            &[],
+        );
+        return Ok(false);
+    }
+
+    // Read existing config (or empty if it doesn't exist yet -- Codex will
+    // create the file on first run, but we can also create it preemptively).
+    let existing = if config_path.exists() {
+        std::fs::read_to_string(config_path)?
+    } else {
+        String::new()
+    };
+
+    // Idempotency guard: any existing [mcp_servers.treeship] table means
+    // we've already installed (or the user installed manually).
+    if existing.contains("[mcp_servers.treeship]") {
+        printer.dim_info(&format!("  {} already configured, skipping", agent.display));
+        return Ok(false);
+    }
+
+    if dry_run {
+        printer.info(&format!("  Would configure {} at {}", agent.display, config_path.display()));
+        return Ok(true);
+    }
+
+    // Build the new content. If the existing file doesn't end in a newline,
+    // start the appended block with one to keep TOML well-formed.
+    let mut new_content = existing.clone();
+    if !new_content.is_empty() && !new_content.ends_with('\n') {
+        new_content.push('\n');
+    }
+    new_content.push_str(CODEX_MCP_BLOCK);
+
+    // Atomic write
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp_path = config_path.with_extension("toml.tmp");
+    std::fs::write(&tmp_path, &new_content)?;
+    std::fs::rename(&tmp_path, config_path)?;
+
+    printer.success(&format!("{} configured", agent.display), &[]);
+    printer.dim_info(&format!("  {}", config_path.display()));
+    printer.dim_info("  Restart Codex so it reloads MCP settings.");
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -310,6 +404,7 @@ pub fn run(
         printer.info("  Treeship works with:");
         printer.info("    Claude Code   ~/.claude/");
         printer.info("    Cursor        ~/.cursor/");
+        printer.info("    Codex CLI     ~/.codex/");
         printer.info("    Hermes        ~/.hermes/ or hermes in PATH");
         printer.info("    OpenClaw      ~/.openclaw/ or openclaw in PATH");
         printer.info("    Cline         ~/.config/cline/");


### PR DESCRIPTION
## Why
Closes the gap in \`treeship add\`'s MCP-agent coverage. Today: Claude Code, Cursor, and Cline are auto-instrumented. Codex isn't — even though Codex CLI supports MCP and the same \`@treeship/mcp\` bridge works against it. A developer running Codex got nothing in their receipts after \`treeship add\`.

Per the trust-fabric vision: every MCP-based coding agent should be a one-command install.

## How
Codex stores MCP config in **TOML** (\`~/.codex/config.toml\`) instead of JSON, so the existing \`install_mcp_config\` (which round-trips serde_json) doesn't fit. New \`install_codex_mcp_config\` does a **text-append** of the \`[mcp_servers.treeship]\` block instead, which:
- Preserves the user's existing comments + formatting
- Avoids pulling \`toml_edit\` in as a dep for one feature
- Is idempotent via a pre-write substring check on the destination block name

Detection: \`~/.codex/\` probe, same pattern as Cursor.

Also adds \`integrations/codex/{README.md,config.toml}\` so users have a documented per-integration entry point matching the cursor/ and claude-code/ shape, and the no-detect help text now lists Codex alongside the others.

## Smoke test
Against \`~/.codex/config.toml\` on the dev machine:
\`\`\`
treeship add --dry-run    # → "Would configure Codex CLI at /Users/zzo/.codex/config.toml"
treeship add codex        # → appends the block, restart hint
treeship add codex        # → "already configured, skipping"  (idempotent)
\`\`\`

Diff after install:
\`\`\`toml
+[mcp_servers.treeship]
+command = "npx"
+args = ["-y", "@treeship/mcp"]
+
+[mcp_servers.treeship.env]
+TREESHIP_ACTOR = "agent://codex"
+TREESHIP_HUB_ENDPOINT = "https://api.treeship.dev"
\`\`\`
Restored from backup after smoke test — no persistent dev-machine changes.

## Test plan
- [ ] CI: cargo build / test passes
- [ ] Manual: install Codex CLI, run \`treeship add\`, confirm block appears in \`~/.codex/config.toml\`
- [ ] Manual: restart Codex, run a tool call, confirm an attestation lands in \`.treeship/sessions/<active>/events.jsonl\` with \`agent_name: "codex"\`
- [ ] Manual: \`treeship session close\` and inspect — Codex should appear in the agent_graph alongside any other agents from the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)