### PR TITLE
fix(receipt): skipped event count is in-band on the sealed receipt (Codex finding #8)

### DIFF
--- a/packages/cli/src/commands/package.rs
+++ b/packages/cli/src/commands/package.rs
@@ -117,6 +117,31 @@ pub fn inspect(
         printer.dim_info(&format!("  ... and {} more", receipt.artifacts.len() - 10));
     }
 
+    // Surface event-log incompleteness when present (Codex finding #8).
+    // The receipt is still cryptographically valid, but it represents
+    // fewer events than were appended to the log because some lines
+    // failed to parse during close. Make that visible without burying
+    // it in the proofs subtree.
+    if receipt.proofs.event_log_skipped > 0 {
+        printer.blank();
+        printer.warn(
+            &format!(
+                "event log incomplete: {} skipped",
+                receipt.proofs.event_log_skipped,
+            ),
+            &[(
+                "what",
+                "events.jsonl had lines that failed to parse during close",
+            ), (
+                "impact",
+                "the receipt does not represent the full event stream",
+            ), (
+                "next",
+                "inspect close-time stderr or events.jsonl to investigate",
+            )],
+        );
+    }
+
     printer.blank();
 
     Ok(())

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -728,7 +728,14 @@ pub fn close(
     }
 
     // ── Compose Session Receipt and build .treeship package ─────────
-    let events = event_log.read_all().unwrap_or_default();
+    // Use read_all_with_stats so the count of malformed lines that
+    // EventLog skipped during parsing flows into the sealed receipt
+    // (Codex finding #8). Without this in-band signal, a downstream
+    // verifier cannot tell a complete receipt from one whose event
+    // log was silently truncated by skipping bad lines.
+    let (events, event_log_skipped) = event_log
+        .read_all_with_stats()
+        .unwrap_or_else(|_| (Vec::new(), 0));
 
     // Build artifact entries from the chain
     let artifact_entries: Vec<session::receipt::ArtifactEntry> = collect_artifact_entries(&ctx, &manifest);
@@ -740,6 +747,12 @@ pub fn close(
     receipt_manifest.summary = summary.clone();
 
     let mut receipt = ReceiptComposer::compose(&receipt_manifest, &events, artifact_entries);
+
+    // Stamp the in-band incompleteness signal. Defaults to 0 (omitted
+    // from canonical JSON via skip_serializing_if) so receipts produced
+    // when the event log was clean stay byte-identical to receipts
+    // produced before this PR landed.
+    receipt.proofs.event_log_skipped = event_log_skipped as u32;
 
     // Override narrative with explicit --headline/--review if provided
     if headline.is_some() || review.is_some() {

--- a/packages/core/src/session/event_log.rs
+++ b/packages/core/src/session/event_log.rs
@@ -237,8 +237,30 @@ impl EventLog {
     /// agent.wrote_file events the aggregator would have happily
     /// processed.
     pub fn read_all(&self) -> Result<Vec<SessionEvent>, EventLogError> {
+        // Drop the skipped count for callers that don't carry it through.
+        // Receipt composition uses read_all_with_stats to record the
+        // count in-band on the sealed receipt -- see Codex finding #8.
+        self.read_all_with_stats().map(|(events, _skipped)| events)
+    }
+
+    /// Same as `read_all` but returns the count of malformed lines that
+    /// were skipped during parsing alongside the valid events.
+    ///
+    /// Codex adversarial review finding #8: skipping malformed events
+    /// on stderr only is silent data loss from the verifier's
+    /// perspective. The receipt gets sealed under a merkle root that
+    /// represents only the events that successfully parsed -- a
+    /// downstream consumer cannot tell whether the receipt is complete
+    /// or whether N events were silently dropped.
+    ///
+    /// session::close calls this and stores the count on
+    /// `receipt.proofs.event_log_skipped`. `treeship package verify`
+    /// surfaces it as a WARN when nonzero so the receipt's
+    /// completeness signal is visible without breaking byte-identical
+    /// re-verification of pre-existing receipts.
+    pub fn read_all_with_stats(&self) -> Result<(Vec<SessionEvent>, usize), EventLogError> {
         if !self.path.exists() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), 0));
         }
         let file = std::fs::File::open(&self.path)?;
         let reader = std::io::BufReader::new(file);
@@ -270,7 +292,7 @@ impl EventLog {
                 events.len(),
             );
         }
-        Ok(events)
+        Ok((events, skipped))
     }
 
     /// Return the current event count.
@@ -596,6 +618,38 @@ mod tests {
             })
             .collect();
         assert_eq!(written_paths, vec!["src/before.rs", "src/after.rs"]);
+
+        // Codex finding #8: the count must be exposed in-band so a
+        // sealed receipt can carry the incompleteness signal. Verify
+        // read_all_with_stats reports it.
+        let (events2, skipped) = log.read_all_with_stats().unwrap();
+        assert_eq!(events2.len(), 2);
+        assert_eq!(skipped, 1, "exactly one malformed line was injected; expected skipped == 1");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_all_with_stats_reports_zero_when_clean() {
+        // No malformed lines -> skipped == 0 -> the receipt's
+        // event_log_skipped field stays default (0) and gets omitted
+        // from canonical JSON. This preserves byte-identical receipts
+        // for the common case where the event log is clean.
+        let dir = std::env::temp_dir().join(format!("treeship-evtlog-clean-{}", rand::random::<u32>()));
+        let log = EventLog::open(&dir).unwrap();
+
+        let mut e = make_event(
+            "ssn_001",
+            EventType::AgentWroteFile {
+                file_path: "x.rs".into(),
+                digest: None, operation: None, additions: None, deletions: None,
+            },
+        );
+        log.append(&mut e).unwrap();
+
+        let (events, skipped) = log.read_all_with_stats().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(skipped, 0);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -244,6 +244,25 @@ pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> 
         checks.push(VerifyCheck::fail("timeline_order", "Timeline entries are not in deterministic order"));
     }
 
+    // event_log completeness: when session::close skipped malformed
+    // event log lines, the count is recorded on receipt.proofs.event_log_skipped.
+    // Surface as WARN (not FAIL) because the receipt is still
+    // cryptographically valid -- we just want a downstream verifier to
+    // know that some evidence was dropped before the receipt was sealed.
+    // A future --strict flag can promote this to FAIL.
+    // Codex adversarial review finding #8.
+    if receipt.proofs.event_log_skipped > 0 {
+        checks.push(VerifyCheck::warn(
+            "event_log_completeness",
+            &format!(
+                "{} event(s) skipped during close (malformed lines in events.jsonl). \
+                 Receipt is cryptographically valid but does not represent the full event stream. \
+                 Inspect close-time stderr or the events.jsonl directly to investigate.",
+                receipt.proofs.event_log_skipped,
+            ),
+        ));
+    }
+
     Ok(checks)
 }
 

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -159,7 +159,19 @@ pub struct ProofsSection {
     pub inclusion_proofs_count: u32,
     #[serde(default)]
     pub zk_proofs_present: bool,
+    /// Count of events.jsonl lines that were skipped during read_all
+    /// because they failed to deserialize. Set by session::close from
+    /// EventLog::read_all_with_stats. Codex adversarial review finding #8:
+    /// without this in-band signal, a receipt sealed after malformed
+    /// events were silently dropped looks complete to a verifier even
+    /// when it isn't. `treeship package verify` surfaces this as a WARN
+    /// when nonzero. Defaults to 0; absent on pre-v0.9.6 receipts so
+    /// they still verify byte-identical.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub event_log_skipped: u32,
 }
+
+fn is_zero_u32(n: &u32) -> bool { *n == 0 }
 
 /// Merkle section of the receipt.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -248,6 +260,7 @@ impl ReceiptComposer {
             merkle_root_valid: merkle_tree.is_some(),
             inclusion_proofs_count: merkle_section.inclusion_proofs.len() as u32,
             zk_proofs_present: false,
+            event_log_skipped: 0, // Set by caller after compose (Codex #8)
         };
 
         // Compute cost/token totals from agent graph


### PR DESCRIPTION
## Summary

Receipt now carries `proofs.event_log_skipped` so a malformed-but-skipped event is visible in the sealed JSON, not lost in stderr. Closes Codex round-1 finding #8.

Originally PR #21 — auto-closed when its base (PR #8) was merged. Re-opened against main.

## Test plan

- [x] `cargo test -p treeship-core --lib` — all green