### PR TITLE
feat(core): git reconciliation at session close (trust-fabric backstop)

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -286,6 +286,14 @@ pub fn start(
     manifest.root_artifact_id = Some(result.artifact_id.clone());
     manifest.authorized_tools = super::declare::read_authorized_tools();
 
+    // Capture the git HEAD SHA at session start so close-time
+    // reconciliation can compute committed-during-session changes.
+    // Fail-open: None for non-git projects; reconciliation falls back
+    // to working-tree-only diffs in that case.
+    if let Ok(cwd) = std::env::current_dir() {
+        manifest.start_commit_sha = session::current_head_sha(&cwd);
+    }
+
     let session_path = ts_dir.join("session.json");
     let json = serde_json::to_string_pretty(&manifest)?;
     std::fs::write(&session_path, &json)?;
@@ -733,9 +741,80 @@ pub fn close(
     // (Codex finding #8). Without this in-band signal, a downstream
     // verifier cannot tell a complete receipt from one whose event
     // log was silently truncated by skipping bad lines.
-    let (events, event_log_skipped) = event_log
+    let (mut events, event_log_skipped) = event_log
         .read_all_with_stats()
         .unwrap_or_else(|_| (Vec::new(), 0));
+
+    // ── Git reconciliation ──────────────────────────────────────────
+    // Backstop layer of the trust-fabric file-capture stack. Catches
+    // any files the agent edited outside captured tool channels:
+    // sed -i inside a Bash command, build outputs, manual edits during
+    // the session. Synthetic AgentWroteFile events are appended to
+    // events.jsonl so they're sealed in the merkle root alongside the
+    // rest of the session's evidence -- not just patched into the
+    // receipt as out-of-band claims.
+    //
+    // Dedup against existing AgentWroteFile/AgentReadFile events by
+    // file_path so a file already captured by hook or MCP isn't
+    // double-counted with a "git-reconcile" entry.
+    //
+    // Fail-open: if not in a git repo, git binary missing, or any
+    // git command errors, reconcile_changes returns an empty Vec and
+    // close proceeds normally.
+    if let Ok(cwd) = std::env::current_dir() {
+        let already_captured: std::collections::BTreeSet<String> = events.iter()
+            .filter_map(|e| match &e.event_type {
+                EventType::AgentWroteFile { file_path, .. } => Some(file_path.clone()),
+                EventType::AgentReadFile { file_path, .. } => Some(file_path.clone()),
+                _ => None,
+            })
+            .collect();
+        let host_id = local_host_id();
+        let trace_id = generate_trace_id();
+        let changes = session::reconcile_changes(&cwd, manifest.start_commit_sha.as_deref());
+        let mut reconciled = 0usize;
+        for change in changes {
+            if already_captured.contains(&change.file_path) {
+                continue;
+            }
+            let mut evt = SessionEvent {
+                session_id: manifest.session_id.clone(),
+                event_id: generate_event_id(),
+                timestamp: now_rfc3339(),
+                sequence_no: 0,
+                trace_id: trace_id.clone(),
+                span_id: generate_span_id(),
+                parent_span_id: None,
+                agent_id: "system://git-reconcile".into(),
+                agent_instance_id: "git-reconcile".into(),
+                agent_name: "git-reconcile".into(),
+                agent_role: Some("reconciler".into()),
+                host_id: host_id.clone(),
+                tool_runtime_id: None,
+                event_type: EventType::AgentWroteFile {
+                    file_path: change.file_path.clone(),
+                    digest: None,
+                    operation: Some(change.operation.clone()),
+                    additions: change.additions,
+                    deletions: change.deletions,
+                },
+                artifact_ref: None,
+                meta: Some(serde_json::json!({"source": "git-reconcile"})),
+            };
+            // Best-effort log append: include the event in the in-memory
+            // composition list either way so the receipt has the data
+            // even if the on-disk log refused (filesystem error, etc.).
+            let _ = event_log.append(&mut evt);
+            events.push(evt);
+            reconciled += 1;
+        }
+        if reconciled > 0 {
+            printer.dim_info(&format!(
+                "  reconciled {reconciled} file{} from git that weren't captured by hook or MCP",
+                if reconciled == 1 { "" } else { "s" },
+            ));
+        }
+    }
 
     // Build artifact entries from the chain
     let artifact_entries: Vec<session::receipt::ArtifactEntry> = collect_artifact_entries(&ctx, &manifest);

--- a/packages/core/src/session/git.rs
+++ b/packages/core/src/session/git.rs
@@ -1,0 +1,244 @@
+//! Git-based reconciliation for session close.
+//!
+//! Backstop layer of the trust-fabric file-capture stack:
+//!
+//!   1. (highest trust) specialized event types (`agent.wrote_file`)
+//!   2. (medium)        promoted from generic `agent.called_tool`
+//!   3. (this module)   shell out to `git` at session close and pick
+//!                      up anything an agent edited outside any
+//!                      captured tool channel
+//!
+//! Why this matters: the trust-fabric bar is "if a file changed, it
+//! must appear in the receipt." Hooks and MCP cover most paths but
+//! not all -- an agent that ran `sed -i` inside a Bash command, a
+//! build tool that modified files, or any other untracked side
+//! effect would otherwise vanish silently. Running `git diff` and
+//! `git ls-files --others` at close catches the rest.
+//!
+//! Fail-open by design: if the working dir isn't a git repo, if the
+//! git binary is missing, or if any git command errors, returns an
+//! empty list. The receipt is still produced; reconciliation is a
+//! best-effort enhancement, never a gate.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// One file change observed via git that wasn't already captured by a
+/// tool channel. Mapped 1:1 into a synthetic `AgentWroteFile` event
+/// at session close so it flows through the normal aggregator and
+/// receipt composition path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitChange {
+    pub file_path: String,
+    /// "created", "modified", "deleted", "renamed", or "untracked".
+    pub operation: String,
+    pub additions: Option<u32>,
+    pub deletions: Option<u32>,
+}
+
+/// Run `git` in `repo_dir` with the given args, returning stdout
+/// trimmed of trailing newline. Returns None on any failure (not
+/// a git repo, git missing, non-zero exit, etc.) -- this module is
+/// fail-open by contract.
+fn git_capture(repo_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C").arg(repo_dir)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let mut s = String::from_utf8(output.stdout).ok()?;
+    while s.ends_with('\n') {
+        s.pop();
+    }
+    Some(s)
+}
+
+/// Fast probe: is this directory inside a git repo?
+fn is_git_repo(repo_dir: &Path) -> bool {
+    git_capture(repo_dir, &["rev-parse", "--is-inside-work-tree"])
+        .as_deref()
+        == Some("true")
+}
+
+/// Translate a git diff/status name-status code to our operation
+/// vocabulary. Codes from `git diff --name-status`: A=added,
+/// M=modified, D=deleted, R=renamed, C=copied, T=type-change,
+/// U=unmerged, plus special "??" for ls-files untracked.
+fn translate_status(code: &str) -> &'static str {
+    match code.chars().next().unwrap_or(' ') {
+        'A' => "created",
+        'D' => "deleted",
+        'R' => "renamed",
+        'C' => "created", // copy = new file at the destination
+        'T' => "modified",
+        '?' => "untracked",
+        _   => "modified", // M, U, anything else
+    }
+}
+
+/// Parse a single line of `git diff --numstat` (additions, deletions,
+/// path). Numeric fields are "-" for binary files; we represent
+/// those as None.
+fn parse_numstat_line(line: &str) -> Option<(String, Option<u32>, Option<u32>)> {
+    let mut parts = line.splitn(3, '\t');
+    let adds_s = parts.next()?;
+    let dels_s = parts.next()?;
+    let path = parts.next()?.to_string();
+    let adds = adds_s.parse::<u32>().ok();
+    let dels = dels_s.parse::<u32>().ok();
+    Some((path, adds, dels))
+}
+
+/// Collect every file change in `repo_dir` worth surfacing in a
+/// session receipt: working-tree modifications (staged or not),
+/// committed-since-`since_sha` changes (when provided), and untracked
+/// files.
+///
+/// Deduplicated across the three sources so a single file shows up
+/// once. When `git diff --numstat` reports additions/deletions for a
+/// path, those are attached; binary files leave them as None.
+///
+/// Returns an empty Vec if `repo_dir` isn't a git repo or git isn't
+/// available -- callers (i.e. session close) should treat absence as
+/// "nothing to reconcile" and continue.
+pub fn reconcile_changes(repo_dir: &Path, since_sha: Option<&str>) -> Vec<GitChange> {
+    if !is_git_repo(repo_dir) {
+        return Vec::new();
+    }
+
+    use std::collections::BTreeMap;
+    // path -> change. BTreeMap so output is deterministic across runs,
+    // which matters for canonical receipt JSON / merkle stability.
+    let mut by_path: BTreeMap<String, GitChange> = BTreeMap::new();
+
+    let mut record = |path: String, op: &str| {
+        by_path.entry(path.clone()).or_insert(GitChange {
+            file_path: path,
+            operation: op.to_string(),
+            additions: None,
+            deletions: None,
+        });
+    };
+
+    // 1. Uncommitted changes vs HEAD (staged + unstaged combined via
+    //    name-status). The common agent case: edited a file, didn't
+    //    commit.
+    if let Some(out) = git_capture(repo_dir, &["diff", "HEAD", "--name-status"]) {
+        for line in out.lines() {
+            let mut parts = line.split('\t');
+            if let (Some(code), Some(path)) = (parts.next(), parts.next()) {
+                let op = translate_status(code);
+                record(path.to_string(), op);
+            }
+        }
+    }
+
+    // 2. Committed-during-session changes if the caller captured a
+    //    starting SHA at session start.
+    if let Some(sha) = since_sha {
+        let range = format!("{sha}..HEAD");
+        if let Some(out) = git_capture(repo_dir, &["diff", &range, "--name-status"]) {
+            for line in out.lines() {
+                let mut parts = line.split('\t');
+                if let (Some(code), Some(path)) = (parts.next(), parts.next()) {
+                    let op = translate_status(code);
+                    record(path.to_string(), op);
+                }
+            }
+        }
+    }
+
+    // 3. Untracked files (new files the agent added but didn't `git
+    //    add`). These never show in `git diff` so they need their own
+    //    pass.
+    if let Some(out) = git_capture(repo_dir, &["ls-files", "--others", "--exclude-standard"]) {
+        for path in out.lines().filter(|l| !l.is_empty()) {
+            record(path.to_string(), "untracked");
+        }
+    }
+
+    // 4. Numstat for the same diff range -- attach additions/deletions
+    //    where available. Numstat reports differently than name-status
+    //    (no rename indicator), so we just match by path.
+    if let Some(out) = git_capture(repo_dir, &["diff", "HEAD", "--numstat"]) {
+        for line in out.lines() {
+            if let Some((path, adds, dels)) = parse_numstat_line(line) {
+                if let Some(entry) = by_path.get_mut(&path) {
+                    entry.additions = adds;
+                    entry.deletions = dels;
+                }
+            }
+        }
+    }
+    if let Some(sha) = since_sha {
+        let range = format!("{sha}..HEAD");
+        if let Some(out) = git_capture(repo_dir, &["diff", &range, "--numstat"]) {
+            for line in out.lines() {
+                if let Some((path, adds, dels)) = parse_numstat_line(line) {
+                    if let Some(entry) = by_path.get_mut(&path) {
+                        entry.additions = adds;
+                        entry.deletions = dels;
+                    }
+                }
+            }
+        }
+    }
+
+    by_path.into_values().collect()
+}
+
+/// Capture the current HEAD commit SHA so it can be stored in the
+/// session manifest at session start. The session close pass uses it
+/// as the diff base for committed-during-session changes. Returns
+/// None when not in a git repo or no commits exist yet.
+pub fn current_head_sha(repo_dir: &Path) -> Option<String> {
+    if !is_git_repo(repo_dir) {
+        return None;
+    }
+    git_capture(repo_dir, &["rev-parse", "HEAD"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_status_maps_known_codes() {
+        assert_eq!(translate_status("A"), "created");
+        assert_eq!(translate_status("M"), "modified");
+        assert_eq!(translate_status("D"), "deleted");
+        assert_eq!(translate_status("R100"), "renamed");
+        assert_eq!(translate_status("??"), "untracked");
+        assert_eq!(translate_status(""), "modified");
+        assert_eq!(translate_status("X"), "modified");
+    }
+
+    #[test]
+    fn parse_numstat_handles_text_and_binary() {
+        let (p, a, d) = parse_numstat_line("12\t3\tsrc/a.rs").unwrap();
+        assert_eq!(p, "src/a.rs");
+        assert_eq!(a, Some(12));
+        assert_eq!(d, Some(3));
+
+        // Binary files: numstat uses "-\t-\tpath".
+        let (p, a, d) = parse_numstat_line("-\t-\tassets/logo.png").unwrap();
+        assert_eq!(p, "assets/logo.png");
+        assert_eq!(a, None);
+        assert_eq!(d, None);
+    }
+
+    #[test]
+    fn reconcile_in_non_git_dir_returns_empty() {
+        let tmp = std::env::temp_dir().join(format!("treeship-not-a-repo-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let result = reconcile_changes(&tmp, None);
+        assert!(result.is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/packages/core/src/session/manifest.rs
+++ b/packages/core/src/session/manifest.rs
@@ -155,6 +155,14 @@ pub struct SessionManifest {
     /// Tools declared as authorized for this session (from declaration.json).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authorized_tools: Vec<String>,
+
+    /// Git HEAD SHA captured at session start, when the project is a
+    /// git repo. Used by session::close to compute committed-during-
+    /// session changes via `git diff <sha>..HEAD` for the
+    /// reconciliation pass. Absent for non-git projects or for
+    /// sessions started before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_commit_sha: Option<String>,
 }
 
 impl SessionManifest {
@@ -179,6 +187,7 @@ impl SessionManifest {
             hosts: Vec::new(),
             tools: Vec::new(),
             authorized_tools: Vec::new(),
+            start_commit_sha: None,
         }
     }
 }
@@ -246,6 +255,7 @@ mod tests {
                 invocation_count: 42,
             }],
             authorized_tools: vec!["read_file".into(), "write_file".into()],
+            start_commit_sha: Some("abc1234567890abcdef1234567890abcdef12345".into()),
         };
         let json = serde_json::to_string_pretty(&m).unwrap();
         let m2: SessionManifest = serde_json::from_str(&json).unwrap();

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -13,6 +13,7 @@ pub mod side_effects;
 pub mod receipt;
 pub mod render;
 pub mod package;
+pub mod git;
 
 pub use manifest::*;
 pub use event::*;
@@ -23,3 +24,4 @@ pub use side_effects::SideEffects;
 pub use receipt::{ArtifactEntry, ReceiptComposer, SessionReceipt};
 pub use render::RenderConfig;
 pub use package::{build_package, read_package, verify_package, VerifyCheck, VerifyStatus};
+pub use git::{reconcile_changes, current_head_sha, GitChange};

--- a/packages/core/src/session/side_effects.rs
+++ b/packages/core/src/session/side_effects.rs
@@ -123,7 +123,7 @@ impl SideEffects {
                         operation: None,
                         additions: None,
                         deletions: None,
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                 }
 
@@ -136,7 +136,7 @@ impl SideEffects {
                         operation: operation.clone(),
                         additions: *additions,
                         deletions: *deletions,
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                 }
 
@@ -167,7 +167,7 @@ impl SideEffects {
                         exit_code: None,
                         duration_ms: None,
                         command: command.clone(),
-                        source: Some("hook".into()),
+                        source: Some(source_from_meta(event, "hook")),
                     });
                     started_processes.insert(
                         (event.agent_instance_id.clone(), process_name.clone()),
@@ -193,7 +193,7 @@ impl SideEffects {
                             exit_code: *exit_code,
                             duration_ms: *duration_ms,
                             command: command.clone(),
-                            source: Some("hook".into()),
+                            source: Some(source_from_meta(event, "hook")),
                         });
                     }
                 }
@@ -294,6 +294,24 @@ fn first_meta_string(event: &SessionEvent, paths: &[&str]) -> Option<String> {
         }
     }
     None
+}
+
+/// Pull a known-good source label off event.meta if present, else
+/// return the default. Lets emitters tag their provenance in meta
+/// without each event variant needing a dedicated field. Recognized
+/// values: `"hook"`, `"mcp"`, `"git-reconcile"`, `"shell-wrap"`.
+/// Anything else falls back to the default (so a typo doesn't pollute
+/// the receipt).
+fn source_from_meta(event: &SessionEvent, default: &str) -> String {
+    let raw = event
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("source"))
+        .and_then(|v| v.as_str());
+    match raw {
+        Some(s @ ("hook" | "mcp" | "git-reconcile" | "shell-wrap")) => s.to_string(),
+        _ => default.to_string(),
+    }
 }
 
 /// Classify a tool name into a side-effects bucket using string contains


### PR DESCRIPTION
## Summary

Backstop layer of the trust-fabric file-capture stack. Catches any files the agent edited outside captured tool channels: `sed -i` inside a Bash command, build outputs, manual edits during the session. Synthetic `AgentWroteFile` events are appended to `events.jsonl` so they're sealed in the merkle root alongside the rest of the session's evidence — not patched into the receipt as out-of-band claims.

Originally PR #12 — auto-closed when its base (PR #11) was merged. Re-opened against main.

## Behavior

- Runs `git diff HEAD --name-status`, `git diff <since>..HEAD --name-status`, and `git ls-files --others --exclude-standard`
- Numstat pass attaches additions/deletions
- Dedups against existing `AgentWroteFile`/`AgentReadFile` events (won't double-count files captured by hook or MCP)
- Fail-open: not in a git repo, git missing, or any git command erroring → returns empty Vec, close proceeds normally

## Test plan

- [x] `cargo test -p treeship-core --lib` — 189/189 green (rebase clean, includes Codex finding #8 stats)
- [x] `cargo build -p treeship-cli` — green