### PR TITLE
fix(release): split prepare and tag phases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,162 +1,257 @@
 #!/bin/bash
-# Treeship release script
-# Usage: ./scripts/release.sh 0.1.1
+# Treeship release script — split into independent phases so accidental
+# tagging is impossible.
 #
-# Bumps version across all packages, commits, tags, and pushes.
-# The GitHub Actions release workflow handles the rest:
-# - Builds binaries for all platforms
-# - Creates GitHub Release
-# - Publishes to npm (if NPM_TOKEN secret is set)
-# - Publishes to crates.io (if CARGO_TOKEN secret is set)
+#   scripts/release.sh prepare <version>
+#       Bump every version site, run preflight, commit. Never tags. Safe to
+#       run during a normal feature workflow.
+#
+#   scripts/release.sh tag <version> --sha <sha> [--yes]
+#       Create the annotated tag. Requires an explicit subcommand, an
+#       explicit target SHA (no implicit HEAD), a clean working tree, no
+#       pre-existing local or remote tag, and either --yes or interactive
+#       confirmation. Never pushes the tag automatically -- the user runs
+#       `git push origin v<version>` after reviewing.
+#
+# Why split phases: v0.9.7's release-machinery PR caught a foot-gun where the
+# unified script bumped+committed+tagged in one pass, producing a local tag
+# even when the workflow only intended to land the bump as a PR. Tagging is
+# the irreversible action that triggers the entire publish pipeline; it must
+# require an explicit, audited gesture.
 
 set -e
 
-VERSION="$1"
+# ---------- prepare ---------------------------------------------------------
 
-if [ -z "$VERSION" ]; then
-  echo "Usage: ./scripts/release.sh <version>"
-  echo "Example: ./scripts/release.sh 0.1.1"
-  echo ""
-  echo "Current versions:"
-  echo "  core:        $(grep '^version' packages/core/Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')"
-  echo "  cli:         $(grep '^version' packages/cli/Cargo.toml | head -1 | sed 's/.*= "//' | sed 's/"//')"
-  echo "  sdk-ts:      $(node -p "require('./packages/sdk-ts/package.json').version")"
-  echo "  mcp:         $(node -p "require('./bridges/mcp/package.json').version")"
-  echo "  a2a:         $(node -p "require('./bridges/a2a/package.json').version")"
-  echo "  verify:      $(node -p "require('./packages/verify-js/package.json').version" 2>/dev/null || echo 'not-built-yet')"
-  echo "  core-wasm:   $(node -p "require('./packages/core-wasm/pkg/package.json').version" 2>/dev/null || echo 'not-built-yet')"
-  echo "  sdk-python:  $(grep '^version' packages/sdk-python/pyproject.toml | head -1 | sed 's/.*= "//' | sed 's/"//')"
-  echo "  npm wrapper: $(node -p "require('./npm/treeship/package.json').version")"
-  exit 1
-fi
+cmd_prepare() {
+  local VERSION="$1"
+  if [ -z "$VERSION" ]; then
+    echo "usage: scripts/release.sh prepare <version>" >&2
+    echo "example: scripts/release.sh prepare 0.9.7" >&2
+    exit 2
+  fi
 
-echo "Releasing Treeship v${VERSION}"
-echo "================================"
-echo ""
+  echo "Preparing v${VERSION} (bump + commit, no tag)"
+  echo "================================"
+  echo
 
-# Rust crates
-echo "Bumping Rust crates..."
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/core/Cargo.toml
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/cli/Cargo.toml
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/core-wasm/Cargo.toml
-sed -i '' "s/treeship-core = { version = \"[^\"]*\"/treeship-core = { version = \"${VERSION}\"/" packages/cli/Cargo.toml
+  # Rust crates
+  echo "Bumping Rust crates..."
+  sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/core/Cargo.toml
+  sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/cli/Cargo.toml
+  sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/core-wasm/Cargo.toml
+  sed -i '' "s/treeship-core = { version = \"[^\"]*\"/treeship-core = { version = \"${VERSION}\"/" packages/cli/Cargo.toml
 
-# TypeScript SDK
-echo "Bumping @treeship/sdk..."
-npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix packages/sdk-ts
+  echo "Bumping @treeship/sdk..."
+  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix packages/sdk-ts
 
-# MCP bridge
-echo "Bumping @treeship/mcp..."
-npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix bridges/mcp
+  echo "Bumping @treeship/mcp..."
+  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix bridges/mcp
 
-# A2A bridge
-echo "Bumping @treeship/a2a..."
-npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix bridges/a2a
+  echo "Bumping @treeship/a2a..."
+  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix bridges/a2a
 
-# @treeship/verify standalone package (if it exists)
-if [ -f packages/verify-js/package.json ]; then
-  echo "Bumping @treeship/verify..."
-  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix packages/verify-js
-  # Pin @treeship/core-wasm exact version in @treeship/verify
-  node -e "
-    const fs = require('fs');
-    const p = JSON.parse(fs.readFileSync('packages/verify-js/package.json', 'utf8'));
-    if (p.dependencies && p.dependencies['@treeship/core-wasm']) {
-      p.dependencies['@treeship/core-wasm'] = '${VERSION}';
-      fs.writeFileSync('packages/verify-js/package.json', JSON.stringify(p, null, 2) + '\n');
-    }
-  "
-fi
-
-# Pin @treeship/core-wasm exact version across any package that depends on it.
-for pkgjson in packages/sdk-ts/package.json bridges/a2a/package.json bridges/mcp/package.json; do
-  if [ -f "$pkgjson" ]; then
+  if [ -f packages/verify-js/package.json ]; then
+    echo "Bumping @treeship/verify..."
+    npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix packages/verify-js
     node -e "
       const fs = require('fs');
-      const p = JSON.parse(fs.readFileSync('$pkgjson', 'utf8'));
+      const p = JSON.parse(fs.readFileSync('packages/verify-js/package.json', 'utf8'));
       if (p.dependencies && p.dependencies['@treeship/core-wasm']) {
         p.dependencies['@treeship/core-wasm'] = '${VERSION}';
-        fs.writeFileSync('$pkgjson', JSON.stringify(p, null, 2) + '\n');
+        fs.writeFileSync('packages/verify-js/package.json', JSON.stringify(p, null, 2) + '\n');
       }
     "
   fi
-done
 
-# Python SDK
-echo "Bumping treeship-sdk (Python)..."
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/sdk-python/pyproject.toml
-sed -i '' "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" packages/sdk-python/treeship_sdk/__init__.py
+  for pkgjson in packages/sdk-ts/package.json bridges/a2a/package.json bridges/mcp/package.json; do
+    if [ -f "$pkgjson" ]; then
+      node -e "
+        const fs = require('fs');
+        const p = JSON.parse(fs.readFileSync('$pkgjson', 'utf8'));
+        if (p.dependencies && p.dependencies['@treeship/core-wasm']) {
+          p.dependencies['@treeship/core-wasm'] = '${VERSION}';
+          fs.writeFileSync('$pkgjson', JSON.stringify(p, null, 2) + '\n');
+        }
+      "
+    fi
+  done
 
-# npm binary wrapper + platform packages
-echo "Bumping npm wrapper..."
-npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix npm/treeship
-for pkg in cli-darwin-arm64 cli-darwin-x64 cli-linux-x64; do
-  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix "npm/@treeship/$pkg"
-done
+  echo "Bumping treeship-sdk (Python)..."
+  sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" packages/sdk-python/pyproject.toml
+  sed -i '' "s/__version__ = \".*\"/__version__ = \"${VERSION}\"/" packages/sdk-python/treeship_sdk/__init__.py
 
-# Update optionalDependencies in wrapper to match
-node -e "
-  const fs = require('fs');
-  const p = JSON.parse(fs.readFileSync('npm/treeship/package.json', 'utf8'));
-  for (const dep of Object.keys(p.optionalDependencies || {})) {
-    p.optionalDependencies[dep] = '${VERSION}';
-  }
-  fs.writeFileSync('npm/treeship/package.json', JSON.stringify(p, null, 2) + '\n');
-"
+  echo "Bumping npm wrapper..."
+  npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix npm/treeship
+  for pkg in cli-darwin-arm64 cli-darwin-x64 cli-linux-x64; do
+    npm version "$VERSION" --no-git-tag-version --allow-same-version --prefix "npm/@treeship/$pkg"
+  done
 
-# Update Cargo.lock
-echo "Updating Cargo.lock..."
-cargo check -p treeship-core 2>/dev/null || true
+  node -e "
+    const fs = require('fs');
+    const p = JSON.parse(fs.readFileSync('npm/treeship/package.json', 'utf8'));
+    for (const dep of Object.keys(p.optionalDependencies || {})) {
+      p.optionalDependencies[dep] = '${VERSION}';
+    }
+    fs.writeFileSync('npm/treeship/package.json', JSON.stringify(p, null, 2) + '\n');
+  "
 
-# Preflight: fail loudly if any manifest, version file, or internal pin still
-# disagrees with the target version. Same script the CI release workflow runs
-# before any publish job. Catches the class of bug that produced the v0.9.6
-# Python drift and the stale @treeship/core-wasm pins.
-echo ""
-echo "Running release version preflight..."
-if ! python3 "$(dirname "$0")/check-release-versions.py" "$VERSION"; then
-  echo ""
-  echo "Preflight failed. Fix the disagreeing sites above before tagging." >&2
-  exit 1
-fi
+  echo "Updating Cargo.lock..."
+  cargo check -p treeship-core 2>/dev/null || true
 
-echo ""
-echo "Versions bumped to ${VERSION}:"
-echo "  packages/core/Cargo.toml"
-echo "  packages/cli/Cargo.toml"
-echo "  packages/core-wasm/Cargo.toml"
-echo "  packages/sdk-ts/package.json"
-echo "  bridges/mcp/package.json"
-echo "  bridges/a2a/package.json"
-if [ -f packages/verify-js/package.json ]; then
-  echo "  packages/verify-js/package.json"
-fi
-echo "  packages/sdk-python/pyproject.toml"
-echo "  npm/treeship/package.json"
-echo "  npm/@treeship/cli-*/package.json"
-echo ""
-echo "Note: @treeship/core-wasm is built and published by GitHub Actions"
-echo "on tag push. The pkg/ directory is regenerated via"
-echo "packages/core-wasm/build-npm.sh."
-echo ""
+  echo
+  echo "Running release version preflight..."
+  if ! python3 "$(dirname "$0")/check-release-versions.py" "$VERSION"; then
+    echo
+    echo "Preflight failed. Fix the disagreeing sites above before committing." >&2
+    exit 1
+  fi
 
-# Commit and tag
-echo "Committing..."
-git add -A
-git commit -m "Release v${VERSION}"
+  echo
+  echo "Committing..."
+  git add -A
+  git commit -m "Release v${VERSION}"
 
-echo "Tagging v${VERSION}..."
-git tag "v${VERSION}"
+  echo
+  echo "Prepare complete. Tag is intentionally NOT created."
+  echo
+  echo "Next steps:"
+  echo "  1. Review the bump commit, optionally update CHANGELOG.md."
+  echo "  2. Open a PR with this branch."
+  echo "  3. After the PR merges and CI is green, ask for explicit tag approval."
+  echo "  4. Tag with:"
+  echo "       scripts/release.sh tag ${VERSION} --sha <merged-main-sha>"
+}
 
-echo ""
-echo "Ready to push. Run:"
-echo ""
-echo "  git push && git push --tags"
-echo ""
-echo "This will trigger GitHub Actions to:"
-echo "  1. Build binaries (Linux, macOS arm64, macOS x64)"
-echo "  2. Create GitHub Release with binaries"
-echo "  3. Publish to npm (if NPM_TOKEN secret is set)"
-echo "  4. Publish to crates.io (if CARGO_TOKEN secret is set)"
-echo ""
-echo "  5. Publish to PyPI (if PYPI_TOKEN secret is set)"
+# ---------- tag -------------------------------------------------------------
+
+cmd_tag() {
+  local VERSION=""
+  local SHA=""
+  local YES=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --sha) SHA="$2"; shift 2 ;;
+      --yes) YES=1; shift ;;
+      -*)    echo "tag: unknown flag $1" >&2; exit 2 ;;
+      *)     if [ -z "$VERSION" ]; then VERSION="$1"; shift; else echo "tag: unexpected positional $1" >&2; exit 2; fi ;;
+    esac
+  done
+
+  if [ -z "$VERSION" ] || [ -z "$SHA" ]; then
+    cat >&2 <<EOF
+usage: scripts/release.sh tag <version> --sha <sha> [--yes]
+example: scripts/release.sh tag 0.9.7 --sha 76059e7 --yes
+
+Why --sha is required: never tag implicit HEAD. The SHA you pass should
+be the merge commit on origin/main for the release PR you intend to ship.
+EOF
+    exit 2
+  fi
+
+  # Guardrail: clean working tree. A tag on dirty state would not match what
+  # CI checks out anyway, but we want loud failure rather than confusion.
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "::error::working tree is dirty -- refusing to tag." >&2
+    git status --short >&2
+    exit 1
+  fi
+
+  # Guardrail: tag must not already exist locally.
+  if git rev-parse --verify --quiet "v${VERSION}" >/dev/null; then
+    echo "::error::local tag v${VERSION} already exists." >&2
+    echo "         If this is a stale tag from a botched run, remove with: git tag -d v${VERSION}" >&2
+    exit 1
+  fi
+
+  # Guardrail: tag must not exist on origin. Cheap protection against
+  # accidentally retagging an already-published release.
+  if git ls-remote --tags origin "v${VERSION}" 2>/dev/null | grep -Fq "refs/tags/v${VERSION}"; then
+    echo "::error::remote tag v${VERSION} already exists on origin." >&2
+    exit 1
+  fi
+
+  # Guardrail: target SHA must exist locally and be reachable.
+  if ! git cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+    echo "::error::SHA ${SHA} not found locally. Did you forget to git fetch?" >&2
+    exit 1
+  fi
+
+  local FULL_SHA TARGET_SUBJECT ORIGIN_MAIN
+  FULL_SHA="$(git rev-parse "${SHA}")"
+  TARGET_SUBJECT="$(git log -1 --format=%s "${FULL_SHA}")"
+  ORIGIN_MAIN="$(git rev-parse origin/main 2>/dev/null || echo '<unknown>')"
+
+  cat <<EOF
+
+About to tag (annotated):
+  tag name:        v${VERSION}
+  target SHA:      ${FULL_SHA}
+  target subject:  ${TARGET_SUBJECT}
+  origin/main:     ${ORIGIN_MAIN}
+
+This will:
+  1. Create local annotated tag v${VERSION} pointing at ${FULL_SHA:0:12}.
+  2. NOT push the tag. Push manually with:
+       git push origin v${VERSION}
+     The push triggers .github/workflows/release.yml which builds binaries
+     and publishes to npm, crates.io, and PyPI.
+
+EOF
+
+  if [ "$YES" -ne 1 ]; then
+    printf "Type 'tag %s' to confirm: " "${VERSION}"
+    read -r CONFIRM
+    if [ "${CONFIRM}" != "tag ${VERSION}" ]; then
+      echo "Aborted." >&2
+      exit 1
+    fi
+  fi
+
+  git tag -a "v${VERSION}" "${FULL_SHA}" -m "Release v${VERSION}"
+  echo
+  echo "Tagged v${VERSION} -> ${FULL_SHA:0:12}."
+  echo "Push when ready:"
+  echo "  git push origin v${VERSION}"
+}
+
+# ---------- usage / dispatch -----------------------------------------------
+
+usage() {
+  cat <<EOF
+Treeship release script.
+
+  scripts/release.sh prepare <version>
+      Bump every version site, run preflight, commit. Does not tag.
+
+  scripts/release.sh tag <version> --sha <sha> [--yes]
+      Create the annotated tag. Required after the prepare PR has merged
+      and you have explicit approval to release.
+
+The default invocation (no subcommand) intentionally errors out so a stray
+\`scripts/release.sh 0.9.7\` cannot retain its old "do everything" semantics.
+
+To inspect every version site without changing anything:
+  python3 scripts/check-release-versions.py <version>
+  python3 scripts/check-release-versions.py --consistency
+EOF
+}
+
+case "${1:-}" in
+  prepare) shift; cmd_prepare "$@" ;;
+  tag)     shift; cmd_tag "$@" ;;
+  ""|-h|--help|help) usage; exit 0 ;;
+  *)
+    cat >&2 <<EOF
+::error::unknown subcommand: $1
+
+The single-arg form 'scripts/release.sh <version>' was removed because
+it tagged implicitly, which produced an accidental local tag during the
+v0.9.7 cutover. Use 'prepare' for the bump and 'tag' for tagging.
+
+EOF
+    usage
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Tiny follow-up to #39. Closes the foot-gun caught during v0.9.7 cutover preparation: the unified `scripts/release.sh <version>` form bumped, committed, AND tagged in one pass, producing a local `v0.9.7` tag during a PR-prep flow that was only supposed to stop at the bump commit. Tagging is the irreversible action that triggers the publish pipeline; it must require an explicit, audited gesture.

## What changes

The script is restructured into two subcommands. The no-arg / legacy single-arg forms intentionally error out (no silent fallback to the old behavior).

```
scripts/release.sh prepare <version>
  bump every version site, run preflight, commit -- and stop.
  Never calls git tag, git push --tags, or git push origin v*.

scripts/release.sh tag <version> --sha <sha> [--yes]
  create the annotated tag, with guardrails:
    - explicit subcommand (no implicit tagging)
    - --sha is mandatory; never tag implicit HEAD
    - working tree must be clean
    - local tag must not already exist
    - remote tag must not already exist on origin
    - prints tag name, target SHA + subject, current origin/main, and
      which workflow will fire
    - requires --yes or an interactive 'type tag <version>' confirmation
    - never pushes the tag; user runs git push origin v<version> manually
```

## Verified locally

- `scripts/release.sh` (no args) → prints usage, exits 0
- `scripts/release.sh 0.9.7` (legacy form) → errors with explanation, exits 2
- `scripts/release.sh tag 0.9.7` (missing --sha) → errors with usage, exits 2
- `grep "git tag\|git push" scripts/release.sh` → only the `tag` subcommand executes them; `prepare` has none

## Out of scope

- Version bump to 0.9.7 (separate cutover PR, opened next)
- Any change to `release.yml` or `check-release-versions.py` (#39 already covers those)

🤖 Generated with [Claude Code](https://claude.com/claude-code)