### PR TITLE
fix(mcp-bridge): drop command/cmd from sanitizer whitelist (round-2 leak)

### DIFF
--- a/bridges/mcp/src/client.ts
+++ b/bridges/mcp/src/client.ts
@@ -35,16 +35,32 @@ import type { ToolReceipt } from './types.js';
 // ---------------------------------------------------------------------------
 
 /// Field names whose values are safe to include in meta.tool_input.
-/// All are paths or commands -- they describe WHICH file or process, not
-/// the contents thereof. If a future MCP tool needs a new safe field,
-/// add it here explicitly. Do not switch to a denylist.
+/// Paths only — the names of files an agent touched. NOT command lines.
+///
+/// Codex round-2 review caught a real leak: shell-style MCP tools
+/// commonly receive raw command strings like
+///   { "command": "curl -H 'Authorization: Bearer sk-live-abcd' https://..." }
+/// Whitelisting the `command` / `cmd` fields meant those strings landed
+/// verbatim in `meta.tool_input.command` and were then copied into the
+/// signed, eventually shareable session log. Operators who put bearer
+/// tokens or signed URLs in their commands would leak them into every
+/// receipt.
+///
+/// Conservative fix: drop `command` / `cmd` from the whitelist entirely.
+/// Shell-style MCP calls promote to the generic `tool_invocations` bucket
+/// (the bridge already records the tool name and result digest), but no
+/// `processes[]` row gets created from the bridge path. Result: shell
+/// tools still appear in the receipt, but raw arg strings stay out of
+/// the log. A later PR can add structured argv0 extraction (recording
+/// the binary name only — `curl`, `bash`, `git` — without the args).
+///
+/// If a future MCP tool needs a new safe field, add it here explicitly.
+/// Do not switch to a denylist.
 const SAFE_TOOL_INPUT_KEYS = [
   'file_path',
   'path',
   'notebook_path',
   'target_file',
-  'command',
-  'cmd',
 ] as const;
 
 /**

--- a/bridges/mcp/test/client.test.ts
+++ b/bridges/mcp/test/client.test.ts
@@ -42,10 +42,23 @@ describe('sanitizeToolInput', () => {
     expect(out).not.toHaveProperty('content');
   });
 
-  it('extracts command for a shell-style call', async () => {
+  it('drops command and cmd entirely (raw command lines leak secrets)', async () => {
+    // Codex round-2: shell-style MCP tools commonly carry secrets in
+    // command args (curl -H 'Authorization: Bearer sk-live-...').
+    // The bridge MUST NOT publish those raw strings into the session log.
+    // Result: shell tools still get an agent.called_tool record from the
+    // bridge (with the tool name and result digest), but no
+    // meta.tool_input.command gets emitted -- so the bearer token never
+    // reaches a sealed receipt.
     const { __sanitizeToolInput } = await import('../src/client.js');
-    const out = __sanitizeToolInput({ command: 'rm -rf /tmp/cache' });
-    expect(out).toEqual({ command: 'rm -rf /tmp/cache' });
+    expect(
+      __sanitizeToolInput({
+        command: "curl -H 'Authorization: Bearer sk-live-abcd' https://api.example.com",
+      }),
+    ).toBeUndefined();
+    expect(
+      __sanitizeToolInput({ cmd: 'rm -rf /important' }),
+    ).toBeUndefined();
   });
 
   it('strips secret-like keys even when they sit alongside whitelisted keys', async () => {
@@ -59,7 +72,12 @@ describe('sanitizeToolInput', () => {
       content: '<file body>',
       text: '<text body>',
       body: '<body>',
+      command: "curl -H 'Authorization: Bearer sk-live-...' .../",
+      cmd: 'echo $API_KEY',
     });
+    // Only the whitelisted path comes through. Notably command/cmd
+    // are NOT in the whitelist (round-2 fix: raw command lines leak
+    // secrets, so they're never published).
     expect(out).toEqual({ file_path: 'README.md' });
   });
 
@@ -80,28 +98,24 @@ describe('sanitizeToolInput', () => {
       __sanitizeToolInput({
         file_path: '', // empty
         path: 42 as unknown as string, // wrong type
-        command: 'echo ok',
+        target_file: 'kept.rs',
       }),
-    ).toEqual({ command: 'echo ok' });
+    ).toEqual({ target_file: 'kept.rs' });
   });
 
-  it('handles all whitelisted keys', async () => {
+  it('handles all whitelisted keys (paths only)', async () => {
     const { __sanitizeToolInput } = await import('../src/client.js');
     const out = __sanitizeToolInput({
       file_path: 'a.rs',
       path: 'b.rs',
       notebook_path: 'c.ipynb',
       target_file: 'd.rs',
-      command: 'echo',
-      cmd: 'grep',
     });
     expect(out).toEqual({
       file_path: 'a.rs',
       path: 'b.rs',
       notebook_path: 'c.ipynb',
       target_file: 'd.rs',
-      command: 'echo',
-      cmd: 'grep',
     });
   });
 });


### PR DESCRIPTION
## Codex round-2 review caught a real secret leak in PR #19's whitelist
Shell-style MCP tools commonly receive raw command strings:
\`\`\`json
{ "command": "curl -H 'Authorization: Bearer sk-live-abcd' https://..." }
\`\`\`
Whitelisting \`command\` / \`cmd\` meant those strings landed verbatim in \`meta.tool_input.command\` and were copied into the signed, eventually shareable session log. **Operators with bearer tokens or signed URLs in their commands would leak them into every receipt** — the exact opposite of what a "sanitized" whitelist is supposed to guarantee.

## Fix
Drop \`command\` / \`cmd\` from the whitelist entirely. Bridge already records the tool name + result digest, so shell-style calls still land in \`tool_invocations\` — just without the raw arg string. No \`processes[]\` row from the bridge path, but no bearer tokens leak.

A future PR can add structured argv0 extraction (binary name only — \`curl\`, \`bash\`, \`git\`) for cross-verify ergonomics without the args.

## Tests (10 pass, including the new leak-prevention case)
- \`drops command and cmd entirely (raw command lines leak secrets)\`
- \`strips secret-like keys\` extended: command/cmd dropped alongside content/password/api_key/token

## Stacked on
[PR #19](https://github.com/zerkerlabs/treeship/pull/19) — the original sanitizer landing.
🤖 Generated with [Claude Code](https://claude.com/claude-code)