### PR TITLE
fix(sdk-python): bump to 0.9.6 (release pipeline left it at 0.9.5)

### DIFF
--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.9.5"
+version = "0.9.6"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-python/treeship_sdk/__init__.py
+++ b/packages/sdk-python/treeship_sdk/__init__.py
@@ -25,4 +25,4 @@ __all__ = [
     "Treeship",
     "TreeshipError",
 ]
-__version__ = "0.9.5"
+__version__ = "0.9.6"


### PR DESCRIPTION
## Summary

The v0.9.6 release version sweep covered \`Cargo.toml\` + npm \`package.json\` files but missed the Python SDK's:
- \`packages/sdk-python/pyproject.toml\`
- \`packages/sdk-python/treeship_sdk/__init__.py\`

twine then built wheels labelled \`0.9.5\` (plus a stale \`0.2.0\` artifact in the dist dir), saw both already on PyPI, and skipped them with \`--skip-existing\`:

\`\`\`
WARNING Skipping treeship_sdk-0.2.0-py3-none-any.whl because it appears to already exist
WARNING Skipping treeship_sdk-0.9.5-py3-none-any.whl because it appears to already exist
WARNING Skipping treeship_sdk-0.2.0.tar.gz because it appears to already exist
\`\`\`

The \`Verify treeship-sdk on PyPI\` step then polled \`https://pypi.org/pypi/treeship-sdk/0.9.6/json\` thirty times over 5 minutes, got HTTP 404 each time, and failed the job.

## Other v0.9.6 publish targets — green

- ✅ crates.io \`treeship-core\` 0.9.6 — published
- ✅ npm \`@treeship/*\` × 8 packages — published
- ✅ GitHub Release with 3 platform binaries — published
- ✅ Smoke test: \`npm install -g treeship@0.9.6 && treeship --version\` → \`treeship 0.9.6\`
- ❌ PyPI \`treeship-sdk\` 0.9.6 — this PR

## After merge

Once this lands on main, push \`v0.9.6\` again? — actually the cleanest move is to push a \`v0.9.6.1\` tag pointing at the merge commit so the release workflow re-fires only the publish-pypi path (the binary builds and other publish targets will see "already exists" and skip cleanly via \`--skip-existing\`). Or push \`v0.9.6\` as a moved tag — also fine since GitHub Release for v0.9.6 already exists and the npm/cargo publishes are idempotent.

Will confirm strategy before re-tagging.

## Test plan

- [x] grep packages/sdk-python for 0.9.5 → zero hits
- [ ] CI green