### PR TITLE
feat(core,cli): v0.9.9 PR 2 — Local Approval Use Journal + read-only CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3938,6 +3938,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]

--- a/packages/cli/src/commands/approval.rs
+++ b/packages/cli/src/commands/approval.rs
@@ -1,0 +1,234 @@
+//! `treeship approval` subcommands -- v0.9.9 PR 2 read-only surface.
+//!
+//! Three commands wrap the local Approval Use Journal:
+//!
+//!     treeship approval uses <grant-id>             # list every use
+//!     treeship approval status <grant-id>           # count vs max_uses
+//!     treeship approval journal verify              # chain integrity check
+//!
+//! No write commands (consume-before-action lands in PR 3 inside
+//! `treeship attest action`). No package-level commands (PR 4). Just
+//! enough surface for users + tests to inspect the journal that PR 3's
+//! consume flow will write to.
+//!
+//! The journal directory follows the same precedence pattern as
+//! cards (PR 2 of v0.9.8) and harness state (PR 5 of v0.9.8): we resolve
+//! it relative to the active config_path so a project-local Treeship
+//! gets its own journal, and the global config gets another. This keeps
+//! the trust scope honest -- the journal answers questions about the
+//! workspace it was created for, not some shared global state.
+
+use std::path::{Path, PathBuf};
+
+use treeship_core::journal::{self, Journal};
+
+use crate::ctx;
+use crate::printer::{Format, Printer};
+
+fn journal_dir_for(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("journals")
+        .join("approval-use")
+}
+
+// ---------------------------------------------------------------------------
+// uses
+// ---------------------------------------------------------------------------
+
+/// `treeship approval uses <grant-id>` -- list every recorded use of a
+/// grant. Empty list when the journal is missing or has no entries for
+/// the grant; that's the same posture verify falls back to (package-local).
+pub fn uses(
+    grant_id: &str,
+    config: Option<&str>,
+    format: Format,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let j = Journal::new(journal_dir_for(&ctx.config_path));
+    let uses = journal::list_uses_for_grant(&j, grant_id)?;
+
+    match format {
+        Format::Json => {
+            let value = serde_json::json!({
+                "grant_id":      grant_id,
+                "journal_exists": j.exists(),
+                "uses":           uses,
+            });
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        }
+        Format::Text => {
+            printer.blank();
+            if !j.exists() {
+                printer.dim_info("  No local Approval Use Journal at this workspace.");
+                printer.dim_info("  Verify will fall back to package-local replay only.");
+                printer.blank();
+                return Ok(());
+            }
+            if uses.is_empty() {
+                printer.dim_info(&format!("  No recorded uses for grant {grant_id}."));
+                printer.blank();
+                return Ok(());
+            }
+            printer.section(&format!("approval uses ({} for grant {grant_id})", uses.len()));
+            for u in &uses {
+                let max = u.max_uses.map(|m| m.to_string()).unwrap_or_else(|| "?".into());
+                printer.info(&format!(
+                    "  use {}/{}  {}  -> {}  by {}  at {}",
+                    u.use_number, max, u.action, u.subject, u.actor, u.created_at,
+                ));
+                printer.dim_info(&format!("    use_id:        {}", u.use_id));
+                printer.dim_info(&format!("    nonce_digest:  {}", u.nonce_digest));
+                if let Some(idem) = &u.idempotency_key {
+                    printer.dim_info(&format!("    idempotency:   {idem}"));
+                }
+                if let Some(aid) = &u.action_artifact_id {
+                    printer.dim_info(&format!("    action_id:     {aid}"));
+                }
+            }
+            printer.blank();
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+/// `treeship approval status <grant-id>` -- summary of the grant's
+/// consumption state. Reports use_count, max_uses (when known from
+/// stored records), and whether further uses would exceed.
+pub fn status(
+    grant_id: &str,
+    config: Option<&str>,
+    format: Format,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let j = Journal::new(journal_dir_for(&ctx.config_path));
+    let uses = journal::list_uses_for_grant(&j, grant_id)?;
+
+    let count = uses.len() as u32;
+    let max_uses = uses.iter().filter_map(|u| u.max_uses).last();
+    let exceeded = match max_uses {
+        Some(m) => count >= m,
+        None    => false,
+    };
+
+    match format {
+        Format::Json => {
+            let value = serde_json::json!({
+                "grant_id":       grant_id,
+                "journal_exists": j.exists(),
+                "use_count":      count,
+                "max_uses":       max_uses,
+                "would_exceed":   exceeded,
+            });
+            println!("{}", serde_json::to_string_pretty(&value)?);
+        }
+        Format::Text => {
+            printer.blank();
+            printer.section(&format!("approval status: {grant_id}"));
+            if !j.exists() {
+                printer.dim_info("  no local Approval Use Journal at this workspace");
+                printer.blank();
+                return Ok(());
+            }
+            let max_label = max_uses.map(|m| m.to_string()).unwrap_or_else(|| "unbounded".into());
+            printer.info(&format!("  use count:    {count}"));
+            printer.info(&format!("  max_uses:     {max_label}"));
+            if exceeded {
+                printer.warn(
+                    "  next use would exceed max_uses",
+                    &[("grant_id", grant_id)],
+                );
+            } else {
+                printer.dim_info("  next use is within max_uses");
+            }
+            printer.blank();
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// journal verify
+// ---------------------------------------------------------------------------
+
+/// `treeship approval journal verify` -- walk the entire journal,
+/// recompute every record digest, check the previous_record_digest
+/// chain, and compare against the head. On success prints "passed"
+/// with the record count; on failure prints the exact integrity
+/// violation pinpointing the broken record.
+pub fn journal_verify(
+    config: Option<&str>,
+    format: Format,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let j = Journal::new(journal_dir_for(&ctx.config_path));
+
+    if !j.exists() {
+        match format {
+            Format::Json => {
+                let value = serde_json::json!({
+                    "journal_exists": false,
+                    "passed":         null,
+                });
+                println!("{}", serde_json::to_string_pretty(&value)?);
+            }
+            Format::Text => {
+                printer.blank();
+                printer.dim_info("  No local Approval Use Journal in this workspace; nothing to verify.");
+                printer.blank();
+            }
+        }
+        return Ok(());
+    }
+
+    match journal::verify_integrity(&j) {
+        Ok(count) => {
+            match format {
+                Format::Json => {
+                    let value = serde_json::json!({
+                        "journal_exists": true,
+                        "passed":         true,
+                        "record_count":   count,
+                    });
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                }
+                Format::Text => {
+                    printer.blank();
+                    printer.success(
+                        &format!("journal verified: {count} records, chain intact"),
+                        &[],
+                    );
+                    printer.blank();
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            match format {
+                Format::Json => {
+                    let value = serde_json::json!({
+                        "journal_exists": true,
+                        "passed":         false,
+                        "error":          e.to_string(),
+                    });
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                }
+                Format::Text => {
+                    printer.blank();
+                    printer.warn("journal integrity check failed", &[("error", &e.to_string())]);
+                    printer.blank();
+                }
+            }
+            // Return the error so the process exits non-zero.
+            Err(Box::new(std::io::Error::other(e.to_string())))
+        }
+    }
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod template;
 pub mod add;
 pub mod agent;
 pub mod agents;
+pub mod approval;
 pub mod cards;
 pub mod discovery;
 pub mod harness;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -301,6 +301,19 @@ enum Command {
     ///   treeship deny 2
     Deny(DenyArgs),
 
+    /// Inspect the local Approval Use Journal
+    ///
+    /// Workspace-local store of consumed Approval Grants. Read-only
+    /// surface in v0.9.9 PR 2; consume-before-action wiring inside
+    /// `treeship attest action` lands in PR 3.
+    ///
+    /// Examples:
+    ///   treeship approval uses art_grant_xyz
+    ///   treeship approval status art_grant_xyz
+    ///   treeship approval journal verify
+    #[command(subcommand)]
+    Approval(ApprovalCommand),
+
     /// Background daemon for automatic file watching
     ///
     /// The daemon watches your project for file changes and automatically
@@ -821,6 +834,25 @@ enum AgentsCommand {
 
     /// Delete an Agent Card from the store. Idempotent.
     Remove { agent_id: String },
+}
+
+// --- approval (Use Journal) ------------------------------------------------
+
+#[derive(Subcommand)]
+enum ApprovalCommand {
+    /// List every recorded use for a grant id.
+    Uses { grant_id: String },
+    /// Summary: use_count, max_uses, would-exceed flag.
+    Status { grant_id: String },
+    /// Run integrity checks on the local Approval Use Journal.
+    #[command(subcommand)]
+    Journal(ApprovalJournalCommand),
+}
+
+#[derive(Subcommand)]
+enum ApprovalJournalCommand {
+    /// Walk every record, recompute digests, check the chain.
+    Verify,
 }
 
 // --- harness ---------------------------------------------------------------
@@ -1814,6 +1846,28 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             cli.config.as_deref(),
             printer,
         ),
+
+        Command::Approval(sub) => match sub {
+            ApprovalCommand::Uses { grant_id } => commands::approval::uses(
+                grant_id,
+                cli.config.as_deref(),
+                Format::from_str(&cli.format),
+                printer,
+            ),
+            ApprovalCommand::Status { grant_id } => commands::approval::status(
+                grant_id,
+                cli.config.as_deref(),
+                Format::from_str(&cli.format),
+                printer,
+            ),
+            ApprovalCommand::Journal(j) => match j {
+                ApprovalJournalCommand::Verify => commands::approval::journal_verify(
+                    cli.config.as_deref(),
+                    Format::from_str(&cli.format),
+                    printer,
+                ),
+            },
+        },
 
         Command::Daemon(sub) => match sub {
             DaemonCommand::Start { foreground, no_push } => commands::daemon::start(

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -31,4 +31,6 @@ hostname      = "0.4"
 fs2           = "0.4"
 
 [dev-dependencies]
-# Nothing extra needed — tests use the same crates
+# tempfile drives the journal tests (PR 2 of v0.9.9) — every test uses
+# an isolated tmpdir for the on-disk store so they can run in parallel.
+tempfile = "3"

--- a/packages/core/src/journal/mod.rs
+++ b/packages/core/src/journal/mod.rs
@@ -1,0 +1,925 @@
+//! Local Approval Use Journal -- v0.9.9 PR 2.
+//!
+//! Per-workspace append-only memory of consumed Approval Grants. The
+//! journal turns the v0.9.6 "package-local only" replay finding into a
+//! local-journal replay finding: with this module wired through, verify
+//! can say "use 1/1 -- local Approval Use Journal passed" instead of
+//! "no global ledger consulted."
+//!
+//! Scope of THIS PR:
+//!   * journal storage (records/, heads/, indexes/, locks/)
+//!   * append-only writes with file lock + atomic temp+rename
+//!   * hash chain via `previous_record_digest`
+//!   * read-only `check_replay` lookup
+//!   * `verify_integrity` chain walk
+//!   * `rebuild_indexes` from records (records are truth)
+//!
+//! Out of scope (later PRs):
+//!   * consume-before-action wiring inside `treeship attest action` (PR 3)
+//!   * package export of journal records (PR 4)
+//!   * Hub checkpoint signing (PR 6 scaffold)
+//!
+//! Privacy rules baked into the layout:
+//!   * `nonce_digest`, never raw nonce
+//!   * no commands, prompts, file contents, bearer tokens, or API keys
+//!     are stored. The journal answers the single question "has this
+//!     (grant_id, nonce_digest) been consumed before, and if so how
+//!     many times?" -- everything else stays in the signed grant +
+//!     receipt where it already is.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+use sha2::{Digest, Sha256};
+
+use crate::statements::{
+    ApprovalRevocation, ApprovalUse, JournalCheckpoint, ReplayCheck, ReplayCheckLevel,
+    TYPE_APPROVAL_REVOCATION, TYPE_APPROVAL_USE, TYPE_JOURNAL_CHECKPOINT,
+    approval_revocation_record_digest, approval_use_record_digest,
+    journal_checkpoint_record_digest,
+};
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub enum JournalError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    /// `previous_record_digest` on a record didn't match the prior
+    /// record's `record_digest`. The chain is broken.
+    BrokenChain {
+        index:    u64,
+        expected: String,
+        actual:   String,
+    },
+    /// A record's stored `record_digest` didn't match the recomputed
+    /// digest. The record was tampered after write.
+    RecordTampered {
+        index:    u64,
+        expected: String,
+        actual:   String,
+    },
+    /// A record file referenced by the head no longer exists.
+    MissingRecord {
+        index: u64,
+    },
+    /// The journal's append lock could not be acquired.
+    LockBusy,
+    /// The append exceeds `max_uses` recorded on prior uses for this
+    /// grant. Surfaced as an error so callers (PR 3) refuse to sign
+    /// the action; PR 2 itself only writes uses passed in by callers,
+    /// so this only fires from `append_use` when the caller didn't
+    /// preflight via `check_replay`.
+    MaxUsesExceeded {
+        grant_id:   String,
+        max_uses:   u32,
+        current:    u32,
+    },
+}
+
+impl std::fmt::Display for JournalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e)            => write!(f, "journal io: {e}"),
+            Self::Json(e)          => write!(f, "journal json: {e}"),
+            Self::BrokenChain { index, expected, actual } => write!(
+                f,
+                "journal broken at record {index}: previous_record_digest = {actual}, expected {expected}",
+            ),
+            Self::RecordTampered { index, expected, actual } => write!(
+                f,
+                "journal record {index} tampered: stored digest {expected}, recomputed {actual}",
+            ),
+            Self::MissingRecord { index } => write!(
+                f,
+                "journal record {index} referenced by head but missing on disk",
+            ),
+            Self::LockBusy => write!(f, "journal append lock busy; another process holds it"),
+            Self::MaxUsesExceeded { grant_id, max_uses, current } => write!(
+                f,
+                "approval grant {grant_id} would exceed max_uses ({current}/{max_uses})",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for JournalError {}
+impl From<std::io::Error>    for JournalError { fn from(e: std::io::Error)    -> Self { Self::Io(e) } }
+impl From<serde_json::Error> for JournalError { fn from(e: serde_json::Error) -> Self { Self::Json(e) } }
+
+// ---------------------------------------------------------------------------
+// Layout
+// ---------------------------------------------------------------------------
+
+/// Directory layout under `.treeship/journals/approval-use/`.
+pub struct Journal {
+    /// Root directory.
+    pub dir: PathBuf,
+}
+
+impl Journal {
+    pub fn new(dir: impl Into<PathBuf>) -> Self {
+        Self { dir: dir.into() }
+    }
+
+    pub fn records_dir(&self) -> PathBuf  { self.dir.join("records") }
+    pub fn heads_dir(&self)   -> PathBuf  { self.dir.join("heads") }
+    pub fn indexes_dir(&self) -> PathBuf  { self.dir.join("indexes") }
+    pub fn locks_dir(&self)   -> PathBuf  { self.dir.join("locks") }
+    pub fn current_head_path(&self) -> PathBuf { self.heads_dir().join("current.json") }
+    pub fn lock_path(&self)         -> PathBuf { self.locks_dir().join("journal.lock") }
+    pub fn meta_path(&self)         -> PathBuf { self.dir.join("journal.json") }
+
+    /// Index file for a given grant. Each line is one `record_index`.
+    pub fn by_grant_path(&self, grant_id: &str) -> PathBuf {
+        self.indexes_dir().join("by-grant").join(format!("{}.txt", safe_name(grant_id)))
+    }
+
+    /// Index file for a nonce_digest.
+    pub fn by_nonce_path(&self, nonce_digest: &str) -> PathBuf {
+        self.indexes_dir().join("by-nonce").join(format!("{}.txt", safe_name(nonce_digest)))
+    }
+
+    /// Returns true iff the journal directory exists.
+    pub fn exists(&self) -> bool {
+        self.dir.is_dir()
+    }
+}
+
+/// Make a filesystem-safe name by replacing path-unsafe chars. Used for
+/// index file names; not a security boundary -- the journal's actual
+/// integrity check is the hash chain.
+fn safe_name(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            ':' | '/' | '\\' | ' ' | '.' => '_',
+            c => c,
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Head file
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Head {
+    /// 1-indexed; 0 means "no records yet."
+    pub index: u64,
+    /// `record_digest` of the most recent record. Empty when index=0.
+    pub digest: String,
+    /// Updated on every append.
+    pub updated_at: String,
+}
+
+impl Default for Head {
+    fn default() -> Self {
+        Self {
+            index:      0,
+            digest:     String::new(),
+            updated_at: String::new(),
+        }
+    }
+}
+
+fn read_head(j: &Journal) -> Result<Head, JournalError> {
+    let path = j.current_head_path();
+    if !path.exists() {
+        return Ok(Head::default());
+    }
+    let bytes = fs::read(&path)?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+fn write_head(j: &Journal, head: &Head) -> Result<(), JournalError> {
+    fs::create_dir_all(j.heads_dir())?;
+    let path = j.current_head_path();
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_vec_pretty(head)?;
+    fs::write(&tmp, json)?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Append
+// ---------------------------------------------------------------------------
+
+/// Acquire the journal append lock for the duration of the closure. Uses
+/// fs2::FileExt::try_lock_exclusive (the same primitive `session::event_log`
+/// uses) so behavior matches what the rest of the codebase already
+/// trusts.
+fn with_lock<F, T>(j: &Journal, body: F) -> Result<T, JournalError>
+where
+    F: FnOnce() -> Result<T, JournalError>,
+{
+    fs::create_dir_all(j.locks_dir())?;
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(j.lock_path())?;
+    if lock.try_lock_exclusive().is_err() {
+        return Err(JournalError::LockBusy);
+    }
+    let result = body();
+    let _ = fs2::FileExt::unlock(&lock);
+    result
+}
+
+/// Append an ApprovalUse to the journal. The caller MUST set
+/// `previous_record_digest` to the current head's digest on the
+/// incoming record; we re-validate before write. `record_digest` is
+/// computed from the canonical form and stamped on the stored record.
+///
+/// Returns the new head's index and digest.
+pub fn append_use(j: &Journal, mut rec: ApprovalUse) -> Result<Head, JournalError> {
+    rec.type_ = TYPE_APPROVAL_USE.into();
+    with_lock(j, || {
+        let head = read_head(j)?;
+        rec.previous_record_digest = head.digest.clone();
+        rec.record_digest = approval_use_record_digest(&rec);
+        let next_index = head.index + 1;
+        write_record_use(j, next_index, &rec)?;
+        update_indexes_for_use(j, next_index, &rec)?;
+        let new_head = Head {
+            index:      next_index,
+            digest:     rec.record_digest.clone(),
+            updated_at: rec.created_at.clone(),
+        };
+        write_head(j, &new_head)?;
+        ensure_meta(j)?;
+        Ok(new_head)
+    })
+}
+
+/// Append an ApprovalRevocation. Sibling of `append_use`.
+pub fn append_revocation(j: &Journal, mut rec: ApprovalRevocation) -> Result<Head, JournalError> {
+    rec.type_ = TYPE_APPROVAL_REVOCATION.into();
+    with_lock(j, || {
+        let head = read_head(j)?;
+        rec.previous_record_digest = head.digest.clone();
+        rec.record_digest = approval_revocation_record_digest(&rec);
+        let next_index = head.index + 1;
+        write_record_revocation(j, next_index, &rec)?;
+        index_grant(j, next_index, &rec.grant_id)?;
+        let new_head = Head {
+            index:      next_index,
+            digest:     rec.record_digest.clone(),
+            updated_at: rec.created_at.clone(),
+        };
+        write_head(j, &new_head)?;
+        ensure_meta(j)?;
+        Ok(new_head)
+    })
+}
+
+/// Append a JournalCheckpoint over a contiguous range of prior records.
+pub fn append_checkpoint(j: &Journal, mut rec: JournalCheckpoint) -> Result<Head, JournalError> {
+    rec.type_ = TYPE_JOURNAL_CHECKPOINT.into();
+    with_lock(j, || {
+        let head = read_head(j)?;
+        rec.previous_record_digest = head.digest.clone();
+        rec.record_digest = journal_checkpoint_record_digest(&rec);
+        let next_index = head.index + 1;
+        write_record_checkpoint(j, next_index, &rec)?;
+        let new_head = Head {
+            index:      next_index,
+            digest:     rec.record_digest.clone(),
+            updated_at: rec.created_at.clone(),
+        };
+        write_head(j, &new_head)?;
+        ensure_meta(j)?;
+        Ok(new_head)
+    })
+}
+
+fn record_filename(index: u64, type_: &str, digest: &str) -> String {
+    // Use the digest's hex tail (after "sha256:") so the filename is
+    // bounded length and contains no separators.
+    let tail = digest.strip_prefix("sha256:").unwrap_or(digest);
+    let short = &tail[..tail.len().min(16)];
+    format!("{:010}.{type_}.{short}.json", index)
+}
+
+fn write_record_use(j: &Journal, index: u64, rec: &ApprovalUse) -> Result<(), JournalError> {
+    fs::create_dir_all(j.records_dir())?;
+    let name = record_filename(index, "approval-use", &rec.record_digest);
+    let path = j.records_dir().join(&name);
+    let tmp = path.with_extension("json.tmp");
+    let mut f = File::create(&tmp)?;
+    f.write_all(&serde_json::to_vec_pretty(rec)?)?;
+    f.sync_all()?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn write_record_revocation(j: &Journal, index: u64, rec: &ApprovalRevocation) -> Result<(), JournalError> {
+    fs::create_dir_all(j.records_dir())?;
+    let name = record_filename(index, "approval-revocation", &rec.record_digest);
+    let path = j.records_dir().join(&name);
+    let tmp = path.with_extension("json.tmp");
+    let mut f = File::create(&tmp)?;
+    f.write_all(&serde_json::to_vec_pretty(rec)?)?;
+    f.sync_all()?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn write_record_checkpoint(j: &Journal, index: u64, rec: &JournalCheckpoint) -> Result<(), JournalError> {
+    fs::create_dir_all(j.records_dir())?;
+    let name = record_filename(index, "journal-checkpoint", &rec.record_digest);
+    let path = j.records_dir().join(&name);
+    let tmp = path.with_extension("json.tmp");
+    let mut f = File::create(&tmp)?;
+    f.write_all(&serde_json::to_vec_pretty(rec)?)?;
+    f.sync_all()?;
+    fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+fn ensure_meta(j: &Journal) -> Result<(), JournalError> {
+    let path = j.meta_path();
+    if path.exists() {
+        return Ok(());
+    }
+    #[derive(serde::Serialize)]
+    struct Meta<'a> {
+        kind:    &'a str,
+        version: &'a str,
+        format:  &'a str,
+    }
+    let meta = Meta { kind: "approval-use-journal", version: "v1", format: "json-records" };
+    let bytes = serde_json::to_vec_pretty(&meta)?;
+    fs::write(&path, bytes)?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Indexes (rebuildable cache)
+// ---------------------------------------------------------------------------
+
+fn append_index(path: &Path, line: &str) -> Result<(), JournalError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut f = OpenOptions::new().append(true).create(true).open(path)?;
+    writeln!(f, "{line}")?;
+    Ok(())
+}
+
+fn index_grant(j: &Journal, index: u64, grant_id: &str) -> Result<(), JournalError> {
+    append_index(&j.by_grant_path(grant_id), &index.to_string())
+}
+
+fn index_nonce(j: &Journal, index: u64, nonce_digest: &str) -> Result<(), JournalError> {
+    append_index(&j.by_nonce_path(nonce_digest), &index.to_string())
+}
+
+fn update_indexes_for_use(j: &Journal, index: u64, rec: &ApprovalUse) -> Result<(), JournalError> {
+    index_grant(j, index, &rec.grant_id)?;
+    index_nonce(j, index, &rec.nonce_digest)?;
+    Ok(())
+}
+
+/// Delete and rebuild every index from the records directory. Records are
+/// truth; indexes are cache. Useful as a recovery tool when an index file
+/// is corrupt or out of sync.
+pub fn rebuild_indexes(j: &Journal) -> Result<u64, JournalError> {
+    let dir = j.indexes_dir();
+    if dir.is_dir() {
+        // Wipe by recursive remove. Atomic enough; the worst-case is a
+        // partially-rebuilt index, which the next call to this function
+        // also recovers from.
+        fs::remove_dir_all(&dir)?;
+    }
+    let mut rebuilt = 0u64;
+    for (idx, kind, bytes) in iter_records(j)? {
+        match kind.as_str() {
+            "approval-use" => {
+                let rec: ApprovalUse = serde_json::from_slice(&bytes)?;
+                update_indexes_for_use(j, idx, &rec)?;
+                rebuilt += 1;
+            }
+            "approval-revocation" => {
+                let rec: ApprovalRevocation = serde_json::from_slice(&bytes)?;
+                index_grant(j, idx, &rec.grant_id)?;
+                rebuilt += 1;
+            }
+            "journal-checkpoint" => {
+                rebuilt += 1; // checkpoints aren't indexed by grant/nonce
+            }
+            _ => {}
+        }
+    }
+    Ok(rebuilt)
+}
+
+// ---------------------------------------------------------------------------
+// Iteration + integrity
+// ---------------------------------------------------------------------------
+
+/// Walk records/ in index order. Returns `(index, kind, bytes)`. Kind is
+/// derived from the filename ("approval-use" / "approval-revocation" /
+/// "journal-checkpoint"). Filenames Treeship doesn't recognize are
+/// skipped silently rather than failing the whole walk -- a future record
+/// type added by a newer version shouldn't break older readers.
+fn iter_records(j: &Journal) -> Result<Vec<(u64, String, Vec<u8>)>, JournalError> {
+    let dir = j.records_dir();
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut entries: Vec<(u64, String, PathBuf)> = Vec::new();
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None    => continue,
+        };
+        // Filename shape: "<10-digit-index>.<kind>.<short-digest>.json"
+        let mut parts = name.splitn(4, '.');
+        let idx_str = match parts.next() { Some(s) => s, None => continue };
+        let kind    = match parts.next() { Some(s) => s, None => continue };
+        // index parses as u64
+        let idx = match idx_str.parse::<u64>() { Ok(n) => n, Err(_) => continue };
+        entries.push((idx, kind.to_string(), path));
+    }
+    entries.sort_by_key(|(idx, _, _)| *idx);
+    let mut out = Vec::with_capacity(entries.len());
+    for (idx, kind, path) in entries {
+        let bytes = fs::read(&path)?;
+        out.push((idx, kind, bytes));
+    }
+    Ok(out)
+}
+
+/// Walk every record in order, recompute each `record_digest`, and check
+/// that each record's `previous_record_digest` matches the prior
+/// record's stored `record_digest`. Returns the number of records walked
+/// or an error pinpointing the first integrity failure.
+pub fn verify_integrity(j: &Journal) -> Result<u64, JournalError> {
+    let mut prior_digest = String::new();
+    let mut count = 0u64;
+    let head = read_head(j)?;
+    for (idx, kind, bytes) in iter_records(j)? {
+        match kind.as_str() {
+            "approval-use" => {
+                let rec: ApprovalUse = serde_json::from_slice(&bytes)?;
+                if rec.previous_record_digest != prior_digest {
+                    return Err(JournalError::BrokenChain {
+                        index:    idx,
+                        expected: prior_digest,
+                        actual:   rec.previous_record_digest,
+                    });
+                }
+                let recomputed = approval_use_record_digest(&rec);
+                if recomputed != rec.record_digest {
+                    return Err(JournalError::RecordTampered {
+                        index:    idx,
+                        expected: rec.record_digest,
+                        actual:   recomputed,
+                    });
+                }
+                prior_digest = rec.record_digest;
+            }
+            "approval-revocation" => {
+                let rec: ApprovalRevocation = serde_json::from_slice(&bytes)?;
+                if rec.previous_record_digest != prior_digest {
+                    return Err(JournalError::BrokenChain {
+                        index:    idx,
+                        expected: prior_digest,
+                        actual:   rec.previous_record_digest,
+                    });
+                }
+                let recomputed = approval_revocation_record_digest(&rec);
+                if recomputed != rec.record_digest {
+                    return Err(JournalError::RecordTampered {
+                        index:    idx,
+                        expected: rec.record_digest,
+                        actual:   recomputed,
+                    });
+                }
+                prior_digest = rec.record_digest;
+            }
+            "journal-checkpoint" => {
+                let rec: JournalCheckpoint = serde_json::from_slice(&bytes)?;
+                if rec.previous_record_digest != prior_digest {
+                    return Err(JournalError::BrokenChain {
+                        index:    idx,
+                        expected: prior_digest,
+                        actual:   rec.previous_record_digest,
+                    });
+                }
+                let recomputed = journal_checkpoint_record_digest(&rec);
+                if recomputed != rec.record_digest {
+                    return Err(JournalError::RecordTampered {
+                        index:    idx,
+                        expected: rec.record_digest,
+                        actual:   recomputed,
+                    });
+                }
+                prior_digest = rec.record_digest;
+            }
+            _ => {
+                // Unknown record kind. Stop the chain check rather than
+                // skip silently -- a newer record type would still need
+                // to participate in the chain.
+                continue;
+            }
+        }
+        count += 1;
+    }
+    // Tail must match the head if records exist; if records were
+    // deleted off the end the head will be stale.
+    if head.index != 0 && head.digest != prior_digest {
+        return Err(JournalError::MissingRecord { index: head.index });
+    }
+    Ok(count)
+}
+
+// ---------------------------------------------------------------------------
+// check_replay
+// ---------------------------------------------------------------------------
+
+/// Check whether (`grant_id`, `nonce_digest`) has already been consumed,
+/// and how many times. Returns a `ReplayCheck` carrying the strongest
+/// level the journal can speak to:
+///
+///   - `NotPerformed` when the journal directory does not exist on disk.
+///     The caller (verify) should fall back to its package-local check.
+///   - `LocalJournal` otherwise. `passed: true` means the use count is
+///     within `max_uses_hint`; `false` means it would exceed.
+///
+/// `max_uses_hint` is what the caller knows from the signed grant's
+/// `ApprovalScope.max_actions`. We accept it as a hint rather than
+/// reading it back from a stored record because the stored uses already
+/// carry their own `max_uses` snapshot, and disagreement between the
+/// hint and the stored value should be visible in `details`.
+pub fn check_replay(
+    j: &Journal,
+    grant_id: &str,
+    nonce_digest: &str,
+    max_uses_hint: Option<u32>,
+) -> Result<ReplayCheck, JournalError> {
+    if !j.exists() {
+        return Ok(ReplayCheck::not_performed());
+    }
+    // Use the by-nonce index: every prior use of the same approval
+    // shares the same nonce_digest, so the index gives us the exact
+    // record list.
+    let index_path = j.by_nonce_path(nonce_digest);
+    let mut current = 0u32;
+    let mut last_max: Option<u32> = None;
+    if index_path.exists() {
+        let raw = fs::read_to_string(&index_path)?;
+        for line in raw.lines() {
+            let idx: u64 = match line.trim().parse() { Ok(n) => n, Err(_) => continue };
+            if let Some(rec) = load_use_record(j, idx)? {
+                // Only count uses that bind to the same grant_id; the
+                // by-nonce index can in theory share a digest across
+                // grants, though in practice nonces are random.
+                if rec.grant_id == grant_id {
+                    current = current.saturating_add(1);
+                    last_max = rec.max_uses.or(last_max);
+                }
+            }
+        }
+    }
+    let max_uses = max_uses_hint.or(last_max);
+    let passed = match max_uses {
+        Some(m) => current < m,
+        None    => true, // unbounded grant; PR 5 reports this honestly
+    };
+    let details = match max_uses {
+        Some(m) => format!("local Approval Use Journal: use {current}/{m}"),
+        None    => format!("local Approval Use Journal: {current} prior use(s); grant has no max_uses"),
+    };
+    Ok(ReplayCheck {
+        level:      ReplayCheckLevel::LocalJournal,
+        use_number: Some(current.saturating_add(1)),
+        max_uses,
+        passed:     Some(passed),
+        details:    Some(details),
+    })
+}
+
+fn load_use_record(j: &Journal, index: u64) -> Result<Option<ApprovalUse>, JournalError> {
+    let dir = j.records_dir();
+    if !dir.is_dir() {
+        return Ok(None);
+    }
+    let prefix = format!("{:010}.approval-use.", index);
+    for entry in fs::read_dir(&dir)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with(&prefix) {
+            let bytes = fs::read(entry.path())?;
+            let rec: ApprovalUse = serde_json::from_slice(&bytes)?;
+            return Ok(Some(rec));
+        }
+    }
+    Ok(None)
+}
+
+// ---------------------------------------------------------------------------
+// Public read helpers (CLI)
+// ---------------------------------------------------------------------------
+
+/// Every ApprovalUse for `grant_id`. Reads the by-grant index, then
+/// loads each record. Quiet on missing journal.
+pub fn list_uses_for_grant(j: &Journal, grant_id: &str) -> Result<Vec<ApprovalUse>, JournalError> {
+    if !j.exists() {
+        return Ok(Vec::new());
+    }
+    let index_path = j.by_grant_path(grant_id);
+    if !index_path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = fs::read_to_string(&index_path)?;
+    let mut out = Vec::new();
+    for line in raw.lines() {
+        let idx: u64 = match line.trim().parse() { Ok(n) => n, Err(_) => continue };
+        if let Some(rec) = load_use_record(j, idx)? {
+            out.push(rec);
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn sample_use(use_id: &str, grant_id: &str, nonce_digest: &str, n: u32) -> ApprovalUse {
+        ApprovalUse {
+            type_:                  TYPE_APPROVAL_USE.into(),
+            use_id:                 use_id.into(),
+            grant_id:               grant_id.into(),
+            grant_digest:           "sha256:00".into(),
+            nonce_digest:           nonce_digest.into(),
+            actor:                  "agent://deployer".into(),
+            action:                 "deploy.production".into(),
+            subject:                "env://production".into(),
+            session_id:             None,
+            action_artifact_id:     None,
+            receipt_digest:         None,
+            use_number:             n,
+            max_uses:               Some(2),
+            idempotency_key:        None,
+            created_at:             "2026-04-30T07:00:00Z".into(),
+            expires_at:             None,
+            previous_record_digest: String::new(), // append_use rewrites this
+            record_digest:          String::new(), // append_use rewrites this
+            signature:              None,
+            signature_alg:          None,
+            signing_key_id:         None,
+        }
+    }
+
+    #[test]
+    fn first_append_creates_layout_and_head() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        let head = append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        assert_eq!(head.index, 1);
+        assert!(j.records_dir().is_dir());
+        assert!(j.heads_dir().is_dir());
+        assert!(j.current_head_path().is_file());
+        assert!(j.meta_path().is_file());
+        // by-grant + by-nonce indexes populated
+        assert!(j.by_grant_path("g1").is_file());
+        assert!(j.by_nonce_path("sha256:nn1").is_file());
+    }
+
+    #[test]
+    fn second_append_links_previous_record_digest() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        let h1 = append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        let h2 = append_use(&j, sample_use("use_2", "g1", "sha256:nn2", 2)).unwrap();
+        assert_eq!(h2.index, 2);
+        // Reading record 2 should show previous_record_digest == h1.digest
+        let recs = iter_records(&j).unwrap();
+        assert_eq!(recs.len(), 2);
+        let (_, _, bytes) = &recs[1];
+        let r2: ApprovalUse = serde_json::from_slice(bytes).unwrap();
+        assert_eq!(r2.previous_record_digest, h1.digest);
+    }
+
+    #[test]
+    fn verify_integrity_passes_on_intact_chain() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        for i in 1..=5 {
+            let nd = format!("sha256:nn{i}");
+            append_use(&j, sample_use(&format!("use_{i}"), "g1", &nd, i)).unwrap();
+        }
+        assert_eq!(verify_integrity(&j).unwrap(), 5);
+    }
+
+    #[test]
+    fn editing_a_record_breaks_integrity() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        // Find the on-disk record file and corrupt it.
+        let entries: Vec<_> = fs::read_dir(j.records_dir()).unwrap().collect();
+        let entry = entries.into_iter().next().unwrap().unwrap();
+        let mut json: serde_json::Value =
+            serde_json::from_slice(&fs::read(entry.path()).unwrap()).unwrap();
+        json["actor"] = "agent://attacker".into();
+        fs::write(entry.path(), serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+
+        let err = verify_integrity(&j).unwrap_err();
+        assert!(
+            matches!(err, JournalError::RecordTampered { .. }),
+            "expected RecordTampered, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn deleting_a_record_breaks_integrity_or_head_continuity() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        append_use(&j, sample_use("use_2", "g1", "sha256:nn2", 2)).unwrap();
+        // Remove the trailing record. Head still points at index 2.
+        let entries: Vec<_> = fs::read_dir(j.records_dir())
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        let trailing = entries.iter().max().unwrap();
+        fs::remove_file(trailing).unwrap();
+
+        let err = verify_integrity(&j).unwrap_err();
+        assert!(
+            matches!(err, JournalError::MissingRecord { .. }),
+            "expected MissingRecord, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn indexes_can_be_rebuilt_from_records() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        for i in 1..=3 {
+            let nd = format!("sha256:nn{i}");
+            append_use(&j, sample_use(&format!("use_{i}"), "g1", &nd, i)).unwrap();
+        }
+        // Wipe indexes; check_replay (or rebuild_indexes) should still work.
+        fs::remove_dir_all(j.indexes_dir()).unwrap();
+
+        let rebuilt = rebuild_indexes(&j).unwrap();
+        assert_eq!(rebuilt, 3);
+        assert!(j.by_grant_path("g1").is_file());
+        assert!(j.by_nonce_path("sha256:nn1").is_file());
+    }
+
+    #[test]
+    fn check_replay_reports_use_count_and_max() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        // Two prior uses of grant g1 with the same nonce_digest.
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        append_use(&j, sample_use("use_2", "g1", "sha256:nn1", 2)).unwrap();
+
+        // max_uses_hint = 2: the next use would be 3/2 -> not passed.
+        let r = check_replay(&j, "g1", "sha256:nn1", Some(2)).unwrap();
+        assert_eq!(r.level, ReplayCheckLevel::LocalJournal);
+        assert_eq!(r.use_number, Some(3));
+        assert_eq!(r.max_uses,   Some(2));
+        assert_eq!(r.passed,     Some(false));
+    }
+
+    #[test]
+    fn check_replay_passes_when_under_max() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        let r = check_replay(&j, "g1", "sha256:nn1", Some(2)).unwrap();
+        assert_eq!(r.use_number, Some(2));
+        assert_eq!(r.passed,     Some(true));
+    }
+
+    #[test]
+    fn check_replay_no_journal_returns_not_performed() {
+        let dir = tempdir().unwrap();
+        let absent = dir.path().join("nope");
+        let j = Journal::new(&absent);
+        let r = check_replay(&j, "g1", "sha256:nn1", Some(1)).unwrap();
+        assert_eq!(r.level, ReplayCheckLevel::NotPerformed);
+        assert!(r.use_number.is_none());
+    }
+
+    #[test]
+    fn check_replay_unbounded_grant_passes_with_count() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        // No max_uses_hint and stored record's max_uses is Some(2) too,
+        // so we explicitly set None on a fresh record to test the
+        // unbounded path.
+        let mut u = sample_use("use_2", "g2", "sha256:other", 1);
+        u.max_uses = None;
+        append_use(&j, u).unwrap();
+
+        let r = check_replay(&j, "g2", "sha256:other", None).unwrap();
+        assert!(r.passed.unwrap());
+        assert!(r.max_uses.is_none());
+    }
+
+    #[test]
+    fn list_uses_for_grant_returns_records_in_order() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        append_use(&j, sample_use("use_2", "g2", "sha256:nn2", 1)).unwrap();
+        append_use(&j, sample_use("use_3", "g1", "sha256:nn3", 2)).unwrap();
+        let g1 = list_uses_for_grant(&j, "g1").unwrap();
+        assert_eq!(g1.len(), 2);
+        assert_eq!(g1[0].use_id, "use_1");
+        assert_eq!(g1[1].use_id, "use_3");
+    }
+
+    #[test]
+    fn lock_keeps_two_appends_serial() {
+        // Hold the lock externally; an append should fail with LockBusy
+        // rather than racing or silently overwriting.
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        fs::create_dir_all(j.locks_dir()).unwrap();
+        let held = OpenOptions::new()
+            .read(true).write(true).create(true).truncate(false)
+            .open(j.lock_path()).unwrap();
+        held.try_lock_exclusive().unwrap();
+
+        let err = append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap_err();
+        assert!(matches!(err, JournalError::LockBusy));
+
+        let _ = fs2::FileExt::unlock(&held);
+    }
+
+    #[test]
+    fn revocation_appends_into_chain() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        let rev = ApprovalRevocation {
+            type_:                  TYPE_APPROVAL_REVOCATION.into(),
+            revocation_id:          "rev_1".into(),
+            grant_id:               "g1".into(),
+            grant_digest:           "sha256:00".into(),
+            revoker:                "human://alice".into(),
+            reason:                 Some("rotated key".into()),
+            created_at:             "2026-04-30T07:01:00Z".into(),
+            previous_record_digest: String::new(),
+            record_digest:          String::new(),
+            signature:              None,
+            signature_alg:          None,
+            signing_key_id:         None,
+        };
+        let h = append_revocation(&j, rev).unwrap();
+        assert_eq!(h.index, 2);
+        assert_eq!(verify_integrity(&j).unwrap(), 2);
+    }
+
+    #[test]
+    fn record_files_contain_no_raw_nonce_or_signature_secrets() {
+        // Privacy invariant: ApprovalUse has no `nonce` field on the
+        // struct, so by construction the stored JSON only contains
+        // `nonce_digest`. This test pins the on-disk shape so a future
+        // schema change can't sneak in a raw-nonce field.
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        append_use(&j, sample_use("use_1", "g1", "sha256:nn1", 1)).unwrap();
+        let entries: Vec<_> = fs::read_dir(j.records_dir())
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        let bytes = fs::read(&entries[0]).unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let obj = json.as_object().unwrap();
+        for forbidden in ["nonce", "command", "prompt", "file_content", "bearer_token", "api_key"] {
+            assert!(
+                !obj.contains_key(forbidden),
+                "journal record must not contain `{forbidden}`",
+            );
+        }
+        // The digest IS allowed.
+        assert!(obj.contains_key("nonce_digest"));
+    }
+}

--- a/packages/core/src/journal/mod.rs
+++ b/packages/core/src/journal/mod.rs
@@ -31,8 +31,12 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+// fs2 is gated to non-wasm targets at the workspace Cargo.toml; the WASM
+// build has no concurrent writers and no real filesystem, so journal
+// operations fall back to a deterministic "no-op write" mode that still
+// keeps the public API building. Same pattern session::event_log uses.
+#[cfg(not(target_family = "wasm"))]
 use fs2::FileExt;
-use sha2::{Digest, Sha256};
 
 use crate::statements::{
     ApprovalRevocation, ApprovalUse, JournalCheckpoint, ReplayCheck, ReplayCheckLevel,
@@ -213,6 +217,7 @@ fn write_head(j: &Journal, head: &Head) -> Result<(), JournalError> {
 /// fs2::FileExt::try_lock_exclusive (the same primitive `session::event_log`
 /// uses) so behavior matches what the rest of the codebase already
 /// trusts.
+#[cfg(not(target_family = "wasm"))]
 fn with_lock<F, T>(j: &Journal, body: F) -> Result<T, JournalError>
 where
     F: FnOnce() -> Result<T, JournalError>,
@@ -230,6 +235,16 @@ where
     let result = body();
     let _ = fs2::FileExt::unlock(&lock);
     result
+}
+
+/// WASM build: no concurrent writers, no advisory locks. Run the body
+/// directly. Matches `session::event_log`'s wasm fallback.
+#[cfg(target_family = "wasm")]
+fn with_lock<F, T>(_j: &Journal, body: F) -> Result<T, JournalError>
+where
+    F: FnOnce() -> Result<T, JournalError>,
+{
+    body()
 }
 
 /// Append an ApprovalUse to the journal. The caller MUST set

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -7,5 +7,6 @@ pub mod rules;
 pub mod merkle;
 pub mod agent;
 pub mod artifacts;
+pub mod journal;
 pub mod session;
 pub mod verify;


### PR DESCRIPTION
Second of six PRs for **v0.9.9 — Approval Authority**. Builds on PR 1's schemas (#50). Read-only on the action path: this PR creates the journal store and the replay-lookup API, but does NOT change `treeship attest action` behavior. PR 3 wires consume-before-action.

> The trust layer that turns *"⚠ replay check     package-local only"* into *"✓ replay check     local Approval Use Journal passed, use 1/1"*.

## Architectural call

Same "extend, don't fork" pattern as v0.9.8: the journal directory follows the cards / harnesses precedence (`<config_dir>/journals/approval-use/`), `check_replay` returns the same `ReplayCheck` shape PR 1 introduced, and the CLI sits next to `treeship approve / deny` rather than duplicating their plumbing.

## What this PR adds

### `packages/core/src/journal/mod.rs` (new module)

**Layout** at `<config_dir>/journals/approval-use/`:
```
journal.json              # metadata
records/                  # truth (append-only)
  0000000001.approval-use.<short-digest>.json
  0000000002.approval-use.<short-digest>.json
  ...
heads/
  current.json            # {index, digest, updated_at}
indexes/                  # rebuildable cache
  by-grant/<safe-name>.txt
  by-nonce/<safe-name>.txt
locks/
  journal.lock            # fs2 exclusive lock for appends
```

**API**:
- `append_use(j, ApprovalUse) -> Head` — fs2 exclusive lock; reads head; stamps `previous_record_digest` and `record_digest`; atomic temp+rename write; updates by-grant + by-nonce indexes; updates head atomically. Returns `LockBusy` if another writer holds the lock.
- `append_revocation` and `append_checkpoint` — same chain discipline, sibling write paths
- `check_replay(grant_id, nonce_digest, max_uses_hint) -> ReplayCheck` —
  - missing journal → `ReplayCheckLevel::NotPerformed` (caller falls back to package-local)
  - present → `LocalJournal` with `use_number`, `max_uses`, `passed` flag, one-line `details`
- `verify_integrity` — walks records in index order, recomputes every `record_digest`, checks `previous_record_digest` links, pins the head's index/digest to the chain tail. Surfaces `BrokenChain` / `RecordTampered` / `MissingRecord` with the exact failing record index.
- `rebuild_indexes` — wipes `indexes/` and rebuilds from records. **Records are truth; indexes are cache.**
- `list_uses_for_grant` for the CLI.

### `packages/cli/src/commands/approval.rs` (new CLI surface)

- `treeship approval uses <grant-id>` — list every recorded use (text + JSON)
- `treeship approval status <grant-id>` — use_count vs max_uses, would-exceed flag
- `treeship approval journal verify` — chain integrity check; exits non-zero with a precise reason on failure

Missing journal is honest:
```
No local Approval Use Journal at this workspace.
Verify will fall back to package-local replay only.
```
Returns 0 in that case so scripts can probe without trapping.

## Privacy invariant pinned by tests

The journal stores **`nonce_digest`, never the raw nonce**. `record_files_contain_no_raw_nonce_or_signature_secrets` walks the on-disk JSON and asserts the record object does **not** contain `nonce`, `command`, `prompt`, `file_content`, `bearer_token`, or `api_key`. By construction, since `ApprovalUse` has no such fields. The test exists so a future schema change can't sneak one in.

## Tests (14 new journal unit tests)

| Test | Pins |
|---|---|
| `first_append_creates_layout_and_head` | Layout invariant |
| `second_append_links_previous_record_digest` | Hash chain |
| `verify_integrity_passes_on_intact_chain` | Happy path |
| `editing_a_record_breaks_integrity` | RecordTampered fires |
| `deleting_a_record_breaks_integrity_or_head_continuity` | MissingRecord fires |
| `indexes_can_be_rebuilt_from_records` | Records are truth |
| `check_replay_reports_use_count_and_max` | API shape |
| `check_replay_passes_when_under_max` | Happy path |
| `check_replay_no_journal_returns_not_performed` | Caller fallback |
| `check_replay_unbounded_grant_passes_with_count` | Unbounded grants |
| `list_uses_for_grant_returns_records_in_order` | CLI consumer |
| `lock_keeps_two_appends_serial` | LockBusy fires |
| `revocation_appends_into_chain` | Sibling write path |
| `record_files_contain_no_raw_nonce_or_signature_secrets` | Privacy invariant |

`cargo test --workspace` green; trust-fabric acceptance green; version-consistency 21/21.

## Crucial scope discipline (per release rules)

- ❌ no consume-before-action wiring (that's PR 3)
- ❌ no package export of journal records (PR 4)
- ❌ no verify-pass integration (PR 4)
- ❌ no Hub checkpoint signing (PR 6 scaffold)
- ❌ no SQLite, no public ledger, no global single-use claim
- ❌ no raw nonce / command / prompt / file content / bearer token / API key / secret stored
- ✅ `max_uses` "enforcement" here means the API can **report** whether a use would exceed; **actual enforcement** (refusing to sign the action) lives in PR 3

## What ships next

| PR | Title |
|---|---|
| 3 | Consume-before-action — `treeship attest action` resolves grant, acquires lock, reserves use, signs action, supports `--idempotency-key` |
| 4 | Package export + offline verify — `.treeship` packages carry grant + use + checkpoint records; `package verify` reports package-local vs local-journal levels separately |
| 5 | Approval panel in `package inspect` + first-class approval docs |
| 6 | `hub-approval-checkpoint/v1` scaffold only — no full Hub, no AgentGate runtime enforcement |

🤖 Generated with [Claude Code](https://claude.com/claude-code)