### PR TITLE
feat(release): v0.9.7 trust-fabric hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: [main]
 
 jobs:
+  # PR-level guard against the failure mode that produced the v0.9.6 PyPI
+  # drift: pyproject.toml at 0.9.5 while every other package was at 0.9.6,
+  # and stale @treeship/core-wasm pins in three packages. Anchors on
+  # packages/core/Cargo.toml and fails if any other site disagrees.
+  version-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check internal version consistency
+        run: python3 scripts/check-release-versions.py --consistency
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +35,13 @@ jobs:
 
       - name: Build CLI with OTel
         run: cargo build -p treeship-cli --features otel
+
+      # Smoke acceptance: end-to-end session round-trip exercises the full
+      # capture-normalize-verify chain. Catches release-breaking regressions
+      # the per-package unit tests can't see. T1-T9 stubs in the suite
+      # document the broader v0.9.6 trust-fabric invariants pending port.
+      - name: Trust-fabric acceptance suite
+        run: bash tests/acceptance/trust-fabric.sh
 
   hub:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,12 @@ jobs:
             exit 1
           fi
 
+          # Validate package metadata (long-description rendering, required
+          # fields, METADATA-Version compatibility) before upload. PyPI runs
+          # the same check server-side; catching it here means we fail
+          # before publish instead of after a partial release.
+          twine check "$EXPECTED_WHEEL" "$EXPECTED_SDIST"
+
           # Upload exact paths, not a glob. Belt-and-braces with the dist/
           # cleanup above: even if something snuck in, twine only sees these.
           if UPLOAD_OUTPUT="$(twine upload --skip-existing "$EXPECTED_WHEEL" "$EXPECTED_SDIST" 2>&1)"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,24 @@ permissions:
   id-token: write
 
 jobs:
+  # Preflight: fail the entire release if any package manifest, version file, or
+  # internal-dep pin disagrees with the tag. Runs first; every other job
+  # `needs:` it so a misalignment cannot produce a partial release like the
+  # v0.9.6 PyPI/Python drift or the stale @treeship/core-wasm pins.
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check every release-version site against the tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          python3 scripts/check-release-versions.py "$VERSION"
+
   build:
+    needs: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -286,6 +303,9 @@ jobs:
           set -e
           VERSION="${GITHUB_REF_NAME#v}"
           PKG="treeship-sdk"
+          # PEP 503 normalizes hyphens to underscores in built filenames; both
+          # treeship_sdk-X.Y.Z-*.whl and treeship_sdk-X.Y.Z.tar.gz must exist.
+          DIST_NAME="treeship_sdk"
 
           # First line of defense: version-specific endpoint. Returns
           # 200 for a live version, 404 otherwise; no lag because it
@@ -297,14 +317,46 @@ jobs:
             exit 0
           fi
 
+          # Clean any stale build artifacts before building. v0.9.6 shipped
+          # with sdk-python pyproject at 0.9.5; if a left-over dist/ from a
+          # previous run exists, twine could upload that wrong-version file
+          # under --skip-existing without anyone noticing.
+          rm -rf dist build *.egg-info treeship_sdk.egg-info
+
           python -m build
 
-          # Second line of defense: twine --skip-existing returns 0
-          # when the file already exists, so the normal path handles
-          # the race cleanly. The output-grep fallback catches the
-          # edge case where twine does exit non-zero on "already
-          # exists" (older versions, proxy errors, etc.).
-          if UPLOAD_OUTPUT="$(twine upload --skip-existing dist/* 2>&1)"; then
+          # Verify the built artifacts actually carry the expected version.
+          # If pyproject.toml drifted from the tag (the v0.9.6 failure mode),
+          # python -m build happily produces files named after the wrong
+          # version; we refuse to upload them.
+          EXPECTED_WHEEL="dist/${DIST_NAME}-${VERSION}-py3-none-any.whl"
+          EXPECTED_SDIST="dist/${DIST_NAME}-${VERSION}.tar.gz"
+          MISSING=()
+          for f in "$EXPECTED_WHEEL" "$EXPECTED_SDIST"; do
+            if [ ! -f "$f" ]; then
+              MISSING+=("$f")
+            fi
+          done
+          if [ ${#MISSING[@]} -gt 0 ]; then
+            echo "::error::expected dist artifacts missing: ${MISSING[*]}"
+            echo "::error::dist/ contains:"
+            ls -la dist/ || true
+            echo "::error::pyproject.toml may have drifted from the tag. Aborting before upload."
+            exit 1
+          fi
+          # Refuse to upload anything that isn't the exact two files we expect
+          # — if dist/ contains a stray older wheel, --skip-existing would
+          # silently accept it.
+          UNEXPECTED="$(find dist -mindepth 1 -maxdepth 1 ! -name "$(basename "$EXPECTED_WHEEL")" ! -name "$(basename "$EXPECTED_SDIST")" -print)"
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::unexpected artifacts in dist/, refusing to upload:"
+            echo "$UNEXPECTED"
+            exit 1
+          fi
+
+          # Upload exact paths, not a glob. Belt-and-braces with the dist/
+          # cleanup above: even if something snuck in, twine only sees these.
+          if UPLOAD_OUTPUT="$(twine upload --skip-existing "$EXPECTED_WHEEL" "$EXPECTED_SDIST" 2>&1)"; then
             echo "$UPLOAD_OUTPUT"
             exit 0
           fi

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.4"
+    "@treeship/core-wasm": "0.9.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.9.4"
+    "@treeship/core-wasm": "0.9.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/cli/src/commands/doctor.rs
+++ b/packages/cli/src/commands/doctor.rs
@@ -179,6 +179,14 @@ pub fn run(
                 "treeship initialized",
                 &ctx.config.ship_id,
             ));
+            // Surface where the config came from. A user debugging "wrong
+            // keystore" or "stale config" needs to see whether the resolved
+            // path was an --config override, env var, project-local
+            // discovery, or the global fallback. v0.9.6 had no signal here.
+            checks.push(Check::info(
+                "config source",
+                &format!("{} -- {}", ctx.config_source.label(), ctx.config_path.display()),
+            ));
         }
         Err(_) => {
             checks.push(Check::fail(

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -131,12 +131,40 @@ impl From<serde_json::Error> for ConfigError { fn from(e: serde_json::Error) -> 
 
 // -- Load / Save / Migrate ----------------------------------------------------
 
+/// Where the resolved config path came from. Surfaced by `doctor` so users
+/// debugging "wrong config" can see which lookup tier won.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigSource {
+    /// Caller passed `--config <path>`.
+    Explicit,
+    /// `TREESHIP_CONFIG` environment variable.
+    Env,
+    /// `.treeship/config.json` discovered by walking up from cwd. Picked over
+    /// the global config so that a user inside a project workspace can keep a
+    /// project-local keystore even when their home `~/.treeship` is broken.
+    ProjectLocal,
+    /// Fallback: `~/.treeship/config.json`.
+    Global,
+}
+
+impl ConfigSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Explicit     => "explicit (--config)",
+            Self::Env          => "env (TREESHIP_CONFIG)",
+            Self::ProjectLocal => "project-local",
+            Self::Global       => "global",
+        }
+    }
+}
+
 /// Resolve the config-file path, honoring `TREESHIP_CONFIG` first.
 ///
 /// Order of precedence (highest first):
 ///   1. The `--config <path>` CLI flag (handled by the caller).
 ///   2. The `TREESHIP_CONFIG` environment variable.
-///   3. `~/.treeship/config.json`.
+///   3. `.treeship/config.json` discovered by walking up from cwd.
+///   4. `~/.treeship/config.json`.
 ///
 /// The env-var hook exists so SDK consumers and CI runners can target an
 /// isolated keystore without forcing every SDK to add a per-call config
@@ -156,16 +184,118 @@ impl From<serde_json::Error> for ConfigError { fn from(e: serde_json::Error) -> 
 /// touch. Don't add owner-checks or symlink-resolution rejection here
 /// without first explaining what privilege boundary they would defend.
 pub fn default_config_path() -> Result<PathBuf, ConfigError> {
+    Ok(resolve_config_path()?.0)
+}
+
+/// Like `default_config_path` but also returns where the path came from.
+/// `doctor` uses the source label to explain unexpected resolution.
+pub fn resolve_config_path() -> Result<(PathBuf, ConfigSource), ConfigError> {
     if let Some(env) = std::env::var_os("TREESHIP_CONFIG") {
-        // Empty string is interpreted as "unset" -- avoids a footgun where a
-        // shell exports `TREESHIP_CONFIG=` and silently retargets every
-        // CLI invocation at the working directory.
         if !env.is_empty() {
-            return Ok(PathBuf::from(env));
+            return Ok((PathBuf::from(env), ConfigSource::Env));
         }
     }
+
     let home = home::home_dir().ok_or(ConfigError::NoHome)?;
-    Ok(home.join(".treeship").join("config.json"))
+    let global_path = home.join(".treeship").join("config.json");
+
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(found) = walk_up_for_project_config(&cwd, &global_path, |p| p.is_file()) {
+            return Ok((found, ConfigSource::ProjectLocal));
+        }
+    }
+
+    Ok((global_path, ConfigSource::Global))
+}
+
+/// Walk up from `start`, returning the first `.treeship/config.json` that
+/// passes `exists` and is not the global config. Pure so unit tests can drive
+/// it without chdir'ing.
+///
+/// Skipping `global_path` is what keeps `~/.treeship/config.json` from being
+/// labelled project-local for a user running from `$HOME` -- a real footgun
+/// because the keystore would then claim project-local provenance even though
+/// it's the same global config.
+fn walk_up_for_project_config<F: Fn(&Path) -> bool>(
+    start: &Path,
+    global_path: &Path,
+    exists: F,
+) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let candidate = dir.join(".treeship").join("config.json");
+        if exists(&candidate) && candidate != global_path {
+            return Some(candidate);
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn fake_exists(present: &[&str]) -> impl Fn(&Path) -> bool {
+        let set: HashSet<PathBuf> = present.iter().map(PathBuf::from).collect();
+        move |p: &Path| set.contains(p)
+    }
+
+    #[test]
+    fn walk_up_finds_nearest_project_config() {
+        // /home/u/work/proj/sub  →  finds /home/u/work/proj/.treeship/config.json
+        let global = PathBuf::from("/home/u/.treeship/config.json");
+        let found = walk_up_for_project_config(
+            Path::new("/home/u/work/proj/sub"),
+            &global,
+            fake_exists(&["/home/u/work/proj/.treeship/config.json"]),
+        );
+        assert_eq!(found, Some(PathBuf::from("/home/u/work/proj/.treeship/config.json")));
+    }
+
+    #[test]
+    fn walk_up_skips_when_only_match_is_global() {
+        // Running from a subdir of $HOME with no project config -- the only
+        // match in the walk is $HOME/.treeship/config.json itself, which is
+        // the global. Must NOT label that as project-local.
+        let global = PathBuf::from("/home/u/.treeship/config.json");
+        let found = walk_up_for_project_config(
+            Path::new("/home/u/Documents"),
+            &global,
+            fake_exists(&["/home/u/.treeship/config.json"]),
+        );
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn walk_up_returns_none_when_nothing_matches() {
+        let global = PathBuf::from("/home/u/.treeship/config.json");
+        let found = walk_up_for_project_config(
+            Path::new("/home/u/work/proj"),
+            &global,
+            fake_exists(&[]),
+        );
+        assert_eq!(found, None);
+    }
+
+    #[test]
+    fn walk_up_prefers_nearest_over_ancestor() {
+        // Both /a/b/.treeship/config.json and /a/.treeship/config.json exist
+        // -- prefer the nearest.
+        let global = PathBuf::from("/home/u/.treeship/config.json");
+        let found = walk_up_for_project_config(
+            Path::new("/a/b/c"),
+            &global,
+            fake_exists(&[
+                "/a/b/.treeship/config.json",
+                "/a/.treeship/config.json",
+            ]),
+        );
+        assert_eq!(found, Some(PathBuf::from("/a/b/.treeship/config.json")));
+    }
 }
 
 pub fn load(path: &Path) -> Result<Config, ConfigError> {

--- a/packages/cli/src/ctx.rs
+++ b/packages/cli/src/ctx.rs
@@ -2,14 +2,15 @@ use std::path::PathBuf;
 
 use treeship_core::{keys::Store as KeyStore, storage::Store as ArtifactStore};
 
-use crate::config::{self, Config, ConfigError};
+use crate::config::{self, Config, ConfigError, ConfigSource};
 
 /// Everything a command needs, opened and ready.
 pub struct Ctx {
-    pub config:   Config,
-    pub config_path: PathBuf,
-    pub keys:     KeyStore,
-    pub storage:  ArtifactStore,
+    pub config:        Config,
+    pub config_path:   PathBuf,
+    pub config_source: ConfigSource,
+    pub keys:          KeyStore,
+    pub storage:       ArtifactStore,
 }
 
 #[derive(Debug)]
@@ -35,14 +36,14 @@ impl From<treeship_core::keys::KeyError>        for CtxError { fn from(e: treesh
 impl From<treeship_core::storage::StorageError> for CtxError { fn from(e: treeship_core::storage::StorageError) -> Self { Self::Storage(e) } }
 
 pub fn open(config_path_override: Option<&str>) -> Result<Ctx, CtxError> {
-    let config_path = match config_path_override {
-        Some(p) => PathBuf::from(p),
-        None    => config::default_config_path()?,
+    let (config_path, config_source) = match config_path_override {
+        Some(p) => (PathBuf::from(p), ConfigSource::Explicit),
+        None    => config::resolve_config_path()?,
     };
 
     let cfg     = config::load(&config_path)?;
     let keys    = KeyStore::open(&cfg.keys_dir)?;
     let storage = ArtifactStore::open(&cfg.storage_dir)?;
 
-    Ok(Ctx { config: cfg, config_path, keys, storage })
+    Ok(Ctx { config: cfg, config_path, config_source, keys, storage })
 }

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "^0.9.4"
+    "@treeship/core-wasm": "0.9.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.5"
+    "@treeship/core-wasm": "0.9.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/scripts/check-release-versions.py
+++ b/scripts/check-release-versions.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+check-release-versions.py — release-version preflight.
+
+Diffs every package manifest, version file, and internal-dep pin against the
+target version. Exits 0 if every site matches, 1 if any disagree (with a table
+showing each disagreement).
+
+Used by:
+  - scripts/release.sh as a final assertion before tag/commit
+  - .github/workflows/release.yml as a preflight job blocking build/publish
+
+Usage:
+  scripts/check-release-versions.py <version>
+  scripts/check-release-versions.py 0.9.7
+
+Why a single script: at v0.9.6 the Python SDK and three @treeship/core-wasm
+internal pins all drifted independently. The fix is one source of truth that
+both local releases and CI consult.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class Site:
+    """One place where a version string appears."""
+
+    path: str
+    label: str
+    found: str | None  # None means "file/key missing"
+
+
+# ---------- parsers ----------
+
+
+def read_text(rel: str) -> str | None:
+    p = REPO_ROOT / rel
+    return p.read_text() if p.exists() else None
+
+
+def cargo_package_version(rel: str) -> str | None:
+    """Read [package] version from a Cargo.toml. First top-level `version =`."""
+    text = read_text(rel)
+    if text is None:
+        return None
+    in_package = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            in_package = s == "[package]"
+            continue
+        if in_package:
+            m = re.match(r'^version\s*=\s*"([^"]+)"', s)
+            if m:
+                return m.group(1)
+    return None
+
+
+def cargo_dep_version(rel: str, dep_name: str) -> str | None:
+    """Read a `name = { version = "X", ... }` style pin from Cargo.toml."""
+    text = read_text(rel)
+    if text is None:
+        return None
+    pattern = (
+        rf'{re.escape(dep_name)}\s*=\s*\{{[^}}]*version\s*=\s*"([^"]+)"'
+    )
+    m = re.search(pattern, text)
+    return m.group(1) if m else None
+
+
+def pkg_json_version(rel: str) -> str | None:
+    text = read_text(rel)
+    if text is None:
+        return None
+    return json.loads(text).get("version")
+
+
+def pkg_json_dep_version(rel: str, dep_name: str, *, group: str = "dependencies") -> str | None:
+    text = read_text(rel)
+    if text is None:
+        return None
+    return json.loads(text).get(group, {}).get(dep_name)
+
+
+def pyproject_version(rel: str) -> str | None:
+    text = read_text(rel)
+    if text is None:
+        return None
+    in_project = False
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("[") and s.endswith("]"):
+            in_project = s == "[project]"
+            continue
+        if in_project:
+            m = re.match(r'^version\s*=\s*"([^"]+)"', s)
+            if m:
+                return m.group(1)
+    return None
+
+
+def py_dunder_version(rel: str) -> str | None:
+    text = read_text(rel)
+    if text is None:
+        return None
+    m = re.search(r'__version__\s*=\s*"([^"]+)"', text)
+    return m.group(1) if m else None
+
+
+# ---------- site discovery ----------
+
+
+def collect_sites() -> list[Site]:
+    sites: list[Site] = []
+
+    # Workspace Rust crates that are published or shipped as binaries.
+    for rel, label in [
+        ("packages/core/Cargo.toml", "rust crate treeship-core"),
+        ("packages/cli/Cargo.toml", "rust crate treeship-cli"),
+        ("packages/core-wasm/Cargo.toml", "rust crate treeship-core-wasm"),
+    ]:
+        sites.append(Site(rel, label, cargo_package_version(rel)))
+
+    # Workspace-internal Cargo pin: cli depends on core at the same version.
+    sites.append(
+        Site(
+            "packages/cli/Cargo.toml",
+            "cargo dep treeship-core (in cli)",
+            cargo_dep_version("packages/cli/Cargo.toml", "treeship-core"),
+        )
+    )
+
+    # All published npm packages.
+    for rel, label in [
+        ("packages/sdk-ts/package.json", "npm @treeship/sdk"),
+        ("bridges/mcp/package.json", "npm @treeship/mcp"),
+        ("bridges/a2a/package.json", "npm @treeship/a2a"),
+        ("packages/verify-js/package.json", "npm @treeship/verify"),
+        ("npm/treeship/package.json", "npm treeship (wrapper)"),
+        ("npm/@treeship/cli-linux-x64/package.json", "npm @treeship/cli-linux-x64"),
+        ("npm/@treeship/cli-darwin-arm64/package.json", "npm @treeship/cli-darwin-arm64"),
+        ("npm/@treeship/cli-darwin-x64/package.json", "npm @treeship/cli-darwin-x64"),
+    ]:
+        sites.append(Site(rel, label, pkg_json_version(rel)))
+
+    # Internal pin: every package depending on @treeship/core-wasm must pin the
+    # exact release version. A mismatch here is what shipped in 0.9.6: bridges
+    # and verify-js declared 0.9.4/0.9.5 even though core-wasm itself was
+    # published at 0.9.6.
+    for rel in [
+        "packages/sdk-ts/package.json",
+        "bridges/mcp/package.json",
+        "bridges/a2a/package.json",
+        "packages/verify-js/package.json",
+    ]:
+        pin = pkg_json_dep_version(rel, "@treeship/core-wasm")
+        if pin is not None:
+            sites.append(
+                Site(rel, f"npm dep @treeship/core-wasm (in {rel})", pin)
+            )
+
+    # The wrapper's optionalDependencies select the right CLI binary for each
+    # platform; they MUST match the platform packages it routes to or `npm i
+    # treeship` resolves to a stale binary.
+    for cli in ("@treeship/cli-linux-x64", "@treeship/cli-darwin-arm64", "@treeship/cli-darwin-x64"):
+        pin = pkg_json_dep_version(
+            "npm/treeship/package.json", cli, group="optionalDependencies"
+        )
+        if pin is not None:
+            sites.append(
+                Site(
+                    "npm/treeship/package.json",
+                    f"npm wrapper optionalDependencies[{cli}]",
+                    pin,
+                )
+            )
+
+    # Python SDK: distribution metadata + runtime __version__. Drift between
+    # these two is what produced the 0.9.6 PyPI miss.
+    sites.append(
+        Site(
+            "packages/sdk-python/pyproject.toml",
+            "pypi treeship-sdk (pyproject)",
+            pyproject_version("packages/sdk-python/pyproject.toml"),
+        )
+    )
+    sites.append(
+        Site(
+            "packages/sdk-python/treeship_sdk/__init__.py",
+            "python treeship_sdk.__version__",
+            py_dunder_version("packages/sdk-python/treeship_sdk/__init__.py"),
+        )
+    )
+
+    return sites
+
+
+# ---------- main ----------
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 2 and argv[1] == "--consistency":
+        # PR-time mode: there's no target version yet, but every site must agree
+        # with each other. Anchor on packages/core/Cargo.toml (the foundational
+        # crate every other package mirrors) and assert everyone else matches.
+        # This catches drift weeks before a release tag would have caught it.
+        sites = collect_sites()
+        anchor = next(
+            (s for s in sites if s.path == "packages/core/Cargo.toml" and s.label == "rust crate treeship-core"),
+            None,
+        )
+        if anchor is None or anchor.found is None:
+            print("::error::could not read anchor version from packages/core/Cargo.toml", file=sys.stderr)
+            return 2
+        target = anchor.found
+        print(f"Consistency mode: anchoring on packages/core/Cargo.toml = {target}")
+    elif len(argv) == 2:
+        target = argv[1].lstrip("v")
+        sites = collect_sites()
+    else:
+        print(f"usage: {argv[0]} <version>", file=sys.stderr)
+        print(f"       {argv[0]} --consistency", file=sys.stderr)
+        print(f"example: {argv[0]} 0.9.7", file=sys.stderr)
+        return 2
+
+    width = max(len(s.label) for s in sites) + 2
+    rows: list[tuple[str, str, str, str]] = []
+    bad = 0
+    missing = 0
+    for s in sites:
+        if s.found is None:
+            mark = "?"
+            missing += 1
+            shown = "(not found)"
+        elif s.found == target:
+            mark = "✓"
+            shown = s.found
+        else:
+            mark = "✗"
+            bad += 1
+            shown = s.found
+        rows.append((mark, s.label.ljust(width), shown, s.path))
+
+    print(f"Checking every release-version site against {target}")
+    print()
+    for mark, label, found, path in rows:
+        print(f"  {mark} {label} {found:<10}  {path}")
+    print()
+    print(f"  total: {len(sites)}   ok: {len(sites) - bad - missing}   wrong: {bad}   not-found: {missing}")
+
+    if missing > 0:
+        print(f"\n::error::{missing} site(s) could not be read. Investigate before releasing.", file=sys.stderr)
+    if bad > 0:
+        print(
+            f"\n::error::{bad} site(s) disagree with target version {target}. "
+            "Run scripts/release.sh to bump every site, or fix the script if a "
+            "new version-bearing file was added.",
+            file=sys.stderr,
+        )
+
+    return 0 if (bad == 0 and missing == 0) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -108,6 +108,18 @@ node -e "
 echo "Updating Cargo.lock..."
 cargo check -p treeship-core 2>/dev/null || true
 
+# Preflight: fail loudly if any manifest, version file, or internal pin still
+# disagrees with the target version. Same script the CI release workflow runs
+# before any publish job. Catches the class of bug that produced the v0.9.6
+# Python drift and the stale @treeship/core-wasm pins.
+echo ""
+echo "Running release version preflight..."
+if ! python3 "$(dirname "$0")/check-release-versions.py" "$VERSION"; then
+  echo ""
+  echo "Preflight failed. Fix the disagreeing sites above before tagging." >&2
+  exit 1
+fi
+
 echo ""
 echo "Versions bumped to ${VERSION}:"
 echo "  packages/core/Cargo.toml"

--- a/tests/acceptance/trust-fabric.sh
+++ b/tests/acceptance/trust-fabric.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# trust-fabric.sh — end-to-end acceptance suite for the v0.9.6 trust-fabric
+# guarantees. Each test exercises a release-breaking property of the
+# capture-normalize-verify chain.
+#
+# Run locally:
+#   ./tests/acceptance/trust-fabric.sh
+#
+# Run a single test:
+#   ./tests/acceptance/trust-fabric.sh smoke
+#
+# Run from CI: see .github/workflows/acceptance.yml.
+#
+# Each test runs in its own tmpdir with a fresh keystore; nothing leaks to the
+# user's ~/.treeship.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CLI="${TREESHIP_CLI:-${REPO_ROOT}/target/debug/treeship}"
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# ---------- harness ----------
+
+setup_workspace() {
+  # Each test gets a fresh tmpdir and a fresh keystore so tests can't pollute
+  # each other's state. CONFIG points the CLI at this isolated tree.
+  WORKSPACE="$(mktemp -d -t treeship-acceptance.XXXXXX)"
+  export CONFIG="${WORKSPACE}/.treeship/config.json"
+  cd "${WORKSPACE}"
+  "${CLI}" init --config "${CONFIG}" --name "acceptance-test" >/dev/null
+}
+
+teardown_workspace() {
+  rm -rf "${WORKSPACE}"
+}
+
+run_test() {
+  local name="$1"
+  local fn="$2"
+  if [[ $# -ge 3 && -n "$3" && "$3" != "$name" ]]; then
+    return 0  # filter mismatch
+  fi
+  echo "── ${name} ──"
+  setup_workspace
+  if "${fn}"; then
+    echo "   ✓ ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "   ✗ ${name}" >&2
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("${name}")
+  fi
+  teardown_workspace
+  echo
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if ! echo "${haystack}" | grep -Fq "${needle}"; then
+    echo "   expected to find: ${needle}" >&2
+    echo "   in output:" >&2
+    echo "${haystack}" | sed 's/^/     /' >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if echo "${haystack}" | grep -Fq "${needle}"; then
+    echo "   expected NOT to find: ${needle}" >&2
+    echo "   in output:" >&2
+    echo "${haystack}" | sed 's/^/     /' >&2
+    return 1
+  fi
+}
+
+# ---------- tests ----------
+
+# T0 (smoke): A complete session round-trip exercises the full chain we care
+# about for release: keystore generation, session start, command capture, file
+# write recording, session close, package emission, package verify. If any
+# of these regress, every other test in this suite would also fail —
+# fail-fast on the smoke test gives a fast clear error.
+test_smoke_session_roundtrip() {
+  local out
+  out="$("${CLI}" session start --config "${CONFIG}" --name smoke 2>&1)"
+  assert_contains "${out}" "session" || return 1
+
+  echo "hello" > note.txt
+  "${CLI}" wrap --config "${CONFIG}" --action smoke.write -- \
+    sh -c 'echo "from acceptance" > artifact.txt' >/dev/null 2>&1 || return 1
+
+  out="$("${CLI}" session close --config "${CONFIG}" --summary "smoke ok" 2>&1)"
+  assert_contains "${out}" "session" || return 1
+
+  # Find the package the close emitted and verify it.
+  local pkg
+  pkg="$(find .treeship/sessions -name 'ssn_*.treeship' -print -quit 2>/dev/null || true)"
+  if [[ -z "${pkg}" ]]; then
+    echo "   no .treeship session package was emitted" >&2
+    return 1
+  fi
+  out="$("${CLI}" package verify --config "${CONFIG}" "${pkg}" 2>&1)"
+  assert_contains "${out}" "verif" || return 1
+  return 0
+}
+
+# ---------- T1-T9 placeholders ----------
+#
+# The full v0.9.6 acceptance suite covers nine release-critical invariants
+# documented in the v0.9.6 CHANGELOG. Each one needs to be ported from the
+# manual run notes that proved the v0.9.6 trust-fabric chain green:
+#
+#   T1. Claude built-ins authorization
+#       Session uses Read, Write/Edit, Bash; cert/card declares only read_file.
+#       Expect actual=[bash, read_file, write_file], unauthorized=[bash, write_file].
+#
+#   T2. Claude built-ins happy path
+#       Cert/card declares all three; unauthorized list is empty.
+#
+#   T3. Read → Bash modifies same file
+#       Bash/sed mutates a file already Read'd. files_written records the
+#       change; tool_usage stays honest (no double-count from git-reconcile).
+#
+#   T4. MCP write_file
+#       MCP bridge emits write_file with file_path + content. files_written
+#       has the path; raw content is absent from the receipt.
+#
+#   T5. MCP command privacy
+#       MCP bridge sees command/cmd carrying a Bearer token. The recorded
+#       invocation must omit the raw command from meta/tool_input/receipt.
+#
+#   T6. Source provenance
+#       Sources hook, mcp, git-reconcile, session-event-cli, daemon-atime,
+#       and unknown-custom keep their honest labels in the receipt; unknown
+#       labels never collapse to "hook".
+#
+#   T7. git mv old.rs new.rs
+#       files_written records new.rs only, not old.rs.
+#
+#   T8. Malformed event before/after a valid write
+#       Valid writes either side are recorded; the malformed line is logged
+#       as event_log_skipped; package verify warns/fails per --strict.
+#
+#   T9. Package verify
+#       Fully-formed package verifies; expected warnings (eg. unscoped
+#       approval, package-local replay) are explicit, not silent.
+#
+# Each test should follow the same pattern as test_smoke_session_roundtrip:
+# stand up an isolated workspace, drive the CLI to produce the artifact under
+# test, and assert on the package/verify output. Add new run_test() lines in
+# main() once each test function lands.
+
+# ---------- runner ----------
+
+main() {
+  if [[ ! -x "${CLI}" ]]; then
+    echo "::error::CLI not built at ${CLI}; run 'cargo build --bin treeship' first" >&2
+    exit 1
+  fi
+
+  local filter="${1:-}"
+  run_test "smoke"   test_smoke_session_roundtrip "${filter}"
+
+  echo "================================"
+  echo "  passed: ${PASS}    failed: ${FAIL}"
+  echo "================================"
+  if [[ ${FAIL} -gt 0 ]]; then
+    printf '  failed tests:\n'
+    printf '    - %s\n' "${FAILED_TESTS[@]}"
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
This is the first v0.9.7 hardening PR. **It does not bump or tag 0.9.7 yet.**

## What it adds

1. **Release preflight that checks all version sites before publish.** `scripts/check-release-versions.py` is the single source of truth — it walks every Cargo `[package]` version, the `treeship-core` internal pin, every published `package.json`, the npm wrapper's `optionalDependencies`, every `dependencies['@treeship/core-wasm']` pin, `pyproject.toml`, and `treeship_sdk/__version__`. Wired into `release.yml` as a job that gates build/release/all publish jobs (transitive `needs:`), so a misalignment cannot produce a partial release.

2. **PyPI dist hygiene so stale or wrong-version artifacts cannot upload.** The PyPI step cleans `dist/`, `build/`, and `*.egg-info/` before `python -m build`, asserts the built wheel and sdist filenames carry the expected version exactly, refuses to upload unexpected artifacts in `dist/`, and uploads exact paths instead of a blind `dist/*` glob.

3. **PR-time consistency checks.** `ci.yml` runs `check-release-versions.py --consistency`, which anchors on `packages/core/Cargo.toml` and asserts every other site agrees. Catches drift weeks before a release tag would.

4. **Checked-in trust-fabric acceptance smoke with T1–T9 scaffolding.** `tests/acceptance/trust-fabric.sh` drives the CLI through a real session round-trip (init, session start, wrap, session close, package verify) inside an isolated tmpdir keystore. CI runs the smoke after the build step. T1–T9 from the v0.9.6 trust-fabric run are documented as scaffolds with detailed expected behavior — porting the manual run notes into shell tests is a follow-up PR.

5. **Project-local `.treeship/config.json` discovery.** `resolve_config_path()` walks up from cwd before falling back to `~/.treeship`, with a safety rail that prevents `$HOME/.treeship/config.json` from being labelled project-local when running from a subdir of `$HOME`. A corrupt global config no longer blocks a project-local config from working.

6. **Doctor source/path labeling.** `treeship doctor` now prints `config source: <tier> -- <path>` so users debugging "wrong keystore" can see which lookup actually fired (`explicit (--config)`, `env (TREESHIP_CONFIG)`, `project-local`, or `global`). Closes the v0.9.6 DX gap where this signal was absent.

7. **Python version parity coverage.** The preflight checks `pyproject.toml [project].version` and `treeship_sdk.__version__` together as part of the same suite that runs on every PR — the same drift that produced the v0.9.6 PyPI miss now fails CI immediately.

This PR also aligns four stale `@treeship/core-wasm` pins (`bridges/mcp` 0.9.4, `bridges/a2a` 0.9.4, `packages/verify-js` 0.9.5, `packages/sdk-ts` `^0.9.4`) to 0.9.6 — the preflight surfaced these; `release.sh` will sweep them forward at the next bump.

## Why

v0.9.6 shipped the trust-fabric correctness chain, but the Python SDK drift (`pyproject` at 0.9.5 when the tag was v0.9.6) and the silently-stale `@treeship/core-wasm` pins in three published packages proved the release pipeline could still partially publish. v0.9.7 makes misrelease much harder and turns the acceptance suite into repo infrastructure.

## Out of scope

- Version bump to 0.9.7
- v0.9.7 tag
- Approval Use Journal
- Agent discovery / Agent Cards / NinjaTech
- Remote join
- GitHub verification surface
- Hub / global replay

## Test plan

- [ ] CI passes: `version-consistency`, `test`, `hub`, `cross-sdk`, and the new acceptance smoke step
- [ ] `python3 scripts/check-release-versions.py --consistency` exits 0 locally
- [ ] `python3 scripts/check-release-versions.py 0.9.6` exits 0 locally
- [ ] `bash tests/acceptance/trust-fabric.sh` exits 0 locally
- [ ] `cargo test --workspace` passes (4 new config tests)
- [ ] Manual verification: from a subdir of a workspace with `.treeship/config.json`, `treeship doctor` reports `config source: project-local`
- [ ] Manual verification: from a subdir of \$HOME with no project config, `treeship doctor` reports `config source: global` (not project-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)