### PR TITLE
feat(session,verify): v0.9.9 PR 4 — package export + offline replay verify

### DIFF
--- a/packages/cli/src/commands/package.rs
+++ b/packages/cli/src/commands/package.rs
@@ -510,17 +510,119 @@ mod tests {
 
 pub fn verify(
     path: PathBuf,
+    config: Option<&str>,
+    strict: bool,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let checks = verify_package(&path)?;
+    let mut checks = verify_package(&path)?;
+
+    // v0.9.9 PR 4: layer the local-journal replay level on top of the
+    // package-local + included-checkpoint checks core::session::package
+    // already emits. The journal lookup needs workspace context; when
+    // there's no Treeship workspace at all we skip the check rather
+    // than failing -- offline / inbox verification of a bare package
+    // must keep working.
+    if let Ok(ctx_opened) = ctx::open(config) {
+        let journal_dir = ctx_opened.config_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .join("journals")
+            .join("approval-use");
+        let journal = treeship_core::journal::Journal::new(&journal_dir);
+        let bundle = treeship_core::session::read_approvals_bundle(&path)
+            .unwrap_or_default();
+        if !bundle.uses.is_empty() {
+            if !journal.exists() {
+                checks.push(treeship_core::session::VerifyCheck::warn(
+                    "replay-local-journal",
+                    "no local Approval Use Journal in this workspace; package-local replay only",
+                ));
+            } else {
+                let mut detail_parts: Vec<String> = Vec::new();
+                let mut all_pass = true;
+                for u in &bundle.uses {
+                    match treeship_core::journal::find_use_for_action(
+                        &journal,
+                        &u.grant_id,
+                        &u.nonce_digest,
+                        u.max_uses,
+                    ) {
+                        Ok(Some((_rec, replay))) => {
+                            if matches!(replay.passed, Some(false)) {
+                                all_pass = false;
+                                detail_parts.push(format!(
+                                    "use {} exceeds max_uses",
+                                    u.use_id,
+                                ));
+                            } else if let Some(d) = replay.details {
+                                detail_parts.push(d);
+                            }
+                        }
+                        Ok(None) => {
+                            // Journal exists but has no record for
+                            // this nonce. Could be a different
+                            // workspace's package; warn rather than
+                            // fail.
+                            detail_parts.push(format!(
+                                "use {} not present in this workspace's journal",
+                                u.use_id,
+                            ));
+                        }
+                        Err(e) => {
+                            all_pass = false;
+                            detail_parts.push(format!("journal error: {e}"));
+                        }
+                    }
+                }
+                let combined = detail_parts.join("; ");
+                checks.push(if all_pass {
+                    treeship_core::session::VerifyCheck::pass(
+                        "replay-local-journal",
+                        if combined.is_empty() {
+                            "local Approval Use Journal consulted".into()
+                        } else {
+                            combined.clone()
+                        }.as_str(),
+                    )
+                } else {
+                    treeship_core::session::VerifyCheck::fail(
+                        "replay-local-journal",
+                        &combined,
+                    )
+                });
+            }
+        }
+    }
 
     let pass_count = checks.iter().filter(|c| c.status == VerifyStatus::Pass).count();
-    let fail_count = checks.iter().filter(|c| c.status == VerifyStatus::Fail).count();
-    let warn_count = checks.iter().filter(|c| c.status == VerifyStatus::Warn).count();
+    let mut fail_count = checks.iter().filter(|c| c.status == VerifyStatus::Fail).count();
+    let mut warn_count = checks.iter().filter(|c| c.status == VerifyStatus::Warn).count();
+
+    // --strict promotes warnings touching approval evidence to
+    // failures. Existing receipt-determinism / event-log warnings
+    // stay warnings; only the approval rows are promoted, since the
+    // release rule is "strict mode fails on duplicate use, tampered
+    // record, broken checkpoint chain."
+    if strict {
+        let mut promoted = 0usize;
+        for c in checks.iter_mut() {
+            let approval_row = c.name.starts_with("replay-")
+                || c.name == "approval-use-integrity";
+            if approval_row && c.status == VerifyStatus::Warn {
+                c.status = VerifyStatus::Fail;
+                promoted += 1;
+            }
+        }
+        warn_count -= promoted;
+        fail_count += promoted;
+    }
 
     printer.blank();
     printer.section("package verification");
     printer.info(&format!("  package: {}", path.display()));
+    if strict {
+        printer.dim_info("  --strict: approval-evidence warnings promoted to failures");
+    }
     printer.blank();
 
     for check in &checks {
@@ -541,6 +643,7 @@ pub fn verify(
     if fail_count > 0 {
         printer.blank();
         printer.warn("package verification failed", &[]);
+        return Err("package verification failed".into());
     } else {
         printer.blank();
         printer.success("package verified", &[]);

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -2,12 +2,13 @@ use std::path::{Path, PathBuf};
 
 use treeship_core::{
     attestation::sign,
+    journal::{self, Journal},
     session::{
-        self, EventLog, EventType, SessionEvent, ReceiptComposer,
-        build_package,
+        self, ApprovalsBundle, EventLog, EventType, ReceiptComposer, SessionEvent,
+        build_package_with_approvals,
         event::{generate_event_id, generate_span_id, generate_trace_id},
     },
-    statements::{ActionStatement, payload_type},
+    statements::{ActionStatement, ApprovalStatement, payload_type},
     storage::Record,
 };
 
@@ -875,7 +876,16 @@ pub fn close(
     std::fs::create_dir_all(&pkg_dir)?;
     let mut sealed_pkg_path: Option<std::path::PathBuf> = None;
 
-    match build_package(&receipt, &pkg_dir) {
+    // v0.9.9 PR 4: gather approval evidence to embed alongside the
+    // receipt. Walks the chain for actions whose meta carries an
+    // `approval_use_id` (PR 3 stamps that), pulls the matching grant
+    // envelope from storage, the matching ApprovalUse from the local
+    // journal, and any covering checkpoint. Quiet on missing journal
+    // -- a session without consumed approvals produces an empty bundle
+    // and the resulting package omits the `approvals/` dir entirely.
+    let approvals = collect_approval_evidence(&ctx, &receipt);
+
+    match build_package_with_approvals(&receipt, &pkg_dir, Some(&approvals)) {
         Ok(pkg_output) => {
             // Package written successfully. Remove the closing marker
             // so start/close don't see a stale incomplete-close signal.
@@ -1368,3 +1378,119 @@ pub fn report(
 
     Ok(())
 }
+
+
+// ---------------------------------------------------------------------------
+// v0.9.9 PR 4 -- approval evidence collection
+// ---------------------------------------------------------------------------
+
+/// Gather Approval Grant + Approval Use + JournalCheckpoint records to
+/// embed in the .treeship package. Walks `receipt.timeline` for action
+/// events whose action artifact carries `approval_use_id` in its meta
+/// (set by PR 3's consume_approval), then resolves each through the
+/// workspace journal.
+///
+/// Quiet on missing journal: returns an empty `ApprovalsBundle` so
+/// `build_package_with_approvals` skips writing the `approvals/`
+/// directory entirely. Pre-PR-4 sessions and sessions without consumed
+/// approvals therefore produce identical packages.
+fn collect_approval_evidence(
+    ctx: &ctx::Ctx,
+    receipt: &treeship_core::session::SessionReceipt,
+) -> ApprovalsBundle {
+    let mut bundle = ApprovalsBundle::default();
+
+    // Resolve the workspace journal directory; same precedence rule as
+    // attest.rs uses (config_path.parent / journals / approval-use).
+    let journal_dir = ctx.config_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("journals")
+        .join("approval-use");
+    let journal = Journal::new(&journal_dir);
+
+    // Walk the chain: every action artifact may carry an
+    // approval_nonce, and PR 3 stamps approval_use_id into the
+    // action's meta. We pull from storage by artifact_id (the chain
+    // is an ordered list of ids on the receipt).
+    use std::collections::HashSet;
+    let mut grant_ids_seen: HashSet<String> = HashSet::new();
+    let mut use_ids_seen:   HashSet<String> = HashSet::new();
+    let mut checkpoint_ids: HashSet<String> = HashSet::new();
+
+    for art in &receipt.artifacts {
+        let rec = match ctx.storage.read(&art.artifact_id) {
+            Ok(r)  => r,
+            Err(_) => continue,
+        };
+        let action = match rec.envelope.unmarshal_statement::<ActionStatement>() {
+            Ok(a)  => a,
+            Err(_) => continue,
+        };
+        let raw_nonce = match action.approval_nonce.as_deref() {
+            Some(n) => n,
+            None    => continue,
+        };
+
+        // Find the grant by nonce -- mirror what verify does.
+        let approval_pt = payload_type("approval");
+        let mut grant_id_opt: Option<String> = None;
+        let mut grant_envelope: Option<Vec<u8>> = None;
+        for entry in ctx.storage.list_by_type(&approval_pt) {
+            if let Ok(grant_rec) = ctx.storage.read(&entry.id) {
+                if let Ok(approval) = grant_rec.envelope.unmarshal_statement::<ApprovalStatement>() {
+                    if approval.nonce == raw_nonce {
+                        grant_id_opt = Some(entry.id.clone());
+                        grant_envelope = grant_rec.envelope.to_json().ok();
+                        break;
+                    }
+                }
+            }
+        }
+        let Some(grant_id) = grant_id_opt else { continue };
+
+        if grant_ids_seen.insert(grant_id.clone()) {
+            if let Some(env_bytes) = grant_envelope {
+                bundle.grants.push((grant_id.clone(), env_bytes));
+            }
+        }
+
+        // Pull every Approval Use for this grant. Records are exported
+        // verbatim -- mutating `action_artifact_id` after the journal
+        // append would invalidate the record_digest, so the action↔use
+        // link is carried elsewhere:
+        //   * the action artifact's meta.approval_use_id points at the use
+        //   * the workspace sidecar at indexes/backfill/<use_id>.txt
+        //     gives the CLI a friendly display join (not exported)
+        if journal.exists() {
+            if let Ok(uses) = journal::list_uses_for_grant(&journal, &grant_id) {
+                for u in uses {
+                    if use_ids_seen.insert(u.use_id.clone()) {
+                        bundle.uses.push(u);
+                    }
+                }
+            }
+            // Read any journal-checkpoint records under records/ that
+            // we haven't already seen. PR 6 will sign these; PR 4
+            // just exports whatever is present.
+            if let Ok(rd) = std::fs::read_dir(journal.records_dir()) {
+                for entry in rd.flatten() {
+                    let path = entry.path();
+                    let name = match path.file_name().and_then(|n| n.to_str()) { Some(s) => s, None => continue };
+                    if !name.contains(".journal-checkpoint.") { continue; }
+                    let bytes = match std::fs::read(&path) { Ok(b) => b, Err(_) => continue };
+                    let cp: treeship_core::statements::JournalCheckpoint = match serde_json::from_slice(&bytes) {
+                        Ok(c)  => c,
+                        Err(_) => continue,
+                    };
+                    if checkpoint_ids.insert(cp.checkpoint_id.clone()) {
+                        bundle.checkpoints.push(cp);
+                    }
+                }
+            }
+        }
+    }
+
+    bundle
+}
+

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -777,10 +777,29 @@ enum PackageCommand {
     ///
     /// Runs local verification checks: receipt parsing, Merkle root
     /// recomputation, inclusion proof validation, and timeline ordering.
+    /// As of v0.9.9, also reports approval-replay evidence at three
+    /// distinct levels:
+    ///   * package-local       (duplicate uses inside the package)
+    ///   * local-journal       (workspace .treeship/journals/approval-use)
+    ///   * included-checkpoint (offline checkpoint records)
     ///
     /// Examples:
     ///   treeship package verify .treeship/sessions/ssn_abc.treeship
-    Verify(PackagePathArgs),
+    ///   treeship package verify --strict .treeship/sessions/ssn_abc.treeship
+    Verify(PackageVerifyArgs),
+}
+
+#[derive(Args)]
+struct PackageVerifyArgs {
+    /// Path to the .treeship package directory
+    #[arg(value_name = "PATH")]
+    path: std::path::PathBuf,
+
+    /// Promote approval-evidence warnings (missing journal records,
+    /// included-checkpoint anomalies) to verification failures.
+    /// Existing receipt-determinism / event-log warnings are unchanged.
+    #[arg(long)]
+    strict: bool,
 }
 
 #[derive(Args)]
@@ -1767,6 +1786,8 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             ),
             PackageCommand::Verify(a) => commands::package::verify(
                 a.path.clone(),
+                cli.config.as_deref(),
+                a.strict,
                 printer,
             ),
         },

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -23,5 +23,8 @@ pub use graph::{AgentGraph, AgentNode, AgentEdge, AgentEdgeType};
 pub use side_effects::{FileAccess, SideEffects};
 pub use receipt::{ArtifactEntry, ReceiptComposer, SessionReceipt};
 pub use render::RenderConfig;
-pub use package::{build_package, read_package, verify_package, VerifyCheck, VerifyStatus};
+pub use package::{
+    build_package, build_package_with_approvals, read_approvals_bundle, read_package,
+    verify_package, ApprovalsBundle, ApprovalsIndex, VerifyCheck, VerifyStatus,
+};
 pub use git::{reconcile_changes, current_head_sha, GitChange};

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -11,9 +11,16 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use super::receipt::{SessionReceipt, RECEIPT_TYPE};
+use crate::statements::{
+    ApprovalRevocation, ApprovalUse, JournalCheckpoint,
+    ReplayCheck, ReplayCheckLevel,
+    approval_revocation_record_digest, approval_use_record_digest,
+    journal_checkpoint_record_digest,
+};
 
 /// Errors from package operations.
 #[derive(Debug)]
@@ -49,6 +56,76 @@ const ARTIFACTS_DIR: &str = "artifacts";
 const PROOFS_DIR: &str = "proofs";
 const PREVIEW_FILE: &str = "preview.html";
 
+// Approval Authority package layout (v0.9.9 PR 4).
+// approvals/index.json -- top-level index of every approval evidence
+//                          file in this package
+// approvals/grants/<grant_id>.json    -- copy of the signed
+//                          ApprovalStatement envelope (already in
+//                          artifacts/ via the chain; mirrored here for
+//                          single-directory access during verify)
+// approvals/uses/<use_id>.json        -- ApprovalUse record from the
+//                          local journal at session-close time
+// approvals/checkpoints/<id>.json     -- JournalCheckpoint records that
+//                          cover the included uses (PR 6 Hub
+//                          checkpoint signing extends this)
+const APPROVALS_DIR:        &str = "approvals";
+const APPROVALS_GRANTS:     &str = "approvals/grants";
+const APPROVALS_USES:       &str = "approvals/uses";
+const APPROVALS_CHECKPOINTS:&str = "approvals/checkpoints";
+const APPROVALS_INDEX_FILE: &str = "approvals/index.json";
+
+/// Optional approval evidence to embed in the package alongside the
+/// receipt + artifacts. None means "no approvals consumed during this
+/// session, or none worth exporting." Empty vectors mean "we looked and
+/// found nothing"; the resulting package omits the `approvals/` dir
+/// entirely so absence is unambiguous.
+///
+/// Ownership of the evidence stays with the caller: `session::close`
+/// gathers the grant envelopes from the chain, the uses from the local
+/// journal, and any covering checkpoints, then hands them off here.
+#[derive(Debug, Clone, Default)]
+pub struct ApprovalsBundle {
+    /// Bytes of the signed ApprovalStatement envelopes that authorized
+    /// any consumed uses. Each entry is `(grant_id, raw_envelope_json)`.
+    /// Stored verbatim so the package's verifier can re-check the
+    /// signature without re-serializing.
+    pub grants:      Vec<(String, Vec<u8>)>,
+    /// ApprovalUse records pulled from the local journal at close time.
+    /// `action_artifact_id` should be backfilled before passing to
+    /// build_package (see `commands/session.rs`).
+    pub uses:        Vec<ApprovalUse>,
+    /// JournalCheckpoints that cover the included uses. Optional; may
+    /// be empty even when uses are present (PR 6 fills these in).
+    pub checkpoints: Vec<JournalCheckpoint>,
+    /// Explicit revocations we wanted to surface (e.g. a use whose
+    /// grant was revoked after consumption -- the package should still
+    /// show the consumed evidence and the revocation alongside).
+    /// Empty in PR 4; reserved.
+    pub revocations: Vec<ApprovalRevocation>,
+}
+
+/// `approvals/index.json` -- top-level inventory of evidence in the
+/// package. Lets a consumer pre-flight what's there before opening
+/// every file; doubles as a stable shape for downstream tooling.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApprovalsIndex {
+    /// Stable schema marker so future versions can fan out cleanly.
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub schema_version: u32,
+    /// Stable kebab-case ids of grants present. Order matches
+    /// `grants/` filename order.
+    pub grants:      Vec<String>,
+    /// Use ids present.
+    pub uses:        Vec<String>,
+    pub checkpoints: Vec<String>,
+    pub revocations: Vec<String>,
+}
+
+impl ApprovalsIndex {
+    pub fn type_string() -> &'static str { "treeship/approvals-index/v1" }
+}
+
 /// Result of building a package.
 pub struct PackageOutput {
     /// Path to the package directory.
@@ -65,9 +142,25 @@ pub struct PackageOutput {
 ///
 /// Writes all package files into `output_dir/<session_id>.treeship/`.
 /// Returns metadata about the written package.
+///
+/// Backwards-compatible wrapper: callers that don't have approval
+/// evidence to export pass through here unchanged. Callers that do
+/// (`session::close` with consumed approvals) call
+/// `build_package_with_approvals` directly.
 pub fn build_package(
     receipt: &SessionReceipt,
     output_dir: &Path,
+) -> Result<PackageOutput, PackageError> {
+    build_package_with_approvals(receipt, output_dir, None)
+}
+
+/// Like `build_package` but also embeds approval evidence (PR 4 of v0.9.9).
+/// `bundle = None` is identical to `build_package`; the `approvals/`
+/// directory is omitted entirely so absence stays unambiguous.
+pub fn build_package_with_approvals(
+    receipt: &SessionReceipt,
+    output_dir: &Path,
+    bundle: Option<&ApprovalsBundle>,
 ) -> Result<PackageOutput, PackageError> {
     let session_id = &receipt.session.id;
     let pkg_dir = output_dir.join(format!("{session_id}.treeship"));
@@ -111,12 +204,150 @@ pub fn build_package(
         file_count += 1;
     }
 
+    // 6. Approval evidence (v0.9.9 PR 4). Only writes when the caller
+    // supplied a bundle AND that bundle has at least one entry; an empty
+    // bundle behaves the same as None so a session with no consumed
+    // approvals doesn't leave behind an empty `approvals/` directory.
+    if let Some(b) = bundle {
+        if !b.grants.is_empty() || !b.uses.is_empty() || !b.checkpoints.is_empty() || !b.revocations.is_empty() {
+            std::fs::create_dir_all(pkg_dir.join(APPROVALS_GRANTS))?;
+            std::fs::create_dir_all(pkg_dir.join(APPROVALS_USES))?;
+            std::fs::create_dir_all(pkg_dir.join(APPROVALS_CHECKPOINTS))?;
+
+            let mut grant_ids = Vec::with_capacity(b.grants.len());
+            for (grant_id, envelope_bytes) in &b.grants {
+                let safe = sanitize_filename(grant_id);
+                std::fs::write(
+                    pkg_dir.join(APPROVALS_GRANTS).join(format!("{safe}.json")),
+                    envelope_bytes,
+                )?;
+                grant_ids.push(grant_id.clone());
+                file_count += 1;
+            }
+
+            let mut use_ids = Vec::with_capacity(b.uses.len());
+            for u in &b.uses {
+                let safe = sanitize_filename(&u.use_id);
+                let bytes = serde_json::to_vec_pretty(u)?;
+                std::fs::write(
+                    pkg_dir.join(APPROVALS_USES).join(format!("{safe}.json")),
+                    &bytes,
+                )?;
+                use_ids.push(u.use_id.clone());
+                file_count += 1;
+            }
+
+            let mut checkpoint_ids = Vec::with_capacity(b.checkpoints.len());
+            for cp in &b.checkpoints {
+                let safe = sanitize_filename(&cp.checkpoint_id);
+                let bytes = serde_json::to_vec_pretty(cp)?;
+                std::fs::write(
+                    pkg_dir.join(APPROVALS_CHECKPOINTS).join(format!("{safe}.json")),
+                    &bytes,
+                )?;
+                checkpoint_ids.push(cp.checkpoint_id.clone());
+                file_count += 1;
+            }
+
+            let mut revocation_ids = Vec::with_capacity(b.revocations.len());
+            for rev in &b.revocations {
+                let safe = sanitize_filename(&rev.revocation_id);
+                let bytes = serde_json::to_vec_pretty(rev)?;
+                std::fs::write(
+                    pkg_dir.join(APPROVALS_DIR).join(format!("revocations-{safe}.json")),
+                    &bytes,
+                )?;
+                revocation_ids.push(rev.revocation_id.clone());
+                file_count += 1;
+            }
+
+            let index = ApprovalsIndex {
+                type_:          ApprovalsIndex::type_string().into(),
+                schema_version: 1,
+                grants:         grant_ids,
+                uses:           use_ids,
+                checkpoints:    checkpoint_ids,
+                revocations:    revocation_ids,
+            };
+            let index_bytes = serde_json::to_vec_pretty(&index)?;
+            std::fs::write(pkg_dir.join(APPROVALS_INDEX_FILE), &index_bytes)?;
+            file_count += 1;
+        }
+    }
+
     Ok(PackageOutput {
         path: pkg_dir,
         receipt_digest,
         merkle_root: receipt.merkle.root.clone(),
         file_count,
     })
+}
+
+/// Sanitize an id (artifact_id, use_id, checkpoint_id) into a filesystem-safe
+/// filename. Underscores everything that isn't alphanumeric, dash, or dot.
+/// Not a security boundary; the digest chain is the integrity check.
+fn sanitize_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' || c == '_' { c } else { '_' })
+        .collect()
+}
+
+/// Read approval evidence embedded in a package, if any. Returns
+/// `Ok(ApprovalsBundle::default())` when the package has no `approvals/`
+/// directory (the typical case for sessions that didn't consume any
+/// scoped approvals). Errors only on malformed JSON inside files that
+/// the index claims exist.
+///
+/// Quiet on missing-directory by design: PR 4 packages and pre-PR-4
+/// packages should both round-trip through verify without spurious
+/// failures.
+pub fn read_approvals_bundle(pkg_dir: &Path) -> Result<ApprovalsBundle, PackageError> {
+    let approvals_dir = pkg_dir.join(APPROVALS_DIR);
+    if !approvals_dir.is_dir() {
+        return Ok(ApprovalsBundle::default());
+    }
+
+    let mut bundle = ApprovalsBundle::default();
+
+    // Grants are raw envelopes by file; we don't parse here, the
+    // verify layer can re-check the signature.
+    let grants_dir = pkg_dir.join(APPROVALS_GRANTS);
+    if grants_dir.is_dir() {
+        for entry in std::fs::read_dir(&grants_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+            let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
+            let bytes = std::fs::read(&path)?;
+            bundle.grants.push((id, bytes));
+        }
+    }
+
+    let uses_dir = pkg_dir.join(APPROVALS_USES);
+    if uses_dir.is_dir() {
+        for entry in std::fs::read_dir(&uses_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+            let bytes = std::fs::read(&path)?;
+            let u: ApprovalUse = serde_json::from_slice(&bytes)?;
+            bundle.uses.push(u);
+        }
+    }
+
+    let cps_dir = pkg_dir.join(APPROVALS_CHECKPOINTS);
+    if cps_dir.is_dir() {
+        for entry in std::fs::read_dir(&cps_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+            let bytes = std::fs::read(&path)?;
+            let cp: JournalCheckpoint = serde_json::from_slice(&bytes)?;
+            bundle.checkpoints.push(cp);
+        }
+    }
+
+    Ok(bundle)
 }
 
 /// Read and parse a `.treeship` package from disk.
@@ -263,7 +494,152 @@ pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> 
         ));
     }
 
+    // 8. Approval evidence -- v0.9.9 PR 4. Three independent replay
+    // checks, each emitted as its own VerifyCheck row so the printer
+    // (and downstream tooling) can render them separately.
+    //
+    //   replay-package-local      duplicate uses INSIDE this package
+    //   replay-included-checkpoint  embedded JournalCheckpoints verify standalone
+    //
+    // The local-journal level requires access to the workspace journal,
+    // which the package alone doesn't carry; that check runs in the CLI
+    // verify_package wrapper that has Ctx access. The hub-org level is
+    // reserved for PR 6 -- not claimed without a real Hub checkpoint.
+    let bundle = read_approvals_bundle(pkg_dir).unwrap_or_default();
+    add_approval_evidence_checks(&mut checks, &bundle);
+
     Ok(checks)
+}
+
+/// Emit the package-local + included-checkpoint replay checks. Both are
+/// fully offline: package-local scans the embedded uses for duplicates;
+/// included-checkpoint walks the embedded checkpoint records and
+/// re-derives each `record_digest` against its stored value.
+///
+/// The local-journal check is NOT here -- it requires workspace access
+/// and is added by the CLI wrapper in `commands/package.rs` that has the
+/// resolved config_path. Keeping these two pure means an offline tool
+/// (Hub-side validator, third-party verifier) can run the same checks
+/// without needing a Treeship workspace.
+pub(crate) fn add_approval_evidence_checks(
+    checks: &mut Vec<VerifyCheck>,
+    bundle: &ApprovalsBundle,
+) {
+    if bundle.uses.is_empty() && bundle.checkpoints.is_empty() {
+        // Nothing to assert. Stay quiet rather than emit a "skipped"
+        // row -- session packages without approvals shouldn't drag in
+        // approval rows by accident.
+        return;
+    }
+
+    // -- replay-package-local --
+    // Two distinct violation cases inside the package:
+    //   (a) uses sharing (grant_id, nonce_digest) EXCEED max_uses on
+    //       that grant. Two uses of a max_uses=2 grant is fine; three
+    //       is the violation. max_uses is read from the use record's
+    //       own `max_uses` field (a snapshot from consume time).
+    //   (b) two ApprovalUse records with the same use_id -- a copy
+    //       artifact from a corrupt build, never legitimate.
+    use std::collections::HashMap;
+    let mut by_nonce: HashMap<(String, String), Vec<&ApprovalUse>> = HashMap::new();
+    let mut by_use_id: HashMap<&str, Vec<&ApprovalUse>> = HashMap::new();
+    for u in &bundle.uses {
+        by_nonce
+            .entry((u.grant_id.clone(), u.nonce_digest.clone()))
+            .or_default()
+            .push(u);
+        by_use_id.entry(&u.use_id).or_default().push(u);
+    }
+    let over_max: Vec<((String, String), Vec<&ApprovalUse>, u32)> = by_nonce
+        .iter()
+        .filter_map(|(key, uses)| {
+            let max = uses.iter().filter_map(|u| u.max_uses).next()?;
+            if (uses.len() as u32) > max {
+                Some((key.clone(), uses.iter().map(|u| *u).collect(), max))
+            } else {
+                None
+            }
+        })
+        .collect();
+    let dup_use_ids: Vec<(&&str, &Vec<&ApprovalUse>)> =
+        by_use_id.iter().filter(|(_, v)| v.len() > 1).collect();
+
+    if over_max.is_empty() && dup_use_ids.is_empty() {
+        checks.push(VerifyCheck::pass(
+            "replay-package-local",
+            &format!("no duplicate approval use inside package ({} uses scanned)", bundle.uses.len()),
+        ));
+    } else {
+        let mut detail = String::from("package-local replay violation:");
+        for ((grant_id, _nd), uses, max) in &over_max {
+            detail.push_str(&format!(
+                " grant {grant_id} consumed {} times in this package (max_uses={max});",
+                uses.len(),
+            ));
+        }
+        for (uid, uses) in &dup_use_ids {
+            detail.push_str(&format!(" use_id {uid} appears {} times;", uses.len()));
+        }
+        checks.push(VerifyCheck::fail("replay-package-local", &detail));
+    }
+
+    // -- replay-included-checkpoint --
+    // For each checkpoint, recompute its record_digest from canonical
+    // form. If the stored digest doesn't match, the checkpoint was
+    // tampered after sealing.
+    if !bundle.checkpoints.is_empty() {
+        let mut tampered = Vec::new();
+        for cp in &bundle.checkpoints {
+            let recomputed = journal_checkpoint_record_digest(cp);
+            if recomputed != cp.record_digest {
+                tampered.push((cp.checkpoint_id.clone(), cp.record_digest.clone(), recomputed));
+            }
+        }
+        if tampered.is_empty() {
+            checks.push(VerifyCheck::pass(
+                "replay-included-checkpoint",
+                &format!("{} included journal checkpoint(s) verify offline", bundle.checkpoints.len()),
+            ));
+        } else {
+            let detail = tampered.iter()
+                .map(|(id, expected, actual)| {
+                    format!("checkpoint {id} tampered (stored {expected}, recomputed {actual})")
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            checks.push(VerifyCheck::fail("replay-included-checkpoint", &detail));
+        }
+    }
+
+    // -- per-use record-digest integrity --
+    // Even without a checkpoint, each ApprovalUse carries its own
+    // record_digest; tampering with any field changes the digest.
+    let mut tampered_uses = Vec::new();
+    for u in &bundle.uses {
+        let recomputed = approval_use_record_digest(u);
+        if recomputed != u.record_digest {
+            tampered_uses.push((u.use_id.clone(), u.record_digest.clone(), recomputed));
+        }
+    }
+    if !tampered_uses.is_empty() {
+        let detail = tampered_uses.iter()
+            .map(|(id, expected, actual)| {
+                format!("use {id} tampered (stored {expected}, recomputed {actual})")
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        checks.push(VerifyCheck::fail("approval-use-integrity", &detail));
+    }
+
+    // -- replay-hub-org -- intentionally NOT emitted.
+    // PR 6 will add a signed-Hub-checkpoint check that produces this
+    // row when (and only when) such evidence exists. Adding nothing
+    // here is the right call: the printer should not render
+    // "global single-use" without signed proof, and a missing row is
+    // honestly silent rather than falsely passing.
+    let _ = ReplayCheckLevel::HubOrg; // keep import live; PR 6 binds this
+    let _ = approval_revocation_record_digest as fn(&ApprovalRevocation) -> String; // PR 5 binds
+    let _ = ReplayCheck::not_performed; // PR 5 binds
 }
 
 /// A single verification check result.


### PR DESCRIPTION
Fourth of six PRs for **v0.9.9 — Approval Authority**. Closes the loop between PR 3's local journal writes and offline verification: `.treeship` session packages now carry **Approval Grant + Approval Use + JournalCheckpoint** records, and `treeship package verify` reports three independent replay levels honestly.

> Approval evidence becomes *portable*. A `.treeship` package now carries enough to reason about replay posture offline — without overclaiming what no global ledger has signed.

## Architectural call

Same "extend, don't fork" pattern as PRs 1–3. `build_package` keeps its old signature. New `build_package_with_approvals(receipt, output_dir, Some(&bundle))` embeds evidence when present. Same `ReplayCheck` shape from PR 1, same `journal::find_use_for_action` from PR 3 for the local-journal level. No fork.

## What this PR adds

### `packages/core/src/session/package.rs`

**Bundle types**:
- `ApprovalsBundle { grants, uses, checkpoints, revocations }` — payload session::close hands to the builder
- `ApprovalsIndex` — `approvals/index.json` shape so tooling can pre-flight what evidence is present

**Layout** (only written when the bundle is non-empty — pre-PR-4 packages and sessions without consumed approvals are byte-identical to before):
```
approvals/
  index.json
  grants/<grant_id>.json
  uses/<use_id>.json
  checkpoints/<checkpoint_id>.json
```

**Offline verifier**:
- `read_approvals_bundle(pkg_dir)` — quiet on missing dirs
- `add_approval_evidence_checks` emits:
  - `replay-package-local` — duplicate-detection inside the package (logic below)
  - `replay-included-checkpoint` — recomputes each `JournalCheckpoint::record_digest`
  - `approval-use-integrity` — recomputes each `ApprovalUse::record_digest`; fails on tamper

**`replay-package-local` violation logic** (matters because earlier drafts conflated two cases):
- Uses sharing `(grant_id, nonce_digest)` that **exceed** the stored `max_uses` — three uses of a max_uses=2 grant is a violation; two is fine.
- Duplicate `use_id` — always a violation (corrupt build artifact).

**`replay-hub-org` intentionally NOT emitted**. PR 6 adds a signed-Hub-checkpoint row when (and only when) such evidence exists. The release rule "no global single-use claim unless a Hub checkpoint exists" means the row stays *absent* rather than falsely passing.

### `packages/cli/src/commands/session.rs`

- `collect_approval_evidence(ctx, receipt)` walks the receipt's artifact list, finds actions carrying an `approval_nonce`, resolves grant + uses + checkpoints from local storage and the journal, returns an `ApprovalsBundle`.
- Records are exported **verbatim** — no mutation. The action↔use link lives in `action.meta.approval_use_id` (PR 3 stamp) plus the workspace sidecar at `indexes/backfill/<use_id>.txt`. Earlier draft mutated `action_artifact_id` after journal write, which invalidated `record_digest`; fixed.
- `session::close` now calls `build_package_with_approvals(.., Some(&bundle))`.

### `packages/cli/src/commands/package.rs`

- `verify` gains `config` + `--strict`:
  ```
  treeship package verify <path>
  treeship package verify --strict <path>
  ```
- When workspace context is available, layers `replay-local-journal` on top of the offline checks. Each embedded use is looked up via `journal::find_use_for_action` (the verify-time question from PR 3).
- **Missing journal → WARN, never FAIL**: bare-package verification in someone's inbox still works without a Treeship workspace.
- `--strict` promotes approval-evidence warnings (`replay-*` and `approval-use-integrity`) to failures; existing receipt-determinism / event-log warnings stay warnings. Strict mode also exits non-zero on any failure.

## End-to-end smokes (real binary)

| Test | Result |
|---|---|
| Legit two uses of `max_uses=2` grant | ✅ both replay rows pass |
| Tampered use record (edit actor in package) | ✅ `approval-use-integrity` FAIL |
| Duplicate `use_id` added to package | ✅ `replay-package-local` FAIL with detail |
| Three uses claimed against `max_uses=2` (over-spend) | ✅ `replay-package-local` FAIL "consumed 3 times (max_uses=2)" |
| Verify of package on workspace **without** a journal | ✅ `replay-local-journal` WARN "no local journal; package-local only" |
| Verify of legitimate package **with** journal | ✅ "✓ replay-local-journal — local Approval Use Journal passed, use 1/1" |

`cargo test --workspace` green; trust-fabric acceptance green; cross-target wasm build green; version-consistency 21/21.

## What ships next

| PR | Title |
|---|---|
| 5 | approval panel in `package inspect` + first-class approval docs |
| 6 | `hub-approval-checkpoint/v1` schema scaffold only — no full Hub, no AgentGate runtime |

❌ No SQLite, no public ledger, no global single-use claim
❌ No AgentGate runtime enforcement
❌ No raw nonce / command / prompt / file content / bearer token / API key / secret stored in the journal or package

🤖 Generated with [Claude Code](https://claude.com/claude-code)