### PR TITLE
feat(cli): v0.9.8 PR 2 — Agent Card store + treeship agents

### DIFF
--- a/packages/cli/src/commands/agent.rs
+++ b/packages/cli/src/commands/agent.rs
@@ -1,15 +1,97 @@
 //! Agent Identity Certificate: treeship agent register
 //!
 //! Produces a .agent package containing identity.json, capabilities.json,
-//! declaration.json, and certificate.html.
+//! declaration.json, and certificate.html. As of v0.9.8, also writes an
+//! Agent Card into the workspace's card store at `.treeship/agents/<id>.json`
+//! so the same registration is visible to `treeship agents` without the user
+//! having to run anything else.
 
 use std::path::Path;
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use sha2::{Digest, Sha256};
 
 use treeship_core::agent::*;
 
+use crate::commands::cards::{self, AgentCard, CardCapabilities, CardProvenance, CardStatus};
+use crate::commands::discovery::{
+    AgentSurface, ConnectionMode, CoverageLevel,
+};
 use crate::{ctx, printer::Printer};
+
+/// Map a user-supplied agent name (e.g. "claude-code", "hermes") to the
+/// canonical `AgentSurface`. Falls back to `ShellWrap` for unknown names so
+/// `treeship agent register --name my-custom-bot` still gets a card.
+fn surface_from_name(name: &str) -> (AgentSurface, Vec<ConnectionMode>, CoverageLevel) {
+    match name.to_ascii_lowercase().as_str() {
+        "claude-code" | "claude" => (
+            AgentSurface::ClaudeCode,
+            vec![ConnectionMode::NativeHook, ConnectionMode::Mcp],
+            CoverageLevel::High,
+        ),
+        "cursor" | "cursor-agent" => (
+            AgentSurface::CursorAgent,
+            vec![ConnectionMode::Mcp],
+            CoverageLevel::Medium,
+        ),
+        "cline" => (
+            AgentSurface::Cline,
+            vec![ConnectionMode::Mcp],
+            CoverageLevel::Medium,
+        ),
+        "codex" => (
+            AgentSurface::Codex,
+            vec![ConnectionMode::Mcp, ConnectionMode::ShellWrap],
+            CoverageLevel::Medium,
+        ),
+        "hermes" => (
+            AgentSurface::Hermes,
+            vec![ConnectionMode::Skill, ConnectionMode::Mcp],
+            CoverageLevel::Medium,
+        ),
+        "openclaw" => (
+            AgentSurface::OpenClaw,
+            vec![ConnectionMode::Skill, ConnectionMode::Mcp],
+            CoverageLevel::Medium,
+        ),
+        "ninjatech-superninja" | "superninja" => (
+            AgentSurface::NinjatechSuperninja,
+            vec![ConnectionMode::Mcp, ConnectionMode::GitReconcile],
+            CoverageLevel::Basic,
+        ),
+        "ninjatech-ninja-dev" | "ninja-dev" => (
+            AgentSurface::NinjatechNinjaDev,
+            vec![ConnectionMode::Mcp, ConnectionMode::ShellWrap],
+            CoverageLevel::Medium,
+        ),
+        "generic-mcp" => (
+            AgentSurface::GenericMcp,
+            vec![ConnectionMode::Mcp],
+            CoverageLevel::Medium,
+        ),
+        _ => (
+            AgentSurface::ShellWrap,
+            vec![ConnectionMode::ShellWrap, ConnectionMode::GitReconcile],
+            CoverageLevel::Basic,
+        ),
+    }
+}
+
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    treeship_core::statements::unix_to_rfc3339(secs)
+}
+
+fn local_hostname() -> String {
+    // Falling back to "local" is safe because the agent ID derivation also
+    // uses workspace path; collisions would have to share both.
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_else(|_| "local".to_string())
+}
 
 /// Register an agent and produce a .agent package.
 pub fn register(
@@ -128,6 +210,66 @@ pub fn register(
     let full_json = serde_json::to_string_pretty(&certificate)?;
     std::fs::write(pkg_dir.join("certificate.json"), &full_json)?;
 
+    // v0.9.8: also write an Agent Card into the workspace card store.
+    // Same data, different file -- the .agent package is the portable
+    // signed certificate users hand off; the card is the local trust
+    // object Treeship uses to show "this agent exists in this workspace,
+    // here's its status." Status starts at NeedsReview because the user
+    // explicitly asked for the agent (provenance: registered) but hasn't
+    // confirmed they want Treeship to act on it.
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    let workspace = ctx
+        .config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let host = local_hostname();
+    let (surface, connection_modes, coverage) = surface_from_name(name);
+    let agent_id = cards::derive_agent_id(surface, &host, &workspace);
+
+    // Pin the certificate by its on-disk content digest. If the .agent
+    // package is later edited (rotation, re-sign, etc), the digest will
+    // diverge and `treeship agents review` can flag it.
+    let cert_digest = {
+        let mut h = Sha256::new();
+        h.update(full_json.as_bytes());
+        let bytes = h.finalize();
+        let mut hex = String::with_capacity(64);
+        for byte in &bytes[..] {
+            use std::fmt::Write;
+            write!(hex, "{byte:02x}").ok();
+        }
+        format!("sha256:{hex}")
+    };
+
+    let now = now_rfc3339();
+    let card = AgentCard {
+        agent_id,
+        agent_name:            name.to_string(),
+        surface,
+        connection_modes,
+        coverage,
+        capabilities: CardCapabilities {
+            bounded_tools:       tools.clone(),
+            escalation_required: declaration.escalation_required.clone(),
+            forbidden:           declaration.forbidden.clone(),
+        },
+        provenance:            CardProvenance::Registered,
+        status:                CardStatus::NeedsReview,
+        host,
+        workspace:             workspace.to_string_lossy().into_owned(),
+        model:                 model.clone(),
+        description:           description.clone(),
+        certificate_digest:    Some(cert_digest),
+        latest_session_id:     None,
+        latest_receipt_digest: None,
+        created_at:            now.clone(),
+        updated_at:            now.clone(),
+    };
+    // upsert preserves any pre-existing session linkage and never demotes
+    // a higher-status card.
+    let merged = cards::upsert(&agents_dir, card, &now)?;
+
     printer.blank();
     printer.success("agent certificate created", &[]);
     printer.info(&format!("  agent:      {}", name));
@@ -135,8 +277,10 @@ pub fn register(
     printer.info(&format!("  tools:      {}", tools.len()));
     printer.info(&format!("  valid:      {} days (until {})", valid_days, valid_until));
     printer.info(&format!("  package:    {}", pkg_dir.display()));
+    printer.info(&format!("  card:       {} ({})", merged.agent_id, merged.status.label()));
     printer.blank();
     printer.hint(&format!("open {}/certificate.html", pkg_dir.display()));
+    printer.dim_info(&format!("  review with: treeship agents review {}", merged.agent_id));
     printer.blank();
 
     Ok(())

--- a/packages/cli/src/commands/agents.rs
+++ b/packages/cli/src/commands/agents.rs
@@ -1,0 +1,246 @@
+//! `treeship agents` -- inspect and manage the local Agent Card store.
+//!
+//! Companion to `treeship add --discover` (which detects) and
+//! `treeship agent register` (which mints a signed certificate). This is
+//! where the user *manages* what got created: list every card, review one,
+//! approve it (Draft -> Active or NeedsReview -> Active), or remove it.
+//!
+//! v0.9.8 surface:
+//!   treeship agents              # list every card
+//!   treeship agents review <id>  # show full card details
+//!   treeship agents approve <id> # promote to Active
+//!   treeship agents remove <id>  # delete the card
+//!
+//! `verified` is set programmatically by `treeship setup` (PR 3) once a
+//! smoke session proves capture. It is intentionally not exposed as a manual
+//! `agents verify` flag in v0.9.8 because the word "verified" must mean
+//! something Treeship checked, not something the user toggled.
+
+use crate::commands::cards::{self, AgentCard, CardStatus};
+use crate::ctx;
+use crate::printer::{Format, Printer};
+
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    treeship_core::statements::unix_to_rfc3339(secs)
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+/// `treeship agents` -- list every card in the workspace's agents directory.
+pub fn list(
+    config: Option<&str>,
+    format: Format,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    let cards_list = cards::list(&agents_dir)?;
+
+    match format {
+        Format::Json => {
+            let value = serde_json::json!({
+                "agents_dir": agents_dir,
+                "cards":      cards_list,
+            });
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        }
+        Format::Text => {
+            print_list(&cards_list, &agents_dir, printer);
+        }
+    }
+    Ok(())
+}
+
+fn print_list(
+    cards_list: &[AgentCard],
+    agents_dir: &std::path::Path,
+    printer: &Printer,
+) {
+    printer.blank();
+    if cards_list.is_empty() {
+        printer.dim_info("  No agent cards yet.");
+        printer.blank();
+        printer.hint("Run `treeship add --discover` to find local agents, then `treeship agent register` to register one.");
+        printer.blank();
+        return;
+    }
+    printer.section(&format!("Agent cards ({})", agents_dir.display()));
+    printer.blank();
+    for card in cards_list {
+        let mark = match card.status {
+            CardStatus::Verified    => "✓",
+            CardStatus::Active      => "✓",
+            CardStatus::NeedsReview => "?",
+            CardStatus::Draft       => "·",
+        };
+        printer.info(&format!(
+            "  {mark} {}  ({})",
+            card.agent_name,
+            card.surface.kind()
+        ));
+        printer.dim_info(&format!("    id:         {}", card.agent_id));
+        printer.dim_info(&format!("    status:     {}", card.status.label()));
+        printer.dim_info(&format!("    coverage:   {}", card.coverage.label()));
+        printer.dim_info(&format!("    provenance: {}", card.provenance.label()));
+        printer.blank();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// review
+// ---------------------------------------------------------------------------
+
+/// `treeship agents review <id>` -- show every field on the card so the
+/// user can decide whether to approve it.
+pub fn review(
+    agent_id: &str,
+    config: Option<&str>,
+    format: Format,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    let card = cards::load(&agents_dir, agent_id)?;
+
+    match format {
+        Format::Json => {
+            println!("{}", serde_json::to_string_pretty(&card)?);
+        }
+        Format::Text => {
+            print_review(&card, printer);
+        }
+    }
+    Ok(())
+}
+
+fn print_review(card: &AgentCard, printer: &Printer) {
+    printer.blank();
+    printer.section(&format!("Agent card: {}", card.agent_name));
+    printer.blank();
+
+    printer.info(&format!("  id:         {}", card.agent_id));
+    printer.info(&format!("  surface:    {}", card.surface.kind()));
+    let conns: Vec<&str> = card
+        .connection_modes
+        .iter()
+        .map(|c| c.label())
+        .collect();
+    printer.info(&format!("  connection: {}", conns.join(" + ")));
+    printer.info(&format!("  coverage:   {}", card.coverage.label()));
+    printer.info(&format!("  status:     {}", card.status.label()));
+    printer.info(&format!("  provenance: {}", card.provenance.label()));
+    printer.info(&format!("  host:       {}", card.host));
+    printer.info(&format!("  workspace:  {}", card.workspace));
+    if let Some(model) = &card.model {
+        printer.info(&format!("  model:      {model}"));
+    }
+    if let Some(desc) = &card.description {
+        printer.info(&format!("  note:       {desc}"));
+    }
+    if let Some(digest) = &card.certificate_digest {
+        printer.info(&format!("  cert:       {digest}"));
+    }
+    if let Some(ssn) = &card.latest_session_id {
+        printer.info(&format!("  last:       session {ssn}"));
+    }
+    printer.dim_info(&format!("  created:    {}", card.created_at));
+    printer.dim_info(&format!("  updated:    {}", card.updated_at));
+
+    if !card.capabilities.bounded_tools.is_empty() {
+        printer.blank();
+        printer.info(&format!(
+            "  tools:      {}",
+            card.capabilities.bounded_tools.join(", ")
+        ));
+    }
+    if !card.capabilities.escalation_required.is_empty() {
+        printer.info(&format!(
+            "  escalate:   {}",
+            card.capabilities.escalation_required.join(", ")
+        ));
+    }
+    if !card.capabilities.forbidden.is_empty() {
+        printer.info(&format!(
+            "  forbidden:  {}",
+            card.capabilities.forbidden.join(", ")
+        ));
+    }
+
+    printer.blank();
+    match card.status {
+        CardStatus::Draft | CardStatus::NeedsReview => {
+            printer.hint(&format!(
+                "Approve with: treeship agents approve {}",
+                card.agent_id
+            ));
+        }
+        CardStatus::Active => {
+            printer.dim_info("  Approved. Treeship will use this card during sessions.");
+        }
+        CardStatus::Verified => {
+            printer.dim_info("  Verified by smoke session. Treeship has confirmed capture works.");
+        }
+    }
+    printer.blank();
+}
+
+// ---------------------------------------------------------------------------
+// approve / remove
+// ---------------------------------------------------------------------------
+
+/// `treeship agents approve <id>` -- promote Draft/NeedsReview to Active.
+/// Refuses to demote an already-Verified card.
+pub fn approve(
+    agent_id: &str,
+    config: Option<&str>,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    let existing = cards::load(&agents_dir, agent_id)?;
+
+    if existing.status == CardStatus::Verified {
+        printer.dim_info(&format!(
+            "  {} is already verified -- nothing to do.",
+            existing.agent_id
+        ));
+        return Ok(());
+    }
+    if existing.status == CardStatus::Active {
+        printer.dim_info(&format!(
+            "  {} is already active.",
+            existing.agent_id
+        ));
+        return Ok(());
+    }
+
+    let updated = cards::set_status(&agents_dir, agent_id, CardStatus::Active, &now_rfc3339())?;
+    printer.blank();
+    printer.success(
+        &format!("approved {}", updated.agent_name),
+        &[("status", updated.status.label())],
+    );
+    printer.dim_info(&format!("  id: {}", updated.agent_id));
+    printer.blank();
+    Ok(())
+}
+
+/// `treeship agents remove <id>` -- delete a card. Idempotent.
+pub fn remove(
+    agent_id: &str,
+    config: Option<&str>,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    cards::remove(&agents_dir, agent_id)?;
+    printer.dim_info(&format!("  removed agent card {agent_id}"));
+    Ok(())
+}
+

--- a/packages/cli/src/commands/cards.rs
+++ b/packages/cli/src/commands/cards.rs
@@ -313,26 +313,53 @@ pub fn save(agents_dir: &Path, card: &AgentCard) -> Result<(), CardError> {
 /// the new values winning; `created_at` is preserved from the existing
 /// record so a re-discovered card doesn't lose its original creation time.
 /// Returns the resulting card.
+///
+/// Trust invariant: if the incoming card carries a different
+/// `certificate_digest` than the stored card, the merged status is forced
+/// down to `NeedsReview`. Re-registering an agent produces a fresh
+/// signature and a fresh certificate; keeping a previously-Active card at
+/// Active when the certificate underneath it changed would let
+/// `treeship agents` lie about what the user has actually approved.
+/// `keep_higher_status` only applies when both cards refer to the same
+/// (or no) certificate.
 pub fn upsert(
     agents_dir: &Path,
     incoming: AgentCard,
     now: &str,
 ) -> Result<AgentCard, CardError> {
     let merged = match load(agents_dir, &incoming.agent_id) {
-        Ok(existing) => AgentCard {
-            created_at:             existing.created_at,
-            updated_at:             now.to_string(),
-            // Preserve user-meaningful state across re-discovery: don't
-            // demote an Active card back to Draft just because a fresh
-            // detection ran.
-            status:                 keep_higher_status(existing.status, incoming.status),
-            // Preserve session linkage: the new card from discovery has
-            // none, but the existing record might.
-            latest_session_id:      existing.latest_session_id.or(incoming.latest_session_id.clone()),
-            latest_receipt_digest:  existing.latest_receipt_digest.or(incoming.latest_receipt_digest.clone()),
-            certificate_digest:     incoming.certificate_digest.clone().or(existing.certificate_digest),
-            ..incoming
-        },
+        Ok(existing) => {
+            let cert_changed = match (&existing.certificate_digest, &incoming.certificate_digest) {
+                (Some(old), Some(new)) => old != new,
+                _ => false,
+            };
+            let status = if cert_changed {
+                // Demote: Active/Verified → NeedsReview. The user must
+                // review the new certificate before the card claims trust
+                // again. Cards that were already lower than NeedsReview
+                // (Draft) stay where they were.
+                match existing.status {
+                    CardStatus::Active | CardStatus::Verified => CardStatus::NeedsReview,
+                    other => other,
+                }
+            } else {
+                // Preserve user-meaningful state across re-discovery: don't
+                // demote an Active card back to Draft just because a fresh
+                // detection ran.
+                keep_higher_status(existing.status, incoming.status)
+            };
+            AgentCard {
+                created_at:             existing.created_at,
+                updated_at:             now.to_string(),
+                status,
+                // Preserve session linkage: the new card from discovery has
+                // none, but the existing record might.
+                latest_session_id:      existing.latest_session_id.or(incoming.latest_session_id.clone()),
+                latest_receipt_digest:  existing.latest_receipt_digest.or(incoming.latest_receipt_digest.clone()),
+                certificate_digest:     incoming.certificate_digest.clone().or(existing.certificate_digest),
+                ..incoming
+            }
+        }
         Err(CardError::NotFound(_)) => incoming,
         Err(e) => return Err(e),
     };
@@ -518,6 +545,79 @@ mod tests {
         incoming.status = CardStatus::NeedsReview;
         let merged = upsert(dir.path(), incoming, now()).unwrap();
         assert_eq!(merged.status, CardStatus::NeedsReview);
+    }
+
+    #[test]
+    fn upsert_demotes_active_when_certificate_digest_changes() {
+        // Trust invariant: re-registering an agent produces a different
+        // certificate. Keeping the card at Active would let
+        // `treeship agents` claim a certificate the user never approved.
+        let dir = tempdir().unwrap();
+        let mut active = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        active.status = CardStatus::Active;
+        active.certificate_digest = Some("sha256:aaa".into());
+        save(dir.path(), &active).unwrap();
+
+        let mut incoming = active.clone();
+        incoming.certificate_digest = Some("sha256:bbb".into());
+        let merged = upsert(dir.path(), incoming, "2026-04-30T10:00:00Z").unwrap();
+
+        assert_eq!(
+            merged.status, CardStatus::NeedsReview,
+            "drift must demote Active to NeedsReview"
+        );
+        assert_eq!(
+            merged.certificate_digest.as_deref(),
+            Some("sha256:bbb"),
+            "the new digest is what's recorded; user must review it"
+        );
+    }
+
+    #[test]
+    fn upsert_demotes_verified_when_certificate_digest_changes() {
+        let dir = tempdir().unwrap();
+        let mut verified = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        verified.status = CardStatus::Verified;
+        verified.certificate_digest = Some("sha256:aaa".into());
+        save(dir.path(), &verified).unwrap();
+
+        let mut incoming = verified.clone();
+        incoming.certificate_digest = Some("sha256:bbb".into());
+        let merged = upsert(dir.path(), incoming, now()).unwrap();
+        assert_eq!(merged.status, CardStatus::NeedsReview);
+    }
+
+    #[test]
+    fn upsert_preserves_active_when_digest_unchanged() {
+        // Regression guard for the no-demotion case: same cert, same
+        // surface → status stays Active. This is what makes idempotent
+        // re-discovery safe.
+        let dir = tempdir().unwrap();
+        let mut active = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        active.status = CardStatus::Active;
+        active.certificate_digest = Some("sha256:aaa".into());
+        save(dir.path(), &active).unwrap();
+
+        let mut incoming = active.clone();
+        incoming.certificate_digest = Some("sha256:aaa".into());
+        incoming.status = CardStatus::Draft;
+        let merged = upsert(dir.path(), incoming, now()).unwrap();
+        assert_eq!(merged.status, CardStatus::Active);
     }
 
     #[test]

--- a/packages/cli/src/commands/cards.rs
+++ b/packages/cli/src/commands/cards.rs
@@ -1,0 +1,593 @@
+//! Persistent Agent Card store.
+//!
+//! An Agent Card is the local trust object Treeship keeps about a specific
+//! agent in this workspace: who it is, where it runs, how Treeship is
+//! attached, what coverage to expect, and what the user has decided to do
+//! with it (draft / needs-review / active / verified). Distinct from the
+//! .agent package produced by `treeship agent register`, which is a signed
+//! certificate -- the certificate is what gets shipped/embedded into
+//! receipts; the card is the workspace inventory.
+//!
+//! Cards live at `.treeship/agents/<id>.json`. The id is deterministic from
+//! (surface, host, workspace) so re-running `treeship setup` doesn't
+//! duplicate entries.
+//!
+//! v0.9.8 scope:
+//!   - persistent JSON store
+//!   - card_status lifecycle: draft -> needs-review -> active -> verified
+//!   - load/save/list/find/upsert
+//!
+//! Out of scope here: the CLI surface (`treeship agents`) and the wiring
+//! that has `agent register` populate the store. Those land alongside this
+//! module in the same PR but live in their own files.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::commands::discovery::{
+    AgentSurface, ConnectionMode, CoverageLevel, DiscoveredAgent,
+};
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+/// Lifecycle of an Agent Card. Movement is one-directional in the happy path
+/// (draft -> needs-review -> active -> verified) but the user can demote
+/// (active -> needs-review) when something changes -- e.g. they re-run
+/// discovery and a coverage level drops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CardStatus {
+    /// Discovered but not yet acknowledged. Treeship made this card without
+    /// asking. The user has not approved attaching to this agent.
+    Draft,
+    /// User has registered an Agent Identity Certificate but has not yet
+    /// reviewed the resulting card. `treeship agents review <id>` clears
+    /// this. Distinct from Draft because a needs-review card carries a real
+    /// signed certificate; Draft cards do not.
+    NeedsReview,
+    /// User has reviewed and approved. Active cards are visible in session
+    /// reports and used to bind tool authorization.
+    Active,
+    /// Active AND a smoke session has proven Treeship can capture this
+    /// agent's events end-to-end. The strongest available status in v0.9.8
+    /// (no global identity verification yet).
+    Verified,
+}
+
+impl CardStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Draft       => "draft",
+            Self::NeedsReview => "needs-review",
+            Self::Active      => "active",
+            Self::Verified    => "verified",
+        }
+    }
+}
+
+/// Snapshot of what an agent is allowed to do. Mirrors the v0.9.6
+/// `treeship attest approval` model so the same vocabulary works at both
+/// authorization and verification time. Empty vectors mean "unscoped" which
+/// the verify pass already labels honestly.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CardCapabilities {
+    /// Tools the agent is authorized to call (canonical names; e.g.
+    /// "read_file", "write_file", "bash").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bounded_tools: Vec<String>,
+    /// Tools that, if invoked, require human approval before execution.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub escalation_required: Vec<String>,
+    /// Tools the agent must never invoke. Listed for documentation and to
+    /// drive future hard-block hooks; v0.9.8 only records, does not enforce.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forbidden: Vec<String>,
+}
+
+/// Provenance of a card -- where the data behind it came from. Helps later
+/// commands explain "this card was generated automatically, you have not
+/// approved it" vs "you registered this with `agent register`."
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CardProvenance {
+    /// Created by discovery (`treeship add --discover` / `treeship setup`).
+    Discovered,
+    /// Created by `treeship agent register`. Carries a signed certificate.
+    Registered,
+    /// Created via `treeship agent add --kind <kind>` for kinds that
+    /// discovery cannot detect (remote VMs, generic wrappers).
+    Manual,
+}
+
+impl CardProvenance {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Discovered => "discovered",
+            Self::Registered => "registered",
+            Self::Manual     => "manual",
+        }
+    }
+}
+
+/// One Agent Card on disk. Designed to round-trip through `serde_json` and
+/// to be human-readable so a user inspecting `.treeship/agents/<id>.json`
+/// understands what each field means.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCard {
+    /// Stable identifier derived from (surface, host, workspace). Filename
+    /// stem in `.treeship/agents/`. Persistent across re-runs.
+    pub agent_id: String,
+    /// Free-form display name. User-editable; defaults to surface display.
+    pub agent_name: String,
+    /// The runtime surface (Claude Code, Cursor, Codex, ...). One of the
+    /// shared discovery enum values.
+    pub surface: AgentSurface,
+    /// Connection modes Treeship intends to use to attach. Multiple modes
+    /// are valid -- Claude Code uses both native-hook and mcp.
+    pub connection_modes: Vec<ConnectionMode>,
+    /// Expected coverage level given the chosen connection modes.
+    pub coverage: CoverageLevel,
+    /// The capabilities that bound this agent's actions.
+    #[serde(default)]
+    pub capabilities: CardCapabilities,
+    /// Where this card came from.
+    pub provenance: CardProvenance,
+    /// Lifecycle status. Drives whether sessions accept this agent.
+    pub status: CardStatus,
+    /// Hostname where this card was created. Stops a card created on a
+    /// laptop from accidentally being used on a remote VM with the same
+    /// surface.
+    pub host: String,
+    /// Workspace this card belongs to. The path of the .treeship dir that
+    /// owned the card when it was created.
+    pub workspace: String,
+    /// Optional model/provider attribution. Distinct from surface --
+    /// Claude Code is a surface, "Anthropic Claude Opus 4.6" is a model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Free-form description / notes. Editable by the user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// SHA-256 digest of the matching `.agent/certificate.json`, if a
+    /// certificate has been registered. Lets `treeship agents review`
+    /// confirm the on-disk cert hasn't drifted from the card's claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certificate_digest: Option<String>,
+    /// ID of the most recent session that involved this agent. None until
+    /// a session closes referencing the card.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_session_id: Option<String>,
+    /// Receipt digest from the latest session involving this agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latest_receipt_digest: Option<String>,
+    /// Creation timestamp (RFC3339).
+    pub created_at: String,
+    /// Last-modified timestamp (RFC3339). Updated on every write.
+    pub updated_at: String,
+}
+
+impl AgentCard {
+    /// Build a draft card from discovery output. Status is always Draft;
+    /// promotion happens through `treeship agents review`.
+    pub fn from_discovery(
+        agent: &DiscoveredAgent,
+        host: &str,
+        workspace: &Path,
+        now: &str,
+    ) -> Self {
+        Self {
+            agent_id:               derive_agent_id(agent.surface, host, workspace),
+            agent_name:             agent.display_name.clone(),
+            surface:                agent.surface,
+            connection_modes:       agent.connection_modes.clone(),
+            coverage:               agent.coverage,
+            capabilities:           CardCapabilities::default(),
+            provenance:             CardProvenance::Discovered,
+            status:                 CardStatus::Draft,
+            host:                   host.to_string(),
+            workspace:              workspace.to_string_lossy().into_owned(),
+            model:                  None,
+            description:            agent.note.clone(),
+            certificate_digest:     None,
+            latest_session_id:      None,
+            latest_receipt_digest:  None,
+            created_at:             now.to_string(),
+            updated_at:             now.to_string(),
+        }
+    }
+}
+
+/// Stable derivation: SHA-256 of "<surface>|<host>|<workspace>", first 16
+/// hex chars prefixed with `agent_`. Same surface on the same host+workspace
+/// always collapses to the same ID, which is what makes idempotent
+/// re-discovery possible.
+pub fn derive_agent_id(surface: AgentSurface, host: &str, workspace: &Path) -> String {
+    let workspace_canon = workspace.to_string_lossy();
+    let mut hasher = Sha256::new();
+    hasher.update(surface.kind().as_bytes());
+    hasher.update(b"|");
+    hasher.update(host.as_bytes());
+    hasher.update(b"|");
+    hasher.update(workspace_canon.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(2 * 16);
+    for byte in &digest[..8] {
+        use std::fmt::Write;
+        write!(hex, "{byte:02x}").unwrap();
+    }
+    format!("agent_{hex}")
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/// Path resolution: the cards directory lives at `<config_dir>/agents/`
+/// where `<config_dir>` is the directory holding the active config.json.
+/// This pairs cards with the keystore they were created against, so a
+/// project-local Treeship gets its own card store and a global one gets
+/// another.
+pub fn agents_dir_for(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("agents")
+}
+
+/// Filename for a card's id. Centralized so callers can't accidentally pick
+/// inconsistent suffixes.
+pub fn card_path(agents_dir: &Path, agent_id: &str) -> PathBuf {
+    agents_dir.join(format!("{agent_id}.json"))
+}
+
+#[derive(Debug)]
+pub enum CardError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    NotFound(String),
+}
+
+impl std::fmt::Display for CardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e)        => write!(f, "card io: {e}"),
+            Self::Json(e)      => write!(f, "card json: {e}"),
+            Self::NotFound(id) => write!(f, "no agent card with id {id:?}"),
+        }
+    }
+}
+
+impl std::error::Error for CardError {}
+impl From<std::io::Error>    for CardError { fn from(e: std::io::Error) -> Self { Self::Io(e) } }
+impl From<serde_json::Error> for CardError { fn from(e: serde_json::Error) -> Self { Self::Json(e) } }
+
+/// Read every `.json` in the cards directory. Returns an empty Vec if the
+/// dir doesn't exist yet -- a fresh Treeship project has no cards.
+pub fn list(agents_dir: &Path) -> Result<Vec<AgentCard>, CardError> {
+    if !agents_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(agents_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = std::fs::read(&path)?;
+        let card: AgentCard = serde_json::from_slice(&bytes)?;
+        out.push(card);
+    }
+    out.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+    Ok(out)
+}
+
+/// Load one card by ID.
+pub fn load(agents_dir: &Path, agent_id: &str) -> Result<AgentCard, CardError> {
+    let path = card_path(agents_dir, agent_id);
+    if !path.exists() {
+        return Err(CardError::NotFound(agent_id.to_string()));
+    }
+    let bytes = std::fs::read(&path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+/// Atomic write: temp file + rename. Permissions stay default (0644) -- the
+/// card itself contains no secrets, only public attribution. The signing
+/// keys behind any registered cert are still in `.treeship/keys/` at 0600.
+pub fn save(agents_dir: &Path, card: &AgentCard) -> Result<(), CardError> {
+    std::fs::create_dir_all(agents_dir)?;
+    let path = card_path(agents_dir, &card.agent_id);
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(card)?;
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Insert-or-update by `agent_id`. If a card exists, fields are merged with
+/// the new values winning; `created_at` is preserved from the existing
+/// record so a re-discovered card doesn't lose its original creation time.
+/// Returns the resulting card.
+pub fn upsert(
+    agents_dir: &Path,
+    incoming: AgentCard,
+    now: &str,
+) -> Result<AgentCard, CardError> {
+    let merged = match load(agents_dir, &incoming.agent_id) {
+        Ok(existing) => AgentCard {
+            created_at:             existing.created_at,
+            updated_at:             now.to_string(),
+            // Preserve user-meaningful state across re-discovery: don't
+            // demote an Active card back to Draft just because a fresh
+            // detection ran.
+            status:                 keep_higher_status(existing.status, incoming.status),
+            // Preserve session linkage: the new card from discovery has
+            // none, but the existing record might.
+            latest_session_id:      existing.latest_session_id.or(incoming.latest_session_id.clone()),
+            latest_receipt_digest:  existing.latest_receipt_digest.or(incoming.latest_receipt_digest.clone()),
+            certificate_digest:     incoming.certificate_digest.clone().or(existing.certificate_digest),
+            ..incoming
+        },
+        Err(CardError::NotFound(_)) => incoming,
+        Err(e) => return Err(e),
+    };
+    save(agents_dir, &merged)?;
+    Ok(merged)
+}
+
+/// Promote a card's status. Returns `Err(CardError::NotFound)` if the card
+/// doesn't exist.
+pub fn set_status(
+    agents_dir: &Path,
+    agent_id: &str,
+    new_status: CardStatus,
+    now: &str,
+) -> Result<AgentCard, CardError> {
+    let mut card = load(agents_dir, agent_id)?;
+    card.status = new_status;
+    card.updated_at = now.to_string();
+    save(agents_dir, &card)?;
+    Ok(card)
+}
+
+/// Delete a card. Returns `Ok(())` even if the file didn't exist -- the
+/// caller's intent is "this card should be gone," and we honor that
+/// idempotently.
+pub fn remove(agents_dir: &Path, agent_id: &str) -> Result<(), CardError> {
+    let path = card_path(agents_dir, agent_id);
+    match std::fs::remove_file(&path) {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Pick the higher of two statuses. Used by `upsert` so re-discovery never
+/// demotes a card.
+fn keep_higher_status(existing: CardStatus, incoming: CardStatus) -> CardStatus {
+    fn rank(s: CardStatus) -> u8 {
+        match s {
+            CardStatus::Draft       => 0,
+            CardStatus::NeedsReview => 1,
+            CardStatus::Active      => 2,
+            CardStatus::Verified    => 3,
+        }
+    }
+    if rank(existing) >= rank(incoming) { existing } else { incoming }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::discovery::{Confidence, ConnectionMode};
+    use tempfile::tempdir;
+
+    fn now() -> &'static str {
+        "2026-04-29T20:00:00Z"
+    }
+
+    fn sample_discovery(surface: AgentSurface) -> DiscoveredAgent {
+        DiscoveredAgent {
+            surface,
+            display_name:     surface.display().to_string(),
+            connection_modes: vec![ConnectionMode::NativeHook, ConnectionMode::Mcp],
+            coverage:         CoverageLevel::High,
+            confidence:       Confidence::High,
+            evidence:         vec![],
+            note:             None,
+        }
+    }
+
+    #[test]
+    fn agent_id_is_stable() {
+        let workspace = Path::new("/home/u/projects/proj-a");
+        let id1 = derive_agent_id(AgentSurface::ClaudeCode, "machine-1", workspace);
+        let id2 = derive_agent_id(AgentSurface::ClaudeCode, "machine-1", workspace);
+        assert_eq!(id1, id2);
+        assert!(id1.starts_with("agent_"));
+    }
+
+    #[test]
+    fn agent_id_changes_with_inputs() {
+        let ws = Path::new("/home/u/projects/proj-a");
+        let base = derive_agent_id(AgentSurface::ClaudeCode, "host", ws);
+        // surface change
+        assert_ne!(base, derive_agent_id(AgentSurface::CursorAgent, "host", ws));
+        // host change
+        assert_ne!(base, derive_agent_id(AgentSurface::ClaudeCode, "other", ws));
+        // workspace change
+        assert_ne!(base, derive_agent_id(AgentSurface::ClaudeCode, "host", Path::new("/elsewhere")));
+    }
+
+    #[test]
+    fn save_load_round_trip() {
+        let dir = tempdir().unwrap();
+        let card = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "test-host",
+            Path::new("/tmp/proj"),
+            now(),
+        );
+        save(dir.path(), &card).unwrap();
+        let loaded = load(dir.path(), &card.agent_id).unwrap();
+        assert_eq!(loaded.agent_id, card.agent_id);
+        assert_eq!(loaded.status, CardStatus::Draft);
+        assert_eq!(loaded.surface, AgentSurface::ClaudeCode);
+    }
+
+    #[test]
+    fn list_returns_sorted() {
+        let dir = tempdir().unwrap();
+        let a = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::CursorAgent),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        let b = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        save(dir.path(), &a).unwrap();
+        save(dir.path(), &b).unwrap();
+        let listed = list(dir.path()).unwrap();
+        assert_eq!(listed.len(), 2);
+        // Sorted by id (sha-derived order, but deterministic).
+        assert!(listed[0].agent_id < listed[1].agent_id);
+    }
+
+    #[test]
+    fn list_on_missing_dir_is_empty() {
+        let dir = tempdir().unwrap();
+        let absent = dir.path().join("nope");
+        assert!(list(&absent).unwrap().is_empty());
+    }
+
+    #[test]
+    fn upsert_does_not_demote_status() {
+        let dir = tempdir().unwrap();
+        // Plant an Active card.
+        let mut active = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        active.status = CardStatus::Active;
+        save(dir.path(), &active).unwrap();
+
+        // Discovery comes back with Draft (the default).
+        let fresh_discovery = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            "2026-04-30T10:00:00Z",
+        );
+        let merged = upsert(dir.path(), fresh_discovery, "2026-04-30T10:00:00Z").unwrap();
+
+        assert_eq!(merged.status, CardStatus::Active);
+        // created_at preserved from the original.
+        assert_eq!(merged.created_at, now());
+        // updated_at advanced.
+        assert_eq!(merged.updated_at, "2026-04-30T10:00:00Z");
+    }
+
+    #[test]
+    fn upsert_promotes_when_incoming_is_higher() {
+        let dir = tempdir().unwrap();
+        let draft = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        save(dir.path(), &draft).unwrap();
+
+        let mut incoming = draft.clone();
+        incoming.status = CardStatus::NeedsReview;
+        let merged = upsert(dir.path(), incoming, now()).unwrap();
+        assert_eq!(merged.status, CardStatus::NeedsReview);
+    }
+
+    #[test]
+    fn upsert_preserves_session_linkage() {
+        let dir = tempdir().unwrap();
+        let mut active = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        active.latest_session_id = Some("ssn_abc".into());
+        active.latest_receipt_digest = Some("sha256:deadbeef".into());
+        save(dir.path(), &active).unwrap();
+
+        let fresh = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        let merged = upsert(dir.path(), fresh, now()).unwrap();
+        assert_eq!(merged.latest_session_id.as_deref(), Some("ssn_abc"));
+        assert_eq!(merged.latest_receipt_digest.as_deref(), Some("sha256:deadbeef"));
+    }
+
+    #[test]
+    fn set_status_promotes() {
+        let dir = tempdir().unwrap();
+        let card = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        save(dir.path(), &card).unwrap();
+        let promoted = set_status(dir.path(), &card.agent_id, CardStatus::Active, "2026-05-01T00:00:00Z").unwrap();
+        assert_eq!(promoted.status, CardStatus::Active);
+        assert_eq!(promoted.updated_at, "2026-05-01T00:00:00Z");
+    }
+
+    #[test]
+    fn set_status_unknown_id_returns_not_found() {
+        let dir = tempdir().unwrap();
+        let err = set_status(dir.path(), "agent_does_not_exist", CardStatus::Active, now())
+            .err()
+            .unwrap();
+        assert!(matches!(err, CardError::NotFound(_)));
+    }
+
+    #[test]
+    fn remove_idempotent() {
+        let dir = tempdir().unwrap();
+        let card = AgentCard::from_discovery(
+            &sample_discovery(AgentSurface::ClaudeCode),
+            "h",
+            Path::new("/tmp/p"),
+            now(),
+        );
+        save(dir.path(), &card).unwrap();
+        remove(dir.path(), &card.agent_id).unwrap();
+        // Second call must not error.
+        remove(dir.path(), &card.agent_id).unwrap();
+        // And the file is actually gone.
+        assert!(!card_path(dir.path(), &card.agent_id).exists());
+    }
+
+    #[test]
+    fn agents_dir_is_sibling_of_config() {
+        let cfg = Path::new("/var/data/.treeship/config.json");
+        assert_eq!(agents_dir_for(cfg), Path::new("/var/data/.treeship/agents"));
+    }
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -19,6 +19,8 @@ pub mod otel;
 pub mod template;
 pub mod add;
 pub mod agent;
+pub mod agents;
+pub mod cards;
 pub mod discovery;
 pub mod declare;
 pub mod package;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -227,6 +227,20 @@ enum Command {
     #[command(subcommand)]
     Agent(AgentCommand),
 
+    /// Manage the local Agent Card store
+    ///
+    /// Cards are workspace trust objects -- who an agent is, where it
+    /// runs, how Treeship is attached. Distinct from the .agent package
+    /// (signed identity certificate produced by `treeship agent register`).
+    ///
+    /// Examples:
+    ///   treeship agents               # list every card
+    ///   treeship agents review <id>   # show full card details
+    ///   treeship agents approve <id>  # promote to active
+    ///   treeship agents remove <id>   # delete the card
+    #[command(subcommand)]
+    Agents(AgentsCommand),
+
     /// List pending approvals
     ///
     /// Shows actions that are blocked waiting for human approval.
@@ -757,6 +771,23 @@ struct AddArgs {
 enum AgentCommand {
     /// Register an agent and create an Identity Certificate
     Register(AgentRegisterArgs),
+}
+
+// --- agents (card store) ---------------------------------------------------
+
+#[derive(Subcommand)]
+enum AgentsCommand {
+    /// List every Agent Card in the workspace's card store.
+    List,
+
+    /// Show full details of one Agent Card by id.
+    Review { agent_id: String },
+
+    /// Promote a Draft or NeedsReview card to Active.
+    Approve { agent_id: String },
+
+    /// Delete an Agent Card from the store. Idempotent.
+    Remove { agent_id: String },
 }
 
 #[derive(Args)]
@@ -1648,6 +1679,30 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 a.description.clone(),
                 a.forbidden.clone(),
                 a.escalation.clone(),
+                cli.config.as_deref(),
+                printer,
+            ),
+        },
+
+        Command::Agents(sub) => match sub {
+            AgentsCommand::List => commands::agents::list(
+                cli.config.as_deref(),
+                Format::from_str(&cli.format),
+                printer,
+            ),
+            AgentsCommand::Review { agent_id } => commands::agents::review(
+                agent_id,
+                cli.config.as_deref(),
+                Format::from_str(&cli.format),
+                printer,
+            ),
+            AgentsCommand::Approve { agent_id } => commands::agents::approve(
+                agent_id,
+                cli.config.as_deref(),
+                printer,
+            ),
+            AgentsCommand::Remove { agent_id } => commands::agents::remove(
+                agent_id,
                 cli.config.as_deref(),
                 printer,
             ),


### PR DESCRIPTION
Second of six PRs for **v0.9.8 — Agents Become Legible**. Builds directly on PR 1 (#43): same `AgentSurface` / `ConnectionMode` / `CoverageLevel` enums power both detection and the new card store, no schema fork.

## The split this PR makes explicit

```
Agent Harness   how Treeship attaches (hooks, MCP, shell-wrap)
Agent Card      who an agent is, what it is allowed to do  ← this PR
Session Report  what the agent actually did                ← PR 5
Receipt         deterministic proof                        (already exists)
```

## Architectural call (matches PR 1)

Extends the existing `treeship agent register` flow rather than forking. Registration now produces both the `.agent` package (signed certificate, portable) AND a card (workspace inventory, local trust object). One schema, no fork.

## What this PR adds

**`commands/cards.rs`** — pure card store, 12 unit tests:
- `CardStatus`: Draft → NeedsReview → Active → Verified
- `CardProvenance`: Discovered | Registered | Manual
- `CardCapabilities`: bounded_tools / escalation_required / forbidden — same vocabulary as v0.9.6 `ApprovalScope`
- `AgentCard` with deterministic `agent_id = sha256("<surface>|<host>|<workspace>")[..8]` — re-running discovery is idempotent
- Atomic save (tmp + rename), list, load, upsert, set_status, remove
- `upsert` preserves higher status (Active never demotes to Draft) and preserves session linkage across re-discovery

**`commands/agents.rs`** — CLI surface:
- `treeship agents list` — text + JSON
- `treeship agents review <id>` — full card details
- `treeship agents approve <id>` — Draft/NeedsReview → Active
- `treeship agents remove <id>` — idempotent

`Verified` is intentionally **not** a manual flag. It's set programmatically by PR 3's `treeship setup` once a smoke session proves capture. The word "verified" must mean Treeship checked something, not the user toggled something.

**`agent register`** — now writes a card:
- After producing the `.agent` package, registers a card with `provenance: Registered` and `status: NeedsReview`
- Pins the certificate digest (sha256 of `certificate.json`) on the card so future tamper detection can flag drift
- Maps `--name` to the canonical `AgentSurface`; unknown names fall through to `ShellWrap` so the feature still works for custom agents
- Existing `.agent` package output unchanged

## Demo

```
$ treeship agent register --name claude-code --tools read_file,write_file,bash --valid-days 30

✓ agent certificate created
  agent:      claude-code
  ship:       ship_9335ade532882ef4
  tools:      3
  valid:      30 days (until 2026-05-30T...)
  package:    /tmp/proj/claude-code.agent
  card:       agent_b95cf24a2fdcfeb9 (needs-review)

   → open /tmp/proj/claude-code.agent/certificate.html
  review with: treeship agents review agent_b95cf24a2fdcfeb9

$ treeship agents list

Agent cards (/tmp/proj/.treeship/agents)

  ? claude-code  (claude-code)
    id:         agent_b95cf24a2fdcfeb9
    status:     needs-review
    coverage:   high
    provenance: registered

$ treeship agents approve agent_b95cf24a2fdcfeb9

✓ approved claude-code
  status:  active

$ treeship agents list --format json | jq '.cards[0].status'
"active"
```

## Tests

- 12 new unit tests in `cards.rs`
- 8 discovery tests from PR 1 still green
- 4 config tests from v0.9.7 still green
- Workspace cargo test: 51 passed
- Acceptance smoke (`tests/acceptance/trust-fabric.sh`): green
- Full lifecycle smoke against real CLI binary (init → register → list → review → approve → JSON → remove): green

## Out of scope (later PRs)

- **PR 3:** `treeship setup` orchestration (discover → draft cards → confirm → instrument → smoke → Verified)
- **PR 4:** integration template profiles per surface
- **PR 5:** Agent Card panel + coverage badges in session reports
- **PR 6:** first-run docs

## Test plan

- [x] `cargo test --workspace` green (51 cli tests)
- [x] `bash tests/acceptance/trust-fabric.sh` green
- [x] `python3 scripts/check-release-versions.py --consistency` green
- [x] Manual lifecycle smoked end-to-end against real binary
- [x] Existing `treeship agent register` UX preserved (only adds new card line in output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)