### PR TITLE
docs: replay-posture honesty sweep (pre-v0.9.6 tag)

### DIFF
--- a/docs/content/blog/agentic-commerce-with-treeship.mdx
+++ b/docs/content/blog/agentic-commerce-with-treeship.mdx
@@ -12,17 +12,21 @@ This is the gap Treeship closes: cryptographic proof of human approval, bound to
 
 ## The approval receipt with nonce binding
 
-The core primitive is simple. A human issues an approval. The approval contains a single-use nonce and an optional scope. When the agent acts, the action receipt echoes the nonce. The two receipts are cryptographically linked. Break one, and the chain breaks.
+The core primitive is simple. A human issues an approval. The approval contains a binding nonce and a signed scope (`allowed_actor`, `allowed_action`, `allowed_subject`, `max_uses`). When the agent acts, the action receipt echoes the nonce. The verifier checks the binding, the scope, and the replay posture as three separate properties.
 
-### Step 1: Human issues an approval
+### Step 1: Human issues a scoped approval
 
 ```bash
 treeship attest approval \
   --approver human://alice \
-  --description "approve payment to acme-corp max $500"
+  --description "approve payment to acme-corp max $500" \
+  --allowed-actor agent://payments \
+  --allowed-action stripe.charge.create \
+  --allowed-subject vendor://acme-corp \
+  --max-uses 1
 ```
 
-This creates a signed approval artifact with a unique nonce and optional scope constraints (max amount, allowed actions, expiration).
+This creates a signed approval artifact with a binding nonce and the signed scope. `--max-uses` is signed into the grant for ledger enforcement (v0.10 / v0.11+); v0.9.6 enforces actor / action / subject statelessly and observes nonce replay package-locally.
 
 ### Step 2: Agent executes the payment with the nonce
 
@@ -43,12 +47,12 @@ The `wrap` command runs the payment command, captures its output, and produces a
 treeship verify --full
 ```
 
-The verification checks:
+The verification checks (and reports each independently):
 - The approval signature is valid (Ed25519)
 - The action signature is valid
-- The nonce in the action matches the nonce in the approval
-- The nonce has not been used before
-- The action falls within the approval's scope
+- **Binding:** the nonce in the action matches the nonce in the approval
+- **Scope:** the action's actor / action / subject fall inside the approval's signed allow-lists; expiry not past
+- **Replay:** the nonce has not been consumed earlier in this verified package (cross-package and cross-machine enforcement land via local Approval Use Journal in v0.10 and Hub checkpoints in v0.11+; verify reports today's posture as `package-local only -- no global ledger consulted`)
 
 ## Why this matters for commerce
 
@@ -58,21 +62,32 @@ The verification checks:
 
 **Cross-org trust.** A vendor can verify the buyer's agent had approval without trusting the buyer's infrastructure. The receipts are self-contained. Verification happens client-side, offline, with no callback to the buyer's systems.
 
-## The nonce prevents replay
+## How the nonce constrains replay
 
-Without the nonce, an agent could reuse a single approval for unlimited purchases. The nonce makes each approval single-use. Once an action receipt echoes a nonce, that nonce is spent. Any second use fails verification.
+Without the nonce, an agent could pass any approval as authorization for any action. The nonce binds approval ↔ action cryptographically: the action receipt must echo the exact nonce of the signed approval, and the verifier checks it.
+
+That binding is the foundation. Replay enforcement layers on top:
+
+- **v0.9.6 (today):** if two actions inside one verified package claim the same nonce, the second fails. Verify reports `replay check: package-local only -- no global ledger consulted`.
+- **v0.10:** a local Approval Use Journal — append-only, hash-chained, with signed Merkle checkpoints — extends the check across all actions seen on a device or workspace.
+- **v0.11+:** Hub-backed checkpoints extend it across machines and teams.
 
 ```bash
-# This fails -- nonce already consumed
+# Today: this fails when verified together with the first use
 treeship wrap \
   --approval-nonce abc123def456 \
   -- stripe charges create \
     --amount 99900 \
     --currency usd \
     --customer cus_other
+# verify error: nonce already consumed by art_... in this package (package-local replay)
+
+# Cross-package replay (e.g. running the same nonce in a different
+# workspace on the same machine) starts failing in v0.10 once the
+# local Approval Use Journal lands.
 ```
 
-The nonce is a small field. It prevents an entire class of replay attacks.
+The signed scope (`--allowed-actor` / `--allowed-action` / `--allowed-subject` / `--max-uses`) is the layer that prevents the same nonce from authorizing a *different* action even before the journal lands — and that part is enforced statelessly today.
 
 ## What Treeship does not do
 

--- a/docs/content/blog/mcp-bridge-agent-attestation.mdx
+++ b/docs/content/blog/mcp-bridge-agent-attestation.mdx
@@ -71,16 +71,14 @@ treeship attest approval \
 The agent receives the nonce. The bridge picks it up from the environment and binds it to the intent artifact. The verifier then enforces that the action is cryptographically linked to the specific approval that authorized it.
 
 ```bash
-treeship verify art_bbb --format json | jq .
-# {
-#   "outcome": "pass",
-#   "approver": "human://approver",
-#   "approval_description": "authorize stripe charge max $500 to acme-corp",
-#   "nonce_status": "matched · single use enforced"
-# }
+treeship verify art_bbb --full
+
+# ✓  approval binding nonce matched a signed approval
+# ✓  approval scope   actor / action / subject matched approval scope
+# ⚠  replay check     package-local only -- no global ledger consulted
 ```
 
-That's the answer to "who authorized this tool call?" It's not "a user with valid credentials ran the agent." It's a specific named human, with a specific approval, cryptographically bound to this specific action, verified to have been used exactly once.
+That's the answer to "who authorized this tool call?" It's not "a user with valid credentials ran the agent." It's a specific named human, with a specific approval, cryptographically bound to this specific action and constrained by a signed scope. Replay defense is package-local in v0.9.6; cross-package and cross-machine enforcement land via the local Approval Use Journal (v0.10) and Hub checkpoints (v0.11+).
 
 ## What never enters a receipt
 

--- a/docs/content/blog/warrants-not-approvals.mdx
+++ b/docs/content/blog/warrants-not-approvals.mdx
@@ -6,6 +6,10 @@ tags: ["security", "authorization", "cryptography", "agents"]
 readTime: "8 min read"
 ---
 
+> **Implementation status (v0.9.6).** This post describes the approval-grant model end to end. As of v0.9.6, Treeship's verify pass enforces three of the four properties below **statelessly**: binding (the nonce ↔ approval link), scope (the actor / action / subject / expiry constraints signed into the grant), and **package-local replay** (a second action claiming the same nonce inside one verified package fails). The fourth property — **cross-package / cross-machine single-use** — requires verifier-side state and is on the roadmap: a local Approval Use Journal in v0.10, Hub-backed checkpoints in v0.11+. Verify reports the replay-check posture honestly today (`replay check: package-local only -- no global ledger consulted`) instead of claiming a guarantee that hasn't been consulted.
+>
+> Bookmark this post; the body below describes the destination, and we'll update it as the journal layers land.
+
 Imagine your agent needs human authorization before executing a payment. You've built an approval flow: the human clicks Approve in a UI, a token is generated and passed to the agent, the agent includes the token in its action record, and downstream systems can verify the token was present.
 
 This is better than no authorization. But it has a vulnerability that's easy to miss.
@@ -66,7 +70,7 @@ action.approvalNonce == approval.nonce
 
 This check is in the Rust core. It cannot be bypassed. And because the nonce is tied to exactly one approval and exactly one action, every vulnerability in the bearer token model is closed:
 
-**Replay** -- the nonce can appear in exactly one action. A second action with the same nonce finds no matching approval (the first action consumed it) and fails verification.
+**Replay** -- the nonce should appear in exactly one consumption. As of v0.9.6, Treeship enforces this within a single verified package (a second action claiming the same nonce in one package fails). The local Approval Use Journal landing in v0.10 extends enforcement to all consumptions on a given device or workspace; Hub-backed checkpoints in v0.11+ extend it to distributed single-use across machines and teams. Verify reports today's posture honestly rather than overclaiming.
 
 **Scope creep** -- the verifier checks the scope fields. A charge for $600 fails when the approval specifies max_amount 450. A different action type fails when the approval specifies allowed_actions.
 
@@ -79,19 +83,24 @@ This check is in the Rust core. It cannot be bypassed. And because the nonce is 
 Here's what an approval-style authorization looks like versus approval-style:
 
 ```bash
-# Approval style -- broad, reusable
+# Bearer-token style -- broad, reusable
 # "approve payment workflows today"
 # Token: bearer_abc123
 # Any action can claim this token
 
-# Approval style -- specific, single-use
+# Approval-grant style -- specific, scoped, replay-observed
 treeship attest approval \
   --approver human://approver \
   --description "stripe charge $450 to acme-corp INV-2847" \
+  --allowed-actor agent://payments \
+  --allowed-action stripe.charge.create \
+  --allowed-subject vendor://acme-corp \
+  --max-uses 1 \
   --expires 2026-03-26T17:00:00Z
 # Nonce: nce_7f8e9d0a
-# Only stripe.charge.create for ≤$450 to acme-corp can use this nonce
-# Only once
+# Only agent://payments calling stripe.charge.create against
+# vendor://acme-corp can consume this nonce. max-uses is signed
+# into the grant for ledger enforcement (v0.10 / v0.11+).
 ```
 
 The approval is not less convenient for the human -- it's one approval action that produces one nonce. The difference is precision: the human is approving a specific thing, not a broad category.
@@ -101,25 +110,15 @@ The approval is not less convenient for the human -- it's one approval action th
 When something goes wrong -- or when nothing has gone wrong but compliance needs to prove it -- approval-based authorization produces a different quality of evidence.
 
 ```bash
-treeship verify art_charge --format json | jq '{
-  outcome,
-  approver: .approver,
-  approval: .warrant_description,
-  nonce_status: .nonce_binding,
-  scope: .scope_valid
-}'
+treeship verify art_charge --full
 
-# {
-#   "outcome": "pass",
-#   "approver": "human://approver",
-#   "approval_description": "stripe charge $450 to acme-corp INV-2847",
-#   "nonce_status": "matched · single use verified",
-#   "scope": true
-# }
+# ✓  approval binding nonce matched a signed approval
+# ✓  approval scope   actor / action / subject matched approval scope
+# ⚠  replay check     package-local only -- no global ledger consulted
 ```
 
-This isn't "a valid authorization token was present." It's a specific named human, approving a specific action, with cryptographic proof the authorization was used exactly once, for exactly the amount and vendor specified, before the expiry time.
+This isn't "a valid authorization token was present." It's a specific named human, approving a specific action against a specific subject by a specific actor, with cryptographic proof the binding holds and the scope was respected.
 
-The replay attack fails here not because of access controls or rate limiting or session management. It fails because the cryptographic structure makes it impossible. The nonce was used. The approval is spent. There is nothing to replay.
+Replay defense in v0.9.6 is package-local — and verify says so plainly rather than claiming a guarantee it can't deliver. The local Approval Use Journal in v0.10 extends that to every action seen on a device; Hub checkpoints in v0.11+ extend it across machines. The cryptographic structure is in place; the enforcement layers are landing in order.
 
-That's the kind of authorization AI agents taking consequential actions actually need.
+That's the kind of authorization AI agents taking consequential actions actually need — and the kind whose limits a system should be honest about today.

--- a/docs/content/docs/cli/approve.mdx
+++ b/docs/content/docs/cli/approve.mdx
@@ -37,7 +37,7 @@ Approve a pending request by number.
 treeship approve 1
 ```
 
-This creates an approval artifact, generates a single-use nonce, and passes it back to the requesting agent. The agent can then include the nonce in its action attestation to prove it had authorization.
+This creates an approval artifact, generates a binding nonce, and passes it back to the requesting agent. The agent then includes the nonce in its action attestation to prove it had authorization.
 
 ## treeship deny
 
@@ -49,6 +49,10 @@ treeship deny 2
 
 This creates a denial artifact. The requesting agent receives the denial and should not proceed with the action.
 
-<Callout type="info">
-Approvals are single-use. If the same nonce is used in two action attestations, the second one will fail verification. This is enforced in the Rust core and cannot be bypassed.
+<Callout type="warn" title="Replay posture (v0.9.6)">
+Treeship's verifier observes nonce replay **only within a single verified package** -- two actions in one package that claim the same nonce, the second fails. This is enforced in the Rust core and cannot be bypassed.
+
+Cross-package and cross-machine replay enforcement is **not yet shipped**. A `--max-uses` value is signed into the grant for future enforcement; verify reports the replay check posture honestly (`replay check: package-local only -- no global ledger consulted`) rather than claiming global single-use.
+
+Roadmap: a local Approval Use Journal lands in v0.10 (device/workspace replay), Hub-backed checkpoints in v0.11+ (distributed replay).
 </Callout>

--- a/docs/content/docs/cli/attest.mdx
+++ b/docs/content/docs/cli/attest.mdx
@@ -98,12 +98,23 @@ Returns the approval artifact ID and the nonce. Pass the nonce to the agent so i
 | Option | Description |
 |--------|-------------|
 | `--approver <uri>` | Approver identity URI (required) |
-| `--subject <id>` | Artifact ID being approved |
+| `--subject <id>` | Artifact ID being approved (the subject of the approval itself) |
 | `--description <text>` | Plain text scope of what is authorized |
+| `--allowed-actor <uri>` | Scope: actor URIs permitted to consume this approval (repeatable) |
+| `--allowed-action <label>` | Scope: action labels permitted under this approval (repeatable) |
+| `--allowed-subject <uri>` | Scope: subject URIs permitted as the action's target (repeatable) |
+| `--max-uses <n>` | Signed into the grant for future ledger enforcement |
+| `--unscoped` | Required to mint a bearer approval (no scope axes set); without it the CLI refuses |
 | `--expires <timestamp>` | RFC 3339 expiry time |
 
-<Callout type="warn">
-Approvals are single-use by default. If the same nonce is used twice, the second action will fail verification. This is enforced in the Rust core and cannot be bypassed.
+<Callout type="warn" title="Scope is the new default">
+As of v0.9.6, `treeship attest approval` refuses to mint an approval that has no scope axis (no `--allowed-*` and no `--max-uses`). Pass `--unscoped` to opt in to a bearer approval explicitly. Verify will warn that an unscoped approval proves binding only -- not actor/action/subject authorization.
+</Callout>
+
+<Callout type="warn" title="Replay posture (v0.9.6)">
+Verifier observes nonce replay **within a single verified package** -- two actions claiming the same nonce in one package, the second fails. Cross-package and cross-machine replay enforcement is not yet shipped. Verify reports the replay check posture honestly (`replay check: package-local only -- no global ledger consulted`) rather than claiming global single-use.
+
+Roadmap: local Approval Use Journal in v0.10 (device/workspace replay), Hub checkpoints in v0.11+ (distributed replay).
 </Callout>
 </Tab>
 <Tab value="handoff">

--- a/docs/content/docs/commerce/compliance.mdx
+++ b/docs/content/docs/commerce/compliance.mdx
@@ -33,7 +33,7 @@ treeship attest action \
   --approval-nonce <nonce>
 ```
 
-The approval nonce is single-use. The agent cannot reuse it for a second action. Verifiers can confirm that the nonce was valid at the time of use.
+The approval is bound to the action by nonce, scoped to a specific actor / action / subject when the approver sets `--allowed-actor` / `--allowed-action` / `--allowed-subject`, and verifiers report exactly what was checked: binding (always), scope (when present), and replay posture (`package-local only -- no global ledger consulted` as of v0.9.6). A local Approval Use Journal for cross-package replay enforcement ships in v0.10.
 
 ## Compliance patterns
 

--- a/docs/content/docs/commerce/overview.mdx
+++ b/docs/content/docs/commerce/overview.mdx
@@ -47,7 +47,7 @@ Each step is signed, chained, and independently verifiable.
 ## What this gives you
 
 - **Audit trail.** Every transaction step has a tamper-proof receipt.
-- **Approval binding.** The payment cannot execute without a valid approval nonce. The nonce is single-use -- it cannot be reused for multiple purchases.
+- **Approval binding + scope.** The payment cannot execute without a valid approval nonce, and the approval's signed scope (`allowed_actor`, `allowed_action`, `allowed_subject`) is checked statelessly against the action -- a `stripe.charge.create` approval cannot authorize a `stripe.refund.create`. Nonce replay is observed within a verified package; cross-package replay enforcement (local Approval Use Journal, Hub checkpoints) is on the v0.10/v0.11 roadmap.
 - **Chain verification.** Anyone can walk the chain from fulfillment back to the original order.
 - **Offline verification.** No API call needed to verify the receipts.
 
@@ -64,7 +64,7 @@ treeship attest approval \
   --expires 24h
 ```
 
-The approval nonce binds to exactly one action. The agent cannot reuse it for multiple purchases.
+The approval's `--max-uses` is signed into the grant and the scope (`allowed_action`, `allowed_subject`) constrains what the agent can do with the nonce. Replay is observed within a verified package; the global / multi-package replay enforcement layer ships in v0.10 (local Approval Use Journal) and v0.11+ (Hub checkpoints).
 
 ### Multi-party transactions
 

--- a/docs/content/docs/commerce/payment-proofs.mdx
+++ b/docs/content/docs/commerce/payment-proofs.mdx
@@ -59,7 +59,7 @@ treeship attest action \
   --approval-nonce nce_a1b2c3d4e5f6
 ```
 
-The verifier confirms that the approval nonce matches a valid approval artifact, proving the payment was authorized. The nonce is single-use -- it cannot be replayed for a second payment.
+The verifier confirms that the approval nonce matches a valid signed approval (binding) and -- if the approver set scope flags -- that the action's actor / action / subject fall inside the approval's allow-lists (scope). Replay posture is reported as package-local; v0.10 adds a local Approval Use Journal for device/workspace replay, v0.11+ adds Hub checkpoints for distributed replay.
 
 ## Using treeship wrap
 

--- a/docs/content/docs/concepts/glossary.mdx
+++ b/docs/content/docs/concepts/glossary.mdx
@@ -14,7 +14,7 @@ Every term below maps to a concrete type or command in the CLI and Rust core.
 | **Treeship** | A local proof system: one Ed25519 keypair, one artifact store, one identity boundary | Ed25519 keypair + config + local artifact store |
 | **Actor** | A human or AI that does work, identified by a URI | `human://alice` or `agent://coder` prefix |
 | **Artifact** | A signed DSSE envelope with a content-addressed `art_` ID. Artifacts chain via `parent_id`. | `Record` in local storage |
-| **Approval** | Cryptographic authorization for an action, bound by a single-use nonce | `ApprovalStatement` / `treeship attest approval` |
+| **Approval** | Cryptographic authorization for an action, bound by a nonce and constrained by a signed scope (actor / action / subject / max-uses) | `ApprovalStatement` / `treeship attest approval` |
 | **Hub** | Hosted infrastructure where Treeships share artifacts | treeship.dev API |
 | **Hub connection** | A named link from your Treeship to a Hub workspace. You can attach, detach, and kill connections independently. | `treeship hub attach` / DPoP keypair |
 | **Chain** | A linked sequence of artifacts with a common root, connected through `parent_id` references | `treeship verify` walks the chain recursively |

--- a/docs/content/docs/guides/approvals.mdx
+++ b/docs/content/docs/guides/approvals.mdx
@@ -1,28 +1,32 @@
 ---
 title: Approvals
-description: An approval is a cryptographic authorization for a specific action, bound by a single-use nonce.
+description: An approval is a cryptographic authorization for an action, bound by a nonce and constrained by a signed scope.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-An approval answers "who authorized this?" -- signed, scoped, single-use, and verifiable.
+An approval answers "who authorized this, to do what, against which subject" -- signed, scoped, and verifiable.
 
 ## How approvals work
 
 ```bash
-# Approver issues an approval
+# Approver issues a scoped approval
 treeship attest approval \
   --approver human://alice \
   --description "approve stripe charge max $500 to acme-corp" \
+  --allowed-actor agent://payments \
+  --allowed-action stripe.charge.create \
+  --max-uses 1 \
   --expires 2026-03-26T18:00:00Z
 
 # Returns:
 # ✓ approval attested
 #   id:    art_approval_abc123
 #   nonce: nce_7f8e9d0a1b2c3d4e
+#   scope: actors=["agent://payments"], actions=["stripe.charge.create"], max_uses=1
 ```
 
-The nonce is a one-time token. Pass it to your agent.
+The nonce is the binding token. Pass it to your agent.
 
 ```bash
 # Agent acts under the approval
@@ -33,16 +37,28 @@ treeship attest action \
   --meta '{"amount":450,"vendor":"acme-corp"}'
 ```
 
-## What makes it binding
+## What gets checked
 
-At verification time, the verifier enforces:
+Treeship's verify pass enforces three independent properties and reports each separately. Conflating them would let a fooled audit reader trust a guarantee that wasn't actually evaluated.
+
+| Property | What it proves | Stateless? |
+|---|---|---|
+| **Binding** | The action's `approvalNonce` matches a real signed approval | Yes |
+| **Scope** | Action's `actor`, `action`, and `subject` are inside the approval's signed allow-lists; approval not expired | Yes |
+| **Replay** | The nonce has not been consumed before | **Verifier-state-dependent** |
 
 ```
-action.approvalNonce == approval.nonce
+✓  approval binding nonce matched a signed approval
+✓  approval scope   actor / action / subject matched approval scope
+⚠  replay check     package-local only -- no global ledger consulted
 ```
 
-<Callout type="warn" title="Nonce binding is mandatory">
-This check is in the Rust core and cannot be skipped. If the nonces do not match, verification fails. If the approval has expired, verification fails. If the same nonce is used twice, the second action has no matching approval to link to.
+<Callout type="warn" title="Replay posture as of v0.9.6">
+Stateless verifiers cannot detect replay across artifacts they never saw. The current implementation observes replay **only within a single verified package** -- if the same nonce appears on two actions in one package, the second fails. A `--max-uses` value is signed into the grant for future enforcement, but no global ledger is consulted yet.
+
+**Roadmap:**
+- **v0.10:** local Approval Use Journal (append-only, hash-chained, with signed Merkle checkpoints) for device/workspace replay enforcement.
+- **v0.11+:** Hub/org checkpoints for distributed single-use across machines and teams.
 </Callout>
 
 ## Approval flags
@@ -51,8 +67,13 @@ This check is in the Rust core and cannot be skipped. If the nonces do not match
 |------|----------|-------------|
 | `--approver <uri>` | Yes | Human or identity URI, e.g. `human://alice` |
 | `--description <text>` | No | Plain text scope of what is authorized |
+| `--allowed-actor <uri>` | No, repeatable | Actor URIs permitted to consume this approval |
+| `--allowed-action <label>` | No, repeatable | Action labels permitted under this approval |
+| `--allowed-subject <uri>` | No, repeatable | Subject URIs permitted as the action's target |
+| `--max-uses <n>` | No | Signed into the grant for future ledger enforcement |
+| `--unscoped` | No | Required to mint a bearer approval (no scope axes set). Without it the CLI refuses, since unscoped approvals authorize any actor / action / subject |
 | `--expires <timestamp>` | No | RFC 3339 expiry time |
-| `--subject <id>` | No | Artifact ID being approved |
+| `--subject <id>` | No | Artifact ID being approved (the subject of the approval itself) |
 
 ## Verifying an approved action
 

--- a/docs/content/docs/guides/how-it-works.mdx
+++ b/docs/content/docs/guides/how-it-works.mdx
@@ -107,9 +107,9 @@ Confirm the payload conforms to the expected Treeship statement schema for its d
 Follow `parentId` links recursively, verifying each ancestor artifact the same way. A broken link at any point fails the entire chain.
 </Step>
 <Step>
-### Check approval binding (if present)
+### Check approval binding, scope, and replay (if present)
 
-If the artifact references an `approvalNonce`, confirm that a matching approval artifact exists in the chain with a valid nonce that has not been reused.
+If the artifact references an `approvalNonce`, confirm a matching signed approval exists; if the approval has a scope, confirm the action's actor / action / subject fall inside the signed allow-lists; observe whether the same nonce was consumed earlier inside this verified package. Verify reports each property as a separate line and is explicit that cross-package replay enforcement is on the v0.10 / v0.11 roadmap, not yet shipped.
 </Step>
 <Step>
 ### Return the result

--- a/docs/content/docs/guides/merkle-proofs.mdx
+++ b/docs/content/docs/guides/merkle-proofs.mdx
@@ -52,24 +52,35 @@ treeship verify --full
 
 The verify page at treeship.dev performs the same verification client-side via WASM. The same Rust code that signs artifacts in the CLI verifies them in the browser.
 
-## Approval nonce binding
+## Approval nonce binding + scope
 
-Single-use nonces prevent approval reuse. The approval artifact contains a nonce. The action artifact must echo that nonce. Verification checks the match.
+The approval artifact contains a nonce and an optional signed scope (`allowed_actors`, `allowed_actions`, `allowed_subjects`, `max_uses`). The action artifact must echo the nonce; verification then checks the binding, the scope, and the replay posture as three separate properties.
 
 ```bash
-# Approval creates the nonce
+# Approval creates the nonce + scope
 treeship attest approval \
   --approver human://alice \
-  --description "approve deployment to staging"
+  --description "approve deployment to staging" \
+  --allowed-actor agent://deployer \
+  --allowed-action deploy.staging \
+  --max-uses 1
 # Output includes: nonce = "n_8f3a..."
 
-# Action must echo the nonce
+# Action must echo the nonce AND match the scope
 treeship wrap \
   --approval-nonce n_8f3a... \
   -- kubectl apply -f staging.yaml
 ```
 
-If an agent tries to reuse a nonce, verification fails. One approval, one action. No replay.
+Verify reports each property separately:
+
+```
+✓  approval binding nonce matched a signed approval
+✓  approval scope   actor / action / subject matched approval scope
+⚠  replay check     package-local only -- no global ledger consulted
+```
+
+If the action's actor / action / subject falls outside the signed scope, verification fails on the scope line and the audit reader sees exactly why. Replay observation is package-local in v0.9.6; cross-package enforcement lands in v0.10 via a local Approval Use Journal (append-only hash chain with signed Merkle checkpoints), and v0.11+ adds Hub-backed checkpoints for distributed replay.
 
 ## Rekor anchoring
 

--- a/docs/content/docs/sdk/python.mdx
+++ b/docs/content/docs/sdk/python.mdx
@@ -67,7 +67,7 @@ Returns `ActionResult(artifact_id)`.
 
 ### `attest_approval(approver, description, expires_in=None)`
 
-Create a signed approval receipt with a single-use nonce.
+Create a signed approval receipt with a binding nonce. (Replay posture is package-local in v0.9.6; cross-package enforcement lands in v0.10 via the local Approval Use Journal.)
 
 Returns `ApprovalResult(artifact_id, nonce)`.
 

--- a/packages/cli/src/commands/approve.rs
+++ b/packages/cli/src/commands/approve.rs
@@ -352,7 +352,7 @@ pub fn approve(
     printer.blank();
     printer.success("approved", &[]);
     printer.info(&format!("  command:  {}", pa.command));
-    printer.info(&format!("  nonce:    {}  (single-use)", nonce));
+    printer.info(&format!("  nonce:    {}  (binding token)", nonce));
     printer.blank();
     printer.dim_info("  The command will now proceed.");
     printer.blank();

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -238,7 +238,7 @@ enum Command {
     /// Approve a pending action
     ///
     /// Approves the Nth pending action (or the first one if N is omitted).
-    /// Creates an ApprovalStatement artifact with a single-use nonce.
+    /// Creates an ApprovalStatement artifact with a binding nonce.
     ///
     /// Examples:
     ///   treeship approve

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -41,7 +41,7 @@ approval = ts.attest_approval(
     approver="human://alice",
     description="approve payment max $500",
 )
-print(approval.nonce)  # single-use nonce
+print(approval.nonce)  # binding token; replay enforcement is package-local in v0.9.6
 
 # Attest with approval binding
 ts.attest_action(

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -122,7 +122,13 @@ class Treeship:
         description: str,
         expires_in: Optional[str] = None,
     ) -> ApprovalResult:
-        """Create a signed approval receipt with a single-use nonce."""
+        """Create a signed approval receipt with a binding nonce.
+
+        v0.9.6 enforces binding + scope (when set on the underlying CLI)
+        statelessly; replay enforcement is package-local. Cross-package
+        and distributed replay enforcement land in v0.10 (local
+        Approval Use Journal) and v0.11+ (Hub-backed checkpoints).
+        """
         args = ["attest", "approval", "--approver", approver, "--description", description, "--format", "json"]
         if expires_in:
             args += ["--expires", expires_in]

--- a/packages/skills/lobster-cash/README.md
+++ b/packages/skills/lobster-cash/README.md
@@ -21,7 +21,7 @@ Treeship doesn't execute payments. lobster.cash does that. Treeship wraps every 
 | Step | What happens | What Treeship proves |
 |------|-------------|---------------------|
 | Wallet check | Agent checks lobster.cash balance | Action attested (Ed25519) |
-| Human approval | User authorizes the payment | Nonce-bound approval (single-use) |
+| Human approval | User authorizes the payment | Scoped approval (binding nonce + actor/action/subject scope; replay package-local) |
 | Payment | lobster.cash executes the transfer | Policy compliance + spend limit (Circom ZK) |
 | Confirmation | lobster.cash confirms status | Receipt attested |
 | Session close | Workflow complete | Full chain proof (RISC Zero) |


### PR DESCRIPTION
## Why

Pre-tag claim-preflight per release directive. Code-level honesty landed in #35 (verify text rewritten); this PR tightens every remaining user-facing surface so the v0.9.6 cutover ships nothing that claims a guarantee it doesn't enforce.

The grep that triggered this:

\`\`\`
grep -R "single-use enforced\\|global single-use\\|cannot be replayed\\|spent.*nothing to replay" \\
  README.md docs packages integrations bridges .github CHANGELOG.md
\`\`\`

…surfaced 11 files claiming nonces are inherently single-use, including a marketing blog post (\`warrants-not-approvals.mdx\`) built around the (now-untrue) guarantee, the CLI \`--help\` output, and the Python SDK docstring.

## Canonical posture (used consistently across all touched files)

> v0.9.6 verifies three properties as separate lines:
> - **Binding:** cryptographic nonce ↔ approval link (always enforced)
> - **Scope:** actor / action / subject / max_uses / expiry signed into the grant, checked statelessly when present
> - **Replay:** package-local only — verify says so plainly via \`replay check: package-local only -- no global ledger consulted\`
>
> **Roadmap:**
> - v0.10: local Approval Use Journal (append-only hash chain + signed Merkle checkpoints) for device/workspace replay
> - v0.11+: Hub-backed checkpoints for distributed replay across machines and teams

## Files

| File | What changed |
|---|---|
| \`docs/content/docs/guides/approvals.mdx\` | Full rewrite: scope flags table + 3-property explanation + roadmap callout |
| \`docs/content/docs/cli/approve.mdx\` | Replaced "single-use, enforced in Rust core" callout with honest replay-posture callout |
| \`docs/content/docs/cli/attest.mdx\` | Added scope flag table + dual callouts (scoped-default + replay posture) |
| \`docs/content/docs/commerce/{overview,compliance,payment-proofs}.mdx\` | Tightened "single-use" claims to scoped/binding language |
| \`docs/content/docs/sdk/python.mdx\` | Tightened approval docstring |
| \`docs/content/docs/guides/{merkle-proofs,how-it-works}.mdx\` | Replaced "no replay" / "has not been reused" with binding + scope + package-local replay |
| \`docs/content/docs/concepts/glossary.mdx\` | Approval definition now mentions scope |
| \`docs/content/blog/warrants-not-approvals.mdx\` | Added implementation-status callout at top + tightened body |
| \`docs/content/blog/mcp-bridge-agent-attestation.mdx\` | Replaced fake "single use enforced" verify output with the real 3-line output |
| \`docs/content/blog/agentic-commerce-with-treeship.mdx\` | Added scope flags to example + rewrote "the nonce prevents replay" section into a layered roadmap explanation |
| \`packages/cli/src/main.rs\` | Clap doc string: "single-use nonce" → "binding nonce" |
| \`packages/cli/src/commands/approve.rs\` | CLI hint output: \`(single-use)\` → \`(binding token)\` |
| \`packages/sdk-python/treeship_sdk/client.py\` | Docstring expanded with v0.9.6 status + roadmap |
| \`packages/sdk-python/README.md\` | Inline comment tightened |
| \`packages/skills/lobster-cash/README.md\` | Workflow table cell tightened |

## What stayed the same

- All Rust + Go logic
- All test code
- The Hub device-enrollment "single-use challenge" copy in \`docs/content/docs/concepts/security.mdx\` — that's a separate concept (a challenge atomically consumed by the Hub server, not a stateless approval nonce)
- Internal code comments warning ourselves not to overclaim (correct as-is)

## Test plan

- [x] Pre-merge grep across docs / packages / integrations / bridges / .github / README.md / CHANGELOG.md returns zero overclaims
- [x] \`cargo build -p treeship-cli\` green
- [ ] CI green (no Rust changes; only doc strings + clap text + READMEs + .mdx)

## After this lands

The v0.9.6 tag is ready to push. The Approval Use Journal design will land as a v0.10 ADR/issue (separate work item, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)