### PR TITLE
fix(session): git reconcile dedupes against writes only, not reads (Codex blocker #2)

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -762,10 +762,25 @@ pub fn close(
     // git command errors, reconcile_changes returns an empty Vec and
     // close proceeds normally.
     if let Ok(cwd) = std::env::current_dir() {
+        // Dedupe ONLY against prior writes, never reads.
+        //
+        // Bug Codex caught in adversarial review: the original filter
+        // included AgentReadFile, which suppressed real writes whenever
+        // the file had been read earlier in the session. Classic miss:
+        // agent reads src/lib.rs (post-tool-use.sh emits AgentReadFile),
+        // then a Bash command runs `sed -i src/lib.rs` (post-tool-use.sh
+        // emits AgentCompletedProcess, NOT AgentWroteFile). Git diff
+        // sees the modification, but reconcile dropped it because the
+        // path was "already captured" as a read. Receipt then showed
+        // the read and the process but no write -- a confidently
+        // incomplete audit trail.
+        //
+        // The trust-fabric bar is "if a file changed during the session,
+        // the receipt shows it." Reads do not change files. Only writes
+        // belong in the dedup set.
         let already_captured: std::collections::BTreeSet<String> = events.iter()
             .filter_map(|e| match &e.event_type {
                 EventType::AgentWroteFile { file_path, .. } => Some(file_path.clone()),
-                EventType::AgentReadFile { file_path, .. } => Some(file_path.clone()),
                 _ => None,
             })
             .collect();


### PR DESCRIPTION
## Summary

Codex adversarial review caught this trust-fabric finding: the git reconciliation pass at session close was suppressing real writes whenever the file had been read earlier in the session.

```
agent reads src/lib.rs           → AgentReadFile event
Bash runs \`sed -i src/lib.rs\`    → AgentCompletedProcess event
                                   (post-tool-use.sh maps Bash to process,
                                    NOT AgentWroteFile)
git diff sees src/lib.rs modified
reconcile drops it because path was "already captured" as a read
```

Receipt then showed the read and the process but no write — a confidently incomplete audit trail. Fix: dedup filter is now `AgentWroteFile` only.

Originally PR #17 — auto-closed when its base (PR #12) was merged. Re-opened against main.

## Test plan

- [x] `cargo build -p treeship-cli` — green