### PR TITLE
feat(cli,docs): v0.9.8 PR 6 — report polish + first-run docs

### DIFF
--- a/docs/content/docs/concepts/agent-cards.mdx
+++ b/docs/content/docs/concepts/agent-cards.mdx
@@ -1,0 +1,106 @@
+---
+title: Agent Cards
+description: Workspace trust objects that describe who an agent is, what it's allowed to do, and which harness it uses.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+An **Agent Card** is the local trust object Treeship keeps about a specific agent in a specific workspace. Cards make agents *accountable*: they capture identity (who the agent is, where it runs, what model is behind it), authorization (which tools it may call, which require human approval, which are forbidden), and the lifecycle status of that local trust decision.
+
+Cards are distinct from three other things they're often confused with:
+
+| Object | What it is | Where it lives |
+|---|---|---|
+| **Harness** | How Treeship attaches to and observes the agent (hooks, MCP, shell-wrap) | Workspace (`.treeship/harnesses/<id>.json`) |
+| **Agent Card** | Who the agent is, what it's allowed, which harness it uses | Workspace (`.treeship/agents/<id>.json`) |
+| **`.agent` package** | Signed Agent Identity Certificate — a portable credential | Anywhere (you ship it) |
+| **Receipt** | Deterministic proof of what the agent actually did in one session | Workspace `.treeship/sessions/<id>.treeship` |
+
+## Card lifecycle
+
+```
+Draft  →  NeedsReview  →  Active  →  Verified
+```
+
+| Status | What it means |
+|---|---|
+| **Draft** | Treeship discovered an agent but the user has not approved attaching to it. Setup writes draft cards on first detection. |
+| **NeedsReview** | Either (a) the user ran `treeship agent register` so a signed certificate exists, or (b) the certificate digest changed under an existing card and we demoted it for re-review. The user has not yet confirmed. |
+| **Active** | The user approved the card via `treeship agents approve` or via `treeship setup --yes` for an instrumented harness. Treeship will use this card during sessions. |
+| **Verified** | A harness-specific smoke proved Treeship can capture the agent's actions on this machine. Reserved for v0.9.9+ per-harness smokes; setup's generic smoke does **not** flip cards to Verified. |
+
+<Callout type="info">
+**Verified is set programmatically, not manually.** There is no `treeship agents verify` flag. The word "verified" must mean Treeship checked something specific, not that the user toggled it.
+</Callout>
+
+## Card shape on disk
+
+```json
+{
+  "agent_id": "agent_b95cf24a2fdcfeb9",
+  "agent_name": "Claude Code",
+  "surface": "claude-code",
+  "connection_modes": ["native-hook", "mcp"],
+  "coverage": "high",
+  "capabilities": {
+    "bounded_tools": ["read_file", "write_file", "bash"],
+    "escalation_required": [],
+    "forbidden": []
+  },
+  "provenance": "discovered",
+  "status": "active",
+  "host": "MacBook-Pro.local",
+  "workspace": "/Users/me/projects/treeship/.treeship",
+  "active_harness_id": "claude-code",
+  "certificate_digest": "sha256:1ed78740...",
+  "created_at": "2026-04-30T03:09:50Z",
+  "updated_at": "2026-04-30T03:11:02Z"
+}
+```
+
+`agent_id` is deterministic from `(surface, host, workspace)` so re-running discovery produces the same card; setup is idempotent.
+
+## Provenance
+
+A card carries `provenance` so consumers can tell which surface authored it:
+
+- **`discovered`** — Treeship found the agent on disk via `treeship add --discover` / `treeship setup`.
+- **`registered`** — `treeship agent register` produced a signed `.agent` package. The card pins `certificate_digest` for tamper detection.
+- **`manual`** — User added the card with `treeship agent add --kind <kind>` for a surface that isn't auto-discoverable (remote VMs, generic-mcp wrappers).
+
+## Certificate digest drift
+
+If a card's `provenance` is `registered` and the user re-registers with different tools or scope, the resulting certificate has a different digest. Treeship demotes the card from Active or Verified back to **NeedsReview** on drift — silently keeping it Active would let `treeship agents` claim a certificate the user never approved.
+
+```
+$ treeship agent register --name claude-code --tools read_file --valid-days 30
+✓ card: needs-review
+
+$ treeship agents approve agent_xxx
+✓ status: active
+
+$ treeship agent register --name claude-code --tools read_file,write_file,bash --valid-days 60
+✓ card: needs-review     ← demoted on cert digest change
+```
+
+## Working with cards
+
+```bash
+treeship agents              # list every card with status + harness
+treeship agents review <id>  # full details
+treeship agents approve <id> # Draft / NeedsReview → Active
+treeship agents remove <id>  # delete the card
+```
+
+JSON output is stable for scripting:
+
+```bash
+treeship agents --format json | jq '.cards[] | select(.status=="active")'
+```
+
+## See also
+
+- [Agent Harnesses](/docs/concepts/harnesses)
+- [Coverage levels](/docs/guides/coverage-levels)
+- [`treeship setup`](/docs/cli/setup) — guided first-run flow that writes cards
+- [`treeship agent register`](/docs/cli/agent) — produce a signed `.agent` package alongside the card

--- a/docs/content/docs/concepts/harnesses.mdx
+++ b/docs/content/docs/concepts/harnesses.mdx
@@ -1,0 +1,127 @@
+---
+title: Agent Harnesses
+description: How Treeship attaches to and observes each agent surface. The differentiator behind Verified coverage.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A **harness** is how Treeship attaches to and observes a specific agent surface. Native hooks for Claude Code, an MCP bridge for Cursor / Codex / Cline, skill files for Hermes / OpenClaw, shell-wrap for any custom agent, git-reconcile as the universal backstop. Harnesses make agents *observable*.
+
+Cards describe **who** an agent is. Harnesses describe **how** Treeship is attached to it. The two stay distinct on purpose: the same surface (Claude Code) might one day have multiple harnesses (native hook vs MCP-only), and the same harness will instrument many cards (every agent of that surface in this workspace).
+
+## The 1:1 mapping today
+
+In v0.9.8, every supported surface has exactly one harness. The harness IDs match what users type to `treeship add`:
+
+| Harness ID | Surface | Coverage | Auto-installable? |
+|---|---|---|---|
+| `claude-code` | Claude Code | high | yes — native hook + MCP |
+| `cursor` | Cursor | medium | yes — MCP |
+| `cline` | Cline | medium | yes — MCP |
+| `codex` | Codex CLI | medium | yes — TOML MCP |
+| `hermes` | Hermes | medium | yes — skill file |
+| `openclaw` | OpenClaw | medium | yes — skill file |
+| `ninjatech-superninja` | NinjaTech / SuperNinja remote | basic | **no** — see [NinjaTech integration](/docs/integrations/ninjatech) |
+| `ninjatech-ninja-dev` | Ninja Dev IDE | medium | **no** — manual MCP |
+| `generic-mcp` | Any MCP client | medium | **no** — manual register |
+| `shell-wrap` | Custom shell-wrap agent | basic | **no** — `treeship wrap` only |
+
+The four "no auto-installer" rows still have manifests. `treeship harness inspect <id>` is honest about what they could capture vs what's actually attached.
+
+## Manifest vs state
+
+Treeship splits harness data into two physically separate types so reports can't conflate "could capture" with "did capture":
+
+**`HarnessManifest`** — static metadata, in code:
+
+```rust
+pub struct HarnessManifest {
+    pub harness_id: &'static str,
+    pub surface: AgentSurface,
+    pub display_name: &'static str,
+    pub connection_modes: &'static [ConnectionMode],
+    pub coverage: CoverageLevel,
+    pub captures: PotentialCaptures,        // ← what this harness COULD capture
+    pub known_gaps: &'static [&'static str],
+    pub privacy_posture: &'static str,
+    pub recommended_backstops: &'static [ConnectionMode],
+    pub install: Option<InstallProfile>,
+}
+```
+
+**`HarnessState`** — per-workspace, on disk at `.treeship/harnesses/<id>.json`:
+
+```rust
+pub struct HarnessState {
+    pub harness_id: String,
+    pub status: HarnessStatus,              // detected / instrumented / verified / ...
+    pub coverage: CoverageLevel,
+    pub active_connection_modes: Vec<ConnectionMode>,
+    pub last_smoke_result: Option<SmokeResult>,
+    pub last_verified_at: Option<String>,
+    pub verified_captures: VerifiedCaptures, // ← what's actually been PROVEN
+    pub linked_agent_ids: Vec<String>,
+    ...
+}
+```
+
+`PotentialCaptures` is `bool` per signal. `VerifiedCaptures` is `Option<bool>` per signal: `Some(true)` proven, `Some(false)` smoke ran but signal didn't fire, `None` never asserted (the default).
+
+## Status lifecycle
+
+```
+Detected → Available → Instrumented → Verified
+                              ↓
+                        Drifted / Degraded / Disabled
+```
+
+| Status | What it means |
+|---|---|
+| **Detected** | A manifest exists; nothing on disk. |
+| **Available** | The manifest has an installer but Treeship hasn't installed it in this workspace. (Reserved for "user declined" path.) |
+| **Instrumented** | Treeship installed the snippet/config. Generic trust-fabric smoke may have passed. |
+| **Verified** | A harness-specific smoke has proven this harness's own capture path on this machine. **Setup's generic smoke does not promote here.** |
+| **Drifted** | The on-disk install no longer matches what Treeship would write. (Reserved for a future drift-check command.) |
+| **Degraded** | Capture is incomplete — a previously-proven signal stopped firing. (Reserved.) |
+| **Disabled** | User explicitly opted out. |
+
+<Callout type="warn">
+Setup's smoke runs a generic `init → session → wrap → close → package verify` round-trip. It proves Treeship's signing pipeline works. It does *not* prove Claude Code's native hook fired, or that Cursor's MCP routing actually captured a tool call. Setup therefore promotes harnesses to **Instrumented**, not Verified. Verified is reserved for harness-specific smokes that exercise each capture signal.
+</Callout>
+
+## CLI
+
+```bash
+treeship harness list                    # every manifest joined with workspace state
+treeship harness inspect <id>            # full manifest + state for one harness
+treeship harness smoke <id>              # generic trust-fabric smoke (does NOT prove harness-specific capture)
+```
+
+`harness inspect` shows two distinct rows:
+
+```
+potential captures (when attached and working):
+  files.read     yes
+  files.write    yes
+  commands.run   yes
+  mcp.call       yes
+  model/provider yes
+
+verified captures (proven by harness-specific smoke):
+  (none yet -- run a real session through this harness)
+```
+
+## How linkage works
+
+When you run `treeship setup` or `treeship agent register`, Treeship records the relationship between a card and its harness in two places:
+
+- `AgentCard.active_harness_id` — points the card at the harness it's attached through.
+- `HarnessState.linked_agent_ids` — lists every card on the other side.
+
+Both update on re-run; `harness inspect <id>` shows linked cards alongside last smoke result.
+
+## See also
+
+- [Agent Cards](/docs/concepts/agent-cards)
+- [Coverage levels](/docs/guides/coverage-levels)
+- Per-integration guides: [Claude Code](/docs/integrations/claude-code), [Cursor](/docs/integrations/cursor), [Codex](/docs/integrations/codex), [NinjaTech](/docs/integrations/ninjatech), [Hermes](/docs/integrations/hermes), [OpenClaw](/docs/integrations/openclaw)

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["trust-fabric", "trust-model", "artifacts", "session-receipts", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
+  "pages": ["trust-fabric", "trust-model", "agent-cards", "harnesses", "artifacts", "session-receipts", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
 }

--- a/docs/content/docs/guides/coverage-levels.mdx
+++ b/docs/content/docs/guides/coverage-levels.mdx
@@ -1,0 +1,115 @@
+---
+title: Coverage levels
+description: What each harness coverage tier actually claims — and what it doesn't.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A harness's **coverage level** is a one-word promise about how much of an agent's behavior Treeship can observe through that harness. Each level documents both what it captures *and what it doesn't*, so readers of a session report aren't surprised by gaps.
+
+| Level | What's captured | Backstops | Typical harnesses |
+|---|---|---|---|
+| **High** | files.read, files.write, commands.run, mcp.call, model/provider | git-reconcile | Claude Code (native hook + MCP) |
+| **Medium** | files.write, commands.run, mcp.call (no files.read, no model attribution by default) | git-reconcile | Cursor, Cline, Codex, Hermes, OpenClaw, Ninja Dev |
+| **Basic** | files.write (via backstop), command boundary only | git-reconcile is doing most of the work | Shell-wrap custom agents, SuperNinja remote |
+| **Backstop only** | files.write only, after the fact | git-reconcile alone | Manual / unknown agents working in the same workspace |
+
+## Potential vs verified
+
+A harness manifest's coverage level is a *potential*: what the harness could capture if attached and working as designed. It is **not** a claim that the harness has actually captured anything in your workspace.
+
+Run `treeship harness inspect <id>` and you'll see two distinct rows:
+
+```
+potential captures (when attached and working):
+  files.read     yes
+  files.write    yes
+  commands.run   yes
+  mcp.call       yes
+  model/provider yes
+
+verified captures (proven by harness-specific smoke):
+  (none yet -- run a real session through this harness)
+```
+
+The `verified captures` row only fills in when a smoke session has exercised that specific signal end-to-end through the harness's own capture path. v0.9.8's `treeship setup` smoke is generic — it proves Treeship's signing pipeline works, not that Claude's native hook fired. Setup leaves verified captures empty and promotes harnesses to **Instrumented** rather than **Verified**.
+
+<Callout type="info">
+**The semantic split is enforced at the type level.** `PotentialCaptures` is `bool` per signal; `VerifiedCaptures` is `Option<bool>`. Nothing in the codebase can render one in the other's slot.
+</Callout>
+
+## High coverage in detail
+
+The Claude Code native hook harness is currently the only **high-coverage** integration. It captures:
+
+| Signal | How |
+|---|---|
+| **files.read** | PostToolUse hook fires on Read; `agent.read_file` event records path + digest. |
+| **files.write** | PostToolUse hook fires on Write/Edit; `agent.wrote_file` records path, digest, op (`created` / `modified` / `deleted`), additions/deletions. |
+| **commands.run** | PostToolUse hook fires on Bash; `agent.ran_process` records command (sanitized), exit code, duration. |
+| **mcp.call** | The bundled `@treeship/mcp` server records every MCP-routed tool call with sanitized inputs. |
+| **model/provider** | SessionEnd hook records the model that produced the session (`claude-opus-4-7`, etc.) and provider (`anthropic`). |
+
+Known gap: tools the user invokes manually inside a Bash command (e.g. `sed -i ...`) don't fire a per-tool hook. The git-reconcile backstop catches the resulting file changes at session close, tagging them with `[git-reconcile]` instead of `[hook]`.
+
+## Medium coverage in detail
+
+MCP harnesses (Cursor, Codex, Cline, Ninja Dev, generic-mcp) capture **what passes through MCP**:
+
+| Signal | How |
+|---|---|
+| **files.write** | MCP tool calls that touch files (`write_file`, `edit_file`) record path + digest. |
+| **commands.run** | MCP tool calls that exec processes record command + exit code. |
+| **mcp.call** | Every MCP-routed tool invocation is recorded with tool name and sanitized inputs. |
+| **files.read** | *Not captured by default.* Some clients route reads through MCP (Cursor's editor read). Most don't. |
+| **model/provider** | *Not captured by default.* Set via `meta.model` if the client emits it. |
+
+Known gap: anything the agent does outside the MCP channel (built-in editor actions, direct shell commands the IDE never routes through MCP) doesn't appear unless `treeship wrap` was used or git-reconcile catches the file change.
+
+Skill harnesses (Hermes, OpenClaw) work differently: they install a `SKILL.md` that tells the agent what to capture. Coverage depends on whether the agent reads the skill and follows its instructions; Treeship measures actual capture honestly via `verified_captures`.
+
+## Basic coverage in detail
+
+Shell-wrap and SuperNinja-remote harnesses see only the command boundary:
+
+| Signal | How |
+|---|---|
+| **files.write** | git-reconcile at session close — the agent's edits are visible only as a `git diff` against `HEAD`. |
+| **commands.run** | `treeship wrap -- <cmd>` records start/end + exit code. **Not the command line itself by default** — Treeship sanitizes that to avoid leaking secrets. |
+| **All other signals** | Not captured. |
+
+Known gap: an attacker (or a confused agent) could write files outside the workspace, set environment variables, or make network calls; only files.write under the workspace is recovered.
+
+## Backstop only
+
+git-reconcile in isolation. The session is essentially a "what did the workspace look like before vs after" diff. Useful as a last resort when nothing else is wired; not enough to prove what an agent did, only what happened in the directory.
+
+## How to raise coverage
+
+| Have | Want | How |
+|---|---|---|
+| **Cursor (medium)** | high | Cursor doesn't currently expose a native hook surface. The MCP-routed signals are the practical ceiling. |
+| **Codex (medium)** | high | Same — Codex's tool surface is MCP. |
+| **SuperNinja (basic)** | medium / high | Wait for v0.9.9's `treeship agent invite` / `treeship join --invite` so Treeship can run inside the remote VM. |
+| **Custom shell-wrap (basic)** | medium | Add an MCP server in front of your custom agent and route tool calls through it; `treeship harness inspect generic-mcp` for the shape. |
+
+## Reading coverage in a session report
+
+`treeship package inspect <pkg>` renders the harness coverage panel as part of the report:
+
+```
+harness coverage (4 attached)
+  Claude Code Native Hook Harness  (instrumented, coverage: high)
+    potential: read=y write=y cmd=y mcp=y model=y
+    verified:  (none yet -- run a real session through this harness)
+    last smoke (pass): setup generic trust-fabric smoke ok (does not prove harness-specific capture)
+    gap: Built-in tools the user invokes outside hooks (manual sed inside Bash) rely on git-reconcile.
+```
+
+Read top-to-bottom: `potential` is the harness's design, `verified` is your workspace's evidence. `last smoke` says exactly what was tested. `gap` lists the honest limits.
+
+## See also
+
+- [Agent Harnesses](/docs/concepts/harnesses)
+- [Agent Cards](/docs/concepts/agent-cards)
+- Integration-specific coverage details: [Claude Code](/docs/integrations/claude-code), [Cursor](/docs/integrations/cursor), [Codex](/docs/integrations/codex), [NinjaTech](/docs/integrations/ninjatech)

--- a/docs/content/docs/guides/first-run.mdx
+++ b/docs/content/docs/guides/first-run.mdx
@@ -1,0 +1,143 @@
+---
+title: First run
+description: From install to first signed receipt in five minutes. Local agents first, remote/VPS attach as an optional second step.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Steps, Step } from 'fumadocs-ui/components/steps';
+
+The fastest path to a signed receipt is a single `treeship setup`. It detects the agents on your machine, draft Agent Cards for each, instruments the ones it can attach to, runs a smoke session to prove the trust-fabric pipeline works, and points you at `treeship session start` to capture your first real run.
+
+> Harnesses make agents observable. Cards make agents accountable. Receipts make their work verifiable.
+
+## Local agents first
+
+<Steps>
+
+<Step>
+
+### Install Treeship
+
+```bash
+npm install -g treeship
+```
+
+Or via Homebrew, Cargo, or the binary download — see [installation](/docs/guides/quickstart#install).
+
+</Step>
+
+<Step>
+
+### Initialize the workspace
+
+```bash
+treeship init
+```
+
+This creates `~/.treeship/` (or a project-local `.treeship/` if you pass `--config .treeship/config.json`), generates an Ed25519 signing key, and writes the config that everything else reads.
+
+</Step>
+
+<Step>
+
+### Run setup
+
+```bash
+treeship setup --yes
+```
+
+`treeship setup` runs four steps:
+
+1. **Detect** local agents (Claude Code, Cursor, Codex, Hermes, OpenClaw, Cline, Ninja Dev, generic MCP).
+2. **Draft Agent Cards** for each detection — one per surface per workspace, idempotent on re-run.
+3. **Confirm and instrument** the ones it can auto-attach to. Cards born from instrumentation move from Draft → Active.
+4. **Smoke** the trust-fabric pipeline (init → session start → wrap → close → package verify) inside an isolated tmpdir. Each instrumented harness moves Detected → Instrumented.
+
+`--yes` skips the confirmation prompt. `--skip-smoke` instruments without smoking. `--no-instrument` only writes draft cards.
+
+<Callout type="info">
+**"Verified" is harness-specific.** The setup smoke proves Treeship's signing pipeline works on this machine. It does *not* prove that any specific harness's capture path (Claude native hook, Cursor MCP, Codex shell-wrap) actually fires. That promotion to Verified is reserved for harness-specific smokes that exercise each capture signal individually. See [Coverage levels](/docs/guides/coverage-levels) for what each level actually claims.
+</Callout>
+
+</Step>
+
+<Step>
+
+### Your first session
+
+```bash
+treeship session start --name "first run"
+treeship wrap -- pytest tests/
+treeship session close --summary "tests pass"
+```
+
+Or just run your normal workflow with the agent of your choice — instrumented harnesses capture automatically, and `git-reconcile` at session close picks up anything that happened outside captured channels.
+
+</Step>
+
+<Step>
+
+### Read the report
+
+```bash
+treeship package inspect .treeship/sessions/ssn_*.treeship
+```
+
+The report has three panels worth scanning first:
+
+- **Agent cards** — every workspace agent, its harness, its status.
+- **Harness coverage** — what each harness *could* capture vs what's been *proven* in this workspace.
+- **Files changed** — every file the agent touched, tagged with the source that recorded it (`hook`, `mcp`, `git-reconcile`, `shell-wrap`).
+
+</Step>
+
+</Steps>
+
+## Remote / VPS / cloud agents come second
+
+Once you have local value — a signed receipt you can read — you can attach agents that don't run on this machine: VPS-based Codex, cloud VMs, NinjaTech / SuperNinja remotes, CI runners.
+
+<Callout type="warn">
+The remote attach flow (`treeship agent invite` and `treeship join --invite`) is **deferred to v0.9.9**. Today, remote agents show up as **draft** cards with `(none yet)` for verified captures. `treeship harness inspect ninjatech-superninja` is honest about what's possible vs what's actually proven.
+</Callout>
+
+The current honest path for remote agents:
+
+```bash
+treeship agent register \
+  --name codex-vps \
+  --tools read_file,write_file,bash \
+  --description "Codex on vps-01"
+```
+
+That writes a `.agent` package (signed certificate) and a card at `needs-review`. After v0.9.9 lands, `treeship agent invite` will replace this with a one-line join command on the remote machine.
+
+## What you'll see after setup
+
+Cards (run `treeship agents`):
+
+```
+Agent cards (5 in workspace)
+  ✓ Claude Code            (claude-code, harness: claude-code, active)
+  ✓ Cursor                 (cursor-agent, harness: cursor, active)
+  ✓ Codex CLI              (codex, harness: codex, active)
+  ✓ OpenClaw               (openclaw, harness: openclaw, active)
+  · SuperNinja             (ninjatech-superninja, harness: ninjatech-superninja, draft)
+```
+
+Harness coverage (run `treeship harness list`):
+
+```
+Harnesses (10 known)
+  ✓ Claude Code Native Hook Harness     id: claude-code      coverage: high      status: instrumented
+  ✓ Cursor MCP Harness                  id: cursor           coverage: medium    status: instrumented
+  ✓ Codex CLI MCP Harness               id: codex            coverage: medium    status: instrumented
+  · NinjaTech / SuperNinja Remote       id: ninjatech-superninja  coverage: basic   status: detected
+  ...
+```
+
+## What's next
+
+- [Agent Cards](/docs/concepts/agent-cards) — workspace trust objects.
+- [Agent Harnesses](/docs/concepts/harnesses) — how Treeship attaches.
+- [Coverage levels](/docs/guides/coverage-levels) — what each tier actually proves.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Get started",
-  "pages": ["introduction", "quickstart", "how-it-works", "templates", "approvals", "handoffs", "workflows", "merkle-proofs", "edge-runtime"]
+  "pages": ["introduction", "quickstart", "first-run", "coverage-levels", "how-it-works", "templates", "approvals", "handoffs", "workflows", "merkle-proofs", "edge-runtime"]
 }

--- a/docs/content/docs/integrations/meta.json
+++ b/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["claude-code", "cursor", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
+  "pages": ["claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
 }

--- a/docs/content/docs/integrations/ninjatech.mdx
+++ b/docs/content/docs/integrations/ninjatech.mdx
@@ -1,0 +1,133 @@
+---
+title: NinjaTech / SuperNinja
+description: Attach Treeship to NinjaTech surfaces — Ninja Dev locally, SuperNinja remote VMs through MCP / GitHub once invite/join lands.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+NinjaTech ships as two distinct agent surfaces, and they need different harnesses:
+
+- **Ninja Dev** — a local IDE / VS Code-style agent. Runs on your machine. Treeship attaches via MCP or shell-wrap.
+- **SuperNinja** — a remote VM agent. Treeship can't auto-discover it locally; it joins through the (forthcoming) `treeship agent invite` flow or via GitHub PR / Actions evidence.
+
+This page covers both. If you're not sure which you're running, `treeship add --discover` will tell you.
+
+## Ninja Dev (local)
+
+### Detection
+
+Treeship looks for these signals on `treeship add --discover`:
+
+- `~/.ninja-dev/` directory
+- `~/.config/ninjatech/` directory
+- A VS Code extension whose dirname starts with `ninjatech` or `ninja-dev`
+- `ninja-dev` or `ninjatech` on `PATH`
+
+Any one is enough to surface a discovery hint. Two or more bumps confidence from `low` to `medium`.
+
+### Harness profile
+
+```
+treeship harness inspect ninjatech-ninja-dev
+```
+
+| Field | Value |
+|---|---|
+| Coverage | medium |
+| Potential captures | files.write, commands.run, mcp.call |
+| Connection modes | mcp, shell-wrap, git-reconcile |
+| Recommended backstops | shell-wrap, git-reconcile |
+
+### Attach
+
+There's no automated installer for Ninja Dev today (`install: None` in the manifest) — the extension's MCP config path varies across versions. Register manually:
+
+```bash
+treeship agent register \
+  --name ninja-dev \
+  --tools read_file,write_file,bash \
+  --description "Ninja Dev IDE local"
+```
+
+Then point your Ninja Dev MCP config at `npx -y @treeship/mcp` — see [the Generic MCP guide](/docs/integrations/mcp) for the shape.
+
+## SuperNinja (remote VM)
+
+### Why it's not auto-discoverable
+
+SuperNinja by definition runs on a machine that isn't yours. Discovery shows it as an always-on hint with `confidence: low`, not as a detection — there's no filesystem signal we could honestly match on.
+
+```
+treeship harness inspect ninjatech-superninja
+```
+
+| Field | Value |
+|---|---|
+| Coverage | basic |
+| Potential captures | files.write (via git-reconcile backstop) |
+| Connection modes | mcp, shell-wrap, git-reconcile |
+| Auto-installable | **no** |
+
+The harness inspect output is honest about this:
+
+```
+known gaps:
+  - SuperNinja runs on a remote VM and is not auto-discoverable locally.
+  - Coverage stays at basic until Treeship runs inside the VM or routes through MCP.
+  - Use `treeship agent invite` to attach a remote host (deferred to v0.9.9).
+```
+
+<Callout type="warn">
+**The full remote attach flow lands in v0.9.9.** Today, you can register a SuperNinja card so it appears in your inventory, but `verified_captures` will stay empty until v0.9.9 ships `treeship agent invite` / `treeship join --invite` and the harness can actually run inside the remote VM.
+</Callout>
+
+### What works today (v0.9.8)
+
+Three honest paths, in order of fidelity:
+
+#### 1. Manual register + git-reconcile backstop
+
+Best when SuperNinja's edits land in your local workspace via PR or rsync:
+
+```bash
+treeship agent register \
+  --name superninja \
+  --tools read_file,write_file,bash \
+  --description "SuperNinja remote VM via PR"
+```
+
+Then run a normal session — git-reconcile at close picks up the diff. The receipt's files-written list will be tagged `[git-reconcile]` instead of `[hook]`, which is the honest source attribution.
+
+#### 2. Manual register + GitHub Actions evidence
+
+If SuperNinja opens PRs against this repo, you can verify those PRs separately and link the receipts. Coming as part of the GitHub verification surface — see [GitHub verification](/docs/integrations/github) (v0.9.9).
+
+#### 3. MCP if the remote routes through it
+
+If your SuperNinja deployment exposes an MCP endpoint, you can point a local `@treeship/mcp` proxy at it and Treeship will see MCP-routed tool calls. This is the same shape as [Generic MCP](/docs/integrations/mcp).
+
+### What lands in v0.9.9
+
+```bash
+# On your local machine
+treeship agent invite \
+  --name superninja \
+  --kind ninjatech-superninja \
+  --host remote-vm
+
+# Output:
+#   Run on the remote VM:
+#     curl -fsSL treeship.dev/setup | sh
+#     treeship join --invite trj_8xK2...
+```
+
+The invite encodes which Ship/workspace the remote should join, expires in 15 minutes, and produces a Host Card + Agent Instance Card on this side once the remote runs `join`. After `join` succeeds, the SuperNinja harness can run *inside* the VM, lifting coverage from basic to medium (or higher if MCP plumbing is wired).
+
+This is intentionally not in v0.9.8. The principle is local-first: get a signed receipt from local agents before adding the remote-attach configuration burden.
+
+## See also
+
+- [Agent Harnesses](/docs/concepts/harnesses) — how harnesses work in general
+- [Coverage levels](/docs/guides/coverage-levels) — what `basic` vs `medium` actually claim
+- [First run](/docs/guides/first-run) — local-first setup flow
+- [Generic MCP](/docs/integrations/mcp) — shape of any custom MCP-backed harness

--- a/packages/cli/src/commands/package.rs
+++ b/packages/cli/src/commands/package.rs
@@ -1,10 +1,75 @@
 //! CLI commands for inspecting and verifying .treeship packages.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use treeship_core::session::{read_package, verify_package, VerifyStatus};
+use treeship_core::session::{read_package, verify_package, FileAccess, VerifyStatus};
 
+use crate::commands::cards;
+use crate::commands::harnesses;
+use crate::ctx;
 use crate::printer::Printer;
+
+// ---------------------------------------------------------------------------
+// Files Changed filtering
+// ---------------------------------------------------------------------------
+
+/// Treeship's own runtime artifacts that should NOT show up in the user's
+/// "files changed" list. These are written by Treeship itself during
+/// session capture and are noise to a reader trying to understand what
+/// the agent did.
+///
+/// Path-shape based, not glob, so the filter is robust whether paths are
+/// absolute, relative, or contain a workspace prefix.
+fn is_treeship_runtime_artifact(path: &str) -> bool {
+    // Strip any leading workspace prefix; we care about the trailing
+    // segment under .treeship/.
+    let key = path
+        .rsplit_once(".treeship/")
+        .map(|(_, after)| after)
+        .unwrap_or(path);
+    if key == path && !path.contains(".treeship/") {
+        return false;
+    }
+    // Specific files
+    if matches!(key, "session.json" | "session.closing") {
+        return true;
+    }
+    // Subdirectories of .treeship that Treeship owns
+    for prefix in &["sessions/", "artifacts/", "tmp/"] {
+        if key.starts_with(prefix) {
+            return true;
+        }
+    }
+    // User-authored .treeship files we explicitly preserve. Listed for
+    // documentation; they fall through to "false" below since none of the
+    // earlier checks matched, but spelling them out keeps the rule
+    // honest if someone adds a sweepier prefix above.
+    let preserved = [
+        "config.yaml", "config.json", "policy.yaml", "declaration.json",
+        "agents/",     // user-approved Agent Cards
+        "harnesses/",  // workspace harness state
+    ];
+    if preserved.iter().any(|p| key.starts_with(p)) {
+        return false;
+    }
+    // Anything else under .treeship/ that we don't recognize stays
+    // visible -- safer to over-show than to hide a file the user might
+    // care about.
+    false
+}
+
+fn source_label(file: &FileAccess) -> &'static str {
+    match file.source.as_deref() {
+        Some("hook")               => "hook",
+        Some("mcp")                => "mcp",
+        Some("git-reconcile")      => "git-reconcile",
+        Some("shell-wrap")         => "shell-wrap",
+        Some("session-event-cli")  => "session-event-cli",
+        Some("daemon-atime")       => "daemon-atime",
+        Some(_)                    => "unknown",
+        None                       => "unknown",
+    }
+}
 
 // ---------------------------------------------------------------------------
 // treeship package inspect <path>
@@ -12,6 +77,7 @@ use crate::printer::Printer;
 
 pub fn inspect(
     path: PathBuf,
+    config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let receipt = read_package(&path)?;
@@ -81,6 +147,23 @@ pub fn inspect(
     printer.info(&format!("  ports opened:   {}", summary.ports_opened));
     printer.info(&format!("  network conns:  {}", summary.network_connections));
 
+    // ---- files changed (with source badges, runtime artifacts filtered) ----
+    print_files_changed(&se.files_written, &se.files_read, printer);
+
+    // ---- workspace-local Agent Cards + Harness coverage ----
+    //
+    // These panels read from the workspace's .treeship/agents/ and
+    // .treeship/harnesses/ stores via cards::list and harnesses::list_states.
+    // No data fork: same modules `treeship agents` and `treeship harness`
+    // already use. If the user is inspecting a package outside any
+    // workspace (no config), we silently skip these panels rather than
+    // erroring -- inspect must work on bare receipts that arrive in
+    // someone's inbox.
+    if let Ok(ctx_opened) = ctx::open(config) {
+        print_agent_cards_panel(&ctx_opened.config_path, printer);
+        print_harness_coverage_panel(&ctx_opened.config_path, printer);
+    }
+
     printer.blank();
     printer.section("timeline");
     printer.info(&format!("  events: {}", receipt.timeline.len()));
@@ -145,6 +228,280 @@ pub fn inspect(
     printer.blank();
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// files changed panel
+// ---------------------------------------------------------------------------
+
+/// Render the files-changed list with source badges. Filters Treeship's
+/// runtime artifacts (session.json, sessions/**, etc.) but preserves
+/// user-authored .treeship trust files (config.yaml, agents/**, etc.).
+///
+/// "Hidden" rather than "removed" -- if the filter dropped anything, we
+/// say so explicitly with a count, so a reader can't mistake a quiet
+/// list for a complete one.
+fn print_files_changed(
+    written: &[FileAccess],
+    read: &[FileAccess],
+    printer: &Printer,
+) {
+    let (visible_w, hidden_w) = partition(written);
+    let (visible_r, hidden_r) = partition(read);
+
+    if visible_w.is_empty() && visible_r.is_empty() && hidden_w == 0 && hidden_r == 0 {
+        return;
+    }
+
+    printer.blank();
+    printer.section("files changed");
+
+    if !visible_w.is_empty() {
+        printer.dim_info(&format!("  written ({}):", visible_w.len()));
+        // Cap at 30 paths so a churn-heavy session doesn't drown the
+        // rest of the report; the count above is the honest total.
+        for f in visible_w.iter().take(30) {
+            let badge = source_label(f);
+            let op = f.operation.as_deref().unwrap_or("write");
+            printer.dim_info(&format!("    [{badge:<17}] {op:<8} {}", f.file_path));
+        }
+        if visible_w.len() > 30 {
+            printer.dim_info(&format!("    ... and {} more", visible_w.len() - 30));
+        }
+    }
+    if !visible_r.is_empty() {
+        printer.dim_info(&format!("  read ({}):", visible_r.len()));
+        for f in visible_r.iter().take(15) {
+            let badge = source_label(f);
+            printer.dim_info(&format!("    [{badge:<17}] read     {}", f.file_path));
+        }
+        if visible_r.len() > 15 {
+            printer.dim_info(&format!("    ... and {} more", visible_r.len() - 15));
+        }
+    }
+    if hidden_w > 0 || hidden_r > 0 {
+        printer.dim_info(&format!(
+            "  hidden: {} write, {} read (Treeship runtime artifacts under .treeship/)",
+            hidden_w, hidden_r,
+        ));
+    }
+}
+
+fn partition(files: &[FileAccess]) -> (Vec<&FileAccess>, usize) {
+    let mut visible = Vec::with_capacity(files.len());
+    let mut hidden = 0usize;
+    for f in files {
+        if is_treeship_runtime_artifact(&f.file_path) {
+            hidden += 1;
+        } else {
+            visible.push(f);
+        }
+    }
+    (visible, hidden)
+}
+
+// ---------------------------------------------------------------------------
+// agent cards panel
+// ---------------------------------------------------------------------------
+
+fn print_agent_cards_panel(config_path: &Path, printer: &Printer) {
+    let agents_dir = cards::agents_dir_for(config_path);
+    let cards_list = match cards::list(&agents_dir) {
+        Ok(list) if !list.is_empty() => list,
+        _ => return, // no cards in this workspace; nothing to render
+    };
+
+    printer.blank();
+    printer.section(&format!("agent cards ({} in workspace)", cards_list.len()));
+    for card in &cards_list {
+        let mark = match card.status {
+            cards::CardStatus::Verified    => "✓",
+            cards::CardStatus::Active      => "✓",
+            cards::CardStatus::NeedsReview => "?",
+            cards::CardStatus::Draft       => "·",
+        };
+        let harness = card.active_harness_id.as_deref().unwrap_or("none");
+        printer.info(&format!(
+            "  {mark} {}  ({}, harness: {}, {})",
+            card.agent_name,
+            card.surface.kind(),
+            harness,
+            card.status.label(),
+        ));
+        if let Some(model) = &card.model {
+            printer.dim_info(&format!("    model:    {model}"));
+        }
+        printer.dim_info(&format!("    host:     {}", card.host));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// harness coverage panel
+// ---------------------------------------------------------------------------
+
+fn print_harness_coverage_panel(config_path: &Path, printer: &Printer) {
+    let dir = harnesses::harnesses_dir_for(config_path);
+    let states = match harnesses::list_states(&dir) {
+        Ok(list) if !list.is_empty() => list,
+        _ => return, // no harness state in this workspace
+    };
+
+    printer.blank();
+    printer.section(&format!("harness coverage ({} attached)", states.len()));
+    for state in &states {
+        let manifest = harnesses::find(&state.harness_id);
+        let display = manifest
+            .map(|m| m.display_name)
+            .unwrap_or(state.harness_id.as_str());
+        printer.info(&format!(
+            "  {}  ({}, coverage: {})",
+            display,
+            state.status.label(),
+            state.coverage.label(),
+        ));
+        // Two distinct rows -- potential vs verified -- to honor the
+        // trust-semantics tightening from PR 5's drift fix.
+        if let Some(m) = manifest {
+            let p = m.captures;
+            printer.dim_info(&format!(
+                "    potential: read={} write={} cmd={} mcp={} model={}",
+                yes_or_no(p.files_read),
+                yes_or_no(p.files_write),
+                yes_or_no(p.commands_run),
+                yes_or_no(p.mcp_call),
+                yes_or_no(p.model_provider),
+            ));
+        }
+        let v = state.verified_captures;
+        if v.is_empty() {
+            printer.dim_info("    verified:  (none yet -- run a real session through this harness)");
+        } else {
+            printer.dim_info(&format!(
+                "    verified:  read={} write={} cmd={} mcp={} model={}",
+                tri(v.files_read),
+                tri(v.files_write),
+                tri(v.commands_run),
+                tri(v.mcp_call),
+                tri(v.model_provider),
+            ));
+        }
+        if let Some(smoke) = &state.last_smoke_result {
+            printer.dim_info(&format!(
+                "    last smoke ({}): {}",
+                if smoke.passed { "pass" } else { "fail" },
+                smoke.summary,
+            ));
+        }
+        // Surface known gaps once so report readers see the honest
+        // limits without having to inspect each harness separately.
+        if !state.known_gaps.is_empty() {
+            for gap in state.known_gaps.iter().take(2) {
+                printer.dim_info(&format!("    gap: {}", gap));
+            }
+            if state.known_gaps.len() > 2 {
+                printer.dim_info(&format!(
+                    "    ... and {} more (run `treeship harness inspect {}`)",
+                    state.known_gaps.len() - 2,
+                    state.harness_id,
+                ));
+            }
+        }
+    }
+}
+
+fn yes_or_no(b: bool) -> &'static str { if b { "y" } else { "n" } }
+fn tri(v: Option<bool>) -> &'static str {
+    match v { Some(true) => "y", Some(false) => "no-fire", None => "?" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_artifacts_are_hidden() {
+        // Files Treeship writes during capture must not pollute the
+        // user's "files changed" list.
+        for hidden in &[
+            ".treeship/session.json",
+            ".treeship/session.closing",
+            ".treeship/sessions/ssn_abc.treeship",
+            ".treeship/artifacts/foo.bin",
+            ".treeship/tmp/scratch",
+            "/abs/path/to/proj/.treeship/session.json",
+            "../../.treeship/sessions/ssn_xyz.treeship",
+        ] {
+            assert!(
+                is_treeship_runtime_artifact(hidden),
+                "{hidden} should be filtered out"
+            );
+        }
+    }
+
+    #[test]
+    fn user_authored_treeship_files_are_preserved() {
+        // Trust files the user actually authors must remain visible
+        // even though they live under .treeship/.
+        for visible in &[
+            ".treeship/config.yaml",
+            ".treeship/config.json",
+            ".treeship/policy.yaml",
+            ".treeship/declaration.json",
+            ".treeship/agents/agent_abc.json",
+            ".treeship/harnesses/claude-code.json",
+            "/abs/proj/.treeship/policy.yaml",
+        ] {
+            assert!(
+                !is_treeship_runtime_artifact(visible),
+                "{visible} must NOT be filtered out -- it's a user-authored trust file"
+            );
+        }
+    }
+
+    #[test]
+    fn non_treeship_files_pass_through() {
+        for path in &["src/main.rs", "README.md", "/etc/hosts", "package.json"] {
+            assert!(
+                !is_treeship_runtime_artifact(path),
+                "{path} is not a Treeship file and must pass through"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_treeship_subpath_stays_visible() {
+        // If someone adds a new file under .treeship/ that we don't
+        // explicitly classify, we err on the side of showing it. The
+        // alternative -- silently filtering anything under .treeship/
+        // -- would hide files the user might care about.
+        assert!(!is_treeship_runtime_artifact(".treeship/something-new.json"));
+    }
+
+    #[test]
+    fn source_label_maps_known_provenance() {
+        for (input, want) in &[
+            (Some("hook"),               "hook"),
+            (Some("mcp"),                "mcp"),
+            (Some("git-reconcile"),      "git-reconcile"),
+            (Some("shell-wrap"),         "shell-wrap"),
+            (Some("session-event-cli"),  "session-event-cli"),
+            (Some("daemon-atime"),       "daemon-atime"),
+            (Some("future-source"),      "unknown"),
+            (None,                       "unknown"),
+        ] {
+            let f = FileAccess {
+                file_path: "x".into(),
+                agent_instance_id: "a".into(),
+                timestamp: "t".into(),
+                digest: None,
+                operation: None,
+                additions: None,
+                deletions: None,
+                source: input.map(|s| s.to_string()),
+            };
+            assert_eq!(source_label(&f), *want, "input {input:?}");
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1717,6 +1717,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
         Command::Package(sub) => match sub {
             PackageCommand::Inspect(a) => commands::package::inspect(
                 a.path.clone(),
+                cli.config.as_deref(),
                 printer,
             ),
             PackageCommand::Verify(a) => commands::package::verify(

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -20,7 +20,7 @@ pub use event::*;
 pub use event_log::EventLog;
 pub use context::PropagationContext;
 pub use graph::{AgentGraph, AgentNode, AgentEdge, AgentEdgeType};
-pub use side_effects::SideEffects;
+pub use side_effects::{FileAccess, SideEffects};
 pub use receipt::{ArtifactEntry, ReceiptComposer, SessionReceipt};
 pub use render::RenderConfig;
 pub use package::{build_package, read_package, verify_package, VerifyCheck, VerifyStatus};


### PR DESCRIPTION
Sixth and final PR for **v0.9.8 — Agents Become Legible**. Brings the user-visible payoff: a session report that surfaces Agent Cards, harness coverage, and source-tagged file changes — plus first-run docs that frame the whole release.

> Harnesses make agents observable. Cards make agents accountable. Receipts make their work verifiable.

## Architectural call (matching PRs 1–5)

Report polish *reads from* the existing modules. It does not duplicate any data.

| Source | Module | What's read |
|---|---|---|
| Files Changed source badges | `core::session::FileAccess.source` | `hook`, `mcp`, `git-reconcile`, `shell-wrap`, `session-event-cli`, `daemon-atime` (existing provenance) |
| Agent Cards panel | `commands::cards::list` | workspace cards from `.treeship/agents/<id>.json` |
| Harness Coverage panel | `commands::harnesses::list_states` + `HARNESSES` | manifest + `.treeship/harnesses/<id>.json` joined |

No new schema. No forked data. Same data the standalone `treeship agents` and `treeship harness` commands already use.

## What this PR adds

### `treeship package inspect` gains three panels

**Files changed** with source badges:
```
files changed
  written (3):
    [hook            ] modified packages/cli/src/commands/add.rs
    [mcp             ] created  notes.txt
    [git-reconcile   ] modified Cargo.lock
  read (2):
    [hook            ] read     README.md
    ...
  hidden: 2 write, 0 read (Treeship runtime artifacts under .treeship/)
```

`.treeship/session.json`, `.treeship/sessions/**`, `.treeship/artifacts/**`, `.treeship/tmp/**` are filtered out. `.treeship/config.yaml`, `.treeship/policy.yaml`, `.treeship/agents/**`, `.treeship/harnesses/**`, `.treeship/declaration.json` are preserved as user-authored trust files. The hidden count is shown explicitly so a quiet list never masquerades as complete.

**Agent cards** panel from the workspace card store:
```
agent cards (5 in workspace)
  ✓ Claude Code   (claude-code, harness: claude-code, active)
    host:     local
  · SuperNinja    (ninjatech-superninja, harness: ninjatech-superninja, draft)
    host:     local
  ...
```

**Harness coverage** panel — preserves PR 5's trust-semantics tightening with two distinct rows:
```
harness coverage (4 attached)
  Claude Code Native Hook Harness  (instrumented, coverage: high)
    potential: read=y write=y cmd=y mcp=y model=y
    verified:  (none yet -- run a real session through this harness)
    last smoke (pass): setup generic trust-fabric smoke ok (does not prove harness-specific capture)
    gap: Built-in tools the user invokes outside hooks (manual sed inside Bash) rely on git-reconcile.
```

`inspect` signature gains a `config: Option<&str>` so the new panels are skipped silently when running on a bare receipt outside a workspace (e.g. one that arrived in someone's inbox).

### First-run docs (5 new pages)

| Page | Purpose |
|---|---|
| `docs/guides/first-run.mdx` | Install → init → setup --yes → session → read report. Local-first; remote attach explicitly deferred to v0.9.9. |
| `docs/concepts/agent-cards.mdx` | Card lifecycle, schema, certificate digest drift demotion, working-with-cards. |
| `docs/concepts/harnesses.mdx` | The 1:1 surface↔harness mapping today; manifest vs state; status lifecycle; the explicit line that setup's generic smoke does NOT promote to Verified. |
| `docs/guides/coverage-levels.mdx` | What `high` / `medium` / `basic` / `backstop-only` actually claim. Per-tier honest gaps. How to read coverage in a session report. |
| `docs/integrations/ninjatech.mdx` | Ninja Dev (local IDE, manual register today) vs SuperNinja (remote, basic coverage until v0.9.9 invite/join). Three honest paths today: manual register + git-reconcile, GitHub PR evidence, MCP proxy. |

`meta.json` updates for concepts, guides, and integrations so the new pages appear in the sidebar.

## Tests

5 new unit tests pin the filter + badge invariants:
- `runtime_artifacts_are_hidden`
- `user_authored_treeship_files_are_preserved`
- `non_treeship_files_pass_through`
- `unknown_treeship_subpath_stays_visible` (err on the side of showing)
- `source_label_maps_known_provenance` (incl. `unknown` for any unrecognized future label)

Total: 79 cli tests pass (74 prior + 5 new).
Acceptance smoke green. Version-consistency green.

## End-to-end demo (real binary)

```
$ treeship init --config .treeship/config.json --name r6
$ treeship setup --yes
✓ Treeship setup complete
  Agents:
    claude-code            active  (high)
    cursor-agent           active  (medium)
    codex                  active  (medium)
    openclaw               active  (medium)
    ninjatech-superninja   draft   (basic)

$ treeship session start --name "first run"
$ treeship wrap -- sh -c 'echo polished > polished.txt'
$ treeship session close --summary "report polish smoke"

$ treeship package inspect .treeship/sessions/ssn_*.treeship
... (existing panels) ...

files changed
  written (1):
    [hook             ] created  polished.txt

agent cards (5 in workspace)
  ✓ Claude Code  (claude-code, harness: claude-code, active)
  ...

harness coverage (4 attached)
  Claude Code Native Hook Harness  (instrumented, coverage: high)
    potential: read=y write=y cmd=y mcp=y model=y
    verified:  (none yet -- run a real session through this harness)
    ...
```

## Out of scope (deferred to v0.9.9 and later)

- `treeship agent invite` / `treeship join --invite` for remote/VPS/SuperNinja attach
- GitHub verification surface (PR Check, Actions artifact)
- Per-harness smokes that exercise specific capture signals (the path to actually populating `verified_captures`)
- Approval Use Journal and Hub/global replay (next major release)

## v0.9.8 release readiness

This PR is the last code/docs change before the v0.9.8 release cutover. All six PRs:

1. ✅ #43 — discovery model + `add --discover`
2. ✅ #44 — Agent Card store + cert digest drift demotion
3. ✅ #45 — `treeship setup` orchestration
4. ✅ #46 — install templates table
5. ✅ #47 — Harness Manager core + trust-semantics tightening
6. **this PR** — report polish + first-run docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)