### PR TITLE
docs(concepts): trust-fabric overview + agent-identity (TLS for AI agents)

### DIFF
--- a/docs/content/docs/concepts/agent-identity.mdx
+++ b/docs/content/docs/concepts/agent-identity.mdx
@@ -1,0 +1,190 @@
+---
+title: Agent Identity
+description: An Agent Identity Certificate is the TLS certificate of an AI agent — a deterministic, signed bundle that says who an agent represents and what it's allowed to do. This page covers the format, how to issue one, and how it binds to session receipts.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A Session Receipt proves *what happened*. An Agent Identity Certificate proves *who is allowed to make that happen, and within what envelope*. Together they form the [trust fabric](/docs/concepts/trust-fabric): one click from "this agent did X" to "this agent is allowed to do X" — both verifiable on a clean machine with no network call.
+
+## The TLS-for-AI-agents analogy, carefully
+
+The web has SSL/TLS certificates: a CA-signed bundle that says "this server represents `acme.com`, here is its public key, here is the validity window." That's why a browser can show a green lock without the user having to call Acme's IT desk.
+
+AI agents need an equivalent. There's currently no broadly adopted, interoperable way for one agent to prove to another (or to a human reviewer) **who it represents, what it's allowed to do, and how it gets paid.** Vertically integrated stacks solve this for their own ecosystem; protocol attempts like x402 solve the payment side; MCP solves the application-layer wiring. None of them produce a single signed artifact a third party can verify offline.
+
+The Agent Identity Certificate is Treeship's answer. It is:
+
+- **A single signed bundle** under one ed25519 key, deterministic to verify
+- **Layered**: identity / capabilities / declaration, each independently inspectable
+- **Independent of any hosting decision** — works for cloud agents, local agents, OSS contributors, enterprise deployments
+- **Bound to receipts** via [cross-verification](/docs/concepts/cross-verification), so the cert isn't just a claim — it's a contract that gets checked against actual behavior
+
+It is *not* a CA-issued public-trust certificate. There is no centralized CA in Treeship; identity bottoms out in the ed25519 keypair generated at `treeship init`. Domain ownership and other trust-amplifying signals are layered on top through separate, optional verification flows.
+
+## The three layers in one bundle
+
+Every Agent Identity Certificate is a deterministic JSON document with three signed sections plus a signature block. The format is defined in `packages/core/src/agent/` and emitted by `treeship agent register`.
+
+### Layer 1 — Identity (who they represent)
+
+```json
+{
+  "agent_name": "deploy-bot",
+  "ship_id": "ship_6232d021805b8fb5",
+  "public_key": "ed25519:gN4kT9pRq2sVxL5wJ8bF6cYzM3aD1eH7iU0oP4nQ2vW8",
+  "issuer": "ship://ship_6232d021805b8fb5",
+  "issued_at": "2026-04-26T17:00:00Z",
+  "valid_until": "2026-07-25T17:00:00Z",
+  "model": "claude-opus-4-7",
+  "description": "Ships acme staging from agent-driven sessions."
+}
+```
+
+Mandatory fields: `agent_name`, `ship_id`, `public_key`, `issuer`, `issued_at`, `valid_until`. Optional: `model`, `description`.
+
+`ship_id` is the cryptographic identity of the issuing machine — it ties this certificate to a specific keystore. Self-issuance is the default (`issuer == "ship://" + ship_id`); future Hub-mediated issuance can use a different issuer URI.
+
+### Layer 2 — Capabilities (what surface they expose)
+
+```json
+{
+  "tools": [
+    { "name": "read_file",  "description": "Read a file from the working tree." },
+    { "name": "write_file", "description": "Create or modify a file." },
+    { "name": "bash",       "description": "Run a shell command." }
+  ],
+  "api_endpoints": [],
+  "mcp_servers": [
+    { "name": "treeship", "command": "npx -y @treeship/mcp" }
+  ]
+}
+```
+
+Capabilities are the *surface* — what the agent can call. Optional descriptions help reviewers understand each tool's purpose without grepping the agent's source.
+
+### Layer 3 — Declaration (the contract)
+
+```json
+{
+  "bounded_actions": ["read_file", "write_file", "bash", "git_diff", "fly_deploy"],
+  "forbidden":       ["git_force_push", "prod_deploy", "delete_branch_main"],
+  "escalation_required": ["prod_db_migrate", "billing_change", "rotate_secrets"]
+}
+```
+
+Declaration is the *contract* — what the agent is *allowed* to call, what it must *never* call, and what requires human approval. This is the layer that gets cross-verified against actual session activity.
+
+`bounded_actions` is usually a subset of `capabilities.tools` (you might have a tool installed but not authorized for a given session). `forbidden` and `escalation_required` exist on the certificate so a verifier can check independently — even an agent that ignores its own contract gets caught at receipt-review time.
+
+### Signature
+
+```json
+{
+  "algorithm": "ed25519",
+  "key_id": "key_2026q1_acme_deploybot",
+  "public_key": "ed25519:gN4kT9pRq2sVxL5wJ8bF6cYzM3aD1eH7iU0oP4nQ2vW8",
+  "signature": "mZkN7tH3xR8cQ4sA1pV5fB2eY6wJ9oU0iL3dG7hT5nM2vX8bC4kP1qS6rW9aE3yF",
+  "signed_fields": "identity+capabilities+declaration"
+}
+```
+
+Ed25519 signature over the canonical JSON of `identity + capabilities + declaration`. Deterministic — the same inputs always produce the same signature, which is itself a safety property (see [the DSSE explainer](/blog/dsse-dead-simple-signing-explained) for why randomized signatures are dangerous in agent infrastructure).
+
+## Issuing a certificate
+
+```bash
+treeship agent register \
+  --name acme-deploy-bot \
+  --description "Ships acme staging from agent-driven sessions" \
+  --tools read_file,write_file,bash,git_diff,fly_deploy \
+  --forbidden git_force_push,prod_deploy \
+  --escalation prod_db_migrate,billing_change \
+  --model claude-opus-4-7 \
+  --valid-days 90
+```
+
+This produces a `.agent` package in the current directory:
+
+```
+acme-deploy-bot.agent/
+├── identity.json       # the identity layer, pretty-printed
+├── capabilities.json   # the capabilities layer, pretty-printed
+├── declaration.json    # the declaration layer, pretty-printed
+├── certificate.json    # the full bundle (all three + signature)
+└── certificate.html    # a self-contained shareable card
+```
+
+You can publish the `.agent` directory to a Hub (so others can fetch the certificate by slug at `treeship.dev/agent/<slug>`) or distribute it directly. Either way, the trust check is local: anyone with `treeship verify --certificate certificate.json` can confirm the signature.
+
+<Callout title="Where does the public key come from?">
+The keypair was generated at `treeship init`. There is no separate CA enrollment step — your machine is its own root of trust. This is intentional: it keeps Treeship installable in five seconds with no upstream dependency. Domain ownership and other trust amplifiers (below) are layered on top, not gating.
+</Callout>
+
+## Trust amplifiers (optional)
+
+A bare certificate proves an ed25519 signature. That's enough for offline verification, but a third party reading the cert may want stronger signals. Treeship's identity backend exposes optional verification flows:
+
+| Amplifier | What it proves | How |
+|---|---|---|
+| **Domain ownership** | "This agent represents acme.com" | DNS TXT record challenge at `_treeship-challenge.acme.com`, verified server-side via `/identity/{slug}/verify-domain` |
+| **Voice fingerprint** | "Communications signed under this cert match the agent's stable style fingerprint" | Style-based fingerprinting via `/identity/{slug}/voice-fingerprint` and `/identity/{slug}/verify-voice` |
+| **Tool manifest verification** | "The tools this cert declares are the tools the agent actually exposes" | Manifest probe via `/identity/{slug}/verify-tools` |
+
+Each amplifier produces an independent attestation that the agent card surfaces as a separate badge. Stronger trust without coupling everything into one mechanism — a single failed amplifier doesn't invalidate the cert; it just narrows what the cert claims.
+
+## Binding to session receipts
+
+The cert is half a contract. The other half is the [Session Receipt](/docs/concepts/session-receipts) — what the agent actually did. Cross-verification binds the two:
+
+```bash
+treeship verify --certificate acme-deploy-bot.agent/certificate.json \
+  ./.treeship/sessions/ssn_a1b2c3d4.treeship
+```
+
+This runs `cross_verify_receipt_and_certificate` (in `packages/core/src/verify/`) and answers four questions:
+
+1. `ship_id_match` — does the receipt's `ship_id` equal the cert's `identity.ship_id`?
+2. `within_validity_window` — was the session inside `[issued_at, valid_until]`?
+3. `unauthorized_calls` — count of tool calls outside `bounded_actions` (must be zero for a clean pass)
+4. `never_called` — declared tools the agent didn't end up using (informational, useful for tightening the next cert)
+
+The function takes `now` as an explicit argument so the check is deterministic and testable: tests pass a fixed value, the CLI passes `SystemTime::now()`, the WASM build passes a JS-supplied timestamp. See [Cross-verification](/docs/concepts/cross-verification) for the full check matrix.
+
+The agent card at `treeship.dev/agent/<slug>` runs this on every recent receipt and surfaces the result as a `✓ no unauthorized calls` badge per row.
+
+## Initial scope: how `bounded_actions` gets determined
+
+Three sources, in order of trust:
+
+1. **Operator-declared at registration.** The `--tools / --forbidden / --escalation` flags. The agent's owner declares the contract upfront and signs it. This is the canonical source.
+2. **Project-declared via `treeship declare`.** Each project can carry its own `.treeship/declaration.json` that lists which tools agents are authorized to use *in this project*. The session receipt records both the agent cert's declaration AND the project declaration; cross-verify treats unauthorized = "called but in neither list."
+3. **Discoverable from the integration.** For MCP-routed agents, the bridge can introspect the tool list the agent connected with. This is the "no-config" path: a fresh `treeship add cursor` registers a default certificate from Cursor's actual MCP capabilities. (Building.)
+
+The two-axis gate (agent declaration AND project declaration) lets the same agent operate under different policies in different projects without re-issuing certs.
+
+## What an agent's URL looks like
+
+Once a certificate is published to a Hub, anyone can view it at:
+
+```
+https://www.treeship.dev/agent/<slug>
+```
+
+Where `<slug>` is the canonical sanitization of `agent_name` (lowercase, spaces → dashes, alphanumeric + dash + underscore only). The page renders identity, capabilities, declaration, recent verified receipts, and the `treeship verify --certificate` snippet for the offline check.
+
+This is the URL operators put in their README, in their docs, on their GitHub profile. It's the public face of the agent's identity — the equivalent of a TLS cert viewer for an HTTPS site.
+
+## What this is not
+
+- **Not a CA-rooted PKI.** There's no globally-trusted root authority. Trust bottoms out in the ship's ed25519 keypair plus optional amplifiers (domain, voice, tool manifest).
+- **Not a hosting decision.** The certificate works for cloud agents, local agents, OSS contributors, enterprise deployments. The only requirement is that the issuing machine has a Treeship keystore.
+- **Not a payment identity.** x402 / lobster.cash flows are wrapped by `treeship wrap` and recorded into receipts; the identity of *who is allowed to spend* is a separate concern from *who is allowed to act*. Future certificates may include a `payment` layer; today they don't.
+- **Not immutable.** Certs expire (default 90 days). Re-issue with the same name to publish a new version. The Merkle history of past receipts under the old cert remains verifiable forever — the cert just stops being usable for new attestations.
+
+## Where to go next
+
+- [Trust fabric](/docs/concepts/trust-fabric) for the full architecture overview
+- [Session Receipts](/docs/concepts/session-receipts) for the activity layer
+- [Cross-verification](/docs/concepts/cross-verification) for the check matrix
+- [`treeship agent register`](/docs/cli/agent) for the CLI reference

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["trust-model", "artifacts", "session-receipts", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
+  "pages": ["trust-fabric", "trust-model", "artifacts", "session-receipts", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
 }

--- a/docs/content/docs/concepts/trust-fabric.mdx
+++ b/docs/content/docs/concepts/trust-fabric.mdx
@@ -1,0 +1,128 @@
+---
+title: Trust fabric
+description: Treeship is a trust fabric for AI agents — the universal layer that gives every agent both a verifiable identity and a verifiable work record. This page is the whole architecture in one read.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+> **Treeship is the trust fabric, not another agent.**
+
+Once Treeship is installed, attaching any serious agent — Claude Code, Cursor, Codex, OpenClaw, Hermes, or any future MCP-compatible agent — should be a one-config-block change. The output is always the same: a verifiable agent identity plus a verifiable work receipt, regardless of vendor. Two surfaces, one trust story.
+
+## The two surfaces
+
+Treeship's trust fabric has two public artifacts. They bind into a single verifiable record but they answer different questions.
+
+| | Identity layer | Activity layer |
+|---|---|---|
+| **URL** | `treeship.dev/agent/<slug>` | `treeship.dev/receipt/<id>` |
+| **Answers** | Who this agent represents and what it's allowed to do | What this agent actually did |
+| **Built from** | `treeship agent register` (CLI) → signed `.agent` package | Session events from hooks + MCP + git, sealed in a Merkle tree |
+| **Signed under** | The ship's ed25519 key | The same key, plus per-artifact ed25519 signatures inside the session |
+| **Binding** | Cross-verification: every receipt must stay inside its agent's declared `bounded_actions` | |
+
+See [Agent Identity](/docs/concepts/agent-identity) for the identity layer, [Session Receipts](/docs/concepts/session-receipts) for the activity layer, and [Cross-verification](/docs/concepts/cross-verification) for the binding.
+
+## Three axes the trust fabric separates cleanly
+
+A clean trust story for agents has to keep three different concerns from collapsing into each other. Treeship treats them as orthogonal:
+
+| Axis | Examples | Where it shows up in the receipt |
+|---|---|---|
+| **Agent surface** | Claude Code, Cursor, Codex, Cline, OpenClaw, Hermes | `agent_name` per event, `agent_graph` per session |
+| **Model + provider** | claude-opus-4-7 / anthropic, gpt-5 / openai, kimi-k2 / moonshot, llama / meta, local / ollama | Provider-colored model pill on each agent card |
+| **Tool channel** | Native hook, MCP gateway, shell wrap, git reconciliation | `source` field on every file row and process row |
+
+Any agent that speaks MCP attaches via the same gateway. Any model behind that agent gets attributed. Any tool channel that touches the working tree gets witnessed.
+
+## The bar
+
+> **If an agent changes code during a Treeship session and the receipt does not show it, Treeship failed.**
+
+Hooks and MCP cover most paths but not all. An agent that runs `sed -i` inside a Bash command, a build tool that modifies generated files, a developer who manually edits during the session — none of those reach a captured tool channel directly. The trust fabric closes that gap with three complementary layers, ranked by attribution strength:
+
+| Layer | Source | What it sees | Trust signal |
+|---|---|---|---|
+| 1 | Specialized event types (`agent.wrote_file`) | Native hook saw the tool fire with full input | `source: "hook"` — highest direct attribution |
+| 2 | Promoted from `agent.called_tool` | MCP bridge captured the call; the aggregator inferred direction from tool name + meta | `source: "mcp"` — medium, direction inferred |
+| 3 | `git diff` at session close | Backstop; catches anything missed | `source: "git-reconcile"` — completeness over direct attribution |
+
+Every file row on a receipt carries one of these `source` labels so a reviewer can see how each change was witnessed, not just that it happened.
+
+## Determinism is a property, not a marketing word
+
+Every artifact Treeship produces is reproducible bit-for-bit from its inputs. This isn't aesthetic — it's the foundation of independent verification.
+
+- **Signatures are deterministic.** Ed25519 signing the same message with the same key always produces the same signature. (RFC 8032 — see the [DSSE explainer](/blog/dsse-dead-simple-signing-explained) for why this matters as a safety property.)
+- **Pre-Authentication Encoding is deterministic.** The PAE format used for signing prepends every payload's type and length so the bytes signed cannot be reinterpreted.
+- **Receipts are deterministic.** The session receipt is a pure aggregation over the event log. Same events in, same `receipt.json` out, same merkle root, same package digest. See [`treeship package inspect`](/docs/cli/package).
+- **Verification is deterministic.** The verifier runs offline on your machine. No network call, no clock skew tolerance applied silently — the caller passes `now` explicitly.
+- **Reconciliation is deterministic.** Git reconciliation at session close uses a `BTreeMap` ordering so two close runs against the same working tree produce byte-identical receipts.
+
+The result: anyone can take a `.treeship` package and an `.agent` certificate, run them through a verifier on a clean machine, and get the same answer Treeship's own renderer got. No server, no account, no trust required.
+
+## How identity gets bound to activity
+
+When you run a Treeship session under a registered agent, three independent records are created and bound together:
+
+1. **The Agent Identity Certificate** (issued at registration) declares `bounded_actions`, `forbidden`, `escalation_required`, and a validity window — all signed under the ship's ed25519 key.
+2. **Session events** are emitted in real time as the agent works. Each event records actor, tool, timestamp, and (when present) the file path or command. The event log is sealed in a Merkle tree at session close.
+3. **The Session Receipt** is composed from those events plus an optional git-reconciliation pass. It carries the same `ship_id` as the certificate.
+
+[Cross-verification](/docs/concepts/cross-verification) (`cross_verify_receipt_and_certificate` in core, `treeship verify --certificate` from the CLI) takes both artifacts and answers a single question: **did this session stay inside the certificate's authorized envelope?**
+
+The result has four orthogonal checks:
+
+- `ship_id_match` — the receipt is signed by the same ship the cert was issued to
+- `within_validity_window` — the session ran while the cert was still valid
+- `unauthorized_calls` — count of tool calls outside `bounded_actions` (must be zero)
+- `never_called` — declared tools the agent didn't end up using (informational; useful for tightening the next cert)
+
+The agent card surfaces this binding visually as a "✓ no unauthorized calls" badge alongside each recent receipt.
+
+## Capture → normalize → reconcile → receipt → verify
+
+The end-to-end pipeline:
+
+```
+   Native hooks    ┐
+   (Claude Code)   │
+                    │
+   MCP bridge      ├─▶  events.jsonl  ──▶  ReceiptComposer  ──▶  receipt.json
+   (Cursor/Codex/  │    (signed in     │    (deterministic       │   (canonical
+    Cline/...)     │     real time)    │     aggregation;        │    JSON,
+                    │                   │     git-reconcile       │    sealed in
+   treeship wrap   │                   │     adds backstop)      │    merkle root)
+   (shell)         ┘                   │                          │
+                                        │                          ▼
+                                        │              treeship package verify
+                                        │              cross_verify_receipt_and_certificate
+                                        │              (offline, deterministic)
+                                        ▼
+                              Sealed in merkle root
+                              alongside the per-artifact
+                              ed25519 signatures
+```
+
+Each stage has its own concept doc:
+
+- **Capture**: [Session Receipts](/docs/concepts/session-receipts) covers the event model. The integration READMEs (`integrations/claude-code-plugin/`, `integrations/cursor/`, `integrations/codex/`, etc) cover per-vendor instrumentation. The MCP gateway is documented in [`bridges/mcp/ATTACHING.md`](https://github.com/zerkerlabs/treeship/blob/main/bridges/mcp/ATTACHING.md).
+- **Normalize**: handled inside `SideEffects::from_events` in `packages/core/src/session/side_effects.rs`. Generic `agent.called_tool` events with file-path metadata get promoted into `files_read` / `files_written` / `processes` so the receipt's headline sections actually reflect the work.
+- **Reconcile**: `packages/core/src/session/git.rs` runs `git diff` at session close and synthesizes events for changes no captured channel saw.
+- **Receipt**: [Session Receipts](/docs/concepts/session-receipts) covers the on-disk format and the package layout.
+- **Verify**: [Trust model](/docs/concepts/trust-model), [Cross-verification](/docs/concepts/cross-verification), and [`treeship package verify`](/docs/cli/package) cover the offline check.
+
+## What this is not
+
+- **Not a hosted runtime.** Treeship doesn't execute agents. It records what they do.
+- **Not a single-vendor stack.** The MCP gateway makes any MCP-compatible agent an equal citizen. Skill-based agents (Hermes, OpenClaw) attach via skill files rather than MCP.
+- **Not a payment layer by itself.** x402 / lobster.cash payment flows can be wrapped via `treeship wrap` and recorded into the same receipt, but identity-of-payment is a separate concern from identity-of-agent.
+- **Not a moderation tool.** The certificate declares what an agent is *allowed* to do. Whether that envelope is appropriate is a policy question, not a Treeship one.
+
+## Where to go next
+
+- New to Treeship? [Quickstart](/docs/guides/quickstart) gets you a verified receipt in 90 seconds.
+- Want to understand the activity layer? [Session Receipts](/docs/concepts/session-receipts).
+- Want to understand the identity layer? [Agent Identity](/docs/concepts/agent-identity).
+- Want to understand the binding? [Cross-verification](/docs/concepts/cross-verification).
+- Want to attach a new agent? [`bridges/mcp/ATTACHING.md`](https://github.com/zerkerlabs/treeship/blob/main/bridges/mcp/ATTACHING.md).


### PR DESCRIPTION
## Why
The trust-fabric direction needs two concept docs to be properly grounded so the marketing language has somewhere factual to point at. Both grounded in real CLI commands and real code paths — every claim points at a concrete file or function.

## What's new
- **\`concepts/trust-fabric.mdx\`** — the architecture overview. Covers the two surfaces (\`/agent/<slug>\` + \`/receipt/<id>\`), the three-axis separation (agent / model / tool channel), the bar (*"if a file changed, it must appear in the receipt"*), the three layers of capture, and **determinism** as a property — five concrete forms, not marketing.
- **\`concepts/agent-identity.mdx\`** — the deep dive on the identity layer. The TLS-for-AI-agents analogy drawn carefully (no CA, but a single signed artifact a third party can verify offline). Three layers in one bundle (identity + capabilities + declaration) shown as real JSON. Full \`treeship agent register\` CLI walkthrough. Trust amplifiers (domain proof, voice fingerprint, tool manifest verification). How initial scope gets determined (operator-declared / project-declared / discoverable). Binding to receipts via the existing cross-verify function.
- **\`concepts/meta.json\`** — new ordering puts trust-fabric first as the overview, agent-identity right after session-receipts as the other half.

## Where this is grounded
| Doc claim | Real anchor in the repo |
|---|---|
| Three signed layers | \`packages/cli/src/commands/agent.rs\` |
| .agent package format | Same file, lines 109-129 |
| ed25519 signing of canonical JSON | \`packages/core/src/agent/\` + \`packages/core/src/attestation/sign.rs\` |
| Cross-verify check matrix | \`cross_verify_receipt_and_certificate\` in \`packages/core/src/verify/\` |
| Domain proof / voice fingerprint flows | \`replit-deployer-v0/treeship-api/routes/identity.py\` |
| Capture → normalize → reconcile pipeline | \`packages/core/src/session/{event_log,side_effects,git}.rs\` |
| Determinism as a property | RFC 8785 (already cited in README), DSSE blog post (existing) |

## What this enables
- Homepage copy can now link to \`/docs/concepts/trust-fabric\` for "what is this?" instead of waving hands.
- A future blog post ("TLS for AI agents") can quote these docs verbatim — same wording across surfaces.
- Reviewers reading the agent card UI ([treeship.dev PR #5](https://github.com/zerkerlabs/treeship.dev/pull/5)) get a one-click link to the concept doc that explains what the cert is.
- The \`bridges/mcp/ATTACHING.md\` (PR #13) can cross-link into trust-fabric.mdx as the framing it builds on.

## Test plan
- [ ] Vercel preview: \`/docs/concepts/trust-fabric\` and \`/docs/concepts/agent-identity\` both render
- [ ] Sidebar order matches the new \`meta.json\` flow
- [ ] All inter-doc links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)