### PR TITLE
fix(init): stop overwriting project config.json with global-extends marker

### DIFF
--- a/packages/cli/src/commands/init.rs
+++ b/packages/cli/src/commands/init.rs
@@ -226,6 +226,76 @@ fn prompt(msg: &str) -> String {
     line
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tempdir() -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("treeship-init-test-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn config_json_is_real_detects_full_config() {
+        // Mimics what config::save writes after init: full Config with
+        // ship_id. write_project_config should leave this alone.
+        let dir = tempdir();
+        let path = dir.join("config.json");
+        std::fs::write(&path, r#"{
+            "ship_id": "ship_abc123",
+            "name": "test",
+            "storage_dir": "/tmp/proj/.treeship/artifacts",
+            "keys_dir": "/tmp/proj/.treeship/keys",
+            "default_key_id": "key_xyz",
+            "hub_connections": {}
+        }"#).unwrap();
+        assert!(config_json_is_real(&path), "real Config with ship_id should be detected as real");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_json_is_real_rejects_marker_stub() {
+        // The marker stub write_project_config used to (over)write. The
+        // helper must return false so write_project_config knows it's
+        // safe to overwrite.
+        let dir = tempdir();
+        let path = dir.join("config.json");
+        std::fs::write(&path, r#"{
+            "extends": "/Users/somebody/.treeship/config.json",
+            "project": true
+        }"#).unwrap();
+        assert!(!config_json_is_real(&path), "marker stub without ship_id must NOT be detected as real");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_json_is_real_rejects_missing_file() {
+        let dir = tempdir();
+        let path = dir.join("does-not-exist.json");
+        assert!(!config_json_is_real(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_json_is_real_rejects_garbage() {
+        let dir = tempdir();
+        let path = dir.join("config.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(!config_json_is_real(&path));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn config_json_is_real_rejects_empty_ship_id() {
+        let dir = tempdir();
+        let path = dir.join("config.json");
+        std::fs::write(&path, r#"{"ship_id": ""}"#).unwrap();
+        assert!(!config_json_is_real(&path), "empty ship_id should not count as real");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
 fn detect_language() -> String {
     let cwd = std::env::current_dir().unwrap_or_default();
     if cwd.join("package.json").exists() || cwd.join("node_modules").exists() {
@@ -269,6 +339,24 @@ fn write_project_config(
 
     // Write a config.json marker so the daemon trust check passes.
     // The daemon requires both config.yaml and config.json to exist in .treeship/.
+    //
+    // BUT: when the user ran `treeship init --config .treeship/config.json`
+    // from this same directory, a REAL Config was already saved at the same
+    // path a few lines earlier in init::run (with ship_id, keys_dir, etc).
+    // The marker stub below would overwrite that real config and silently
+    // turn the project into an "extends global ~/.treeship" stub -- which
+    // means every subsequent command resolves through global state and a
+    // broken global keystore blocks project-local work even though the
+    // project has perfectly good local keys.
+    //
+    // Detect that case: if config.json exists and parses as a real Config
+    // (has the ship_id field), leave it alone. The daemon trust check still
+    // passes because the file exists; the project stays self-contained.
+    let marker_path = ts_dir.join("config.json");
+    if config_json_is_real(&marker_path) {
+        return Ok(());
+    }
+
     let global_config = crate::config::default_config_path()
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default();
@@ -276,7 +364,6 @@ fn write_project_config(
         "extends": global_config,
         "project": true,
     });
-    let marker_path = ts_dir.join("config.json");
     std::fs::write(&marker_path, serde_json::to_vec_pretty(&marker)?)?;
     #[cfg(unix)]
     {
@@ -285,4 +372,19 @@ fn write_project_config(
     }
 
     Ok(())
+}
+
+/// Returns true if the file at `path` exists and parses as a full Config
+/// (i.e. has a `ship_id` field). Used to decide whether write_project_config
+/// should leave an existing config.json alone vs overwrite it with a marker.
+fn config_json_is_real(path: &std::path::Path) -> bool {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+    let val: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    val.get("ship_id").and_then(|v| v.as_str()).is_some_and(|s| !s.is_empty())
 }


### PR DESCRIPTION
## The bug Codex found
> A broken \`~/.treeship\` keystore blocks Treeship globally, **and worse**, project-local \`treeship init --config .treeship/config.json\` still ends up depending on the broken global config/keystore. That makes local project setup and smoke tests fail even after regenerating project keys.

## Root cause
\`write_project_config\` (init.rs:270-285) unconditionally writes a \`config.json\` marker stub:
\`\`\`json
{
  "extends": "/Users/<you>/.treeship/config.json",
  "project": true
}
\`\`\`

The marker exists to satisfy the daemon's trust check (which requires both \`config.yaml\` and \`config.json\` in \`.treeship/\`). But when init was called with \`--config /proj/.treeship/config.json\` and the user is cwd=\`/proj\`, the marker_path computed as \`cwd/.treeship/config.json\` is **the same path** where \`init::run\` just saved a real Config a few lines earlier.

The marker write blew away the real config — silently turning the project into a global-extending stub even though every local key was correctly generated under \`/proj/.treeship/keys/\`. Subsequent commands resolve through the broken global state.

## Fix
Check whether \`config.json\` already exists with a real Config shape (a non-empty \`ship_id\` field) before writing the marker. If it does, leave it alone. The daemon trust check still passes because the file exists; the project stays self-contained; subsequent commands resolve project-local without touching \`~/.treeship\`.

## Tests (5 new, all passing)
- \`detects_full_config\` — real Config with ship_id is preserved
- \`rejects_marker_stub\` — the old extends-stub format is not "real"
- \`rejects_missing_file\` — helper returns false, doesn't panic
- \`rejects_garbage\` — malformed JSON returns false
- \`rejects_empty_ship_id\` — presence isn't enough; field must be non-empty

## Smoke test (manual)
\`\`\`bash
mkdir -p /tmp/treeship-iso-test && cd /tmp/treeship-iso-test
treeship init --config .treeship/config.json --name iso-test
jq -r '.ship_id // "MARKER (BUG)"' .treeship/config.json
# before this fix: prints "MARKER (BUG)"
# after this fix:  prints a real ship_<fingerprint>
\`\`\`

## What this PR does NOT do (deferred)
This is **one piece** of the larger keystore-isolation track. Follow-ups still needed:
- Make \`machine_seed\` location project-aware so \`derive_machine_key\` doesn't always reach for \`~/.treeship/machine_seed\`
- Add \`treeship doctor --fix\` for safe global keystore repair (backup → move aside → reinit → smoke-test, refusing to run with an active session unless \`--yes\`)
- Improve the MAC-verification-failed error message to reference the new repair command

## Test plan
- [ ] CI green
- [ ] Manual smoke test above
- [ ] Project-local \`treeship session start --config .treeship/config.json\` works even if \`~/.treeship\` keystore is broken (which is the whole point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)