### PR TITLE
fix(receipt): tool_usage.actual aggregates specialized events (Codex blocker #1)

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -755,10 +755,25 @@ pub fn close(
     // git command errors, reconcile_changes returns an empty Vec and
     // close proceeds normally.
     if let Ok(cwd) = std::env::current_dir() {
+        // Dedupe ONLY against prior writes, never reads.
+        //
+        // Bug Codex caught in adversarial review: the original filter
+        // included AgentReadFile, which suppressed real writes whenever
+        // the file had been read earlier in the session. Classic miss:
+        // agent reads src/lib.rs (post-tool-use.sh emits AgentReadFile),
+        // then a Bash command runs `sed -i src/lib.rs` (post-tool-use.sh
+        // emits AgentCompletedProcess, NOT AgentWroteFile). Git diff
+        // sees the modification, but reconcile dropped it because the
+        // path was "already captured" as a read. Receipt then showed
+        // the read and the process but no write -- a confidently
+        // incomplete audit trail.
+        //
+        // The trust-fabric bar is "if a file changed during the session,
+        // the receipt shows it." Reads do not change files. Only writes
+        // belong in the dedup set.
         let already_captured: std::collections::BTreeSet<String> = events.iter()
             .filter_map(|e| match &e.event_type {
                 EventType::AgentWroteFile { file_path, .. } => Some(file_path.clone()),
-                EventType::AgentReadFile { file_path, .. } => Some(file_path.clone()),
                 _ => None,
             })
             .collect();

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -286,6 +286,14 @@ pub fn start(
     manifest.root_artifact_id = Some(result.artifact_id.clone());
     manifest.authorized_tools = super::declare::read_authorized_tools();
 
+    // Capture the git HEAD SHA at session start so close-time
+    // reconciliation can compute committed-during-session changes.
+    // Fail-open: None for non-git projects; reconciliation falls back
+    // to working-tree-only diffs in that case.
+    if let Ok(cwd) = std::env::current_dir() {
+        manifest.start_commit_sha = session::current_head_sha(&cwd);
+    }
+
     let session_path = ts_dir.join("session.json");
     let json = serde_json::to_string_pretty(&manifest)?;
     std::fs::write(&session_path, &json)?;
@@ -728,7 +736,78 @@ pub fn close(
     }
 
     // ── Compose Session Receipt and build .treeship package ─────────
-    let events = event_log.read_all().unwrap_or_default();
+    let mut events = event_log.read_all().unwrap_or_default();
+
+    // ── Git reconciliation ──────────────────────────────────────────
+    // Backstop layer of the trust-fabric file-capture stack. Catches
+    // any files the agent edited outside captured tool channels:
+    // sed -i inside a Bash command, build outputs, manual edits during
+    // the session. Synthetic AgentWroteFile events are appended to
+    // events.jsonl so they're sealed in the merkle root alongside the
+    // rest of the session's evidence -- not just patched into the
+    // receipt as out-of-band claims.
+    //
+    // Dedup against existing AgentWroteFile/AgentReadFile events by
+    // file_path so a file already captured by hook or MCP isn't
+    // double-counted with a "git-reconcile" entry.
+    //
+    // Fail-open: if not in a git repo, git binary missing, or any
+    // git command errors, reconcile_changes returns an empty Vec and
+    // close proceeds normally.
+    if let Ok(cwd) = std::env::current_dir() {
+        let already_captured: std::collections::BTreeSet<String> = events.iter()
+            .filter_map(|e| match &e.event_type {
+                EventType::AgentWroteFile { file_path, .. } => Some(file_path.clone()),
+                EventType::AgentReadFile { file_path, .. } => Some(file_path.clone()),
+                _ => None,
+            })
+            .collect();
+        let host_id = local_host_id();
+        let trace_id = generate_trace_id();
+        let changes = session::reconcile_changes(&cwd, manifest.start_commit_sha.as_deref());
+        let mut reconciled = 0usize;
+        for change in changes {
+            if already_captured.contains(&change.file_path) {
+                continue;
+            }
+            let mut evt = SessionEvent {
+                session_id: manifest.session_id.clone(),
+                event_id: generate_event_id(),
+                timestamp: now_rfc3339(),
+                sequence_no: 0,
+                trace_id: trace_id.clone(),
+                span_id: generate_span_id(),
+                parent_span_id: None,
+                agent_id: "system://git-reconcile".into(),
+                agent_instance_id: "git-reconcile".into(),
+                agent_name: "git-reconcile".into(),
+                agent_role: Some("reconciler".into()),
+                host_id: host_id.clone(),
+                tool_runtime_id: None,
+                event_type: EventType::AgentWroteFile {
+                    file_path: change.file_path.clone(),
+                    digest: None,
+                    operation: Some(change.operation.clone()),
+                    additions: change.additions,
+                    deletions: change.deletions,
+                },
+                artifact_ref: None,
+                meta: Some(serde_json::json!({"source": "git-reconcile"})),
+            };
+            // Best-effort log append: include the event in the in-memory
+            // composition list either way so the receipt has the data
+            // even if the on-disk log refused (filesystem error, etc.).
+            let _ = event_log.append(&mut evt);
+            events.push(evt);
+            reconciled += 1;
+        }
+        if reconciled > 0 {
+            printer.dim_info(&format!(
+                "  reconciled {reconciled} file{} from git that weren't captured by hook or MCP",
+                if reconciled == 1 { "" } else { "s" },
+            ));
+        }
+    }
 
     // Build artifact entries from the chain
     let artifact_entries: Vec<session::receipt::ArtifactEntry> = collect_artifact_entries(&ctx, &manifest);

--- a/packages/core/src/session/git.rs
+++ b/packages/core/src/session/git.rs
@@ -1,0 +1,244 @@
+//! Git-based reconciliation for session close.
+//!
+//! Backstop layer of the trust-fabric file-capture stack:
+//!
+//!   1. (highest trust) specialized event types (`agent.wrote_file`)
+//!   2. (medium)        promoted from generic `agent.called_tool`
+//!   3. (this module)   shell out to `git` at session close and pick
+//!                      up anything an agent edited outside any
+//!                      captured tool channel
+//!
+//! Why this matters: the trust-fabric bar is "if a file changed, it
+//! must appear in the receipt." Hooks and MCP cover most paths but
+//! not all -- an agent that ran `sed -i` inside a Bash command, a
+//! build tool that modified files, or any other untracked side
+//! effect would otherwise vanish silently. Running `git diff` and
+//! `git ls-files --others` at close catches the rest.
+//!
+//! Fail-open by design: if the working dir isn't a git repo, if the
+//! git binary is missing, or if any git command errors, returns an
+//! empty list. The receipt is still produced; reconciliation is a
+//! best-effort enhancement, never a gate.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// One file change observed via git that wasn't already captured by a
+/// tool channel. Mapped 1:1 into a synthetic `AgentWroteFile` event
+/// at session close so it flows through the normal aggregator and
+/// receipt composition path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitChange {
+    pub file_path: String,
+    /// "created", "modified", "deleted", "renamed", or "untracked".
+    pub operation: String,
+    pub additions: Option<u32>,
+    pub deletions: Option<u32>,
+}
+
+/// Run `git` in `repo_dir` with the given args, returning stdout
+/// trimmed of trailing newline. Returns None on any failure (not
+/// a git repo, git missing, non-zero exit, etc.) -- this module is
+/// fail-open by contract.
+fn git_capture(repo_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C").arg(repo_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let mut s = String::from_utf8(output.stdout).ok()?;
+    while s.ends_with('\n') {
+        s.pop();
+    }
+    Some(s)
+}
+
+/// Fast probe: is this directory inside a git repo?
+fn is_git_repo(repo_dir: &Path) -> bool {
+    git_capture(repo_dir, &["rev-parse", "--is-inside-work-tree"])
+        .as_deref()
+        == Some("true")
+}
+
+/// Translate a git diff/status name-status code to our operation
+/// vocabulary. Codes from `git diff --name-status`: A=added,
+/// M=modified, D=deleted, R=renamed, C=copied, T=type-change,
+/// U=unmerged, plus special "??" for ls-files untracked.
+fn translate_status(code: &str) -> &'static str {
+    match code.chars().next().unwrap_or(' ') {
+        'A' => "created",
+        'D' => "deleted",
+        'R' => "renamed",
+        'C' => "created", // copy = new file at the destination
+        'T' => "modified",
+        '?' => "untracked",
+        _   => "modified", // M, U, anything else
+    }
+}
+
+/// Parse a single line of `git diff --numstat` (additions, deletions,
+/// path). Numeric fields are "-" for binary files; we represent
+/// those as None.
+fn parse_numstat_line(line: &str) -> Option<(String, Option<u32>, Option<u32>)> {
+    let mut parts = line.splitn(3, '\t');
+    let adds_s = parts.next()?;
+    let dels_s = parts.next()?;
+    let path = parts.next()?.to_string();
+    let adds = adds_s.parse::<u32>().ok();
+    let dels = dels_s.parse::<u32>().ok();
+    Some((path, adds, dels))
+}
+
+/// Collect every file change in `repo_dir` worth surfacing in a
+/// session receipt: working-tree modifications (staged or not),
+/// committed-since-`since_sha` changes (when provided), and untracked
+/// files.
+///
+/// Deduplicated across the three sources so a single file shows up
+/// once. When `git diff --numstat` reports additions/deletions for a
+/// path, those are attached; binary files leave them as None.
+///
+/// Returns an empty Vec if `repo_dir` isn't a git repo or git isn't
+/// available -- callers (i.e. session close) should treat absence as
+/// "nothing to reconcile" and continue.
+pub fn reconcile_changes(repo_dir: &Path, since_sha: Option<&str>) -> Vec<GitChange> {
+    if !is_git_repo(repo_dir) {
+        return Vec::new();
+    }
+
+    use std::collections::BTreeMap;
+    // path -> change. BTreeMap so output is deterministic across runs,
+    // which matters for canonical receipt JSON / merkle stability.
+    let mut by_path: BTreeMap<String, GitChange> = BTreeMap::new();
+
+    let mut record = |path: String, op: &str| {
+        by_path.entry(path.clone()).or_insert(GitChange {
+            file_path: path,
+            operation: op.to_string(),
+            additions: None,
+            deletions: None,
+        });
+    };
+
+    // 1. Uncommitted changes vs HEAD (staged + unstaged combined via
+    //    name-status). The common agent case: edited a file, didn't
+    //    commit.
+    if let Some(out) = git_capture(repo_dir, &["diff", "HEAD", "--name-status"]) {
+        for line in out.lines() {
+            let mut parts = line.split('\t');
+            if let (Some(code), Some(path)) = (parts.next(), parts.next()) {
+                let op = translate_status(code);
+                record(path.to_string(), op);
+            }
+        }
+    }
+
+    // 2. Committed-during-session changes if the caller captured a
+    //    starting SHA at session start.
+    if let Some(sha) = since_sha {
+        let range = format!("{sha}..HEAD");
+        if let Some(out) = git_capture(repo_dir, &["diff", &range, "--name-status"]) {
+            for line in out.lines() {
+                let mut parts = line.split('\t');
+                if let (Some(code), Some(path)) = (parts.next(), parts.next()) {
+                    let op = translate_status(code);
+                    record(path.to_string(), op);
+                }
+            }
+        }
+    }
+
+    // 3. Untracked files (new files the agent added but didn't `git
+    //    add`). These never show in `git diff` so they need their own
+    //    pass.
+    if let Some(out) = git_capture(repo_dir, &["ls-files", "--others", "--exclude-standard"]) {
+        for path in out.lines().filter(|l| !l.is_empty()) {
+            record(path.to_string(), "untracked");
+        }
+    }
+
+    // 4. Numstat for the same diff range -- attach additions/deletions
+    //    where available. Numstat reports differently than name-status
+    //    (no rename indicator), so we just match by path.
+    if let Some(out) = git_capture(repo_dir, &["diff", "HEAD", "--numstat"]) {
+        for line in out.lines() {
+            if let Some((path, adds, dels)) = parse_numstat_line(line) {
+                if let Some(entry) = by_path.get_mut(&path) {
+                    entry.additions = adds;
+                    entry.deletions = dels;
+                }
+            }
+        }
+    }
+    if let Some(sha) = since_sha {
+        let range = format!("{sha}..HEAD");
+        if let Some(out) = git_capture(repo_dir, &["diff", &range, "--numstat"]) {
+            for line in out.lines() {
+                if let Some((path, adds, dels)) = parse_numstat_line(line) {
+                    if let Some(entry) = by_path.get_mut(&path) {
+                        entry.additions = adds;
+                        entry.deletions = dels;
+                    }
+                }
+            }
+        }
+    }
+
+    by_path.into_values().collect()
+}
+
+/// Capture the current HEAD commit SHA so it can be stored in the
+/// session manifest at session start. The session close pass uses it
+/// as the diff base for committed-during-session changes. Returns
+/// None when not in a git repo or no commits exist yet.
+pub fn current_head_sha(repo_dir: &Path) -> Option<String> {
+    if !is_git_repo(repo_dir) {
+        return None;
+    }
+    git_capture(repo_dir, &["rev-parse", "HEAD"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_status_maps_known_codes() {
+        assert_eq!(translate_status("A"), "created");
+        assert_eq!(translate_status("M"), "modified");
+        assert_eq!(translate_status("D"), "deleted");
+        assert_eq!(translate_status("R100"), "renamed");
+        assert_eq!(translate_status("??"), "untracked");
+        assert_eq!(translate_status(""), "modified");
+        assert_eq!(translate_status("X"), "modified");
+    }
+
+    #[test]
+    fn parse_numstat_handles_text_and_binary() {
+        let (p, a, d) = parse_numstat_line("12\t3\tsrc/a.rs").unwrap();
+        assert_eq!(p, "src/a.rs");
+        assert_eq!(a, Some(12));
+        assert_eq!(d, Some(3));
+
+        // Binary files: numstat uses "-\t-\tpath".
+        let (p, a, d) = parse_numstat_line("-\t-\tassets/logo.png").unwrap();
+        assert_eq!(p, "assets/logo.png");
+        assert_eq!(a, None);
+        assert_eq!(d, None);
+    }
+
+    #[test]
+    fn reconcile_in_non_git_dir_returns_empty() {
+        let tmp = std::env::temp_dir().join(format!("treeship-not-a-repo-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let result = reconcile_changes(&tmp, None);
+        assert!(result.is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/packages/core/src/session/manifest.rs
+++ b/packages/core/src/session/manifest.rs
@@ -155,6 +155,14 @@ pub struct SessionManifest {
     /// Tools declared as authorized for this session (from declaration.json).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authorized_tools: Vec<String>,
+
+    /// Git HEAD SHA captured at session start, when the project is a
+    /// git repo. Used by session::close to compute committed-during-
+    /// session changes via `git diff <sha>..HEAD` for the
+    /// reconciliation pass. Absent for non-git projects or for
+    /// sessions started before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_commit_sha: Option<String>,
 }
 
 impl SessionManifest {
@@ -179,6 +187,7 @@ impl SessionManifest {
             hosts: Vec::new(),
             tools: Vec::new(),
             authorized_tools: Vec::new(),
+            start_commit_sha: None,
         }
     }
 }
@@ -246,6 +255,7 @@ mod tests {
                 invocation_count: 42,
             }],
             authorized_tools: vec!["read_file".into(), "write_file".into()],
+            start_commit_sha: Some("abc1234567890abcdef1234567890abcdef12345".into()),
         };
         let json = serde_json::to_string_pretty(&m).unwrap();
         let m2: SessionManifest = serde_json::from_str(&json).unwrap();

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -13,6 +13,7 @@ pub mod side_effects;
 pub mod receipt;
 pub mod render;
 pub mod package;
+pub mod git;
 
 pub use manifest::*;
 pub use event::*;
@@ -23,3 +24,4 @@ pub use side_effects::SideEffects;
 pub use receipt::{ArtifactEntry, ReceiptComposer, SessionReceipt};
 pub use render::RenderConfig;
 pub use package::{build_package, read_package, verify_package, VerifyCheck, VerifyStatus};
+pub use git::{reconcile_changes, current_head_sha, GitChange};

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -456,27 +456,78 @@ pub fn parse_ship_id_from_actor(actor: &str) -> Option<String> {
 
 /// Extract a human-readable label from an EventType.
 /// Derive tool usage from side effects and the declared authorized tools list.
+///
+/// Bug Codex caught in adversarial review: previously this function counted
+/// only `side_effects.tool_invocations` (built from `EventType::AgentCalledTool`).
+/// But Claude Code's PostToolUse hook emits SPECIALIZED events for built-in
+/// tools (`agent.wrote_file` for Write/Edit, `agent.completed_process` for
+/// Bash, `agent.read_file` for Read, etc) -- those events never landed in
+/// `tool_invocations`, so a certificate that omitted "Bash" or "Write"
+/// passed cross-verification cleanly even when the agent ran them.
+///
+/// The fix: also count side effects from specialized event types under
+/// canonical tool names that match what an operator would declare in
+/// `bounded_actions`. Naming follows Claude Code conventions (Read, Write,
+/// Bash, WebFetch) since those are the tools users actually declare. A
+/// cert that uses an alternate naming scheme (e.g. `files.write`) needs
+/// to declare both for now -- a future TODO is canonical mapping at the
+/// cert layer.
 fn derive_tool_usage(
     side_effects: &SideEffects,
     authorized_tools: &[String],
 ) -> Option<ToolUsage> {
     use std::collections::BTreeMap;
 
-    if side_effects.tool_invocations.is_empty() && authorized_tools.is_empty() {
+    let total_specialized = side_effects.files_read.len()
+        + side_effects.files_written.len()
+        + side_effects.processes.len()
+        + side_effects.network_connections.len();
+
+    if side_effects.tool_invocations.is_empty()
+        && total_specialized == 0
+        && authorized_tools.is_empty()
+    {
         return None;
     }
 
-    // Count actual tool usage
+    // Count actual tool usage from generic agent.called_tool events.
     let mut counts: BTreeMap<String, u32> = BTreeMap::new();
     for inv in &side_effects.tool_invocations {
         *counts.entry(inv.tool_name.clone()).or_insert(0) += 1;
+    }
+
+    // ALSO count specialized events. These come from native hooks
+    // (claude-code-plugin's PostToolUse) and from git reconciliation,
+    // and they were previously invisible to cross-verification.
+    if !side_effects.files_read.is_empty() {
+        *counts.entry("Read".to_string()).or_insert(0) +=
+            side_effects.files_read.len() as u32;
+    }
+    if !side_effects.files_written.is_empty() {
+        // Maps Write, Edit, MultiEdit, NotebookEdit, and git-reconciled
+        // changes alike -- post-tool-use.sh dispatches all of those into
+        // agent.wrote_file, and the aggregator does not preserve which
+        // specific built-in produced the change.
+        *counts.entry("Write".to_string()).or_insert(0) +=
+            side_effects.files_written.len() as u32;
+    }
+    if !side_effects.processes.is_empty() {
+        *counts.entry("Bash".to_string()).or_insert(0) +=
+            side_effects.processes.len() as u32;
+    }
+    if !side_effects.network_connections.is_empty() {
+        *counts.entry("WebFetch".to_string()).or_insert(0) +=
+            side_effects.network_connections.len() as u32;
     }
 
     let actual: Vec<ToolUsageEntry> = counts.iter()
         .map(|(name, &count)| ToolUsageEntry { tool_name: name.clone(), count })
         .collect();
 
-    // Find tools called that were NOT in the declared list
+    // Find tools used that were NOT in the declared list. With specialized
+    // events now contributing, this catches the hole the certificate was
+    // built to prevent: an agent whose cert says "no Bash" but who ran
+    // Bash anyway via Claude Code's built-in.
     let unauthorized = if authorized_tools.is_empty() {
         Vec::new()
     } else {
@@ -565,28 +616,30 @@ mod tests {
         )
     }
 
-    fn make_events() -> Vec<SessionEvent> {
-        let mk = |seq: u64, inst: &str, et: EventType| -> SessionEvent {
-            SessionEvent {
-                session_id: "ssn_001".into(),
-                event_id: format!("evt_{:016x}", seq),
-                timestamp: format!("2026-04-05T08:{:02}:00Z", seq),
-                sequence_no: seq,
-                trace_id: "trace_1".into(),
-                span_id: format!("span_{seq}"),
-                parent_span_id: None,
-                agent_id: format!("agent://{inst}"),
-                agent_instance_id: inst.into(),
-                agent_name: inst.into(),
-                agent_role: None,
-                host_id: "host_1".into(),
-                tool_runtime_id: None,
-                event_type: et,
-                artifact_ref: None,
-                meta: None,
-            }
-        };
+    /// Module-level event constructor so the tool-authorization regression
+    /// tests below can reuse it without each redefining the closure.
+    fn mk(seq: u64, inst: &str, et: EventType) -> SessionEvent {
+        SessionEvent {
+            session_id: "ssn_001".into(),
+            event_id: format!("evt_{:016x}", seq),
+            timestamp: format!("2026-04-05T08:{:02}:00Z", seq),
+            sequence_no: seq,
+            trace_id: "trace_1".into(),
+            span_id: format!("span_{seq}"),
+            parent_span_id: None,
+            agent_id: format!("agent://{inst}"),
+            agent_instance_id: inst.into(),
+            agent_name: inst.into(),
+            agent_role: None,
+            host_id: "host_1".into(),
+            tool_runtime_id: None,
+            event_type: et,
+            artifact_ref: None,
+            meta: None,
+        }
+    }
 
+    fn make_events() -> Vec<SessionEvent> {
         vec![
             mk(0, "root", EventType::SessionStarted),
             mk(1, "root", EventType::AgentStarted { parent_agent_instance_id: None }),
@@ -678,5 +731,118 @@ mod tests {
         let d1 = ReceiptComposer::digest(&r1).unwrap();
         let d2 = ReceiptComposer::digest(&r2).unwrap();
         assert_eq!(d1, d2);
+    }
+
+    // ── Tool authorization regression tests (Codex finding #1) ──
+    //
+    // Specialized event types (agent.wrote_file, agent.completed_process,
+    // agent.read_file) must contribute to tool_usage.actual so that a
+    // certificate's bounded_actions list can correctly flag unauthorized
+    // built-in tool usage. Before this fix, only agent.called_tool fed
+    // tool_usage.actual, so a cert that omitted "Bash" still passed even
+    // when the agent ran Bash via Claude Code's built-in.
+
+    fn manifest_with_authorized(tools: Vec<&str>) -> SessionManifest {
+        let mut m = make_manifest();
+        m.authorized_tools = tools.into_iter().map(String::from).collect();
+        m
+    }
+
+    #[test]
+    fn cert_omitting_bash_flags_unauthorized_when_session_runs_bash() {
+        let manifest = manifest_with_authorized(vec!["Read", "Write"]); // NO Bash
+        // Hook-emitted process event: this is what claude-code-plugin's
+        // PostToolUse hook produces when the agent uses the Bash built-in.
+        let events = vec![
+            mk(0, "root", EventType::SessionStarted),
+            mk(1, "agent", EventType::AgentCompletedProcess {
+                process_name: "rm -rf /".into(),
+                exit_code: Some(0),
+                duration_ms: Some(50),
+                command: Some("rm -rf /".into()),
+            }),
+            mk(2, "root", EventType::SessionClosed { summary: None, duration_ms: Some(1000) }),
+        ];
+        let receipt = ReceiptComposer::compose(&manifest, &events, vec![]);
+        let tu = receipt.tool_usage.expect("tool_usage must be populated");
+        assert!(
+            tu.unauthorized.iter().any(|t| t == "Bash"),
+            "Bash must be flagged as unauthorized when cert omits it; got unauthorized={:?}, actual={:?}",
+            tu.unauthorized, tu.actual,
+        );
+    }
+
+    #[test]
+    fn cert_omitting_write_flags_unauthorized_when_session_writes_file() {
+        let manifest = manifest_with_authorized(vec!["Read", "Bash"]); // NO Write
+        let events = vec![
+            mk(0, "root", EventType::SessionStarted),
+            mk(1, "agent", EventType::AgentWroteFile {
+                file_path: "src/secret.rs".into(),
+                digest: None, operation: Some("modified".into()),
+                additions: Some(10), deletions: Some(0),
+            }),
+            mk(2, "root", EventType::SessionClosed { summary: None, duration_ms: Some(1000) }),
+        ];
+        let receipt = ReceiptComposer::compose(&manifest, &events, vec![]);
+        let tu = receipt.tool_usage.expect("tool_usage must be populated");
+        assert!(
+            tu.unauthorized.iter().any(|t| t == "Write"),
+            "Write must be flagged as unauthorized when cert omits it; got unauthorized={:?}, actual={:?}",
+            tu.unauthorized, tu.actual,
+        );
+    }
+
+    #[test]
+    fn cert_includes_read_write_bash_passes_clean_when_all_used() {
+        let manifest = manifest_with_authorized(vec!["Read", "Write", "Bash"]);
+        let events = vec![
+            mk(0, "root", EventType::SessionStarted),
+            mk(1, "agent", EventType::AgentReadFile { file_path: "package.json".into(), digest: None }),
+            mk(2, "agent", EventType::AgentWroteFile {
+                file_path: "src/lib.rs".into(),
+                digest: None, operation: Some("modified".into()),
+                additions: Some(5), deletions: Some(2),
+            }),
+            mk(3, "agent", EventType::AgentCompletedProcess {
+                process_name: "bun test".into(),
+                exit_code: Some(0), duration_ms: Some(2000),
+                command: Some("bun test".into()),
+            }),
+            mk(4, "root", EventType::SessionClosed { summary: None, duration_ms: Some(5000) }),
+        ];
+        let receipt = ReceiptComposer::compose(&manifest, &events, vec![]);
+        let tu = receipt.tool_usage.expect("tool_usage must be populated");
+        assert!(
+            tu.unauthorized.is_empty(),
+            "all tools declared in cert should pass clean; got unauthorized={:?}",
+            tu.unauthorized,
+        );
+        // And the actual list shows what the agent did, by canonical name.
+        let actual_names: std::collections::BTreeSet<String> =
+            tu.actual.iter().map(|e| e.tool_name.clone()).collect();
+        assert!(actual_names.contains("Read"));
+        assert!(actual_names.contains("Write"));
+        assert!(actual_names.contains("Bash"));
+    }
+
+    #[test]
+    fn webfetch_unauthorized_flagged_when_cert_omits_it() {
+        let manifest = manifest_with_authorized(vec!["Read", "Write", "Bash"]); // NO WebFetch
+        let events = vec![
+            mk(0, "root", EventType::SessionStarted),
+            mk(1, "agent", EventType::AgentConnectedNetwork {
+                destination: "evil.example.com".into(),
+                port: Some(443),
+            }),
+            mk(2, "root", EventType::SessionClosed { summary: None, duration_ms: Some(1000) }),
+        ];
+        let receipt = ReceiptComposer::compose(&manifest, &events, vec![]);
+        let tu = receipt.tool_usage.expect("tool_usage must be populated");
+        assert!(
+            tu.unauthorized.iter().any(|t| t == "WebFetch"),
+            "WebFetch must be flagged as unauthorized when cert omits it; got unauthorized={:?}",
+            tu.unauthorized,
+        );
     }
 }

--- a/packages/core/src/session/side_effects.rs
+++ b/packages/core/src/session/side_effects.rs
@@ -123,7 +123,7 @@ impl SideEffects {
                         operation: None,
                         additions: None,
                         deletions: None,
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                 }
 
@@ -136,7 +136,7 @@ impl SideEffects {
                         operation: operation.clone(),
                         additions: *additions,
                         deletions: *deletions,
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                 }
 
@@ -167,7 +167,7 @@ impl SideEffects {
                         exit_code: None,
                         duration_ms: None,
                         command: command.clone(),
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                     started_processes.insert(
                         (event.agent_instance_id.clone(), process_name.clone()),
@@ -193,7 +193,7 @@ impl SideEffects {
                             exit_code: *exit_code,
                             duration_ms: *duration_ms,
                             command: command.clone(),
-                            source: Some("hook".into()),
+                            source: Some(source_from_meta(event, "hook")),
                         });
                     }
                 }
@@ -294,6 +294,24 @@ fn first_meta_string(event: &SessionEvent, paths: &[&str]) -> Option<String> {
         }
     }
     None
+}
+
+/// Pull a known-good source label off event.meta if present, else
+/// return the default. Lets emitters tag their provenance in meta
+/// without each event variant needing a dedicated field. Recognized
+/// values: `"hook"`, `"mcp"`, `"git-reconcile"`, `"shell-wrap"`.
+/// Anything else falls back to the default (so a typo doesn't pollute
+/// the receipt).
+fn source_from_meta(event: &SessionEvent, default: &str) -> String {
+    let raw = event
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("source"))
+        .and_then(|v| v.as_str());
+    match raw {
+        Some(s @ ("hook" | "mcp" | "git-reconcile" | "shell-wrap")) => s.to_string(),
+        _ => default.to_string(),
+    }
 }
 
 /// Classify a tool name into a side-effects bucket using string contains

--- a/packages/core/src/session/side_effects.rs
+++ b/packages/core/src/session/side_effects.rs
@@ -24,6 +24,23 @@ pub struct FileAccess {
     pub additions: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deletions: Option<u32>,
+    /// Provenance: how the file change was witnessed.
+    /// - `"hook"`        : structured event from a native hook (e.g.
+    ///                     claude-code-plugin's PostToolUse → agent.wrote_file).
+    ///                     Highest trust -- the integration hook saw the
+    ///                     tool call directly with full input context.
+    /// - `"mcp"`         : promoted from a generic agent.called_tool event
+    ///                     by inspecting meta.tool_input.file_path. Medium
+    ///                     trust -- the MCP bridge saw the tool fire but
+    ///                     we inferred the direction (read vs write) from
+    ///                     tool name heuristics.
+    /// - `"git-reconcile"`: backstop -- collected from `git diff` at session
+    ///                     close to catch files an agent edited outside any
+    ///                     captured tool channel. Lowest direct trust but
+    ///                     highest completeness guarantee.
+    /// Absent on legacy receipts that predate this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// A port opened by an agent.
@@ -59,6 +76,10 @@ pub struct ProcessExecution {
     /// Full command string (e.g. "npm test --runInBand"). Absent in legacy events.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    /// Same provenance scheme as FileAccess::source. `"hook"`, `"mcp"`,
+    /// `"shell-wrap"` (for treeship wrap'd commands), or absent on legacy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// A tool invocation by an agent.
@@ -102,6 +123,7 @@ impl SideEffects {
                         operation: None,
                         additions: None,
                         deletions: None,
+                        source: Some("hook".into()),
                     });
                 }
 
@@ -114,6 +136,7 @@ impl SideEffects {
                         operation: operation.clone(),
                         additions: *additions,
                         deletions: *deletions,
+                        source: Some("hook".into()),
                     });
                 }
 
@@ -144,6 +167,7 @@ impl SideEffects {
                         exit_code: None,
                         duration_ms: None,
                         command: command.clone(),
+                        source: Some("hook".into()),
                     });
                     started_processes.insert(
                         (event.agent_instance_id.clone(), process_name.clone()),
@@ -169,6 +193,7 @@ impl SideEffects {
                             exit_code: *exit_code,
                             duration_ms: *duration_ms,
                             command: command.clone(),
+                            source: Some("hook".into()),
                         });
                     }
                 }
@@ -180,6 +205,24 @@ impl SideEffects {
                         timestamp: event.timestamp.clone(),
                         duration_ms: *duration_ms,
                     });
+
+                    // ── MCP promotion path ───────────────────────────────
+                    // Generic agent.called_tool events emitted by MCP
+                    // bridges (or any tool channel that doesn't dispatch
+                    // into specialized event types) carry their useful
+                    // payload in meta. Inspect meta.tool_input.{file_path,
+                    // path, command} and promote to files_read /
+                    // files_written / processes so the receipt's "Files
+                    // changed" and "Commands run" sections actually
+                    // reflect the work, not just a count of tool calls.
+                    //
+                    // The bar (per the trust-fabric direction): if a file
+                    // changed during the session, it must appear in the
+                    // receipt. Without this promotion path, an agent
+                    // editing files via MCP-routed tools shows up as
+                    // "tool_invocations: N" with files_written empty --
+                    // a confidently incomplete audit trail.
+                    promote_mcp_called_tool(event, tool_name, &mut se);
                 }
 
                 _ => {}
@@ -211,6 +254,174 @@ pub struct SideEffectSummary {
     pub network_connections: u32,
     pub processes: u32,
     pub tool_invocations: u32,
+}
+
+// ---------------------------------------------------------------------------
+// MCP promotion helpers
+//
+// When an agent.called_tool event was emitted by an MCP bridge (or any
+// tool channel that doesn't dispatch into specialized event types), the
+// useful payload lives in `event.meta`. These helpers inspect known
+// shapes (`meta.tool_input.file_path`, `meta.tool_input.command`, the
+// flattened variants) and tool-name heuristics to promote the tool call
+// into the right side-effects bucket with `source: "mcp"`.
+//
+// Heuristics are intentionally generous on the write side: when the
+// tool name is ambiguous, we err toward files_written rather than
+// dropping the path. The trust-fabric bar is "if a file changed, it
+// must appear in the receipt" -- losing a real change is worse than
+// classifying a read as a write.
+// ---------------------------------------------------------------------------
+
+/// Read a string from event.meta following a dotted path
+/// (e.g. "tool_input.file_path"). Returns None if any segment is
+/// absent or the leaf isn't a string.
+fn meta_string(event: &SessionEvent, dotted_path: &str) -> Option<String> {
+    let mut cur = event.meta.as_ref()?;
+    for segment in dotted_path.split('.') {
+        cur = cur.get(segment)?;
+    }
+    cur.as_str().map(|s| s.to_string())
+}
+
+/// Try a list of dotted paths in priority order; first non-empty wins.
+fn first_meta_string(event: &SessionEvent, paths: &[&str]) -> Option<String> {
+    for path in paths {
+        if let Some(v) = meta_string(event, path) {
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+/// Classify a tool name into a side-effects bucket using string contains
+/// heuristics. Different agents call their file ops different things
+/// (Read vs read_file vs view, Write vs write_file vs save, Bash vs
+/// shell vs exec), so we match on substring rather than exact name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolCategory {
+    Read,
+    Write,
+    Process,
+    Unknown,
+}
+
+fn classify_tool(tool_name: &str) -> ToolCategory {
+    let t = tool_name.to_lowercase();
+    // Process / shell first -- "execute" matches before generic "exec".
+    if t.contains("bash") || t.contains("shell") || t.contains("exec")
+        || t.contains("run_command") || t.contains("ran_command")
+    {
+        return ToolCategory::Process;
+    }
+    // Writes: any mutation verb wins. Order matters because "edit" is a
+    // strong signal even when the tool name also contains "file".
+    if t.contains("write") || t.contains("edit") || t.contains("create_file")
+        || t.contains("modify") || t.contains("patch") || t.contains("save_file")
+        || t.contains("delete_file") || t.contains("remove_file") || t.contains("rename_file")
+    {
+        return ToolCategory::Write;
+    }
+    // Reads
+    if t.contains("read") || t.contains("view_file") || t.contains("cat_file")
+        || t.contains("open_file") || t.contains("get_file_contents")
+    {
+        return ToolCategory::Read;
+    }
+    ToolCategory::Unknown
+}
+
+fn promote_mcp_called_tool(
+    event: &SessionEvent,
+    tool_name: &str,
+    se: &mut SideEffects,
+) {
+    let category = classify_tool(tool_name);
+
+    // File path candidates -- check tool_input first (Claude Code +
+    // most MCP servers), then flattened (some bridges flatten meta).
+    let file_path = first_meta_string(event, &[
+        "tool_input.file_path",
+        "tool_input.path",
+        "tool_input.notebook_path",
+        "tool_input.target_file",
+        "file_path",
+        "path",
+    ]);
+
+    // Command candidates for shell-style tools.
+    let command = first_meta_string(event, &[
+        "tool_input.command",
+        "command",
+        "tool_input.cmd",
+        "cmd",
+    ]);
+
+    match (category, file_path, command) {
+        (ToolCategory::Read, Some(p), _) => {
+            se.files_read.push(FileAccess {
+                file_path: p,
+                agent_instance_id: event.agent_instance_id.clone(),
+                timestamp: event.timestamp.clone(),
+                digest: None,
+                operation: None,
+                additions: None,
+                deletions: None,
+                source: Some("mcp".into()),
+            });
+        }
+        (ToolCategory::Write, Some(p), _) => {
+            se.files_written.push(FileAccess {
+                file_path: p,
+                agent_instance_id: event.agent_instance_id.clone(),
+                timestamp: event.timestamp.clone(),
+                digest: None,
+                operation: None,
+                additions: None,
+                deletions: None,
+                source: Some("mcp".into()),
+            });
+        }
+        (ToolCategory::Process, _, Some(cmd)) => {
+            // Trim long commands to a usable process_name; the full
+            // command string is preserved in `command`.
+            let short = cmd.chars().take(120).collect::<String>();
+            se.processes.push(ProcessExecution {
+                process_name: short,
+                agent_instance_id: event.agent_instance_id.clone(),
+                started_at: event.timestamp.clone(),
+                exit_code: None,
+                duration_ms: None,
+                command: Some(cmd),
+                source: Some("mcp".into()),
+            });
+        }
+        (ToolCategory::Unknown, Some(p), _) => {
+            // Tool name didn't match any known verb but a file path is
+            // present in meta. Conservative call: record as a write so
+            // the file at minimum surfaces in the receipt. The trust-
+            // fabric bar is completeness; misclassifying a read as a
+            // write is recoverable, dropping the path silently is not.
+            se.files_written.push(FileAccess {
+                file_path: p,
+                agent_instance_id: event.agent_instance_id.clone(),
+                timestamp: event.timestamp.clone(),
+                digest: None,
+                operation: None,
+                additions: None,
+                deletions: None,
+                source: Some("mcp".into()),
+            });
+        }
+        _ => {
+            // No usable payload -- the tool_invocation entry written by
+            // the caller above is the only record. Acceptable: this is
+            // the "tool call we know happened but nothing to promote"
+            // case (e.g. a search or list-files MCP tool).
+        }
+    }
 }
 
 #[cfg(test)]
@@ -267,5 +478,142 @@ mod tests {
         assert_eq!(se.processes.len(), 1);
         assert_eq!(se.processes[0].exit_code, Some(0));
         assert_eq!(se.processes[0].duration_ms, Some(5000));
+    }
+
+    /// Construct an agent.called_tool event with the given tool name and
+    /// arbitrary meta JSON. Used by MCP promotion tests below.
+    fn called_tool_with_meta(tool_name: &str, meta: serde_json::Value) -> SessionEvent {
+        let mut e = evt(EventType::AgentCalledTool {
+            tool_name: tool_name.into(),
+            tool_input_digest: None,
+            tool_output_digest: None,
+            duration_ms: None,
+        });
+        e.meta = Some(meta);
+        e
+    }
+
+    #[test]
+    fn hook_file_events_carry_source_hook() {
+        // Regression: every existing emission path must tag itself so the
+        // receipt page can render provenance ("observed via hook") on
+        // each file row.
+        let events = vec![
+            evt(EventType::AgentReadFile { file_path: "src/a.rs".into(), digest: None }),
+            evt(EventType::AgentWroteFile { file_path: "src/b.rs".into(), digest: None, operation: None, additions: None, deletions: None }),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.files_read[0].source.as_deref(), Some("hook"));
+        assert_eq!(se.files_written[0].source.as_deref(), Some("hook"));
+    }
+
+    #[test]
+    fn mcp_called_tool_with_file_path_promotes_to_files_written() {
+        // The trust-fabric invariant: a file changed during the session
+        // must appear in the receipt. Even when the only signal is a
+        // generic agent.called_tool event with the path tucked inside
+        // meta.tool_input.file_path (the shape the engineer's events.jsonl
+        // had), the aggregator must surface it.
+        let events = vec![
+            called_tool_with_meta(
+                "Edit",
+                serde_json::json!({
+                    "source": "mcp-bridge",
+                    "tool_input": { "file_path": "src/api/receipt.ts" },
+                }),
+            ),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.files_written.len(), 1, "Edit with file_path must promote to files_written");
+        assert_eq!(se.files_written[0].file_path, "src/api/receipt.ts");
+        assert_eq!(se.files_written[0].source.as_deref(), Some("mcp"));
+        // tool_invocations also gets the entry -- the original record
+        // is preserved alongside the promotion.
+        assert_eq!(se.tool_invocations.len(), 1);
+    }
+
+    #[test]
+    fn mcp_read_tool_promotes_to_files_read() {
+        let events = vec![
+            called_tool_with_meta(
+                "Read",
+                serde_json::json!({ "tool_input": { "file_path": "package.json" } }),
+            ),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.files_read.len(), 1);
+        assert_eq!(se.files_read[0].file_path, "package.json");
+        assert_eq!(se.files_read[0].source.as_deref(), Some("mcp"));
+    }
+
+    #[test]
+    fn mcp_bash_tool_promotes_to_processes() {
+        let events = vec![
+            called_tool_with_meta(
+                "Bash",
+                serde_json::json!({ "tool_input": { "command": "bun test --run" } }),
+            ),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.processes.len(), 1);
+        assert_eq!(se.processes[0].command.as_deref(), Some("bun test --run"));
+        assert_eq!(se.processes[0].source.as_deref(), Some("mcp"));
+    }
+
+    #[test]
+    fn mcp_unknown_tool_with_path_defaults_to_files_written() {
+        // Trust-fabric bar: when the tool name doesn't match any known
+        // verb but meta carries a file_path, record as files_written
+        // rather than dropping the path. Misclassifying a read as a
+        // write is recoverable; silently losing a real change is not.
+        let events = vec![
+            called_tool_with_meta(
+                "mcp__weird-vendor__do_thing",
+                serde_json::json!({ "tool_input": { "file_path": "config.toml" } }),
+            ),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.files_written.len(), 1);
+        assert_eq!(se.files_written[0].file_path, "config.toml");
+        assert_eq!(se.files_written[0].source.as_deref(), Some("mcp"));
+    }
+
+    #[test]
+    fn mcp_called_tool_without_meta_does_not_promote() {
+        // Plain agent.called_tool with no useful meta: the
+        // tool_invocation entry is the only record. We do NOT invent a
+        // file path or fail loudly -- this is the "search/list/info"
+        // tool case that legitimately has no side effect.
+        let events = vec![
+            called_tool_with_meta("ls", serde_json::json!({"source": "mcp-bridge"})),
+        ];
+        let se = SideEffects::from_events(&events);
+        assert_eq!(se.files_read.len(), 0);
+        assert_eq!(se.files_written.len(), 0);
+        assert_eq!(se.processes.len(), 0);
+        assert_eq!(se.tool_invocations.len(), 1);
+    }
+
+    #[test]
+    fn mcp_promotion_handles_alt_path_field_names() {
+        // Different MCP servers use different conventions for the path
+        // field. We try a list of common ones.
+        for path_field in &["tool_input.path", "tool_input.target_file", "file_path", "path"] {
+            let mut meta_obj = serde_json::Map::new();
+            // Build a nested object matching the dotted path.
+            let parts: Vec<&str> = path_field.split('.').collect();
+            if parts.len() == 1 {
+                meta_obj.insert(parts[0].into(), serde_json::json!("x.txt"));
+            } else {
+                let inner = serde_json::json!({ parts[1]: "x.txt" });
+                meta_obj.insert(parts[0].into(), inner);
+            }
+            let events = vec![called_tool_with_meta("Edit", serde_json::Value::Object(meta_obj))];
+            let se = SideEffects::from_events(&events);
+            assert_eq!(
+                se.files_written.len(), 1,
+                "expected promotion via {} but got nothing", path_field,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Codex adversarial review finding #1 — ship blocker
The trust loop "cert says agent is allowed to do X, receipt proves agent did Y, cross-verify confirms Y is in X" was **broken for every Claude Code built-in tool**.

## The hole
\`\`\`
Cert: bounded_actions = ["Read", "Write"]   (NO "Bash")
Session: agent runs rm -rf / via Claude Code's Bash built-in
         → claude-code-plugin's PostToolUse hook emits
           agent.completed_process (NOT agent.called_tool)
receipt.tool_usage.actual = []   (only counted agent.called_tool)
cross_verify_receipt_and_certificate: PASS (no unauthorized tools)
\`\`\`

A cert that explicitly forbid Bash failed to flag a session that ran Bash to delete the working tree. The trust fabric's central verification gate was a no-op for the most-used integration.

## Root cause
\`derive_tool_usage\` in \`receipt.rs:475-477\` only counted \`side_effects.tool_invocations\` (built from \`EventType::AgentCalledTool\`). Claude Code's PostToolUse hook dispatches every built-in into specialized event types — \`agent.read_file\`, \`agent.wrote_file\`, \`agent.completed_process\`, \`agent.connected_network\` — and none of those flowed into \`tool_usage.actual\`.

## Fix
\`derive_tool_usage\` now ALSO counts side effects from specialized events under canonical tool names that match what an operator declares in \`bounded_actions\`:

| Side effect | Canonical name |
|---|---|
| \`files_read\` | \`Read\` |
| \`files_written\` | \`Write\` |
| \`processes\` | \`Bash\` |
| \`network_connections\` | \`WebFetch\` |

Names follow Claude Code conventions because that is what operators actually declare today. A cert using alternate naming (\`files.write\`) needs to declare both for now — canonical mapping at the cert layer is a follow-up TODO.

## Tests (4 new, all 4 existing still pass)
- \`cert_omitting_bash_flags_unauthorized_when_session_runs_bash\` — the exact scenario above
- \`cert_omitting_write_flags_unauthorized_when_session_writes_file\` — same shape with Write
- \`cert_includes_read_write_bash_passes_clean_when_all_used\` — positive case
- \`webfetch_unauthorized_flagged_when_cert_omits_it\` — network enforcement

Plus refactor: extracted the test event constructor \`mk\` to module scope.

## Stacked on
[fix/git-reconcile-dedup-writes-only](https://github.com/zerkerlabs/treeship/pulls?q=fix/git-reconcile-dedup-writes-only) (Blocker 2). The two together close the two trust-fabric holes Codex found.

## Acceptance test (per the directive)
\`\`\`
treeship agent register --name test-agent --tools Read,Write --valid-days 90
treeship session start --name unauthorized-bash-test
# agent uses Claude Code Bash for any command
treeship session close
treeship verify --certificate test-agent.agent/certificate.json .treeship/sessions/<id>.treeship
# Before: PASS (no unauthorized)
# After:  FAIL with "unauthorized: [Bash]"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)