### PR TITLE
fix(mcp-bridge): emit sanitized meta.tool_input so file events promote (Codex blocker #3)

### DIFF
--- a/bridges/mcp/src/client.ts
+++ b/bridges/mcp/src/client.ts
@@ -11,6 +11,65 @@ import { attestAction, attestReceipt, emitSessionEvent } from './attest.js';
 import { hashPayload } from './utils.js';
 import type { ToolReceipt } from './types.js';
 
+// ---------------------------------------------------------------------------
+// Tool-input sanitization for session events
+//
+// Codex finding #3: the receipt's MCP promotion logic
+// (packages/core/src/session/side_effects.rs::promote_mcp_called_tool)
+// looks for `meta.tool_input.{file_path,path,notebook_path,target_file,
+// command,cmd}` to lift a generic agent.called_tool into a specialized
+// files_read / files_written / processes side effect. Without those
+// fields in meta, every MCP-routed file write in a session shows up as
+// "tool_invocations: 1" with no file appearing in files_written -- the
+// trust-fabric "files changed" guarantee silently breaks for the entire
+// MCP path (Cursor, Codex, Cline, all custom MCP file-op servers).
+//
+// Whitelist-only by design. The bridge does NOT pass through arbitrary
+// caller-supplied keys. Passing the whole arguments object would leak
+// content/text/body/password/token/secret/api_key fields and any
+// caller-defined sensitive payload into the (signed, eventually
+// shareable) session log. Only the small set of path/command keys we
+// know are safe to publish make it through; everything else stays in
+// the args_digest in the intent attestation, where the operator can
+// audit it locally without the digest leaving their machine.
+// ---------------------------------------------------------------------------
+
+/// Field names whose values are safe to include in meta.tool_input.
+/// All are paths or commands -- they describe WHICH file or process, not
+/// the contents thereof. If a future MCP tool needs a new safe field,
+/// add it here explicitly. Do not switch to a denylist.
+const SAFE_TOOL_INPUT_KEYS = [
+  'file_path',
+  'path',
+  'notebook_path',
+  'target_file',
+  'command',
+  'cmd',
+] as const;
+
+/**
+ * Extract only the whitelisted keys from a tool's raw arguments.
+ * Returns undefined when no whitelisted keys are present (so the meta
+ * field is omitted entirely rather than serialized as `{}`).
+ *
+ * Exported (named `__sanitizeToolInput`) only so the regression suite
+ * can pin the whitelist behavior. The underscore prefix signals
+ * internal use; callers in this package should not import it.
+ */
+export function __sanitizeToolInput(
+  args: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!args || typeof args !== 'object') return undefined;
+  const out: Record<string, unknown> = {};
+  for (const key of SAFE_TOOL_INPUT_KEYS) {
+    const v = (args as Record<string, unknown>)[key];
+    if (typeof v === 'string' && v.length > 0) {
+      out[key] = v;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export class TreeshipMCPClient extends Client {
   private _actor: string;
   private _disabled: boolean;
@@ -116,6 +175,15 @@ export class TreeshipMCPClient extends Client {
       // timeline, side effects, and agent graph. The signed artifact
       // (above) is the cryptographic proof; the session event is what
       // makes it human-readable in the receipt.
+      //
+      // Sanitized tool_input is included in meta so the core's MCP
+      // promotion logic (packages/core/src/session/side_effects.rs)
+      // can lift file/process side effects into files_read /
+      // files_written / processes. Without this, an agent writing a
+      // file via @treeship/mcp shows up as "tool_invocations: 1" with
+      // no promoted side effect -- the file change vanishes from the
+      // receipt's "Files changed" section. Codex adversarial review
+      // finding #3.
       emitSessionEvent({
         type: 'agent.called_tool',
         tool: params.name,
@@ -127,6 +195,7 @@ export class TreeshipMCPClient extends Client {
         meta: {
           source: 'mcp-bridge',
           is_error: result?.isError ?? !!error,
+          tool_input: __sanitizeToolInput(params.arguments),
         },
       }).catch(() => {}); // best-effort, never block
 

--- a/bridges/mcp/test/client.test.ts
+++ b/bridges/mcp/test/client.test.ts
@@ -19,3 +19,89 @@ describe('@treeship/mcp', () => {
     expect(Client.prototype).toBeInstanceOf(OriginalClient);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression tests for the meta.tool_input sanitizer (Codex blocker #3).
+//
+// The whole point of the sanitizer is that it lets the receipt's MCP
+// promotion logic see file paths and commands so files_written / processes
+// populate, while NEVER leaking content / text / body / password / token /
+// secret / api_key into the (signed, eventually shareable) session log.
+//
+// These tests pin both halves: the right keys come through, the wrong
+// keys do not.
+// ---------------------------------------------------------------------------
+describe('sanitizeToolInput', () => {
+  it('extracts file_path for a write_file-style call', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    const out = __sanitizeToolInput({
+      file_path: 'src/secret.rs',
+      content: 'super secret content here',
+    });
+    expect(out).toEqual({ file_path: 'src/secret.rs' });
+    expect(out).not.toHaveProperty('content');
+  });
+
+  it('extracts command for a shell-style call', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    const out = __sanitizeToolInput({ command: 'rm -rf /tmp/cache' });
+    expect(out).toEqual({ command: 'rm -rf /tmp/cache' });
+  });
+
+  it('strips secret-like keys even when they sit alongside whitelisted keys', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    const out = __sanitizeToolInput({
+      file_path: 'README.md',
+      password: 'hunter2',
+      api_key: 'sk-live-abcd',
+      token: 'eyJhbGc...',
+      secret: 'classified',
+      content: '<file body>',
+      text: '<text body>',
+      body: '<body>',
+    });
+    expect(out).toEqual({ file_path: 'README.md' });
+  });
+
+  it('returns undefined when no whitelisted keys are present', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    expect(__sanitizeToolInput({ random: 'value', foo: 'bar' })).toBeUndefined();
+  });
+
+  it('returns undefined for missing or non-object arguments', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    expect(__sanitizeToolInput(undefined)).toBeUndefined();
+    expect(__sanitizeToolInput(null as unknown as Record<string, unknown>)).toBeUndefined();
+  });
+
+  it('drops empty-string and non-string values for whitelisted keys', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    expect(
+      __sanitizeToolInput({
+        file_path: '', // empty
+        path: 42 as unknown as string, // wrong type
+        command: 'echo ok',
+      }),
+    ).toEqual({ command: 'echo ok' });
+  });
+
+  it('handles all whitelisted keys', async () => {
+    const { __sanitizeToolInput } = await import('../src/client.js');
+    const out = __sanitizeToolInput({
+      file_path: 'a.rs',
+      path: 'b.rs',
+      notebook_path: 'c.ipynb',
+      target_file: 'd.rs',
+      command: 'echo',
+      cmd: 'grep',
+    });
+    expect(out).toEqual({
+      file_path: 'a.rs',
+      path: 'b.rs',
+      notebook_path: 'c.ipynb',
+      target_file: 'd.rs',
+      command: 'echo',
+      cmd: 'grep',
+    });
+  });
+});


### PR DESCRIPTION
## Codex adversarial review finding #3 — ship blocker
[PR #11](https://github.com/zerkerlabs/treeship/pull/11)'s MCP promotion (which lifts a generic \`agent.called_tool\` event into a specialized \`files_read\` / \`files_written\` / \`processes\` side effect) looks for \`meta.tool_input.{file_path, path, notebook_path, target_file, command, cmd}\`. But Treeship's own MCP bridge — the universal attach path for **every** MCP-compatible coding agent — only emitted \`meta.source\` and \`meta.is_error\`.

So a real \`write_file\` call via \`@treeship/mcp\` stayed as \`tool_invocations: 1\` with **no file in files_written**. In a non-git workspace, or for an ignored file like \`.env\`, the change vanished from the receipt entirely.

The trust-fabric "files changed" guarantee was silently broken for the **entire MCP path** — the same path PR #13 advertises as "the universal attach for any MCP-compatible coding agent."

## Fix
\`bridges/mcp/src/client.ts\` now extracts a small whitelist of safe keys from \`params.arguments\` and includes them as \`meta.tool_input\` on the \`agent.called_tool\` event:

| Field | Why |
|---|---|
| \`file_path\` | Claude Code style |
| \`path\` | Cursor / many MCP servers |
| \`notebook_path\` | Jupyter |
| \`target_file\` | Some refactoring tools |
| \`command\` | Shell-style tools |
| \`cmd\` | Shell-style alias |

**Whitelist by design, not denylist.** Passing the whole arguments object would leak \`content\` / \`text\` / \`body\` / \`password\` / \`token\` / \`secret\` / \`api_key\` and any caller-defined sensitive payload into the (signed, eventually shareable) session log. Only the path/command keys we know are safe to publish make it through; everything else stays in the \`args_digest\` in the intent attestation, where the operator can audit locally.

## Tests (7 new, all 3 existing pass)
- \`extracts file_path for write_file-style calls\`
- \`extracts command for shell-style calls\`
- \`strips secret-like keys\` (the security regression — password, api_key, token, secret, content, text, body all dropped even when alongside whitelisted keys)
- \`returns undefined when no whitelisted keys present\` (so meta.tool_input is omitted entirely)
- \`handles undefined / null / non-object args\`
- \`drops empty-string and non-string values\`
- \`handles all six whitelisted keys\`

## Independent of #17 and #18
The three Codex-blocker PRs together close the trust-fabric chain end-to-end:
- **#17** — git reconcile no longer drops real writes after prior reads
- **#18** — tool_usage.actual aggregates specialized events so cross-verify catches unauthorized Bash/Write
- **This PR** — MCP bridge emits the meta shape PR #11 promotion was already designed to consume

## Acceptance test (per the directive)
\`\`\`
# Through Treeship MCP bridge:
write_file(file_path="mcp.txt", content="secret-ish content")
treeship session close
→ receipt.files_written includes mcp.txt
→ receipt does NOT include "secret-ish content"  (path-only sanitization)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)