### PR TITLE
fix(cross-sdk): use workspace-local core-wasm instead of npm registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -76,6 +78,12 @@ jobs:
 
       - name: Build CLI
         run: cargo build --bin treeship
+
+      # Cross-SDK builds @treeship/core-wasm from source (so it tests the
+      # workspace, not whatever was last published to npm). wasm-pack is
+      # required.
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install tsx
         run: |

--- a/tests/cross-sdk/run.sh
+++ b/tests/cross-sdk/run.sh
@@ -24,15 +24,83 @@ if [[ -z "${TREESHIP_SKIP_BUILD:-}" ]]; then
   (cd "$REPO_ROOT" && cargo build --bin treeship)
 fi
 
-# 2. Build the TypeScript SDK if its dist/ is missing or older than src/.
-# The runner imports from packages/sdk-ts/dist/ (real .js, full module
-# resolution); building on demand here means a developer who hasn't
-# touched the SDK in a while still gets a green run.
+# 2. Build the TypeScript SDK against the workspace's @treeship/core-wasm,
+# not the npm registry copy. During cutover PRs (e.g. v0.9.7), the SDK's
+# package.json declares the *next* core-wasm version which has not yet
+# been published; resolving that from npm gives ETARGET. The contract
+# suite's job is to verify the workspace, not yesterday's published
+# graph, so we build core-wasm locally and install it into the SDK as
+# a file: tarball before npm install.
+#
+# Original package.json + package-lock.json are restored on EXIT so
+# local invocations leave the working tree clean.
 SDK_TS_DIR="$REPO_ROOT/packages/sdk-ts"
-if [[ ! -f "$SDK_TS_DIR/dist/index.js" ]] || [[ -n "$(find "$SDK_TS_DIR/src" -newer "$SDK_TS_DIR/dist/index.js" -type f 2>/dev/null | head -1)" ]]; then
-  echo "==> building TS SDK" >&2
-  (cd "$SDK_TS_DIR" && npm install --no-audit --no-fund --silent && npm run build --silent)
+CORE_WASM_DIR="$REPO_ROOT/packages/core-wasm"
+CORE_WASM_PKG_DIR="$CORE_WASM_DIR/pkg"
+TARBALL_DIR="$REPO_ROOT/target/cross-sdk-npm"
+
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+::error::wasm-pack not found. Cross-SDK builds @treeship/core-wasm from
+source and needs wasm-pack on PATH. Install with:
+  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+or:
+  cargo install wasm-pack --locked
+EOF
+  exit 3
 fi
+
+# Determine the version from the SDK manifest -- this is the version
+# pyproject/Cargo/package.json all agree on after `release.sh prepare`,
+# which is the version we're testing here. Strip any leading semver
+# prefix (^, ~, =, v) so build-npm.sh receives a clean version.
+CORE_WASM_VERSION="$(node -p "require('$SDK_TS_DIR/package.json').dependencies['@treeship/core-wasm'].replace(/^[\\^~=v]+/, '')")"
+
+echo "==> building local @treeship/core-wasm@${CORE_WASM_VERSION}" >&2
+(cd "$CORE_WASM_DIR" && bash build-npm.sh "$CORE_WASM_VERSION" >&2)
+
+mkdir -p "$TARBALL_DIR"
+echo "==> packing local @treeship/core-wasm" >&2
+CORE_WASM_TGZ_NAME="$(cd "$CORE_WASM_PKG_DIR" && npm pack --pack-destination "$TARBALL_DIR" --silent)"
+CORE_WASM_TGZ="$TARBALL_DIR/$CORE_WASM_TGZ_NAME"
+if [[ ! -f "$CORE_WASM_TGZ" ]]; then
+  echo "::error::expected tarball at $CORE_WASM_TGZ but it doesn't exist" >&2
+  exit 1
+fi
+
+# Snapshot package.json + lockfile, restore on any exit. Without this, a
+# Ctrl-C halfway through would leave a dev's working tree pointing at a
+# file: dependency.
+SDK_PKG="$SDK_TS_DIR/package.json"
+SDK_LOCK="$SDK_TS_DIR/package-lock.json"
+SDK_PKG_BAK="$(mktemp -t cross-sdk-pkg.XXXXXX)"
+SDK_LOCK_BAK="$(mktemp -t cross-sdk-lock.XXXXXX)"
+cp "$SDK_PKG" "$SDK_PKG_BAK"
+if [[ -f "$SDK_LOCK" ]]; then cp "$SDK_LOCK" "$SDK_LOCK_BAK"; else : > "$SDK_LOCK_BAK"; fi
+restore_sdk_manifests() {
+  if [[ -f "$SDK_PKG_BAK" ]]; then mv "$SDK_PKG_BAK" "$SDK_PKG"; fi
+  if [[ -s "$SDK_LOCK_BAK" ]]; then
+    mv "$SDK_LOCK_BAK" "$SDK_LOCK"
+  else
+    rm -f "$SDK_LOCK_BAK" "$SDK_LOCK"
+  fi
+}
+trap restore_sdk_manifests EXIT
+
+# Rewrite the dependency to point at the local tarball, then install +
+# build. Lockfile is removed so npm doesn't try to honor a registry
+# resolution from a previous run.
+node - "$SDK_PKG" "$CORE_WASM_TGZ" <<'NODE'
+const fs = require('fs');
+const [pkgPath, tgz] = process.argv.slice(2);
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+pkg.dependencies = pkg.dependencies || {};
+pkg.dependencies['@treeship/core-wasm'] = `file:${tgz}`;
+fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+NODE
+
+echo "==> building TS SDK against local core-wasm" >&2
+(cd "$SDK_TS_DIR" && rm -f package-lock.json && rm -rf node_modules/@treeship/core-wasm && npm install --no-audit --no-fund --silent && npm run build --silent)
 
 # 3. Generate corpus.
 echo "==> generating test vectors" >&2


### PR DESCRIPTION
Pre-cutover hardening fix. Unblocks #41's cross-SDK matrix without weakening the v0.9.7 release-graph invariant.

## Root cause

`tests/cross-sdk/run.sh` resolves `@treeship/core-wasm` from the npm registry. During cutover preparation, the SDK manifest correctly declares the *next* `core-wasm` version (the version we're about to publish) — but that version doesn't exist on npm yet, so `npm install` returns `ETARGET`. v0.9.6 only got away with this because its internal pins were stale (0.9.4 / 0.9.5), which #39's preflight surfaced as a separate bug. With the preflight enforced, every cutover would hit this until cross-SDK stops reaching the registry for workspace-internal deps.

## What this PR does

`tests/cross-sdk/run.sh`:
- Builds `@treeship/core-wasm` from source via `packages/core-wasm/build-npm.sh "$VERSION"` (same script `release.yml` uses).
- `npm pack`s the result into `target/cross-sdk-npm/`.
- Rewrites `packages/sdk-ts/package.json` to depend on `file:<tarball>` for the test install.
- Restores `package.json` + `package-lock.json` on EXIT (trap covers Ctrl-C, errors, and normal completion).
- Drops the skip-if-fresh logic for `sdk-ts/dist`: the build now depends on a freshly-built core-wasm tarball that the source-timestamp heuristic can't see.
- Fails up front with a clear error and install paths if `wasm-pack` is missing.

`.github/workflows/ci.yml`:
- Adds `wasm32-unknown-unknown` to the cross-sdk job's Rust toolchain.
- Adds an `Install wasm-pack` step (mirrors `release.yml`).

## Why option 2 over the alternatives

- **Reverting the pins (option 1)** would re-introduce the exact v0.9.6 stale-pin class of bug that #39's preflight exists to prevent.
- **Release-time pin rewriting (option 3)** is more complex and makes the manifest state in PRs less honest — you want the repository at the release commit to describe the release graph exactly.
- **Workspace-local build (this PR)** keeps the clean invariant: release manifests point at the release version, CI tests the workspace version, publish ships the same graph CI tested.

## Test plan

Verified locally on this branch:

- [x] With `packages/sdk-ts` pinning `@treeship/core-wasm@0.9.6` (current main state), Phase A vector parity and Phase B roundtrip both pass.
- [x] With the pin temporarily set to `@treeship/core-wasm@0.9.7` (unpublished — simulates the #41 condition), Phase A and Phase B both pass.
- [x] Working tree clean after script run: only the script edit itself remains modified, no leftover `package.json`/`package-lock.json` mutations.
- [ ] CI green across all 8 matrix legs (will confirm once GH Actions runs).

## After this lands

1. Merge this on green CI.
2. Rebase #41 (cutover) onto fresh `main` and re-run its CI — cross-SDK should now go green against the 0.9.7 pins.
3. Merge #41 on green CI.
4. Ask for explicit tag approval.
5. `scripts/release.sh tag 0.9.7 --sha <merge-sha>` (the new script requires the explicit subcommand, the SHA, and a typed `tag 0.9.7` confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)