### PR TITLE
feat(cli): v0.9.8 PR 3 — treeship setup orchestration

### DIFF
--- a/packages/cli/src/commands/agent.rs
+++ b/packages/cli/src/commands/agent.rs
@@ -85,13 +85,6 @@ fn now_rfc3339() -> String {
     treeship_core::statements::unix_to_rfc3339(secs)
 }
 
-fn local_hostname() -> String {
-    // Falling back to "local" is safe because the agent ID derivation also
-    // uses workspace path; collisions would have to share both.
-    std::env::var("HOSTNAME")
-        .or_else(|_| std::env::var("COMPUTERNAME"))
-        .unwrap_or_else(|_| "local".to_string())
-}
 
 /// Register an agent and produce a .agent package.
 pub fn register(
@@ -223,7 +216,7 @@ pub fn register(
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .to_path_buf();
-    let host = local_hostname();
+    let host = cards::local_hostname();
     let (surface, connection_modes, coverage) = surface_from_name(name);
     let agent_id = cards::derive_agent_id(surface, &host, &workspace);
 

--- a/packages/cli/src/commands/cards.rs
+++ b/packages/cli/src/commands/cards.rs
@@ -201,6 +201,16 @@ impl AgentCard {
     }
 }
 
+/// Best-effort local hostname for use in agent_id derivation. Falls back
+/// to "local" when neither HOSTNAME nor COMPUTERNAME is set; collisions
+/// only happen if (surface, "local", workspace_path) repeats, which means
+/// the same workspace anyway.
+pub fn local_hostname() -> String {
+    std::env::var("HOSTNAME")
+        .or_else(|_| std::env::var("COMPUTERNAME"))
+        .unwrap_or_else(|_| "local".to_string())
+}
+
 /// Stable derivation: SHA-256 of "<surface>|<host>|<workspace>", first 16
 /// hex chars prefixed with `agent_`. Same surface on the same host+workspace
 /// always collapses to the same ID, which is what makes idempotent

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod agent;
 pub mod agents;
 pub mod cards;
 pub mod discovery;
+pub mod setup;
 pub mod declare;
 pub mod package;
 pub mod prove;

--- a/packages/cli/src/commands/setup.rs
+++ b/packages/cli/src/commands/setup.rs
@@ -1,0 +1,453 @@
+//! `treeship setup` -- guided first-run orchestration.
+//!
+//! Composition over the existing PR 1 / PR 2 modules:
+//!
+//!   1. `init` (delegated) if the user has no Treeship config yet
+//!   2. `discovery::discover` (PR 1) to find local agents
+//!   3. `cards::upsert` (PR 2) to write Draft cards for each detection
+//!   4. confirm with the user before instrumenting (or `--yes`)
+//!   5. delegate to existing `add::run` for actual config writes
+//!   6. optional smoke session that proves Treeship can capture; on success,
+//!      promote the matching card's status to `Verified`
+//!
+//! `setup` deliberately doesn't have its own detector or its own
+//! instrumenter. Adding either would re-introduce the "two of these
+//! exist now" problem that PRs 1 and 2 closed.
+//!
+//! Verification semantics: `Verified` means a smoke session proved
+//! Treeship can capture session events end-to-end on this machine, against
+//! a real isolated keystore. It is *not* a claim about the live agent
+//! itself doing the right thing -- v0.9.8 has no global identity check.
+//! The verify pass output preserves this honesty.
+
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcCommand;
+
+use crate::commands::cards::{self, AgentCard, CardStatus};
+use crate::commands::discovery::{self, DiscoveredAgent, Env};
+use crate::ctx;
+use crate::printer::Printer;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub struct SetupOpts {
+    /// Skip the confirmation prompt before instrumenting. Equivalent to
+    /// `treeship add --all`.
+    pub yes: bool,
+    /// Skip the smoke verification pass. Useful in CI sandboxes that
+    /// can't fork another Treeship binary, and as a fast escape hatch
+    /// for users who only want detection + cards.
+    pub skip_smoke: bool,
+    /// Skip instrumentation entirely -- only detect + draft cards.
+    pub no_instrument: bool,
+}
+
+impl Default for SetupOpts {
+    fn default() -> Self {
+        Self {
+            yes:           false,
+            skip_smoke:    false,
+            no_instrument: false,
+        }
+    }
+}
+
+/// `treeship setup` entry point.
+pub fn run(
+    config: Option<&str>,
+    opts: SetupOpts,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    printer.blank();
+    printer.section("Treeship setup");
+    printer.blank();
+
+    // Step 1: ensure init. We don't auto-run it -- the user invoked setup
+    // for a reason and might have a project-local keystore expectation;
+    // surfacing the missing config and pointing at `init` is friendlier
+    // than silently creating a global one.
+    let ctx_result = ctx::open(config);
+    let ctx = match ctx_result {
+        Ok(c) => c,
+        Err(_) => {
+            printer.warn("  Treeship is not initialized in this workspace.", &[]);
+            printer.blank();
+            printer.hint("Run: treeship init   (or `treeship init --config <path>` for a project-local config)");
+            printer.dim_info("  After init, re-run `treeship setup` and Treeship will pick up where you left off.");
+            printer.blank();
+            return Ok(());
+        }
+    };
+    printer.dim_info(&format!("  config:    {}", ctx.config_path.display()));
+    printer.dim_info(&format!("  ship:      {}", ctx.config.ship_id));
+
+    // Step 2: discover local agents.
+    let env = Env::current();
+    let agents = discovery::discover(&env);
+
+    if agents.is_empty() {
+        printer.blank();
+        printer.dim_info("  No agents detected on this machine.");
+        printer.blank();
+        printer.hint("Treeship still works -- start a session with `treeship session start` and wrap commands with `treeship wrap`.");
+        printer.blank();
+        return Ok(());
+    }
+
+    // Step 3: write draft cards for everything we found. Idempotent --
+    // re-running setup never loses Active/Verified cards or their session
+    // linkage (see cards::upsert).
+    let agents_dir = cards::agents_dir_for(&ctx.config_path);
+    let workspace = ctx
+        .config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let host = cards::local_hostname();
+    let now = now_rfc3339();
+
+    let mut written: Vec<AgentCard> = Vec::new();
+    for agent in &agents {
+        let card = AgentCard::from_discovery(agent, &host, &workspace, &now);
+        match cards::upsert(&agents_dir, card, &now) {
+            Ok(merged) => written.push(merged),
+            Err(e) => printer.warn(
+                &format!("could not save card for {}", agent.display_name),
+                &[("error", &e.to_string())],
+            ),
+        }
+    }
+
+    print_detection_summary(&written, printer);
+
+    if opts.no_instrument {
+        printer.dim_info("  --no-instrument set; skipping instrumentation and smoke.");
+        printer.blank();
+        printer.hint("Approve cards manually with `treeship agents review <id>` then `treeship agents approve <id>`.");
+        printer.blank();
+        return Ok(());
+    }
+
+    // Step 4: confirm.
+    let confirmed = if opts.yes {
+        true
+    } else if io::stdin().is_terminal_lite() {
+        prompt_yes_no("Instrument these agents now? (Y/n): ", true)
+    } else {
+        // Non-interactive (no --yes, no TTY). Be conservative: only write
+        // cards, never instrument silently.
+        false
+    };
+
+    if !confirmed {
+        printer.dim_info("  Skipping instrumentation. Run `treeship add` or re-run `treeship setup --yes` later.");
+        printer.blank();
+        return Ok(());
+    }
+
+    // Step 5: delegate to existing `add::run`. Same instrumenter as
+    // `treeship add`, no fork.
+    printer.blank();
+    printer.section("Instrumenting");
+    printer.blank();
+    let names_for_add: Vec<String> = written
+        .iter()
+        // Only instrument agents we actually have an instrumentation path
+        // for. SuperNinja (remote VM) and GenericMcp/ShellWrap fall through
+        // to their cards but `add::run` won't recognize them as installable
+        // names today; passing them would just be a no-op printed warning.
+        .filter(|c| matches!(
+            c.surface,
+            discovery::AgentSurface::ClaudeCode
+            | discovery::AgentSurface::CursorAgent
+            | discovery::AgentSurface::Cline
+            | discovery::AgentSurface::Codex
+            | discovery::AgentSurface::Hermes
+            | discovery::AgentSurface::OpenClaw
+        ))
+        .map(|c| match c.surface {
+            discovery::AgentSurface::ClaudeCode  => "claude-code".to_string(),
+            discovery::AgentSurface::CursorAgent => "cursor".to_string(),
+            discovery::AgentSurface::Cline       => "cline".to_string(),
+            discovery::AgentSurface::Codex       => "codex".to_string(),
+            discovery::AgentSurface::Hermes      => "hermes".to_string(),
+            discovery::AgentSurface::OpenClaw    => "openclaw".to_string(),
+            // unreachable thanks to the filter above
+            _                                    => String::new(),
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut instrumented_cards: Vec<&AgentCard> = Vec::new();
+    if names_for_add.is_empty() {
+        printer.dim_info("  No agents in this set have an automated instrumenter yet.");
+    } else {
+        // `add::run` takes ownership of stdout for its own printing; let
+        // it run. `--all` (true) skips its prompt since we already asked.
+        crate::commands::add::run(names_for_add, true, false, printer)?;
+        // Promote instrumented Draft cards to NeedsReview. The user just
+        // confirmed they want Treeship attached to these agents -- the
+        // card status should reflect "something to review" rather than
+        // "yet to be looked at." Smoke (next step) pushes them further to
+        // Verified.
+        instrumented_cards = written
+            .iter()
+            .filter(|c| matches!(
+                c.surface,
+                discovery::AgentSurface::ClaudeCode
+                | discovery::AgentSurface::CursorAgent
+                | discovery::AgentSurface::Cline
+                | discovery::AgentSurface::Codex
+                | discovery::AgentSurface::Hermes
+                | discovery::AgentSurface::OpenClaw
+            ))
+            .collect();
+        for card in &instrumented_cards {
+            if card.status == CardStatus::Draft {
+                if let Err(e) = cards::set_status(
+                    &agents_dir,
+                    &card.agent_id,
+                    CardStatus::NeedsReview,
+                    &now_rfc3339(),
+                ) {
+                    printer.warn(
+                        &format!("could not promote {} to needs-review", card.agent_id),
+                        &[("error", &e.to_string())],
+                    );
+                }
+            }
+        }
+    }
+
+    // Step 6: smoke verify.
+    if opts.skip_smoke {
+        let final_cards = cards::list(&agents_dir).unwrap_or(written.clone());
+        print_complete(&final_cards, false, printer);
+        return Ok(());
+    }
+
+    let smoke_ok = match run_smoke_session(printer) {
+        Ok(()) => true,
+        Err(e) => {
+            printer.warn(
+                "smoke session did not complete; cards stay at draft / needs-review",
+                &[("error", &e.to_string())],
+            );
+            false
+        }
+    };
+
+    if smoke_ok {
+        // Smoke proved Treeship can capture on this machine. Promote
+        // every instrumented card straight to Verified. Cards we did not
+        // instrument (SuperNinja remote, generic-mcp without a known
+        // surface) stay at Draft -- smoke can't speak for them.
+        for card in &instrumented_cards {
+            if let Err(e) = cards::set_status(
+                &agents_dir,
+                &card.agent_id,
+                CardStatus::Verified,
+                &now_rfc3339(),
+            ) {
+                printer.warn(
+                    &format!("could not promote {} to verified", card.agent_id),
+                    &[("error", &e.to_string())],
+                );
+            }
+        }
+    }
+
+    // Re-read from disk so the summary reflects the latest status after
+    // any promotions we just made.
+    let final_cards = match cards::list(&agents_dir) {
+        Ok(list) => list,
+        Err(_) => written,
+    };
+    print_complete(&final_cards, smoke_ok, printer);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Smoke session
+// ---------------------------------------------------------------------------
+
+/// Run the same end-to-end round-trip the `tests/acceptance/trust-fabric.sh`
+/// suite uses: init, session start, wrap, session close, package verify.
+/// Runs entirely inside a tmpdir keystore so it never touches the user's
+/// real config or artifacts.
+///
+/// What this proves: Treeship's hooks, signing pipeline, session log,
+/// package emission, and verify pass all work on this machine. It does
+/// NOT prove that any specific instrumented agent will produce capture
+/// (the user has to run a real session for that). The note on the
+/// completion screen says so.
+fn run_smoke_session(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    let exe = std::env::current_exe()?;
+    let workspace = tempfile::tempdir()?;
+    let cfg = workspace.path().join(".treeship").join("config.json");
+
+    printer.blank();
+    printer.section("Smoke session");
+    printer.dim_info(&format!("  workspace: {}", workspace.path().display()));
+    printer.dim_info("  isolated tmpdir keystore -- doesn't touch your real config");
+
+    // Run every smoke subcommand inside the workspace tmpdir so cwd and
+    // config agree on where session state lives. Mixing cwds caused
+    // `session close` to mis-locate session.json during setup smoke.
+    let ws = workspace.path();
+    run_subcommand_in(ws, &exe, &["init", "--config", to_str(&cfg), "--name", "setup-smoke"])?;
+    run_subcommand_in(ws, &exe, &["session", "start", "--config", to_str(&cfg), "--name", "setup-smoke"])?;
+    run_subcommand_in(ws, &exe, &["wrap", "--config", to_str(&cfg), "--action", "setup.smoke", "--", "true"])?;
+    run_subcommand_in(ws, &exe, &["session", "close", "--config", to_str(&cfg), "--summary", "setup smoke ok"])?;
+    let pkg = find_recent_package(ws)?;
+    run_subcommand_in(ws, &exe, &["package", "verify", "--config", to_str(&cfg), &pkg.to_string_lossy()])?;
+
+    printer.dim_info("  ✓ smoke session captured and verified");
+    Ok(())
+}
+
+fn to_str(p: &Path) -> &str {
+    // Setup paths are tmpdirs we created; UTF-8 is fine on every OS we
+    // build for. Falling back to "" would just produce a confusing error
+    // downstream, so panic loudly here if the platform invariant breaks.
+    p.to_str().expect("tmpdir path must be UTF-8")
+}
+
+fn run_subcommand_in(cwd: &Path, exe: &Path, args: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+    let output = ProcCommand::new(exe)
+        .current_dir(cwd)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let summary = stderr.lines().last().unwrap_or("(no stderr)").to_string();
+        return Err(format!(
+            "{} {}: exit {} -- {}",
+            exe.display(),
+            args.join(" "),
+            output.status,
+            summary
+        )
+        .into());
+    }
+    Ok(())
+}
+
+fn find_recent_package(workspace: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let sessions = workspace.join(".treeship").join("sessions");
+    if !sessions.is_dir() {
+        return Err(format!("smoke session produced no .treeship/sessions/ at {}", sessions.display()).into());
+    }
+    let mut best: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(&sessions)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("treeship") {
+            continue;
+        }
+        let mtime = entry.metadata()?.modified()?;
+        match &best {
+            Some((t, _)) if *t >= mtime => {}
+            _ => best = Some((mtime, path)),
+        }
+    }
+    best.map(|(_, p)| p).ok_or_else(|| {
+        format!("no .treeship session package found under {}", sessions.display()).into()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+fn print_detection_summary(cards_list: &[AgentCard], printer: &Printer) {
+    printer.blank();
+    printer.section("Detected agents");
+    printer.blank();
+    for card in cards_list {
+        let mark = match card.status {
+            CardStatus::Verified | CardStatus::Active => "✓",
+            CardStatus::NeedsReview                   => "?",
+            CardStatus::Draft                         => "·",
+        };
+        printer.info(&format!(
+            "  {mark} {}  ({}, coverage: {})",
+            card.agent_name,
+            card.surface.kind(),
+            card.coverage.label(),
+        ));
+    }
+}
+
+fn print_complete(cards_list: &[AgentCard], smoke_ok: bool, printer: &Printer) {
+    printer.blank();
+    printer.success("Treeship setup complete", &[]);
+    printer.blank();
+    printer.info("  Agents:");
+    for card in cards_list {
+        printer.info(&format!(
+            "    {}    {} ({})",
+            card.surface.kind(),
+            match card.status {
+                CardStatus::Verified    => "verified",
+                CardStatus::Active      => "active",
+                CardStatus::NeedsReview => "needs review",
+                CardStatus::Draft       => "draft",
+            },
+            card.coverage.label(),
+        ));
+    }
+    printer.blank();
+    if smoke_ok {
+        printer.dim_info("  Smoke session proved Treeship can capture on this machine.");
+        printer.dim_info("  Live-agent capture only proven when you run a real session.");
+    } else {
+        printer.dim_info("  Smoke session skipped or failed; cards remain at draft / needs-review.");
+    }
+    printer.blank();
+    printer.hint("Next: treeship session start --name \"first run\"");
+    printer.blank();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    treeship_core::statements::unix_to_rfc3339(secs)
+}
+
+fn prompt_yes_no(prompt: &str, default_yes: bool) -> bool {
+    print!("  {prompt}");
+    io::stdout().flush().ok();
+    let mut buf = String::new();
+    if io::stdin().read_line(&mut buf).is_err() {
+        return default_yes;
+    }
+    let trimmed = buf.trim().to_lowercase();
+    if trimmed.is_empty() {
+        return default_yes;
+    }
+    matches!(trimmed.as_str(), "y" | "yes")
+}
+
+/// Tiny shim so callers don't need to import `IsTerminal` themselves;
+/// also gives us one place to switch the implementation if we move to
+/// `crossterm::tty::IsTty` later.
+trait IsTerminalLite {
+    fn is_terminal_lite(&self) -> bool;
+}
+
+impl<T: io::IsTerminal> IsTerminalLite for T {
+    fn is_terminal_lite(&self) -> bool {
+        self.is_terminal()
+    }
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -241,6 +241,23 @@ enum Command {
     #[command(subcommand)]
     Agents(AgentsCommand),
 
+    /// Guided first-run setup -- detect agents, draft cards, instrument, smoke verify
+    ///
+    /// One command for the typical first-run flow:
+    ///   1. detect agents on this machine
+    ///   2. write a draft Agent Card for each (idempotent on re-run)
+    ///   3. confirm before modifying any agent's config
+    ///   4. instrument those agents (Treeship MCP, hooks, skill files)
+    ///   5. run a smoke session to prove Treeship can capture
+    ///   6. promote cards to Verified on smoke success
+    ///
+    /// Examples:
+    ///   treeship setup
+    ///   treeship setup --yes               # non-interactive, instrument all
+    ///   treeship setup --skip-smoke        # cards + instrumentation only
+    ///   treeship setup --no-instrument     # cards only, no config writes
+    Setup(SetupArgs),
+
     /// List pending approvals
     ///
     /// Shows actions that are blocked waiting for human approval.
@@ -788,6 +805,23 @@ enum AgentsCommand {
 
     /// Delete an Agent Card from the store. Idempotent.
     Remove { agent_id: String },
+}
+
+// --- setup -----------------------------------------------------------------
+
+#[derive(Args)]
+struct SetupArgs {
+    /// Skip the confirmation prompt before instrumenting.
+    #[arg(long)]
+    yes: bool,
+
+    /// Skip the smoke verification pass after instrumentation.
+    #[arg(long)]
+    skip_smoke: bool,
+
+    /// Detect + draft cards only -- do not modify any agent config files.
+    #[arg(long)]
+    no_instrument: bool,
 }
 
 #[derive(Args)]
@@ -1683,6 +1717,16 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 printer,
             ),
         },
+
+        Command::Setup(a) => commands::setup::run(
+            cli.config.as_deref(),
+            commands::setup::SetupOpts {
+                yes:           a.yes,
+                skip_smoke:    a.skip_smoke,
+                no_instrument: a.no_instrument,
+            },
+            printer,
+        ),
 
         Command::Agents(sub) => match sub {
             AgentsCommand::List => commands::agents::list(


### PR DESCRIPTION
Third of six PRs for **v0.9.8 — Agents Become Legible**. Composes PR 1 (#43) discovery and PR 2 (#44) card store with the existing `treeship add` instrumenter and a small smoke session.

## Architectural call (consistent with PRs 1 and 2)

Setup is **glue, not a third detector** and **not a third instrumenter**. It calls into:

| Step | Module | What it does |
|---|---|---|
| 1. Detect | `discovery::discover` (PR 1) | Find local agents |
| 2. Draft cards | `cards::upsert` (PR 2) | Idempotent on re-run, never demotes Active/Verified |
| 3. Confirm | local prompt or `--yes` | Non-interactive defaults to "no" so CI never touches user configs |
| 4. Instrument | `add::run` (existing) | The same instrumenter `treeship add` already uses |
| 5. Smoke | tempdir self-fork | init → session start → wrap → close → package verify |
| 6. Promote | `cards::set_status` | Draft → NeedsReview (instrumented) → Verified (smoke proven) |

Same "extend, don't fork" pattern as PRs 1 and 2. No new detection rules, no new instrumentation rules.

## Lifecycle (matches the v0.9.8 spec)

```
Discovered    →  Draft
Instrumented  →  NeedsReview     ("now there's something to review")
Smoke proves  →  Verified         ("Treeship can capture on this machine")
Manual deny   →  stays Draft
SuperNinja /  →  stays Draft      (Treeship can't speak for remote VMs)
remote-only        regardless of smoke
```

## What this PR adds

**`commands/setup.rs`** — `treeship setup` entry point with:
- `--yes` skip the confirmation prompt
- `--skip-smoke` cards + instrumentation only
- `--no-instrument` detect + draft cards only, no config writes
- Non-interactive without `--yes` defaults to a safe "no"
- Filters instrumentation to surfaces `add::run` actually knows about today (claude-code, cursor, cline, codex, hermes, openclaw); other surfaces stay drafted but uninstrumented

**Smoke session** — mirrors `tests/acceptance/trust-fabric.sh` end-to-end inside a tempdir keystore. All subcommands run with the same tempdir cwd so `session.json` / `sessions/` / `package verify` agree on file locations. On failure, surfaces a stderr-tail summary; cards stay at Draft / NeedsReview. "Verified" only ever means Treeship checked something.

**Tiny refactor**: hoists `local_hostname()` from `agent.rs` into `cards.rs` as public so `agent register` and `setup` use the same function.

If no config exists, `setup` does **not** auto-init. It points at `treeship init` instead — silently creating a global config when the user might have expected project-local would be a surprise.

## Demo (real machine, 5 surfaces detected)

```
$ treeship setup --no-instrument
Detected agents
  · Claude Code  (claude-code, coverage: high)
  · Cursor       (cursor-agent, coverage: medium)
  · Codex CLI    (codex, coverage: medium)
  · OpenClaw     (openclaw, coverage: medium)
  · SuperNinja   (ninjatech-superninja, coverage: basic)
  --no-instrument set; skipping instrumentation and smoke.

$ treeship setup --yes --skip-smoke
✓ Treeship setup complete
  Agents:
    claude-code           needs review (high)
    cursor-agent          needs review (medium)
    codex                 needs review (medium)
    openclaw              needs review (medium)
    ninjatech-superninja  draft (basic)

$ treeship setup --yes
Smoke session
  workspace: /tmp/.tmpx4dMtk
  isolated tmpdir keystore -- doesn't touch your real config
  ✓ smoke session captured and verified

✓ Treeship setup complete
  Agents:
    claude-code           verified (high)
    cursor-agent          verified (medium)
    codex                 verified (medium)
    openclaw              verified (medium)
    ninjatech-superninja  draft (basic)

  Smoke session proved Treeship can capture on this machine.
  Live-agent capture only proven when you run a real session.
```

## Tests

- 8 discovery tests (PR 1) still green
- 15 card store tests (PR 2 + drift fix) still green
- Workspace `cargo test`: 51 passed
- `bash tests/acceptance/trust-fabric.sh`: green
- `python3 scripts/check-release-versions.py --consistency`: 21/21
- End-to-end smoke against real binary: **all three setup modes** drive the lifecycle correctly (no-instrument → 5 drafts; --skip-smoke → 4 needs-review + SuperNinja draft; --yes → 4 verified + SuperNinja draft)

## Out of scope

- **PR 4:** integration template profiles per surface (the instrumenter currently has hardcoded paths for the 6 known surfaces; templates pull this into a data table)
- **PR 5:** Agent Card panel + coverage badges in session reports
- **PR 6:** first-run docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)