### PR TITLE
fix(approval): v0.9.10 close replay/binding/checkpoint bypasses

### DIFF
--- a/docs/release-adversarial/v0.9.9.md
+++ b/docs/release-adversarial/v0.9.9.md
@@ -123,3 +123,52 @@ Per release policy (replay bypass → cut patch immediately), all four blockers 
 - Mode: targeted adversarial review with the threat model above pasted in
 - Subagent: `codex:codex-rescue` — synthesized findings; raw transcript not preserved
 - Verification: each Codex-cited file:line was independently read and the gap reproduced in the actual code before being recorded as a confirmed blocker. No Codex finding was accepted on its own; this document records only verified gaps.
+
+---
+
+## v0.9.10 PR A — round 2 re-check
+
+After the four blockers above were closed in `fix/0.9.10-approval-authority-patch` (commit `e62127a`), a second targeted Codex pass scoped to the fix diff confirmed Blocker 1 was closed but flagged three adjacent gaps the first-round fixes had introduced.
+
+### Round-2 findings
+
+**RE-CHECK VERDICT (round 2):**
+- Blocker 1 (TOCTOU race): closed
+- Blocker 2 (action↔use binding): partially closed
+- Blocker 3 (nonce binding): partially closed
+- Blocker 4 (chain continuity): partially closed
+
+**Round-2 confirmed sub-blockers**
+
+1. **Action envelope content not verified.** `read_approvals_bundle` loads `artifacts/*.json` and treats the filename stem as the artifact_id. `approval-use-action-binding` parses the envelope and reads `meta.approval_use_id` but never re-derives the artifact_id from the envelope's PAE bytes. An attacker controlling the package can write any forged unsigned action JSON to `artifacts/<id>.json` and the binding row trusts it. — `packages/core/src/session/package.rs` L373, L385, L780.
+2. **Grant envelope content not verified.** `approval-use-nonce-binding` hashes `grant.nonce` from the parsed grant envelope, but the envelope is only parsed, not content-id-verified, before its nonce is trusted. A forged grant payload with any nonce makes the row pass. — `packages/core/src/session/package.rs` L707, L712.
+3. **Chain continuity only checks set membership.** A fully rewritten self-consistent chain, mid-chain `previous_record_digest == ""`, disconnected embedded subchains, and cycles all still pass. — `packages/core/src/session/package.rs` L868.
+
+**Round-2 secondary items**
+- No explicit retry-after-`LockBusy` test for callers reusing the same `idempotency_key`.
+- New package tests use dummy envelope signatures; no signature-validation path exercised.
+
+### Round-2 resolution (commit follows)
+
+1. **Content-addressing gate on action envelopes.** In `add_approval_evidence_checks`, before parsing each `bundle.action_envelopes[i].1` for `meta.approval_use_id`, re-derive `artifact_id_from_pae(pae(payload_type, payload))` and require it to equal the filename stem (`bundle.action_envelopes[i].0`). Mismatch → `approval-use-action-binding` FAIL with detail "envelope substituted or tampered." Real envelopes pass because they were signed over the same PAE bytes that produced the artifact_id; only forgeries fail.
+2. **Content-addressing gate on grant envelopes.** Same shape: derive the grant_id from the envelope's PAE bytes, require it to equal the bundle's `grants[i].0`. Failure → `approval-use-nonce-binding` FAIL.
+3. **Tightened chain continuity.** Algorithm rewritten to require:
+   - exactly one record with `previous_record_digest == ""` (genesis);
+   - no two records sharing the same non-empty `previous_record_digest` (forks);
+   - no cycles (visited set during walk);
+   - every record reachable from the genesis (no disconnected subchains).
+   Each violation surfaces with a specific detail message.
+4. **Idempotency-retry regression test.** Pinned in `journal::tests::reserve_use_retry_after_lock_busy_does_not_bypass_max_uses`: five sequential retries against the same `(grant_id, nonce_digest)` after an initial successful reserve all return `MaxUsesExceeded`; on-disk record count stays at 1.
+
+### Round-2 tests added
+
+| Test | Pins | File |
+|---|---|---|
+| `forged_action_envelope_under_wrong_id_fails_content_addressing` | Action envelope content addressing | `packages/core/tests/approval_evidence_binding.rs` |
+| `forged_grant_envelope_under_real_id_fails_content_addressing` | Grant envelope content addressing | `packages/core/tests/approval_evidence_binding.rs` |
+| `multiple_genesis_records_fail_chain_continuity` | Single-genesis invariant | same |
+| `forked_chain_two_records_share_prev_fails_chain_continuity` | No-fork invariant | same |
+| `disconnected_subchain_fails_chain_continuity` | Connected-from-genesis invariant | same |
+| `reserve_use_retry_after_lock_busy_does_not_bypass_max_uses` | Idempotency retry safety | `packages/core/src/journal/mod.rs` |
+
+After round-2 patch: 251 core unit tests + 17 binding integration tests + 7 hub-checkpoint integration tests + acceptance smoke all green. Round-3 Codex re-check pending; this entry will be amended with that verdict before merge.

--- a/docs/release-adversarial/v0.9.9.md
+++ b/docs/release-adversarial/v0.9.9.md
@@ -1,0 +1,125 @@
+# v0.9.9 — Approval Authority — adversarial review
+
+**Date:** 2026-04-30 (post-publish)
+**Reviewer:** Codex CLI 0.118.0, in adversarial / "challenge" mode
+**Scope:** v0.9.8..v0.9.9 trust-surface diff (PRs #50–#55)
+**Verdict:** **NOT SHIP-AS-IS.** v0.9.10 patch warranted. Four real blockers found and verified against the code.
+
+---
+
+## Threat model used
+
+The 10 invariants the verifier was challenged to break:
+
+1. Nonces bind: action's `meta.approval_use_id` references a `ApprovalUse` whose `nonce_digest` matches the grant's signed nonce.
+2. Scopes authorize: actor / action / subject match approval scope.
+3. Approval Uses bind to action artifact, not free-floating.
+4. Local journal enforces local replay: `(grant_id, nonce_digest)` exceeding `max_uses` is rejected.
+5. Package export makes approval evidence portable and round-trippable.
+6. Included-checkpoint verification offline + tamper-evident via `record_digest` recompute.
+7. Hub/org replay PASS only when (a) checkpoint declares `kind: hub-org`, (b) every required Hub field present, (c) Ed25519 signature verifies, (d) every `ApprovalUse.use_id` ∈ `covered_use_ids`.
+8. No raw commands, prompts, file contents, bearer tokens, or secrets in approval-use evidence.
+9. Strict mode (`--strict`) fails on tamper / scope / coverage violations.
+10. Default mode warns without overclaiming. Never says "global single-use enforced" without verified evidence.
+
+---
+
+## BLOCKERS (verified against code)
+
+### Blocker 1 — TOCTOU race in `reserve_in_journal` bypasses `max_uses`
+
+- **Files:** `packages/cli/src/commands/attest.rs:660–746`, `packages/core/src/journal/mod.rs:221–280` (`with_lock` + `append_use`)
+- **Invariant violated:** 4 (local journal enforces local replay).
+- **Repro:**
+  ```
+  treeship attest action --approval-nonce N --max-uses 1 --grant <gid> <action>
+  ```
+  Run twice in parallel against a fresh journal. Both processes pass `journal::check_replay` BEFORE the append lock is acquired. Each then calls `journal::append_use`, which serializes through `with_lock`. The lock prevents simultaneous filesystem writes, but neither writer re-checks replay after acquiring the lock — so both records get written. `max_uses=1` is exceeded.
+- **Where the gap is:** `reserve_in_journal` calls `check_replay` (line ~679) and `list_uses_for_grant` (line ~692) entirely outside `with_lock`. `append_use` takes the lock internally only for write, not for the replay decision.
+- **Fix sketch:** Move `check_replay` and the `prior_count` derivation INSIDE `with_lock` — re-check that `existing_count + 1 ≤ max_uses` after acquiring the lock. Equivalent to the SQL `SELECT … FOR UPDATE` pattern. Tests must include a parallel-attest case.
+
+### Blocker 2 — `meta.approval_use_id` ignored at verify time
+
+- **Files:** `packages/cli/src/commands/session.rs:1397–1495` (`collect_approval_evidence`), `packages/core/src/journal/mod.rs:680–683` (the `find_use_for_action` comment that flags this gap).
+- **Invariant violated:** 3 (Approval Uses bind to action artifact).
+- **Repro:**
+  1. Run a real session with one approved action; close session; export package.
+  2. Open the action artifact's JSON inside the package; mutate `meta.approval_use_id` to a nonexistent or unrelated `use_id` (or delete the field).
+  3. Run `treeship package verify <pkg>`. Verify still passes — including under `--strict`.
+- **Where the gap is:** `collect_approval_evidence` resolves uses purely by `(grant_id, nonce_digest)`, then calls `journal::list_uses_for_grant(&grant_id)` and dumps every matching use into the bundle. The action artifact's `meta.approval_use_id` is mentioned in a comment (line 1462–1463) but never used to filter or validate. The explicit pointer is decorative.
+- **Fix sketch:** When an action carries `meta.approval_use_id`, require that the resolved use_id matches. Otherwise emit a `approval-use-binding` failure row.
+
+### Blocker 3 — `nonce_digest` in `ApprovalUse` not cross-checked against grant's signed nonce
+
+- **Files:** `packages/core/src/session/package.rs:524–584` (`add_approval_evidence_checks` `replay-package-local` branch), `packages/core/src/session/package.rs:614–632` (`approval-use-integrity`).
+- **Invariants violated:** 1 (nonces bind), 5 (package evidence portable).
+- **Repro:**
+  1. Export a package containing one `ApprovalUse` and its grant.
+  2. Edit `approvals/uses/<use_id>.json`: change `nonce_digest` to a different value. Recompute `record_digest` from the canonical form (it includes `nonce_digest`, so individual digest stays consistent).
+  3. Run `treeship package verify --strict <pkg>`. Passes.
+- **Where the gap is:** `add_approval_evidence_checks` reads `u.nonce_digest` directly from the use record. The grant's signed nonce (in the bundle's grants list) is never hashed and compared. The `approval-use-integrity` check only re-derives `record_digest` from the use's own fields — so an internally consistent forgery passes.
+- **Fix sketch:** In `add_approval_evidence_checks`, pull the grant for each use, compute `nonce_digest(grant.nonce)`, compare to `use.nonce_digest`. Mismatch → fail (default warn, strict fail).
+
+### Blocker 4 — Journal chain integrity not verified in package replay
+
+- **Files:** `packages/core/src/journal/mod.rs:484–561` (`verify_integrity` exists but unused in package path), `packages/core/src/session/package.rs:524–632` (`add_approval_evidence_checks` does NOT call any chain walk).
+- **Invariant violated:** 6 (included-checkpoint tamper-evident).
+- **Repro:**
+  1. Export a package with multiple uses + a `LocalJournal` checkpoint.
+  2. In `approvals/uses/`, rewrite the chain consistently: insert a forged use record, update the next record's `previous_record_digest` to point at the forgery, recompute each record_digest end-to-end. Update the checkpoint's `previous_record_digest` to anchor on the rewritten tail. All individual digests recompute correctly.
+  3. Run `treeship package verify --strict <pkg>`. Passes.
+- **Where the gap is:** `replay-included-checkpoint` only recomputes each checkpoint's *individual* `record_digest`. `approval-use-integrity` only recomputes each use's *individual* `record_digest`. Neither walks the `previous_record_digest` chain across embedded records. `verify_integrity` is a complete chain walker (484–561) but lives on the workspace journal and is never invoked on the package's embedded sub-chain.
+- **Fix sketch:** Add a `replay-package-chain` row that orders the embedded uses + checkpoints by `previous_record_digest`, recomputes each digest, and validates the chain links match. The chain anchor for offline replay is either: (a) a Hub-signed checkpoint at the tail, or (b) explicit "anchor unknown" warning. Without an anchor, the chain is *internally consistent* but not provably non-rewritten — make that explicit in the output rather than silent.
+
+---
+
+## IMPORTANT NON-BLOCKERS
+
+- Hub-org replay (`replay-hub-org`) signature + coverage logic is correctly wired. `canonical_hub_signing_bytes` includes every signing-relevant field, signature is verified against embedded public key, coverage is per-use. The four-gate rule from PR #55 holds. **Files:** `packages/core/src/statements/approval_use.rs:523–581`, `packages/core/src/session/package.rs:632–730`.
+- Strict-mode promotion logic is correctly implemented in the CLI verify path. The gap is in what the underlying checks actually prove (Blockers 1–4), not in whether `--strict` escalates them. **Files:** `packages/cli/src/commands/package.rs:1074–1091`.
+- Hub public-key substitution (attacker controls package, declares own `hub_public_key`, signs with matching private key) is a known v0.9.9 trust-model limitation, not a new bypass. The CHANGELOG and docs already call this out as deferred to a future "issuer / registry identity" release. **Files:** `packages/core/src/statements/approval_use.rs:550–568`.
+
+---
+
+## COPY / CLAIM ISSUES
+
+- **`approval-use-integrity` check label** — under-claims integrity. The label implies the use record's *content* is integrity-checked, but the check only re-derives `record_digest` from the use's own fields and does not validate `nonce_digest` against the grant's signed nonce. Either rename to `approval-use-record-digest` or strengthen the check.
+- **Default-mode `replay-*` PASS rendering** — when underlying evidence binding is incomplete (Blockers 2–4), a `✓` row currently prints "passed" even though the proof is partial. Default mode should either downgrade to `consistent / unverified-pass` wording or condition the `✓` on the full proof chain. Today's rendering risks the exact "global single-use enforced" overclaim the v0.9.9 honesty rule was supposed to prevent.
+
+---
+
+## TESTS TO ADD (post-fix)
+
+| Test | Invariant | Suggested location |
+|---|---|---|
+| `attest_max_uses_race_fails_when_parallel` | 4 (concurrent replay) | `packages/cli/tests/attest.rs` |
+| `action_meta_use_id_missing_is_rejected` | 3 (action↔use binding) | `packages/cli/tests/session.rs` or new integration |
+| `package_verify_rejects_use_nonce_mismatch` | 1, 5 (nonce binding) | `packages/core/tests/session_package.rs` (new) |
+| `package_verify_rejects_forged_journal_chain` | 6 (chain tamper-evidence) | `packages/core/tests/session_package.rs` |
+| `strict_mode_promotes_replay_and_integrity_warnings_to_fail` | 9 (strict honesty) | `packages/cli/tests/package.rs` |
+
+---
+
+## Triage decision
+
+| Finding | Severity | Action |
+|---|---|---|
+| Blocker 1 — TOCTOU race | High (replay bypass) | **v0.9.10 patch** |
+| Blocker 2 — action↔use unenforced | High (binding bypass) | **v0.9.10 patch** |
+| Blocker 3 — nonce_digest unbound | High (binding bypass) | **v0.9.10 patch** |
+| Blocker 4 — chain unverified in package | High (tamper-evidence bypass) | **v0.9.10 patch** |
+| Copy: `approval-use-integrity` underclaim | Medium | Same patch (label + behavior) |
+| Copy: default-mode `✓` overclaim | Medium | Same patch (rendering rule) |
+| Hub key substitution (no issuer registry) | Known limitation | Already documented as deferred; out of scope here |
+| Tests post-fix | Required | Land alongside each fix |
+
+Per release policy (replay bypass → cut patch immediately), all four blockers warrant **v0.9.10**. v0.9.9 packages should remain readable but verifiers calling `--strict` against tampered packages cannot assume safety until v0.9.10 lands.
+
+---
+
+## Codex pass attestation
+
+- Tool: `codex-cli 0.118.0` at `/Users/zzo/.nvm/versions/node/v22.20.0/bin/codex`
+- Mode: targeted adversarial review with the threat model above pasted in
+- Subagent: `codex:codex-rescue` — synthesized findings; raw transcript not preserved
+- Verification: each Codex-cited file:line was independently read and the gap reproduced in the actual code before being recorded as a confirmed blocker. No Codex finding was accepted on its own; this document records only verified gaps.

--- a/docs/release-adversarial/v0.9.9.md
+++ b/docs/release-adversarial/v0.9.9.md
@@ -171,4 +171,33 @@ After the four blockers above were closed in `fix/0.9.10-approval-authority-patc
 | `disconnected_subchain_fails_chain_continuity` | Connected-from-genesis invariant | same |
 | `reserve_use_retry_after_lock_busy_does_not_bypass_max_uses` | Idempotency retry safety | `packages/core/src/journal/mod.rs` |
 
-After round-2 patch: 251 core unit tests + 17 binding integration tests + 7 hub-checkpoint integration tests + acceptance smoke all green. Round-3 Codex re-check pending; this entry will be amended with that verdict before merge.
+After round-2 patch: 251 core unit tests + 17 binding integration tests + 7 hub-checkpoint integration tests + acceptance smoke all green.
+
+### Round-3 Codex re-check
+
+Scope: did round 2 close the three sub-blockers, and did it introduce any new bypass adjacent to the same surface?
+
+**Round-3 verdict (per Codex):**
+- Round-2 fix #1 (action content-addressing): **closed**
+- Round-2 fix #2 (grant content-addressing): **closed**
+- Round-2 fix #3 (chain continuity tighten): **closed**
+- New blockers introduced by round 2: **(none)**
+
+**Overall:** ship. PR A is merge-ready once CI lands.
+
+**Secondary follow-ups (non-blocking, tracked for next hardening pass — NOT merge gates):**
+
+1. Duplicate `grant_id` entries in `bundle.grants` are not explicitly rejected; the `grant_nonce_digest` HashMap silently last-wins. Real packages produced by `build_package_with_approvals` deduplicate by sanitized filename, so this is hard to trigger in production, but a defensive explicit-failure check (`return Fail` on second insertion under the same id) would make the row's behavior loud and unambiguous. — `packages/core/src/session/package.rs:709–744`.
+2. Test coverage for chain shapes that pass the algorithm by accident is partial. Round-2 tests cover dangling, multiple genesis, fork (two records sharing prev), and disconnected/2-cycle. Missing: a 3-cycle (a→b→c→a) and a self-loop (record's own digest equals its previous_record_digest). The current algorithm should reject both via the visited-set walk, but a regression test should pin that. — `packages/core/tests/approval_evidence_binding.rs`.
+
+Both are filed in the v0.9.10 follow-ups list and will land in the next approval-authority hardening PR (not v0.9.10 itself, since neither is a bypass).
+
+### Final triage decision
+
+| Round | Findings | Action |
+|---|---|---|
+| Round 1 (v0.9.9 publish) | 4 verified blockers | v0.9.10 PR A round-1 commit `e62127a` |
+| Round 2 (re-check on round 1) | 3 adjacent sub-blockers | v0.9.10 PR A round-2 commit `29a46a3` |
+| Round 3 (re-check on round 2) | 0 blockers, 2 non-blocking secondaries | Ship; secondaries deferred to follow-up |
+
+PR A status after round 3: **merge-ready** pending the last cross-SDK macOS matrix job and the Codex secondaries get filed as a follow-up issue.

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -4,7 +4,7 @@ use treeship_core::{
     journal::{self, Journal},
     statements::{
         ActionStatement, ApprovalScope, ApprovalStatement, ApprovalUse, DecisionStatement,
-        EndorsementStatement, HandoffStatement, ReceiptStatement, ReplayCheckLevel,
+        EndorsementStatement, HandoffStatement, ReceiptStatement,
         SubjectRef, TYPE_APPROVAL_USE, payload_type, nonce_digest,
     },
     storage::Record,
@@ -669,27 +669,17 @@ fn reserve_in_journal(
         }
     }
 
-    // Replay check BEFORE writing. check_replay reports
-    // ReplayCheckLevel::NotPerformed when no journal exists yet, which
-    // for a first-use is fine -- we proceed to write and the journal
-    // gets created on first append. When journal exists, "passed"
-    // false means max_uses would be exceeded.
-    let replay = journal::check_replay(&j, grant_id, &nonce_digest, max_uses)?;
-    if matches!(replay.level, ReplayCheckLevel::LocalJournal) {
-        if matches!(replay.passed, Some(false)) {
-            return Err(format!(
-                "approval grant {grant_id} would exceed max_uses ({} of {})",
-                replay.use_number.map(|n| n.saturating_sub(1)).unwrap_or(0),
-                replay.max_uses.map(|m| m.to_string()).unwrap_or_else(|| "?".into()),
-            ).into());
-        }
-    }
-
-    // Compute use_number from the existing record list (the list above
-    // already counted them; but we re-derive here to keep this function
-    // self-contained when called without the idempotency-key path).
-    let prior_count = journal::list_uses_for_grant(&j, grant_id)?.len() as u32;
-    let use_number = prior_count.saturating_add(1);
+    // The replay check + use_number derivation + append happen as one
+    // atomic operation inside `journal::reserve_use`. v0.9.9 PR 3 split
+    // these into separate calls (check_replay outside, append_use
+    // inside its own lock), which let two parallel attests both pass
+    // the replay check before either acquired the append lock --
+    // bypassing `max_uses=1`. v0.9.10 closes the race.
+    //
+    // `use_number` is stamped by `reserve_use` from the grant-wide
+    // count observed inside the lock; the value we put here is just a
+    // placeholder.
+    let use_number = 0u32;
 
     // Use_id is a fresh UUID-style hex token. Same shape as nonces.
     let use_id = {
@@ -742,12 +732,19 @@ fn reserve_in_journal(
         signing_key_id:         None,
     };
 
-    journal::append_use(&j, record).map_err(|e| -> Box<dyn std::error::Error> {
+    let head = journal::reserve_use(&j, record, max_uses).map_err(|e| -> Box<dyn std::error::Error> {
         format!("could not reserve approval use in journal: {e}").into()
     })?;
+    // reserve_use stamped use_number inside the lock; recover it from
+    // the just-written record so the user-visible message is accurate.
+    let actual_use_number = journal::list_uses_for_grant(&j, grant_id)
+        .ok()
+        .and_then(|uses| uses.iter().find(|u| u.use_id == use_id).map(|u| u.use_number))
+        .unwrap_or(0);
+    let _ = head;
 
     printer.dim_info(&format!(
-        "  approval use reserved: {use_id} (use {use_number}/{})",
+        "  approval use reserved: {use_id} (use {actual_use_number}/{})",
         max_uses.map(|m| m.to_string()).unwrap_or_else(|| "unbounded".into()),
     ));
 

--- a/packages/cli/src/commands/package.rs
+++ b/packages/cli/src/commands/package.rs
@@ -722,6 +722,106 @@ fn print_approval_authority_panel(
         let _ = ReplayCheckLevel::HubOrg;
     }
 
+    // v0.9.10 PR A: bundle-level integrity rows. Render once per
+    // package after the per-use replay rows. Each is computed inline
+    // from the bundle so the panel stays self-contained even when the
+    // verify checks haven't been threaded through.
+    if !bundle.uses.is_empty() {
+        use treeship_core::statements::approval_use_record_digest;
+        let tampered_digest = bundle.uses.iter().any(|u| {
+            approval_use_record_digest(u) != u.record_digest
+        });
+        printer.dim_info(&format!(
+            "  {} approval-use-record-digest    {}",
+            if tampered_digest { "✗" } else { "✓" },
+            if tampered_digest { "one or more use records tampered post-write" }
+            else { "every use record's stored digest recomputes identically" },
+        ));
+
+        // Nonce binding: each use's nonce_digest must equal
+        // nonce_digest(grant.nonce) for the grant carried in the
+        // package. If the grant is missing from the bundle, the row
+        // reports the gap honestly.
+        use treeship_core::attestation::envelope::Envelope;
+        use treeship_core::statements::{nonce_digest, ApprovalStatement};
+        let mut grant_nonce_digest: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        for (gid, env_bytes) in &bundle.grants {
+            if let Ok(env) = Envelope::from_json(env_bytes) {
+                if let Ok(g) = env.unmarshal_statement::<ApprovalStatement>() {
+                    grant_nonce_digest.insert(gid.clone(), nonce_digest(&g.nonce));
+                }
+            }
+        }
+        let nonce_ok = bundle.uses.iter().all(|u| {
+            grant_nonce_digest.get(&u.grant_id).map_or(false, |d| d == &u.nonce_digest)
+        });
+        printer.dim_info(&format!(
+            "  {} approval-use-nonce-binding    {}",
+            if nonce_ok { "✓" } else { "✗" },
+            if nonce_ok { "use.nonce_digest == sha256(grant.nonce) for every use" }
+            else { "one or more uses do not bind to a grant signed nonce" },
+        ));
+
+        // Action binding row: empty action_envelopes -> "not asserted"
+        // (pre-v0.9.10 packages); otherwise pass/fail based on the
+        // approval_use_id pointer + nonce match.
+        if bundle.action_envelopes.is_empty() {
+            printer.dim_info(
+                "  - approval-use-action-binding  not asserted by package (pre-v0.9.10 -- artifacts/ empty)",
+            );
+        } else {
+            use treeship_core::statements::ActionStatement;
+            let use_ids: std::collections::HashSet<&str> =
+                bundle.uses.iter().map(|u| u.use_id.as_str()).collect();
+            let mut all_ok = true;
+            let mut bound = 0usize;
+            for (_aid, env_bytes) in &bundle.action_envelopes {
+                let Ok(env) = Envelope::from_json(env_bytes) else { all_ok = false; continue };
+                let Ok(action) = env.unmarshal_statement::<ActionStatement>() else { all_ok = false; continue };
+                let Some(raw_nonce) = action.approval_nonce.as_deref() else { continue };
+                let claimed = action.meta.as_ref()
+                    .and_then(|m| m.get("approval_use_id"))
+                    .and_then(|v| v.as_str());
+                match claimed {
+                    Some(uid) if use_ids.contains(uid) => {
+                        let expected = nonce_digest(raw_nonce);
+                        let matched = bundle.uses.iter().find(|u| u.use_id == uid);
+                        if matched.map_or(false, |u| u.nonce_digest == expected) {
+                            bound += 1;
+                        } else {
+                            all_ok = false;
+                        }
+                    }
+                    _ => all_ok = false,
+                }
+            }
+            printer.dim_info(&format!(
+                "  {} approval-use-action-binding  {}",
+                if all_ok { "✓" } else { "✗" },
+                if all_ok {
+                    format!("{bound} action(s) bind cleanly to embedded use records")
+                } else {
+                    "one or more actions fail action↔use binding".into()
+                },
+            ));
+        }
+
+        // Chain continuity: every previous_record_digest must point at
+        // an in-package record_digest or be empty (genesis).
+        let mut owned: std::collections::HashSet<String> = std::collections::HashSet::new();
+        owned.insert(String::new());
+        for u in &bundle.uses          { owned.insert(u.record_digest.clone()); }
+        for cp in &bundle.checkpoints  { owned.insert(cp.record_digest.clone()); }
+        let chain_ok = bundle.uses.iter().all(|u| owned.contains(&u.previous_record_digest))
+            && bundle.checkpoints.iter().all(|cp| owned.contains(&cp.previous_record_digest));
+        printer.dim_info(&format!(
+            "  {} approval-use-chain-continuity {}",
+            if chain_ok { "✓" } else { "✗" },
+            if chain_ok { "every previous_record_digest anchors in-package or genesis" }
+            else { "one or more previous_record_digest values dangle" },
+        ));
+    }
+
     printer.blank();
 }
 
@@ -1079,8 +1179,18 @@ pub fn verify(
     if strict {
         let mut promoted = 0usize;
         for c in checks.iter_mut() {
+            // Approval-evidence rows: every replay-* row plus the
+            // four binding/integrity rows from v0.9.10 PR A. The old
+            // `approval-use-integrity` label is kept here for backward
+            // compatibility with any external tooling that pinned on
+            // it, but the live emitter now uses
+            // `approval-use-record-digest`.
             let approval_row = c.name.starts_with("replay-")
-                || c.name == "approval-use-integrity";
+                || c.name == "approval-use-integrity"
+                || c.name == "approval-use-record-digest"
+                || c.name == "approval-use-nonce-binding"
+                || c.name == "approval-use-action-binding"
+                || c.name == "approval-use-chain-continuity";
             if approval_row && c.status == VerifyStatus::Warn {
                 c.status = VerifyStatus::Fail;
                 promoted += 1;

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1423,6 +1423,10 @@ fn collect_approval_evidence(
             Ok(r)  => r,
             Err(_) => continue,
         };
+        // Snapshot the raw envelope BEFORE unmarshaling so we can ship
+        // it in the package -- v0.9.10 PR A relies on the verifier
+        // being able to read action.meta.approval_use_id offline.
+        let envelope_bytes_for_package = rec.envelope.to_json().ok();
         let action = match rec.envelope.unmarshal_statement::<ActionStatement>() {
             Ok(a)  => a,
             Err(_) => continue,
@@ -1431,6 +1435,16 @@ fn collect_approval_evidence(
             Some(n) => n,
             None    => continue,
         };
+        // Only record the envelope for actions that actually consumed
+        // an approval; an action without `approval_nonce` doesn't need
+        // to ship for the binding check.
+        if let Some(env_bytes) = envelope_bytes_for_package {
+            // Deduplicate by artifact_id; the receipt may reference the
+            // same artifact twice in pathological cases.
+            if !bundle.action_envelopes.iter().any(|(id, _)| id == &art.artifact_id) {
+                bundle.action_envelopes.push((art.artifact_id.clone(), env_bytes));
+            }
+        }
 
         // Find the grant by nonce -- mirror what verify does.
         let approval_pt = payload_type("approval");
@@ -1455,17 +1469,28 @@ fn collect_approval_evidence(
             }
         }
 
-        // Pull every Approval Use for this grant. Records are exported
-        // verbatim -- mutating `action_artifact_id` after the journal
-        // append would invalidate the record_digest, so the action↔use
-        // link is carried elsewhere:
-        //   * the action artifact's meta.approval_use_id points at the use
-        //   * the workspace sidecar at indexes/backfill/<use_id>.txt
-        //     gives the CLI a friendly display join (not exported)
+        // Pull the Approval Use(s) bound to THIS action. Records are
+        // exported verbatim -- mutating `action_artifact_id` after the
+        // journal append would invalidate the record_digest, so the
+        // action↔use link is carried as `meta.approval_use_id` on the
+        // signed action envelope. v0.9.10 PR A: when the action carries
+        // that pointer, export ONLY the referenced use; previously we
+        // dumped every use for the grant, which let an attacker's
+        // tampered package reference unrelated uses.
+        let action_use_id_hint: Option<String> = action
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("approval_use_id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
         if journal.exists() {
             if let Ok(uses) = journal::list_uses_for_grant(&journal, &grant_id) {
                 for u in uses {
-                    if use_ids_seen.insert(u.use_id.clone()) {
+                    let take = match &action_use_id_hint {
+                        Some(target) => &u.use_id == target,
+                        None         => true, // legacy behavior when no pointer
+                    };
+                    if take && use_ids_seen.insert(u.use_id.clone()) {
                         bundle.uses.push(u);
                     }
                 }

--- a/packages/core/src/journal/mod.rs
+++ b/packages/core/src/journal/mod.rs
@@ -1131,6 +1131,38 @@ mod tests {
         assert!(matches!(err, JournalError::MaxUsesExceeded { .. }));
     }
 
+    /// Round-2 hardening: idempotency-key retries through the
+    /// CLI's `reserve_in_journal` should NOT bypass `reserve_use`'s
+    /// max_uses gate. The CLI checks the idempotency key against
+    /// existing uses *before* calling `reserve_use`; this test
+    /// confirms that path doesn't sneak a second reservation past
+    /// max_uses=1 just because a flaky retry uses the same key.
+    ///
+    /// The journal-level invariant we pin here: even if a caller
+    /// repeatedly invokes `reserve_use` with the same record after a
+    /// `LockBusy`, the second call sees the first record (now
+    /// committed) and rejects with `MaxUsesExceeded`. There is no
+    /// "free retry" loophole.
+    #[test]
+    fn reserve_use_retry_after_lock_busy_does_not_bypass_max_uses() {
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        // First reserve commits use_1.
+        reserve_use(&j, sample_use("use_1", "g1", "sha256:nn_retry", 0), Some(1)).unwrap();
+        // Subsequent reserves with the SAME nonce all fail with
+        // MaxUsesExceeded -- no retry-bypass window.
+        for i in 0..5 {
+            let err = reserve_use(
+                &j,
+                sample_use(&format!("use_retry_{i}"), "g1", "sha256:nn_retry", 0),
+                Some(1),
+            ).expect_err("retry must fail");
+            assert!(matches!(err, JournalError::MaxUsesExceeded { .. }));
+        }
+        let stored = list_uses_for_grant(&j, "g1").unwrap();
+        assert_eq!(stored.len(), 1, "exactly one record on disk despite 5 retries");
+    }
+
     #[test]
     fn reserve_use_concurrent_max_uses_1_only_one_succeeds() {
         // The headline regression test for the v0.9.9 TOCTOU race.

--- a/packages/core/src/journal/mod.rs
+++ b/packages/core/src/journal/mod.rs
@@ -273,6 +273,69 @@ pub fn append_use(j: &Journal, mut rec: ApprovalUse) -> Result<Head, JournalErro
     })
 }
 
+/// Atomic check-and-append for the consume path. Combines `check_replay` +
+/// append under a single journal lock so concurrent consume paths cannot
+/// bypass `max_uses` via TOCTOU race.
+///
+/// v0.9.9 PR 3 (`reserve_in_journal` in attest.rs) ran `check_replay` and
+/// derived `use_number` *outside* `with_lock`, then called `append_use`
+/// (which takes the lock only for the write). Two parallel attests could
+/// both pass the pre-lock replay check, then queue serially through the
+/// lock, and both would write — exceeding `max_uses=1`. v0.9.10 closes
+/// that race by doing the check *inside* the lock.
+///
+/// The function also stamps `use_number` from the grant-wide count
+/// observed at lock-acquire time. Callers should pass the record with
+/// `use_number = 0` (or any value); it will be overwritten.
+///
+/// Returns the new head on success. On replay violation, returns
+/// `JournalError::MaxUsesExceeded` and writes nothing — the lock is
+/// released without state change.
+pub fn reserve_use(
+    j: &Journal,
+    mut rec: ApprovalUse,
+    max_uses: Option<u32>,
+) -> Result<Head, JournalError> {
+    rec.type_ = TYPE_APPROVAL_USE.into();
+    with_lock(j, || {
+        // Replay check inside the lock. `check_replay` reads the
+        // by-nonce index; while we hold the exclusive lock, no other
+        // writer can mutate that index, so the count is correct.
+        let replay = check_replay(j, &rec.grant_id, &rec.nonce_digest, max_uses)?;
+        if let Some(false) = replay.passed {
+            let current = replay
+                .use_number
+                .map(|n| n.saturating_sub(1))
+                .unwrap_or(0);
+            return Err(JournalError::MaxUsesExceeded {
+                grant_id: rec.grant_id.clone(),
+                max_uses: replay.max_uses.unwrap_or(0),
+                current,
+            });
+        }
+        // Stamp use_number from grant-wide count, also inside the lock,
+        // so two parallel reservations on the same grant cannot both
+        // claim the same use_number.
+        let prior_count = list_uses_for_grant(j, &rec.grant_id)?.len() as u32;
+        rec.use_number = prior_count.saturating_add(1);
+        // Append.
+        let head = read_head(j)?;
+        rec.previous_record_digest = head.digest.clone();
+        rec.record_digest = approval_use_record_digest(&rec);
+        let next_index = head.index + 1;
+        write_record_use(j, next_index, &rec)?;
+        update_indexes_for_use(j, next_index, &rec)?;
+        let new_head = Head {
+            index:      next_index,
+            digest:     rec.record_digest.clone(),
+            updated_at: rec.created_at.clone(),
+        };
+        write_head(j, &new_head)?;
+        ensure_meta(j)?;
+        Ok(new_head)
+    })
+}
+
 /// Append an ApprovalRevocation. Sibling of `append_use`.
 pub fn append_revocation(j: &Journal, mut rec: ApprovalRevocation) -> Result<Head, JournalError> {
     rec.type_ = TYPE_APPROVAL_REVOCATION.into();
@@ -1002,5 +1065,130 @@ mod tests {
         }
         // The digest IS allowed.
         assert!(obj.contains_key("nonce_digest"));
+    }
+
+    // -- v0.9.10 PR A: reserve_use atomic check+append regression tests --
+
+    #[test]
+    fn reserve_use_first_call_succeeds_and_stamps_use_number() {
+        // Caller passes use_number=0; reserve_use stamps it from the
+        // grant-wide count observed inside the lock.
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        let mut rec = sample_use("use_1", "g1", "sha256:nn1", 0);
+        rec.use_number = 0;
+        let head = reserve_use(&j, rec, Some(1)).unwrap();
+        assert_eq!(head.index, 1);
+        let stored = list_uses_for_grant(&j, "g1").unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].use_number, 1, "reserve_use must stamp use_number=1 for the first use");
+    }
+
+    #[test]
+    fn reserve_use_max_uses_1_serial_second_call_rejects() {
+        // Sequential second call with the same nonce against
+        // max_uses=1 must error with MaxUsesExceeded BEFORE writing.
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        reserve_use(&j, sample_use("use_1", "g1", "sha256:nn_a", 0), Some(1)).unwrap();
+
+        let err = reserve_use(&j, sample_use("use_2", "g1", "sha256:nn_a", 0), Some(1))
+            .expect_err("second consume of max_uses=1 grant must fail");
+        match err {
+            JournalError::MaxUsesExceeded { grant_id, max_uses, current } => {
+                assert_eq!(grant_id, "g1");
+                assert_eq!(max_uses, 1);
+                assert_eq!(current, 1);
+            }
+            other => panic!("expected MaxUsesExceeded, got {other:?}"),
+        }
+        // Crucially, the second record is NOT written.
+        let stored = list_uses_for_grant(&j, "g1").unwrap();
+        assert_eq!(stored.len(), 1, "rejected reserve must not append");
+    }
+
+    #[test]
+    fn reserve_use_max_uses_2_two_uses_pass_third_rejects() {
+        // Legitimate multi-use grant: two distinct nonces, same grant.
+        let dir = tempdir().unwrap();
+        let j = Journal::new(dir.path());
+        let mut a = sample_use("use_1", "g1", "sha256:nn_a", 0); a.max_uses = Some(2);
+        let mut b = sample_use("use_2", "g1", "sha256:nn_b", 0); b.max_uses = Some(2);
+        reserve_use(&j, a, Some(2)).unwrap();
+        reserve_use(&j, b, Some(2)).unwrap();
+        // A third nonce with max_uses=2 is fine (per-nonce check, not
+        // per-grant); the journal's invariant is single-use-per-nonce.
+        let mut c = sample_use("use_3", "g1", "sha256:nn_c", 0); c.max_uses = Some(2);
+        reserve_use(&j, c, Some(2)).unwrap();
+        // But a SECOND consume of nn_a violates max_uses=2 because
+        // that nonce already has 1 use; 1+1 = 2 is within bound, so
+        // this second use of nn_a is actually allowed — pin that.
+        let mut a2 = sample_use("use_1b", "g1", "sha256:nn_a", 0); a2.max_uses = Some(2);
+        reserve_use(&j, a2, Some(2)).unwrap();
+        // A THIRD consume of nn_a exceeds max_uses=2.
+        let mut a3 = sample_use("use_1c", "g1", "sha256:nn_a", 0); a3.max_uses = Some(2);
+        let err = reserve_use(&j, a3, Some(2)).expect_err("third use of same nonce must fail");
+        assert!(matches!(err, JournalError::MaxUsesExceeded { .. }));
+    }
+
+    #[test]
+    fn reserve_use_concurrent_max_uses_1_only_one_succeeds() {
+        // The headline regression test for the v0.9.9 TOCTOU race.
+        //
+        // Eight threads race to reserve the same (grant_id, nonce_digest)
+        // against max_uses=1. With v0.9.9's split check_replay/append_use
+        // pattern, two threads could both pass the pre-lock replay check
+        // and write — exceeding max_uses. With v0.9.10's reserve_use,
+        // the check happens INSIDE the lock; exactly one thread wins.
+        //
+        // Outcomes for the 7 losers are a mix of:
+        //   - LockBusy: the lock was held when they tried try_lock
+        //   - MaxUsesExceeded: they got the lock after the winner
+        //     released, saw the winner's record, declined to write
+        // Both are correct — neither is a bypass.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::thread;
+
+        let dir = tempdir().unwrap();
+        let dir_path = Arc::new(dir.path().to_path_buf());
+        let success = Arc::new(AtomicUsize::new(0));
+        let lock_busy = Arc::new(AtomicUsize::new(0));
+        let max_exceeded = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let dir_path = Arc::clone(&dir_path);
+            let success = Arc::clone(&success);
+            let lock_busy = Arc::clone(&lock_busy);
+            let max_exceeded = Arc::clone(&max_exceeded);
+            handles.push(thread::spawn(move || {
+                let j = Journal::new(dir_path.as_path());
+                let rec = sample_use(
+                    &format!("use_{i}"),
+                    "g1",
+                    "sha256:race_nonce",
+                    0,
+                );
+                match reserve_use(&j, rec, Some(1)) {
+                    Ok(_)                                            => { success.fetch_add(1, Ordering::SeqCst); }
+                    Err(JournalError::LockBusy)                      => { lock_busy.fetch_add(1, Ordering::SeqCst); }
+                    Err(JournalError::MaxUsesExceeded { .. })        => { max_exceeded.fetch_add(1, Ordering::SeqCst); }
+                    Err(other) => panic!("unexpected error: {other:?}"),
+                }
+            }));
+        }
+        for h in handles { h.join().unwrap(); }
+
+        let s = success.load(Ordering::SeqCst);
+        let lb = lock_busy.load(Ordering::SeqCst);
+        let me = max_exceeded.load(Ordering::SeqCst);
+        assert_eq!(s, 1, "exactly one of 8 concurrent reserves must succeed; got {s} (lock_busy={lb}, max_exceeded={me})");
+        assert_eq!(s + lb + me, 8, "every thread accounted for");
+
+        // Belt-and-braces: only one record actually on disk for this nonce.
+        let stored = list_uses_for_grant(&Journal::new(dir.path()), "g1").unwrap();
+        let same_nonce = stored.iter().filter(|u| u.nonce_digest == "sha256:race_nonce").count();
+        assert_eq!(same_nonce, 1, "exactly one record on disk for the contested nonce");
     }
 }

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -102,6 +102,15 @@ pub struct ApprovalsBundle {
     /// show the consumed evidence and the revocation alongside).
     /// Empty in PR 4; reserved.
     pub revocations: Vec<ApprovalRevocation>,
+
+    /// Bytes of each action artifact's signed envelope that consumed an
+    /// approval. Each entry is `(action_artifact_id, raw_envelope_json)`.
+    /// v0.9.10 PR A: shipped to close the action↔use binding gap. The
+    /// verifier extracts `meta.approval_use_id` from each envelope and
+    /// cross-checks it against the package's use records. Empty in
+    /// pre-v0.9.10 packages; readers must treat absence as "binding
+    /// not asserted by package" rather than "binding present and OK."
+    pub action_envelopes: Vec<(String, Vec<u8>)>,
 }
 
 /// `approvals/index.json` -- top-level inventory of evidence in the
@@ -209,10 +218,24 @@ pub fn build_package_with_approvals(
     // bundle behaves the same as None so a session with no consumed
     // approvals doesn't leave behind an empty `approvals/` directory.
     if let Some(b) = bundle {
-        if !b.grants.is_empty() || !b.uses.is_empty() || !b.checkpoints.is_empty() || !b.revocations.is_empty() {
+        if !b.grants.is_empty() || !b.uses.is_empty() || !b.checkpoints.is_empty() || !b.revocations.is_empty() || !b.action_envelopes.is_empty() {
             std::fs::create_dir_all(pkg_dir.join(APPROVALS_GRANTS))?;
             std::fs::create_dir_all(pkg_dir.join(APPROVALS_USES))?;
             std::fs::create_dir_all(pkg_dir.join(APPROVALS_CHECKPOINTS))?;
+            // v0.9.10 PR A: write action envelopes that consumed an
+            // approval. The artifacts/ directory was created earlier
+            // for the package layout but never populated; closing the
+            // action↔use binding gap requires the verifier to be able
+            // to read each consuming action's `meta.approval_use_id`.
+            std::fs::create_dir_all(pkg_dir.join(ARTIFACTS_DIR))?;
+            for (artifact_id, envelope_bytes) in &b.action_envelopes {
+                let safe = sanitize_filename(artifact_id);
+                std::fs::write(
+                    pkg_dir.join(ARTIFACTS_DIR).join(format!("{safe}.json")),
+                    envelope_bytes,
+                )?;
+                file_count += 1;
+            }
 
             let mut grant_ids = Vec::with_capacity(b.grants.len());
             for (grant_id, envelope_bytes) in &b.grants {
@@ -344,6 +367,24 @@ pub fn read_approvals_bundle(pkg_dir: &Path) -> Result<ApprovalsBundle, PackageE
             let bytes = std::fs::read(&path)?;
             let cp: JournalCheckpoint = serde_json::from_slice(&bytes)?;
             bundle.checkpoints.push(cp);
+        }
+    }
+
+    // v0.9.10 PR A: read action envelopes shipped to support the
+    // action↔use binding check. Pre-v0.9.10 packages have an empty
+    // artifacts/ dir (the dir was created but never populated); the
+    // bundle's `action_envelopes` stays empty in that case, and the
+    // verifier reports the binding row honestly as "not asserted by
+    // package" rather than silently passing.
+    let arts_dir = pkg_dir.join(ARTIFACTS_DIR);
+    if arts_dir.is_dir() {
+        for entry in std::fs::read_dir(&arts_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") { continue; }
+            let id = path.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_string();
+            let bytes = std::fs::read(&path)?;
+            bundle.action_envelopes.push((id, bytes));
         }
     }
 
@@ -611,9 +652,15 @@ pub(crate) fn add_approval_evidence_checks(
         }
     }
 
-    // -- per-use record-digest integrity --
-    // Even without a checkpoint, each ApprovalUse carries its own
-    // record_digest; tampering with any field changes the digest.
+    // -- approval-use-record-digest --
+    // Each ApprovalUse carries its own record_digest computed over the
+    // canonical form of the record (minus the digest itself). Tampering
+    // any field changes the digest. v0.9.10 PR A renames this from the
+    // older `approval-use-integrity` because the prior label suggested
+    // it covered nonce/action binding -- it didn't, and Codex's v0.9.9
+    // adversarial review flagged the over-claim. The honest scope of
+    // this row is "each use's stored digest matches its canonical
+    // recompute"; the binding checks are now separate rows below.
     let mut tampered_uses = Vec::new();
     for u in &bundle.uses {
         let recomputed = approval_use_record_digest(u);
@@ -621,14 +668,240 @@ pub(crate) fn add_approval_evidence_checks(
             tampered_uses.push((u.use_id.clone(), u.record_digest.clone(), recomputed));
         }
     }
-    if !tampered_uses.is_empty() {
-        let detail = tampered_uses.iter()
-            .map(|(id, expected, actual)| {
-                format!("use {id} tampered (stored {expected}, recomputed {actual})")
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        checks.push(VerifyCheck::fail("approval-use-integrity", &detail));
+    if !bundle.uses.is_empty() {
+        if tampered_uses.is_empty() {
+            checks.push(VerifyCheck::pass(
+                "approval-use-record-digest",
+                &format!("{} use record(s) recompute identically", bundle.uses.len()),
+            ));
+        } else {
+            let detail = tampered_uses.iter()
+                .map(|(id, expected, actual)| {
+                    format!("use {id} tampered (stored {expected}, recomputed {actual})")
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            checks.push(VerifyCheck::fail("approval-use-record-digest", &detail));
+        }
+    }
+
+    // -- approval-use-nonce-binding --
+    // Cross-check each use's `nonce_digest` against the corresponding
+    // grant's *signed* nonce. v0.9.9 trusted the use's nonce_digest
+    // verbatim, which let an attacker who controls the package mutate
+    // it (and recompute record_digest) to claim consumption of a grant
+    // whose nonce was never actually used. This row closes that gap.
+    //
+    // Discipline: the grant envelope is the source of truth. We pull
+    // the raw `nonce` from the grant's payload, hash it via the same
+    // `nonce_digest` helper that attest used, and compare to each
+    // use's stored `nonce_digest`. Mismatch -> fail.
+    if !bundle.uses.is_empty() {
+        use crate::attestation::envelope::Envelope;
+        use crate::statements::{nonce_digest, ApprovalStatement};
+        // Build a grant_id -> expected_nonce_digest map from the bundle's
+        // grant envelopes. Skip grants we can't parse (the receipt's
+        // signature checks would catch those upstream; here we just
+        // can't speak to their binding).
+        let mut grant_nonce_digest: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        for (grant_id, env_bytes) in &bundle.grants {
+            let env = match Envelope::from_json(env_bytes) {
+                Ok(e)  => e,
+                Err(_) => continue,
+            };
+            let approval: ApprovalStatement = match env.unmarshal_statement() {
+                Ok(a)  => a,
+                Err(_) => continue,
+            };
+            grant_nonce_digest.insert(grant_id.clone(), nonce_digest(&approval.nonce));
+        }
+        let mut mismatches: Vec<String> = Vec::new();
+        let mut missing_grants: Vec<String> = Vec::new();
+        for u in &bundle.uses {
+            match grant_nonce_digest.get(&u.grant_id) {
+                Some(expected) => {
+                    if expected != &u.nonce_digest {
+                        mismatches.push(format!(
+                            "use {} claims nonce_digest {} but grant {} signed nonce hashes to {}",
+                            u.use_id, u.nonce_digest, u.grant_id, expected,
+                        ));
+                    }
+                }
+                None => {
+                    missing_grants.push(format!(
+                        "use {} references grant {} but the grant envelope is not in the package",
+                        u.use_id, u.grant_id,
+                    ));
+                }
+            }
+        }
+        if mismatches.is_empty() && missing_grants.is_empty() {
+            checks.push(VerifyCheck::pass(
+                "approval-use-nonce-binding",
+                &format!("{} use record(s) bind to grant signed nonces", bundle.uses.len()),
+            ));
+        } else {
+            let mut detail = String::new();
+            if !mismatches.is_empty()    { detail.push_str(&mismatches.join("; ")); }
+            if !missing_grants.is_empty() {
+                if !detail.is_empty() { detail.push_str("; "); }
+                detail.push_str(&missing_grants.join("; "));
+            }
+            checks.push(VerifyCheck::fail("approval-use-nonce-binding", &detail));
+        }
+    }
+
+    // -- approval-use-action-binding --
+    // Cross-check each consuming action's `meta.approval_use_id`
+    // against the package's use records. v0.9.9 ignored this pointer
+    // entirely; the package didn't even ship action envelopes, so the
+    // verifier could not see the field. v0.9.10 PR A: action envelopes
+    // ride along in `artifacts/`, and this row pins that every action
+    // declaring it consumed an approval has a use record for that
+    // exact use_id, with matching grant_id and matching
+    // `nonce_digest(approval_nonce)`.
+    //
+    // Honesty rule: when bundle.action_envelopes is empty (pre-v0.9.10
+    // packages, or a v0.9.10 package with no consuming actions
+    // recorded), this row reports `not asserted by package` rather
+    // than silent PASS.
+    if !bundle.uses.is_empty() {
+        use crate::attestation::envelope::Envelope;
+        use crate::statements::{nonce_digest, ActionStatement};
+        if bundle.action_envelopes.is_empty() {
+            checks.push(VerifyCheck::warn(
+                "approval-use-action-binding",
+                "no action envelopes embedded -- action↔use binding not asserted by package (pre-v0.9.10)",
+            ));
+        } else {
+            let use_ids: std::collections::HashSet<&str> = bundle.uses.iter().map(|u| u.use_id.as_str()).collect();
+            let mut violations: Vec<String> = Vec::new();
+            let mut bound_count = 0usize;
+            for (artifact_id, env_bytes) in &bundle.action_envelopes {
+                let env = match Envelope::from_json(env_bytes) {
+                    Ok(e)  => e,
+                    Err(_) => {
+                        violations.push(format!("action {artifact_id} envelope unparseable"));
+                        continue;
+                    }
+                };
+                let action: ActionStatement = match env.unmarshal_statement() {
+                    Ok(a)  => a,
+                    Err(_) => {
+                        violations.push(format!("action {artifact_id} not an ActionStatement"));
+                        continue;
+                    }
+                };
+                // Action envelopes shipped only when they consumed an
+                // approval, but be defensive: if there's no
+                // approval_nonce, skip silently.
+                let raw_nonce = match action.approval_nonce.as_deref() {
+                    Some(n) => n,
+                    None    => continue,
+                };
+                let claimed_use_id = action
+                    .meta
+                    .as_ref()
+                    .and_then(|m| m.get("approval_use_id"))
+                    .and_then(|v| v.as_str());
+                let Some(claimed_use_id) = claimed_use_id else {
+                    violations.push(format!(
+                        "action {artifact_id} consumed an approval but its meta has no approval_use_id"
+                    ));
+                    continue;
+                };
+                if !use_ids.contains(claimed_use_id) {
+                    violations.push(format!(
+                        "action {artifact_id} claims approval_use_id={} but no such use is embedded",
+                        claimed_use_id,
+                    ));
+                    continue;
+                }
+                // The use exists; cross-check that its nonce_digest
+                // matches the action's approval_nonce hash.
+                let expected = nonce_digest(raw_nonce);
+                let matched_use = bundle.uses.iter().find(|u| u.use_id == claimed_use_id);
+                if let Some(u) = matched_use {
+                    if u.nonce_digest != expected {
+                        violations.push(format!(
+                            "action {artifact_id} approval_nonce hashes to {} but use {} stores nonce_digest {}",
+                            expected, claimed_use_id, u.nonce_digest,
+                        ));
+                        continue;
+                    }
+                }
+                bound_count += 1;
+            }
+            if violations.is_empty() {
+                checks.push(VerifyCheck::pass(
+                    "approval-use-action-binding",
+                    &format!("{bound_count} consuming action(s) bind cleanly to embedded use records"),
+                ));
+            } else {
+                checks.push(VerifyCheck::fail(
+                    "approval-use-action-binding",
+                    &violations.join("; "),
+                ));
+            }
+        }
+    }
+
+    // -- approval-use-chain-continuity --
+    // v0.9.9 verified each use's individual record_digest but never
+    // walked the `previous_record_digest` chain across the embedded
+    // records. An attacker could rewrite an entire chain consistently
+    // (recomputing each digest along the way) and the per-record
+    // checks all passed.
+    //
+    // We can only do a *partial* chain walk in offline package replay:
+    // the package ships only records the session touched, not the
+    // workspace journal's full history, so the chain we see may have
+    // gaps. What we CAN check: every embedded record's
+    // previous_record_digest must point at SOME record_digest that
+    // either (a) belongs to another embedded record, or (b) is
+    // explicitly the empty string (genesis). A dangling
+    // previous_record_digest pointing at nothing is a bypass attempt.
+    //
+    // Anchoring against a Hub-signed checkpoint is handled separately
+    // by replay-hub-org (the signature covers previous_record_digest);
+    // here we report internal consistency only.
+    if !bundle.uses.is_empty() || !bundle.checkpoints.is_empty() {
+        // Collect every digest the package "owns" as a chain link.
+        let mut owned: std::collections::HashSet<String> = std::collections::HashSet::new();
+        owned.insert(String::new()); // genesis is a valid prev pointer
+        for u in &bundle.uses          { owned.insert(u.record_digest.clone()); }
+        for cp in &bundle.checkpoints  { owned.insert(cp.record_digest.clone()); }
+        let mut dangling: Vec<String> = Vec::new();
+        for u in &bundle.uses {
+            if !owned.contains(&u.previous_record_digest) {
+                dangling.push(format!(
+                    "use {} previous_record_digest {} not anchored in package",
+                    u.use_id, u.previous_record_digest,
+                ));
+            }
+        }
+        for cp in &bundle.checkpoints {
+            if !owned.contains(&cp.previous_record_digest) {
+                dangling.push(format!(
+                    "checkpoint {} previous_record_digest {} not anchored in package",
+                    cp.checkpoint_id, cp.previous_record_digest,
+                ));
+            }
+        }
+        if dangling.is_empty() {
+            checks.push(VerifyCheck::pass(
+                "approval-use-chain-continuity",
+                &format!(
+                    "{} record(s) form a self-consistent chain (every previous_record_digest anchors in-package or genesis)",
+                    bundle.uses.len() + bundle.checkpoints.len(),
+                ),
+            ));
+        } else {
+            checks.push(VerifyCheck::fail(
+                "approval-use-chain-continuity",
+                &dangling.join("; "),
+            ));
+        }
     }
 
     // -- replay-hub-org -- v0.9.9 PR 6.

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -692,26 +692,53 @@ pub(crate) fn add_approval_evidence_checks(
     // it (and recompute record_digest) to claim consumption of a grant
     // whose nonce was never actually used. This row closes that gap.
     //
-    // Discipline: the grant envelope is the source of truth. We pull
-    // the raw `nonce` from the grant's payload, hash it via the same
-    // `nonce_digest` helper that attest used, and compare to each
-    // use's stored `nonce_digest`. Mismatch -> fail.
+    // Discipline: the grant envelope is the source of truth. Before
+    // pulling the raw `nonce` from the grant's payload we verify the
+    // envelope's *content addressing* -- recompute the artifact_id
+    // from the envelope's PAE bytes and confirm it equals the grant_id
+    // the package claims. v0.9.10 PR A round 1 only parsed the
+    // envelope without this check; that left a forgery window where
+    // an attacker could ship an arbitrary unsigned envelope under any
+    // grant_id filename. v0.9.10 PR A round 2 closes the window: only
+    // a bytes-identical envelope produces the same artifact_id under
+    // SHA-256.
     if !bundle.uses.is_empty() {
         use crate::attestation::envelope::Envelope;
+        use crate::attestation::{pae, artifact_id_from_pae};
         use crate::statements::{nonce_digest, ApprovalStatement};
-        // Build a grant_id -> expected_nonce_digest map from the bundle's
-        // grant envelopes. Skip grants we can't parse (the receipt's
-        // signature checks would catch those upstream; here we just
-        // can't speak to their binding).
         let mut grant_nonce_digest: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+        let mut tampered_grants: Vec<String> = Vec::new();
         for (grant_id, env_bytes) in &bundle.grants {
             let env = match Envelope::from_json(env_bytes) {
                 Ok(e)  => e,
-                Err(_) => continue,
+                Err(_) => {
+                    tampered_grants.push(format!("grant {grant_id} envelope unparseable"));
+                    continue;
+                }
             };
+            // Content-addressing check: derive the artifact_id from
+            // the envelope's PAE bytes and confirm it matches the
+            // claimed grant_id. If they differ the envelope was
+            // substituted or its bytes were tampered post-sign.
+            let derived = match env.payload_bytes() {
+                Ok(p) => artifact_id_from_pae(&pae(&env.payload_type, &p)),
+                Err(_) => {
+                    tampered_grants.push(format!("grant {grant_id} envelope payload undecodable"));
+                    continue;
+                }
+            };
+            if &derived != grant_id {
+                tampered_grants.push(format!(
+                    "grant {grant_id} envelope content derives to {derived} -- envelope substituted or tampered",
+                ));
+                continue;
+            }
             let approval: ApprovalStatement = match env.unmarshal_statement() {
                 Ok(a)  => a,
-                Err(_) => continue,
+                Err(_) => {
+                    tampered_grants.push(format!("grant {grant_id} payload not an ApprovalStatement"));
+                    continue;
+                }
             };
             grant_nonce_digest.insert(grant_id.clone(), nonce_digest(&approval.nonce));
         }
@@ -729,25 +756,26 @@ pub(crate) fn add_approval_evidence_checks(
                 }
                 None => {
                     missing_grants.push(format!(
-                        "use {} references grant {} but the grant envelope is not in the package",
+                        "use {} references grant {} but no usable grant envelope is in the package",
                         u.use_id, u.grant_id,
                     ));
                 }
             }
         }
-        if mismatches.is_empty() && missing_grants.is_empty() {
+        if mismatches.is_empty() && missing_grants.is_empty() && tampered_grants.is_empty() {
             checks.push(VerifyCheck::pass(
                 "approval-use-nonce-binding",
-                &format!("{} use record(s) bind to grant signed nonces", bundle.uses.len()),
+                &format!(
+                    "{} use record(s) bind to content-addressed grant signed nonces",
+                    bundle.uses.len(),
+                ),
             ));
         } else {
-            let mut detail = String::new();
-            if !mismatches.is_empty()    { detail.push_str(&mismatches.join("; ")); }
-            if !missing_grants.is_empty() {
-                if !detail.is_empty() { detail.push_str("; "); }
-                detail.push_str(&missing_grants.join("; "));
-            }
-            checks.push(VerifyCheck::fail("approval-use-nonce-binding", &detail));
+            let mut parts: Vec<String> = Vec::new();
+            if !tampered_grants.is_empty() { parts.push(tampered_grants.join("; ")); }
+            if !mismatches.is_empty()      { parts.push(mismatches.join("; ")); }
+            if !missing_grants.is_empty()  { parts.push(missing_grants.join("; ")); }
+            checks.push(VerifyCheck::fail("approval-use-nonce-binding", &parts.join("; ")));
         }
     }
 
@@ -767,6 +795,7 @@ pub(crate) fn add_approval_evidence_checks(
     // than silent PASS.
     if !bundle.uses.is_empty() {
         use crate::attestation::envelope::Envelope;
+        use crate::attestation::{pae, artifact_id_from_pae};
         use crate::statements::{nonce_digest, ActionStatement};
         if bundle.action_envelopes.is_empty() {
             checks.push(VerifyCheck::warn(
@@ -785,6 +814,26 @@ pub(crate) fn add_approval_evidence_checks(
                         continue;
                     }
                 };
+                // Content-addressing gate: derive the artifact_id
+                // from the envelope's PAE bytes and require it to
+                // match the filename stem the package shipped this
+                // envelope under. Without this gate an attacker
+                // controlling the package can write any forged
+                // unsigned action JSON to artifacts/<id>.json and the
+                // binding rows would trust it.
+                let derived = match env.payload_bytes() {
+                    Ok(p) => artifact_id_from_pae(&pae(&env.payload_type, &p)),
+                    Err(_) => {
+                        violations.push(format!("action {artifact_id} envelope payload undecodable"));
+                        continue;
+                    }
+                };
+                if &derived != artifact_id {
+                    violations.push(format!(
+                        "action {artifact_id} envelope content derives to {derived} -- envelope substituted or tampered",
+                    ));
+                    continue;
+                }
                 let action: ActionStatement = match env.unmarshal_statement() {
                     Ok(a)  => a,
                     Err(_) => {
@@ -792,9 +841,6 @@ pub(crate) fn add_approval_evidence_checks(
                         continue;
                     }
                 };
-                // Action envelopes shipped only when they consumed an
-                // approval, but be defensive: if there's no
-                // approval_nonce, skip silently.
                 let raw_nonce = match action.approval_nonce.as_deref() {
                     Some(n) => n,
                     None    => continue,
@@ -817,8 +863,6 @@ pub(crate) fn add_approval_evidence_checks(
                     ));
                     continue;
                 }
-                // The use exists; cross-check that its nonce_digest
-                // matches the action's approval_nonce hash.
                 let expected = nonce_digest(raw_nonce);
                 let matched_use = bundle.uses.iter().find(|u| u.use_id == claimed_use_id);
                 if let Some(u) = matched_use {
@@ -835,7 +879,9 @@ pub(crate) fn add_approval_evidence_checks(
             if violations.is_empty() {
                 checks.push(VerifyCheck::pass(
                     "approval-use-action-binding",
-                    &format!("{bound_count} consuming action(s) bind cleanly to embedded use records"),
+                    &format!(
+                        "{bound_count} consuming action(s) bind cleanly to content-addressed envelope(s)",
+                    ),
                 ));
             } else {
                 checks.push(VerifyCheck::fail(
@@ -853,53 +899,139 @@ pub(crate) fn add_approval_evidence_checks(
     // (recomputing each digest along the way) and the per-record
     // checks all passed.
     //
-    // We can only do a *partial* chain walk in offline package replay:
-    // the package ships only records the session touched, not the
-    // workspace journal's full history, so the chain we see may have
-    // gaps. What we CAN check: every embedded record's
-    // previous_record_digest must point at SOME record_digest that
-    // either (a) belongs to another embedded record, or (b) is
-    // explicitly the empty string (genesis). A dangling
-    // previous_record_digest pointing at nothing is a bypass attempt.
+    // Algorithm (v0.9.10 PR A round 2): build a graph of embedded
+    // records keyed by record_digest, then require the embedded
+    // records to form a SINGLE linked list with exactly one genesis
+    // (previous_record_digest == "") and no cycles, forks, or
+    // disconnected subchains.
     //
-    // Anchoring against a Hub-signed checkpoint is handled separately
-    // by replay-hub-org (the signature covers previous_record_digest);
-    // here we report internal consistency only.
+    //   - Dangling prev pointer (not in `owned`) -> fail.
+    //   - More than one record with prev == ""    -> fail (mid-chain
+    //     genesis is a forgery primitive).
+    //   - Two records sharing the same prev       -> fail (fork).
+    //   - Cycle reached during the walk           -> fail.
+    //   - Walk doesn't reach every record         -> fail (disconnected
+    //     subchain).
+    //
+    // We can only check *internal* consistency offline -- the package
+    // doesn't ship the workspace journal's full history, so the chain
+    // we see may be a contiguous prefix or window. Anchoring against
+    // a Hub-signed checkpoint is replay-hub-org's job; here we report
+    // structural consistency only.
     if !bundle.uses.is_empty() || !bundle.checkpoints.is_empty() {
-        // Collect every digest the package "owns" as a chain link.
-        let mut owned: std::collections::HashSet<String> = std::collections::HashSet::new();
-        owned.insert(String::new()); // genesis is a valid prev pointer
-        for u in &bundle.uses          { owned.insert(u.record_digest.clone()); }
-        for cp in &bundle.checkpoints  { owned.insert(cp.record_digest.clone()); }
-        let mut dangling: Vec<String> = Vec::new();
+        use std::collections::{HashMap, HashSet};
+        // Each record carries a label for diagnostics + its own
+        // record_digest + previous_record_digest.
+        struct Node<'a> { label: String, digest: &'a str, prev: &'a str }
+        let mut nodes: Vec<Node> = Vec::new();
         for u in &bundle.uses {
-            if !owned.contains(&u.previous_record_digest) {
-                dangling.push(format!(
-                    "use {} previous_record_digest {} not anchored in package",
-                    u.use_id, u.previous_record_digest,
-                ));
-            }
+            nodes.push(Node {
+                label: format!("use {}", u.use_id),
+                digest: u.record_digest.as_str(),
+                prev: u.previous_record_digest.as_str(),
+            });
         }
         for cp in &bundle.checkpoints {
-            if !owned.contains(&cp.previous_record_digest) {
-                dangling.push(format!(
-                    "checkpoint {} previous_record_digest {} not anchored in package",
-                    cp.checkpoint_id, cp.previous_record_digest,
+            nodes.push(Node {
+                label: format!("checkpoint {}", cp.checkpoint_id),
+                digest: cp.record_digest.as_str(),
+                prev: cp.previous_record_digest.as_str(),
+            });
+        }
+
+        let owned: HashSet<&str> = std::iter::once("")
+            .chain(nodes.iter().map(|n| n.digest))
+            .collect();
+
+        let mut violations: Vec<String> = Vec::new();
+        // Dangling prev: pointer not in owned set.
+        for n in &nodes {
+            if !owned.contains(n.prev) {
+                violations.push(format!(
+                    "{} previous_record_digest {} not anchored in package",
+                    n.label, n.prev,
                 ));
             }
         }
-        if dangling.is_empty() {
+        // Genesis count: only one record allowed to have prev == "".
+        let genesis: Vec<&Node> = nodes.iter().filter(|n| n.prev.is_empty()).collect();
+        if genesis.len() > 1 {
+            violations.push(format!(
+                "{} records claim previous_record_digest='' (genesis): {}",
+                genesis.len(),
+                genesis.iter().map(|n| n.label.clone()).collect::<Vec<_>>().join(", "),
+            ));
+        }
+        // Forks: two records sharing the same non-empty prev.
+        let mut by_prev: HashMap<&str, Vec<&Node>> = HashMap::new();
+        for n in &nodes {
+            by_prev.entry(n.prev).or_default().push(n);
+        }
+        for (prev, group) in &by_prev {
+            if group.len() > 1 && !prev.is_empty() {
+                violations.push(format!(
+                    "fork: {} records share previous_record_digest {}: {}",
+                    group.len(),
+                    prev,
+                    group.iter().map(|n| n.label.clone()).collect::<Vec<_>>().join(", "),
+                ));
+            }
+        }
+
+        // Walk from genesis (if exactly one) following digest-as-prev
+        // links. Detect cycles and unreachable records.
+        if violations.is_empty() {
+            let by_digest: HashMap<&str, &Node> = nodes.iter().map(|n| (n.digest, n)).collect();
+            let next_of: HashMap<&str, &Node> = nodes
+                .iter()
+                .filter(|n| !n.prev.is_empty())
+                .map(|n| (n.prev, *(&n)))
+                .collect();
+            let start = match genesis.first() {
+                Some(g) => Some(*g),
+                None    => None,
+            };
+            let mut visited: HashSet<&str> = HashSet::new();
+            let mut current = start;
+            while let Some(node) = current {
+                if !visited.insert(node.digest) {
+                    violations.push(format!(
+                        "cycle detected at {} (record_digest {})",
+                        node.label, node.digest,
+                    ));
+                    break;
+                }
+                current = next_of.get(node.digest).copied();
+            }
+            // Disconnected: walk didn't include every node.
+            if violations.is_empty() && visited.len() != nodes.len() {
+                let unreached: Vec<String> = nodes.iter()
+                    .filter(|n| !visited.contains(n.digest))
+                    .map(|n| n.label.clone())
+                    .collect();
+                if !unreached.is_empty() {
+                    violations.push(format!(
+                        "disconnected subchain: {} record(s) not reachable from genesis: {}",
+                        unreached.len(),
+                        unreached.join(", "),
+                    ));
+                }
+            }
+            let _ = by_digest; // reserved for future cross-checks
+        }
+
+        if violations.is_empty() {
             checks.push(VerifyCheck::pass(
                 "approval-use-chain-continuity",
                 &format!(
-                    "{} record(s) form a self-consistent chain (every previous_record_digest anchors in-package or genesis)",
-                    bundle.uses.len() + bundle.checkpoints.len(),
+                    "{} record(s) form a single connected linked list from one genesis with no cycles or forks",
+                    nodes.len(),
                 ),
             ));
         } else {
             checks.push(VerifyCheck::fail(
                 "approval-use-chain-continuity",
-                &dangling.join("; "),
+                &violations.join("; "),
             ));
         }
     }

--- a/packages/core/tests/approval_evidence_binding.rs
+++ b/packages/core/tests/approval_evidence_binding.rs
@@ -1,0 +1,436 @@
+//! Integration tests for v0.9.10 PR A: closing the four trust-bypass
+//! paths Codex's adversarial review of v0.9.9 found.
+//!
+//! Each test builds a fixture `.treeship` package with deliberately
+//! tampered approval evidence and asserts that `verify_package` flags
+//! the right row. The tests are the regression pins for:
+//!
+//!   1. action↔use binding (via meta.approval_use_id)        → approval-use-action-binding
+//!   2. nonce binding (use.nonce_digest vs grant.nonce)      → approval-use-nonce-binding
+//!   3. record-digest integrity (renamed from -integrity)    → approval-use-record-digest
+//!   4. embedded chain continuity                            → approval-use-chain-continuity
+//!
+//! The TOCTOU race fix (Blocker 1) is unit-tested in the journal
+//! module itself; this file exercises only the package-level checks.
+
+use serde_json::{json, Value};
+
+use treeship_core::session::{
+    build_package_with_approvals, read_approvals_bundle, verify_package,
+    ApprovalsBundle, VerifyStatus,
+};
+use treeship_core::statements::{
+    ApprovalUse, TYPE_APPROVAL_USE, approval_use_record_digest, nonce_digest,
+};
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+fn make_use_with_nonce(use_id: &str, grant_id: &str, raw_nonce: &str) -> ApprovalUse {
+    let mut u = ApprovalUse {
+        type_:                  TYPE_APPROVAL_USE.into(),
+        use_id:                 use_id.into(),
+        grant_id:               grant_id.into(),
+        grant_digest:           "sha256:00".into(),
+        nonce_digest:           nonce_digest(raw_nonce),
+        actor:                  "agent://deployer".into(),
+        action:                 "deploy.production".into(),
+        subject:                "env://production".into(),
+        session_id:             None,
+        action_artifact_id:     None,
+        receipt_digest:         None,
+        use_number:             1,
+        max_uses:               Some(1),
+        idempotency_key:        None,
+        created_at:             "2026-04-30T08:00:00Z".into(),
+        expires_at:             None,
+        previous_record_digest: String::new(),
+        record_digest:          String::new(),
+        signature:              None,
+        signature_alg:          None,
+        signing_key_id:         None,
+    };
+    u.record_digest = approval_use_record_digest(&u);
+    u
+}
+
+/// Build a fake-but-canonical signed ApprovalStatement envelope JSON
+/// carrying the given raw nonce. The signatures aren't real Ed25519
+/// here; we only need `Envelope::from_json` + `unmarshal_statement`
+/// to succeed, and the verifier to read the grant's `nonce` field.
+fn fake_grant_envelope(_grant_id: &str, raw_nonce: &str) -> Vec<u8> {
+    use base64::Engine;
+    // Field names match ApprovalStatement's serde renames
+    // (timestamp / approver / nonce / delegatable required).
+    let payload = json!({
+        "type": "treeship/approval/v1",
+        "timestamp": "2026-04-30T07:00:00Z",
+        "approver": "human://alice",
+        "subject": { "uri": "env://production" },
+        "delegatable": false,
+        "nonce": raw_nonce,
+    });
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&payload).unwrap());
+    let env = json!({
+        "payload": payload_b64,
+        "payloadType": "application/vnd.treeship.approval.v1+json",
+        "signatures": [{ "keyid": "key_test", "sig": "AA" }],
+    });
+    serde_json::to_vec(&env).unwrap()
+}
+
+/// Build a fake-but-canonical signed ActionStatement envelope JSON
+/// carrying the given approval_nonce and meta.approval_use_id. Useful
+/// for testing what verify sees when the action envelope ships in
+/// `artifacts/`.
+fn fake_action_envelope(
+    artifact_id: &str,
+    raw_nonce: &str,
+    approval_use_id: Option<&str>,
+) -> (String, Vec<u8>) {
+    use base64::Engine;
+    let meta: Value = match approval_use_id {
+        Some(id) => json!({ "approval_use_id": id }),
+        None     => json!({}),
+    };
+    // Field names match ActionStatement's serde renames
+    // (approvalNonce / parentId / policyRef / type / timestamp).
+    let payload = json!({
+        "type": "treeship/action/v1",
+        "timestamp": "2026-04-30T08:00:00Z",
+        "actor": "agent://deployer",
+        "action": "deploy.production",
+        "subject": { "uri": "env://production" },
+        "approvalNonce": raw_nonce,
+        "meta": meta,
+    });
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&payload).unwrap());
+    let env = json!({
+        "payload": payload_b64,
+        "payloadType": "application/vnd.treeship.action.v1+json",
+        "signatures": [{ "keyid": "key_test", "sig": "AA" }],
+    });
+    (artifact_id.to_string(), serde_json::to_vec(&env).unwrap())
+}
+
+fn make_minimal_receipt(action_artifact_ids: &[&str]) -> treeship_core::session::SessionReceipt {
+    use treeship_core::session::{
+        manifest::SessionManifest,
+        receipt::{ArtifactEntry, ReceiptComposer},
+        event::{EventType, SessionEvent},
+    };
+    let manifest = SessionManifest::new(
+        "ssn_v0_9_10_test".into(),
+        "agent://test".into(),
+        "2026-04-30T08:00:00Z".into(),
+        1745035200000,
+    );
+    let mk = |seq: u64, et: EventType| -> SessionEvent {
+        SessionEvent {
+            session_id: "ssn_v0_9_10_test".into(),
+            event_id: format!("evt_{:016x}", seq),
+            timestamp: format!("2026-04-30T08:00:{:02}Z", seq),
+            sequence_no: seq,
+            trace_id: "tr".into(),
+            span_id: format!("sp_{seq}"),
+            parent_span_id: None,
+            agent_id: "agent://test".into(),
+            agent_instance_id: "test".into(),
+            agent_name: "test".into(),
+            agent_role: None,
+            host_id: "host_1".into(),
+            tool_runtime_id: None,
+            event_type: et,
+            artifact_ref: None,
+            meta: None,
+        }
+    };
+    let events = vec![
+        mk(0, EventType::SessionStarted),
+        mk(1, EventType::AgentStarted { parent_agent_instance_id: None }),
+        mk(2, EventType::AgentCompleted { termination_reason: None }),
+        mk(3, EventType::SessionClosed { summary: None, duration_ms: None }),
+    ];
+    let artifacts: Vec<ArtifactEntry> = action_artifact_ids
+        .iter()
+        .map(|id| ArtifactEntry {
+            artifact_id: id.to_string(),
+            payload_type: "application/vnd.treeship.action.v1+json".into(),
+            digest: None,
+            signed_at: None,
+        })
+        .collect();
+    ReceiptComposer::compose(&manifest, &events, artifacts)
+}
+
+fn build(bundle: ApprovalsBundle, action_ids: &[&str]) -> std::path::PathBuf {
+    let receipt = make_minimal_receipt(action_ids);
+    let tmp = std::env::temp_dir().join(format!("treeship-bind-{}", rand::random::<u32>()));
+    let out = build_package_with_approvals(&receipt, &tmp, Some(&bundle)).unwrap();
+    out.path
+}
+
+fn find_check<'a>(
+    checks: &'a [treeship_core::session::VerifyCheck],
+    name: &str,
+) -> Option<&'a treeship_core::session::VerifyCheck> {
+    checks.iter().find(|c| c.name == name)
+}
+
+// ---------------------------------------------------------------------------
+// Fix 2 — action↔use binding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn action_envelope_with_correct_use_id_binds_cleanly() {
+    let nonce = "raw_nonce_alpha";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_real"));
+    bundle.action_envelopes.push((art_id, env));
+
+    let pkg = build(bundle, &["art_a"]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-action-binding")
+        .expect("approval-use-action-binding row required");
+    assert_eq!(row.status, VerifyStatus::Pass, "expected PASS, got: {row:?}");
+    assert!(row.detail.contains("bind cleanly"), "detail: {}", row.detail);
+}
+
+#[test]
+fn action_envelope_with_nonexistent_use_id_fails_binding() {
+    // The exact v0.9.9 attack: action.meta.approval_use_id points at a
+    // use_id that has no record. v0.9.9 verify ignored this; v0.9.10
+    // catches it.
+    let nonce = "raw_nonce_beta";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_does_not_exist"));
+    bundle.action_envelopes.push((art_id, env));
+
+    let pkg = build(bundle, &["art_a"]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-action-binding")
+        .expect("approval-use-action-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on missing use_id, got: {row:?}");
+    assert!(row.detail.contains("use_does_not_exist"), "detail: {}", row.detail);
+}
+
+#[test]
+fn action_envelope_missing_use_id_pointer_fails_binding() {
+    // Action carries approval_nonce but its meta has no
+    // approval_use_id. v0.9.9 didn't care; v0.9.10 fails.
+    let nonce = "raw_nonce_gamma";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    let (art_id, env) = fake_action_envelope("art_a", nonce, None); // no approval_use_id
+    bundle.action_envelopes.push((art_id, env));
+
+    let pkg = build(bundle, &["art_a"]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-action-binding")
+        .expect("approval-use-action-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail);
+    assert!(row.detail.contains("no approval_use_id"), "detail: {}", row.detail);
+}
+
+#[test]
+fn package_without_action_envelopes_warns_binding_unasserted() {
+    // Pre-v0.9.10 packages: artifacts/ dir empty, no action envelopes
+    // shipped. Verify must NOT silently pass; it must report the row
+    // as `not asserted by package`.
+    let nonce = "raw_nonce_delta";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    // No action_envelopes deliberately.
+
+    let pkg = build(bundle, &["art_a"]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-action-binding")
+        .expect("approval-use-action-binding row required");
+    assert_eq!(row.status, VerifyStatus::Warn);
+    assert!(row.detail.contains("not asserted by package"), "detail: {}", row.detail);
+}
+
+// ---------------------------------------------------------------------------
+// Fix 3 — nonce binding (use.nonce_digest vs grant.nonce)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn use_nonce_digest_matches_grant_signed_nonce_passes() {
+    let nonce = "raw_nonce_epsilon";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-nonce-binding")
+        .expect("approval-use-nonce-binding row required");
+    assert_eq!(row.status, VerifyStatus::Pass, "expected PASS, got: {row:?}");
+}
+
+#[test]
+fn tampered_use_nonce_digest_fails_binding() {
+    // The exact v0.9.9 attack: edit the use's nonce_digest to claim a
+    // different consumption, then recompute record_digest. v0.9.9
+    // accepted; v0.9.10 cross-checks against the grant's signed nonce.
+    let real_nonce = "raw_nonce_zeta";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", real_nonce)));
+
+    let mut tampered_use = make_use_with_nonce("use_real", "g1", real_nonce);
+    // Mutate nonce_digest to claim consumption of a different grant's
+    // nonce. Recompute record_digest so the per-record digest still
+    // matches (this is the v0.9.9 forgery primitive).
+    tampered_use.nonce_digest = nonce_digest("a_different_nonce");
+    tampered_use.record_digest = approval_use_record_digest(&tampered_use);
+    bundle.uses.push(tampered_use);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-nonce-binding")
+        .expect("approval-use-nonce-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on nonce mismatch, got: {row:?}");
+    assert!(
+        row.detail.contains("hashes to") || row.detail.contains("nonce_digest"),
+        "detail: {}",
+        row.detail,
+    );
+}
+
+#[test]
+fn use_referencing_unknown_grant_fails_binding() {
+    let mut bundle = ApprovalsBundle::default();
+    // Use without its grant in the bundle.
+    bundle.uses.push(make_use_with_nonce("use_orphan", "g_missing", "n"));
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-nonce-binding")
+        .expect("approval-use-nonce-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail);
+    assert!(row.detail.contains("not in the package"), "detail: {}", row.detail);
+}
+
+// ---------------------------------------------------------------------------
+// Fix 4 — embedded chain continuity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn embedded_chain_anchored_to_genesis_passes() {
+    let nonce = "raw_nonce_eta";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    let u = make_use_with_nonce("use_real", "g1", nonce);
+    // Default previous_record_digest is empty string = genesis.
+    bundle.uses.push(u);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Pass);
+}
+
+#[test]
+fn dangling_previous_record_digest_fails_chain_continuity() {
+    // Attacker rewrites a use record's previous_record_digest to point
+    // at an arbitrary value not anchored in this package.
+    let nonce = "raw_nonce_theta";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    let mut u = make_use_with_nonce("use_real", "g1", nonce);
+    u.previous_record_digest = "sha256:dangling_anchor_no_record_here".into();
+    u.record_digest = approval_use_record_digest(&u); // re-sync digest after edit
+    bundle.uses.push(u);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on dangling chain, got: {row:?}");
+    assert!(row.detail.contains("not anchored"), "detail: {}", row.detail);
+}
+
+#[test]
+fn two_use_chain_with_correct_links_passes() {
+    let nonce_a = "raw_nonce_iota_a";
+    let nonce_b = "raw_nonce_iota_b";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce_a)));
+    bundle.grants.push(("g2".into(), fake_grant_envelope("g2", nonce_b)));
+
+    let u1 = make_use_with_nonce("use_1", "g1", nonce_a);
+    let u1_digest = u1.record_digest.clone();
+    let mut u2 = make_use_with_nonce("use_2", "g2", nonce_b);
+    u2.previous_record_digest = u1_digest;
+    u2.record_digest = approval_use_record_digest(&u2);
+    bundle.uses.push(u1);
+    bundle.uses.push(u2);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Pass);
+}
+
+// ---------------------------------------------------------------------------
+// Fix 5 — record-digest rename + label hygiene
+// ---------------------------------------------------------------------------
+
+#[test]
+fn renamed_record_digest_row_emits_for_present_uses() {
+    let nonce = "raw_nonce_kappa";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    assert!(
+        find_check(&checks, "approval-use-record-digest").is_some(),
+        "v0.9.10 must emit approval-use-record-digest",
+    );
+    assert!(
+        find_check(&checks, "approval-use-integrity").is_none(),
+        "v0.9.10 must NOT emit the old approval-use-integrity label",
+    );
+}
+
+#[test]
+fn read_back_round_trips_action_envelopes() {
+    // The v0.9.10 package format ships action envelopes in
+    // `artifacts/`; round-trip via build + read_approvals_bundle.
+    let nonce = "raw_nonce_lambda";
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
+    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_real"));
+    bundle.action_envelopes.push((art_id.clone(), env.clone()));
+
+    let pkg = build(bundle, &["art_a"]);
+
+    let read_back = read_approvals_bundle(&pkg).unwrap();
+    assert_eq!(read_back.action_envelopes.len(), 1);
+    assert_eq!(read_back.action_envelopes[0].0, art_id);
+    assert_eq!(read_back.action_envelopes[0].1, env);
+}

--- a/packages/core/tests/approval_evidence_binding.rs
+++ b/packages/core/tests/approval_evidence_binding.rs
@@ -1,14 +1,12 @@
 //! Integration tests for v0.9.10 PR A: closing the four trust-bypass
-//! paths Codex's adversarial review of v0.9.9 found.
+//! paths Codex's adversarial review of v0.9.9 found, plus the
+//! adjacent hardenings the v0.9.10 PR A round-2 re-check flagged
+//! (content-addressed envelope verification, tightened chain
+//! continuity).
 //!
 //! Each test builds a fixture `.treeship` package with deliberately
 //! tampered approval evidence and asserts that `verify_package` flags
-//! the right row. The tests are the regression pins for:
-//!
-//!   1. action↔use binding (via meta.approval_use_id)        → approval-use-action-binding
-//!   2. nonce binding (use.nonce_digest vs grant.nonce)      → approval-use-nonce-binding
-//!   3. record-digest integrity (renamed from -integrity)    → approval-use-record-digest
-//!   4. embedded chain continuity                            → approval-use-chain-continuity
+//! the right row.
 //!
 //! The TOCTOU race fix (Blocker 1) is unit-tested in the journal
 //! module itself; this file exercises only the package-level checks.
@@ -55,14 +53,15 @@ fn make_use_with_nonce(use_id: &str, grant_id: &str, raw_nonce: &str) -> Approva
     u
 }
 
-/// Build a fake-but-canonical signed ApprovalStatement envelope JSON
-/// carrying the given raw nonce. The signatures aren't real Ed25519
-/// here; we only need `Envelope::from_json` + `unmarshal_statement`
-/// to succeed, and the verifier to read the grant's `nonce` field.
-fn fake_grant_envelope(_grant_id: &str, raw_nonce: &str) -> Vec<u8> {
+/// Build a fake-but-canonical signed ApprovalStatement envelope JSON.
+/// Returns `(derived_grant_id, envelope_bytes)` where the grant_id is
+/// derived from the envelope's PAE bytes via `artifact_id_from_pae` --
+/// matching production sign behavior. v0.9.10 PR A round 2 verifies
+/// content addressing, so test fixtures must produce envelopes whose
+/// derived id matches the grant_id we ship them under.
+fn fake_grant_envelope(raw_nonce: &str) -> (String, Vec<u8>) {
     use base64::Engine;
-    // Field names match ApprovalStatement's serde renames
-    // (timestamp / approver / nonce / delegatable required).
+    use treeship_core::attestation::{pae, artifact_id_from_pae};
     let payload = json!({
         "type": "treeship/approval/v1",
         "timestamp": "2026-04-30T07:00:00Z",
@@ -71,32 +70,31 @@ fn fake_grant_envelope(_grant_id: &str, raw_nonce: &str) -> Vec<u8> {
         "delegatable": false,
         "nonce": raw_nonce,
     });
-    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .encode(serde_json::to_vec(&payload).unwrap());
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+    let payload_type = "application/vnd.treeship.approval.v1+json";
+    let pae_bytes = pae(payload_type, &payload_bytes);
+    let derived_id = artifact_id_from_pae(&pae_bytes);
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&payload_bytes);
     let env = json!({
         "payload": payload_b64,
-        "payloadType": "application/vnd.treeship.approval.v1+json",
+        "payloadType": payload_type,
         "signatures": [{ "keyid": "key_test", "sig": "AA" }],
     });
-    serde_json::to_vec(&env).unwrap()
+    (derived_id, serde_json::to_vec(&env).unwrap())
 }
 
-/// Build a fake-but-canonical signed ActionStatement envelope JSON
-/// carrying the given approval_nonce and meta.approval_use_id. Useful
-/// for testing what verify sees when the action envelope ships in
-/// `artifacts/`.
+/// Build a fake-but-canonical signed ActionStatement envelope JSON.
+/// Returns `(derived_artifact_id, envelope_bytes)`.
 fn fake_action_envelope(
-    artifact_id: &str,
     raw_nonce: &str,
     approval_use_id: Option<&str>,
 ) -> (String, Vec<u8>) {
     use base64::Engine;
+    use treeship_core::attestation::{pae, artifact_id_from_pae};
     let meta: Value = match approval_use_id {
         Some(id) => json!({ "approval_use_id": id }),
         None     => json!({}),
     };
-    // Field names match ActionStatement's serde renames
-    // (approvalNonce / parentId / policyRef / type / timestamp).
     let payload = json!({
         "type": "treeship/action/v1",
         "timestamp": "2026-04-30T08:00:00Z",
@@ -106,14 +104,17 @@ fn fake_action_envelope(
         "approvalNonce": raw_nonce,
         "meta": meta,
     });
-    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .encode(serde_json::to_vec(&payload).unwrap());
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+    let payload_type = "application/vnd.treeship.action.v1+json";
+    let pae_bytes = pae(payload_type, &payload_bytes);
+    let derived_id = artifact_id_from_pae(&pae_bytes);
+    let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&payload_bytes);
     let env = json!({
         "payload": payload_b64,
-        "payloadType": "application/vnd.treeship.action.v1+json",
+        "payloadType": payload_type,
         "signatures": [{ "keyid": "key_test", "sig": "AA" }],
     });
-    (artifact_id.to_string(), serde_json::to_vec(&env).unwrap())
+    (derived_id, serde_json::to_vec(&env).unwrap())
 }
 
 fn make_minimal_receipt(action_artifact_ids: &[&str]) -> treeship_core::session::SessionReceipt {
@@ -181,19 +182,20 @@ fn find_check<'a>(
 }
 
 // ---------------------------------------------------------------------------
-// Fix 2 — action↔use binding
+// Fix 2 — action↔use binding (content-addressed)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn action_envelope_with_correct_use_id_binds_cleanly() {
     let nonce = "raw_nonce_alpha";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
+    let (art_id, env) = fake_action_envelope(nonce, Some("use_real"));
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
-    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_real"));
-    bundle.action_envelopes.push((art_id, env));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
+    bundle.action_envelopes.push((art_id.clone(), env));
 
-    let pkg = build(bundle, &["art_a"]);
+    let pkg = build(bundle, &[art_id.as_str()]);
     let checks = verify_package(&pkg).unwrap();
 
     let row = find_check(&checks, "approval-use-action-binding")
@@ -204,17 +206,15 @@ fn action_envelope_with_correct_use_id_binds_cleanly() {
 
 #[test]
 fn action_envelope_with_nonexistent_use_id_fails_binding() {
-    // The exact v0.9.9 attack: action.meta.approval_use_id points at a
-    // use_id that has no record. v0.9.9 verify ignored this; v0.9.10
-    // catches it.
     let nonce = "raw_nonce_beta";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
+    let (art_id, env) = fake_action_envelope(nonce, Some("use_does_not_exist"));
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
-    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_does_not_exist"));
-    bundle.action_envelopes.push((art_id, env));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
+    bundle.action_envelopes.push((art_id.clone(), env));
 
-    let pkg = build(bundle, &["art_a"]);
+    let pkg = build(bundle, &[art_id.as_str()]);
     let checks = verify_package(&pkg).unwrap();
 
     let row = find_check(&checks, "approval-use-action-binding")
@@ -225,16 +225,15 @@ fn action_envelope_with_nonexistent_use_id_fails_binding() {
 
 #[test]
 fn action_envelope_missing_use_id_pointer_fails_binding() {
-    // Action carries approval_nonce but its meta has no
-    // approval_use_id. v0.9.9 didn't care; v0.9.10 fails.
     let nonce = "raw_nonce_gamma";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
+    let (art_id, env) = fake_action_envelope(nonce, None);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
-    let (art_id, env) = fake_action_envelope("art_a", nonce, None); // no approval_use_id
-    bundle.action_envelopes.push((art_id, env));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
+    bundle.action_envelopes.push((art_id.clone(), env));
 
-    let pkg = build(bundle, &["art_a"]);
+    let pkg = build(bundle, &[art_id.as_str()]);
     let checks = verify_package(&pkg).unwrap();
 
     let row = find_check(&checks, "approval-use-action-binding")
@@ -245,16 +244,13 @@ fn action_envelope_missing_use_id_pointer_fails_binding() {
 
 #[test]
 fn package_without_action_envelopes_warns_binding_unasserted() {
-    // Pre-v0.9.10 packages: artifacts/ dir empty, no action envelopes
-    // shipped. Verify must NOT silently pass; it must report the row
-    // as `not asserted by package`.
     let nonce = "raw_nonce_delta";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
-    // No action_envelopes deliberately.
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
 
-    let pkg = build(bundle, &["art_a"]);
+    let pkg = build(bundle, &[]);
     let checks = verify_package(&pkg).unwrap();
 
     let row = find_check(&checks, "approval-use-action-binding")
@@ -263,16 +259,55 @@ fn package_without_action_envelopes_warns_binding_unasserted() {
     assert!(row.detail.contains("not asserted by package"), "detail: {}", row.detail);
 }
 
+/// Round-2 hardening regression: an attacker writes a forged action
+/// envelope at `artifacts/<some_id>.json` whose content does NOT
+/// derive to that id. v0.9.10 PR A round 1 trusted the file name and
+/// parsed `meta.approval_use_id` from arbitrary bytes; round 2 rejects
+/// because content-derived artifact_id mismatches the filename stem.
+#[test]
+fn forged_action_envelope_under_wrong_id_fails_content_addressing() {
+    use treeship_core::session::ApprovalsBundle;
+    let nonce = "raw_nonce_forge_action";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
+
+    // Real action envelope -> derives to art_a.
+    let (real_art_id, real_env) = fake_action_envelope(nonce, Some("use_real"));
+    // Different action envelope (different nonce, different
+    // approval_use_id) -> derives to a different art_b.
+    let (fake_art_id, fake_env) = fake_action_envelope("a_different_nonce", Some("use_real"));
+    assert_ne!(real_art_id, fake_art_id, "fixture sanity: forge must derive to a distinct id");
+
+    // The attack: ship the FORGED envelope under the REAL id. The
+    // file content does not derive to its filename.
+    bundle.action_envelopes.push((real_art_id.clone(), fake_env));
+
+    let pkg = build(bundle, &[real_art_id.as_str()]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-action-binding")
+        .expect("approval-use-action-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on substituted envelope, got: {row:?}");
+    assert!(
+        row.detail.contains("substituted or tampered") || row.detail.contains("content derives"),
+        "detail: {}",
+        row.detail,
+    );
+}
+
 // ---------------------------------------------------------------------------
-// Fix 3 — nonce binding (use.nonce_digest vs grant.nonce)
+// Fix 3 — nonce binding (content-addressed grant envelope)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn use_nonce_digest_matches_grant_signed_nonce_passes() {
     let nonce = "raw_nonce_epsilon";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
 
     let pkg = build(bundle, &[]);
     let checks = verify_package(&pkg).unwrap();
@@ -284,17 +319,11 @@ fn use_nonce_digest_matches_grant_signed_nonce_passes() {
 
 #[test]
 fn tampered_use_nonce_digest_fails_binding() {
-    // The exact v0.9.9 attack: edit the use's nonce_digest to claim a
-    // different consumption, then recompute record_digest. v0.9.9
-    // accepted; v0.9.10 cross-checks against the grant's signed nonce.
     let real_nonce = "raw_nonce_zeta";
+    let (g_id, g_env) = fake_grant_envelope(real_nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", real_nonce)));
-
-    let mut tampered_use = make_use_with_nonce("use_real", "g1", real_nonce);
-    // Mutate nonce_digest to claim consumption of a different grant's
-    // nonce. Recompute record_digest so the per-record digest still
-    // matches (this is the v0.9.9 forgery primitive).
+    bundle.grants.push((g_id.clone(), g_env));
+    let mut tampered_use = make_use_with_nonce("use_real", &g_id, real_nonce);
     tampered_use.nonce_digest = nonce_digest("a_different_nonce");
     tampered_use.record_digest = approval_use_record_digest(&tampered_use);
     bundle.uses.push(tampered_use);
@@ -306,7 +335,7 @@ fn tampered_use_nonce_digest_fails_binding() {
         .expect("approval-use-nonce-binding row required");
     assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on nonce mismatch, got: {row:?}");
     assert!(
-        row.detail.contains("hashes to") || row.detail.contains("nonce_digest"),
+        row.detail.contains("hashes to") || row.detail.contains("nonce_digest") || row.detail.contains("substituted"),
         "detail: {}",
         row.detail,
     );
@@ -315,7 +344,6 @@ fn tampered_use_nonce_digest_fails_binding() {
 #[test]
 fn use_referencing_unknown_grant_fails_binding() {
     let mut bundle = ApprovalsBundle::default();
-    // Use without its grant in the bundle.
     bundle.uses.push(make_use_with_nonce("use_orphan", "g_missing", "n"));
 
     let pkg = build(bundle, &[]);
@@ -324,21 +352,52 @@ fn use_referencing_unknown_grant_fails_binding() {
     let row = find_check(&checks, "approval-use-nonce-binding")
         .expect("approval-use-nonce-binding row required");
     assert_eq!(row.status, VerifyStatus::Fail);
-    assert!(row.detail.contains("not in the package"), "detail: {}", row.detail);
+    assert!(row.detail.contains("no usable grant envelope"), "detail: {}", row.detail);
+}
+
+/// Round-2 hardening regression: an attacker substitutes a forged
+/// grant envelope (different nonce) under the original grant_id
+/// filename. The use record's nonce_digest claims to match the real
+/// grant's nonce, but the envelope on disk no longer carries that
+/// nonce. v0.9.10 PR A round 1 trusted the parsed envelope; round 2
+/// rejects because the envelope's content-derived id no longer
+/// matches its filename.
+#[test]
+fn forged_grant_envelope_under_real_id_fails_content_addressing() {
+    let real_nonce = "raw_nonce_grant_real";
+    let (real_g_id, _real_env) = fake_grant_envelope(real_nonce);
+    let (_, forged_env) = fake_grant_envelope("a_completely_different_nonce");
+    // Sanity: the forged envelope content does NOT derive to real_g_id.
+
+    let mut bundle = ApprovalsBundle::default();
+    // Ship the forged envelope under the real grant_id filename.
+    bundle.grants.push((real_g_id.clone(), forged_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &real_g_id, real_nonce));
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-nonce-binding")
+        .expect("approval-use-nonce-binding row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on substituted grant envelope, got: {row:?}");
+    assert!(
+        row.detail.contains("substituted or tampered") || row.detail.contains("content derives"),
+        "detail: {}",
+        row.detail,
+    );
 }
 
 // ---------------------------------------------------------------------------
-// Fix 4 — embedded chain continuity
+// Fix 4 — embedded chain continuity (single connected linked list)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn embedded_chain_anchored_to_genesis_passes() {
     let nonce = "raw_nonce_eta";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    let u = make_use_with_nonce("use_real", "g1", nonce);
-    // Default previous_record_digest is empty string = genesis.
-    bundle.uses.push(u);
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
 
     let pkg = build(bundle, &[]);
     let checks = verify_package(&pkg).unwrap();
@@ -349,14 +408,13 @@ fn embedded_chain_anchored_to_genesis_passes() {
 
 #[test]
 fn dangling_previous_record_digest_fails_chain_continuity() {
-    // Attacker rewrites a use record's previous_record_digest to point
-    // at an arbitrary value not anchored in this package.
     let nonce = "raw_nonce_theta";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    let mut u = make_use_with_nonce("use_real", "g1", nonce);
+    bundle.grants.push((g_id.clone(), g_env));
+    let mut u = make_use_with_nonce("use_real", &g_id, nonce);
     u.previous_record_digest = "sha256:dangling_anchor_no_record_here".into();
-    u.record_digest = approval_use_record_digest(&u); // re-sync digest after edit
+    u.record_digest = approval_use_record_digest(&u);
     bundle.uses.push(u);
 
     let pkg = build(bundle, &[]);
@@ -372,13 +430,15 @@ fn dangling_previous_record_digest_fails_chain_continuity() {
 fn two_use_chain_with_correct_links_passes() {
     let nonce_a = "raw_nonce_iota_a";
     let nonce_b = "raw_nonce_iota_b";
+    let (g1_id, g1_env) = fake_grant_envelope(nonce_a);
+    let (g2_id, g2_env) = fake_grant_envelope(nonce_b);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce_a)));
-    bundle.grants.push(("g2".into(), fake_grant_envelope("g2", nonce_b)));
+    bundle.grants.push((g1_id.clone(), g1_env));
+    bundle.grants.push((g2_id.clone(), g2_env));
 
-    let u1 = make_use_with_nonce("use_1", "g1", nonce_a);
+    let u1 = make_use_with_nonce("use_1", &g1_id, nonce_a);
     let u1_digest = u1.record_digest.clone();
-    let mut u2 = make_use_with_nonce("use_2", "g2", nonce_b);
+    let mut u2 = make_use_with_nonce("use_2", &g2_id, nonce_b);
     u2.previous_record_digest = u1_digest;
     u2.record_digest = approval_use_record_digest(&u2);
     bundle.uses.push(u1);
@@ -392,6 +452,124 @@ fn two_use_chain_with_correct_links_passes() {
     assert_eq!(row.status, VerifyStatus::Pass);
 }
 
+/// Round-2 hardening regression: two records both claim
+/// `previous_record_digest == ""` (genesis). A real journal has
+/// exactly one genesis record (the chronologically first); seeing
+/// two means an attacker fabricated a second "first record" mid-chain
+/// to launder a forged record into the linked list.
+#[test]
+fn multiple_genesis_records_fail_chain_continuity() {
+    let nonce_a = "raw_nonce_genesis_a";
+    let nonce_b = "raw_nonce_genesis_b";
+    let (g1_id, g1_env) = fake_grant_envelope(nonce_a);
+    let (g2_id, g2_env) = fake_grant_envelope(nonce_b);
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push((g1_id.clone(), g1_env));
+    bundle.grants.push((g2_id.clone(), g2_env));
+
+    // Both records have prev = "" -> two genesis claims.
+    let mut u1 = make_use_with_nonce("use_1", &g1_id, nonce_a);
+    u1.previous_record_digest = String::new();
+    u1.record_digest = approval_use_record_digest(&u1);
+    let mut u2 = make_use_with_nonce("use_2", &g2_id, nonce_b);
+    u2.previous_record_digest = String::new();
+    u2.record_digest = approval_use_record_digest(&u2);
+    bundle.uses.push(u1);
+    bundle.uses.push(u2);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on multiple genesis, got: {row:?}");
+    assert!(row.detail.contains("genesis"), "detail: {}", row.detail);
+}
+
+/// Round-2 hardening regression: two records share the same non-empty
+/// `previous_record_digest`. That's a fork; an honest journal has
+/// exactly one record per prev pointer.
+#[test]
+fn forked_chain_two_records_share_prev_fails_chain_continuity() {
+    let nonce_a = "raw_nonce_fork_a";
+    let nonce_b = "raw_nonce_fork_b";
+    let nonce_c = "raw_nonce_fork_c";
+    let (g_a, env_a) = fake_grant_envelope(nonce_a);
+    let (g_b, env_b) = fake_grant_envelope(nonce_b);
+    let (g_c, env_c) = fake_grant_envelope(nonce_c);
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push((g_a.clone(), env_a));
+    bundle.grants.push((g_b.clone(), env_b));
+    bundle.grants.push((g_c.clone(), env_c));
+
+    // u1 is genesis; both u2 and u3 link back to u1 -> fork.
+    let u1 = make_use_with_nonce("use_1", &g_a, nonce_a);
+    let u1_digest = u1.record_digest.clone();
+    let mut u2 = make_use_with_nonce("use_2", &g_b, nonce_b);
+    u2.previous_record_digest = u1_digest.clone();
+    u2.record_digest = approval_use_record_digest(&u2);
+    let mut u3 = make_use_with_nonce("use_3", &g_c, nonce_c);
+    u3.previous_record_digest = u1_digest;
+    u3.record_digest = approval_use_record_digest(&u3);
+    bundle.uses.push(u1);
+    bundle.uses.push(u2);
+    bundle.uses.push(u3);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on fork, got: {row:?}");
+    assert!(row.detail.contains("fork") || row.detail.contains("share previous_record_digest"),
+        "detail: {}", row.detail);
+}
+
+/// Round-2 hardening regression: a disconnected subchain. Two
+/// records form a linked list but neither links to genesis (both
+/// have prev pointing at each other's record_digest -- a cycle). An
+/// honest chain walks from genesis to tail with no cycles.
+#[test]
+fn disconnected_subchain_fails_chain_continuity() {
+    let nonce_a = "raw_nonce_disconn_a";
+    let nonce_b = "raw_nonce_disconn_b";
+    let (g_a, env_a) = fake_grant_envelope(nonce_a);
+    let (g_b, env_b) = fake_grant_envelope(nonce_b);
+    let mut bundle = ApprovalsBundle::default();
+    bundle.grants.push((g_a.clone(), env_a));
+    bundle.grants.push((g_b.clone(), env_b));
+
+    // u1's prev is u2's digest; u2's prev is u1's digest -> 2-cycle,
+    // no genesis reachable.
+    let mut u1 = make_use_with_nonce("use_1", &g_a, nonce_a);
+    let mut u2 = make_use_with_nonce("use_2", &g_b, nonce_b);
+    // First compute provisional digests, then point at each other.
+    let u1_digest_v0 = u1.record_digest.clone();
+    let u2_digest_v0 = u2.record_digest.clone();
+    u1.previous_record_digest = u2_digest_v0;
+    u1.record_digest = approval_use_record_digest(&u1);
+    u2.previous_record_digest = u1_digest_v0;
+    u2.record_digest = approval_use_record_digest(&u2);
+    bundle.uses.push(u1);
+    bundle.uses.push(u2);
+
+    let pkg = build(bundle, &[]);
+    let checks = verify_package(&pkg).unwrap();
+
+    let row = find_check(&checks, "approval-use-chain-continuity")
+        .expect("approval-use-chain-continuity row required");
+    assert_eq!(row.status, VerifyStatus::Fail, "expected FAIL on disconnected/cyclic chain, got: {row:?}");
+    // Expect any of "dangling", "disconnected", "cycle" depending on
+    // which gate fires first; the chain is structurally broken
+    // either way.
+    assert!(
+        row.detail.contains("not anchored")
+            || row.detail.contains("disconnected")
+            || row.detail.contains("cycle"),
+        "detail: {}", row.detail,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Fix 5 — record-digest rename + label hygiene
 // ---------------------------------------------------------------------------
@@ -399,9 +577,10 @@ fn two_use_chain_with_correct_links_passes() {
 #[test]
 fn renamed_record_digest_row_emits_for_present_uses() {
     let nonce = "raw_nonce_kappa";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
 
     let pkg = build(bundle, &[]);
     let checks = verify_package(&pkg).unwrap();
@@ -418,16 +597,15 @@ fn renamed_record_digest_row_emits_for_present_uses() {
 
 #[test]
 fn read_back_round_trips_action_envelopes() {
-    // The v0.9.10 package format ships action envelopes in
-    // `artifacts/`; round-trip via build + read_approvals_bundle.
     let nonce = "raw_nonce_lambda";
+    let (g_id, g_env) = fake_grant_envelope(nonce);
+    let (art_id, env) = fake_action_envelope(nonce, Some("use_real"));
     let mut bundle = ApprovalsBundle::default();
-    bundle.grants.push(("g1".into(), fake_grant_envelope("g1", nonce)));
-    bundle.uses.push(make_use_with_nonce("use_real", "g1", nonce));
-    let (art_id, env) = fake_action_envelope("art_a", nonce, Some("use_real"));
+    bundle.grants.push((g_id.clone(), g_env));
+    bundle.uses.push(make_use_with_nonce("use_real", &g_id, nonce));
     bundle.action_envelopes.push((art_id.clone(), env.clone()));
 
-    let pkg = build(bundle, &["art_a"]);
+    let pkg = build(bundle, &[art_id.as_str()]);
 
     let read_back = read_approvals_bundle(&pkg).unwrap();
     assert_eq!(read_back.action_envelopes.len(), 1);


### PR DESCRIPTION
## Summary

Closes the four trust-bypass paths Codex's adversarial review of v0.9.9 Approval Authority found and verified against the actual code. The findings are saved in `docs/release-adversarial/v0.9.9.md`. v0.9.10 cutover (version bump + CHANGELOG) lands as the next PR after this merges.

The honesty rule from v0.9.9 — *never claim a stronger replay level than the embedded evidence supports* — is preserved end-to-end. Where the package format previously lacked the data to assert a binding, the verifier now reports that gap explicitly rather than silently passing.

## Out of scope (deferred from v0.9.9 list)

- Full Hub server / signing service
- Issuer / registry identity (trusted-key pinning)
- AgentGate runtime enforcement
- Mobile/desktop approval apps

## What ships

### Blocker 1 — TOCTOU race in `reserve_in_journal`
- `packages/core/src/journal/mod.rs`: new `reserve_use` that runs `check_replay` and `use_number` derivation **inside** `with_lock` and stamps the use_number from the count observed at lock-acquire time. Existing `append_use` is preserved for tests / trusted callers.
- `packages/cli/src/commands/attest.rs`: `reserve_in_journal` now calls `journal::reserve_use` for the consume path. The previous separate `check_replay` + `list_uses_for_grant` + `append_use` is gone.

### Blocker 2 — Action↔use binding
- `ApprovalsBundle` gains `action_envelopes: Vec<(String, Vec<u8>)>`.
- `build_package_with_approvals` now writes each consuming action's envelope to `pkg_dir/artifacts/<artifact_id>.json` (the dir was always created but never populated pre-v0.9.10).
- `read_approvals_bundle` reads them back.
- `collect_approval_evidence` (a) snapshots envelopes, (b) when an action carries `meta.approval_use_id`, exports ONLY the referenced use (previously dumped every use for the grant — gave a tampered package room to reference unrelated uses).
- New `approval-use-action-binding` verify row: `✓` when every consuming action's `meta.approval_use_id` resolves to a use_id in the bundle AND the action's `approval_nonce` hashes to that use's `nonce_digest`. `✗` on any binding violation. `-` (warn) when the package ships no action envelopes (pre-v0.9.10 packages — explicit "not asserted by package" rather than silent pass).

### Blocker 3 — `nonce_digest` cross-check
- New `approval-use-nonce-binding` verify row: for each use, parse the matching grant envelope, compute `nonce_digest(grant.nonce)` via the same helper attest used, compare to `use.nonce_digest`. Mismatch → `✗`. The grant envelope is the source of truth; the use's nonce_digest is now treated as an assertion to be verified.

### Blocker 4 — Chain continuity
- New `approval-use-chain-continuity` verify row: builds the set of record_digests "owned" by the package (every embedded use + checkpoint + genesis ""), asserts every use's and checkpoint's `previous_record_digest` resolves to an owned digest. Dangling pointers → `✗`. Hub-signature anchoring is still `replay-hub-org`'s job.

### Label hygiene (Fix 5)
- Renamed `approval-use-integrity` → `approval-use-record-digest`. The old label over-claimed integrity scope. Strict-mode matcher keeps the old label too for backward compat.
- `--strict` promotes every new row (record-digest, nonce-binding, action-binding, chain-continuity) alongside the existing `replay-*` rows.
- `treeship package inspect` panel renders the four new rows as a bundle-level integrity summary right after the per-use replay rows.

## Acceptance (per release plan)

- [x] `max_uses=1` concurrent consume: only one succeeds — `reserve_use_concurrent_max_uses_1_only_one_succeeds` (8 threads contend; exactly one wins; on-disk record count is 1)
- [x] `max_uses=2` legitimate two uses pass — `reserve_use_max_uses_2_two_uses_pass_third_rejects`
- [x] Third use of same nonce fails — same test
- [x] Tampered `meta.approval_use_id` fails — `action_envelope_with_nonexistent_use_id_fails_binding`
- [x] Missing `meta.approval_use_id` fails — `action_envelope_missing_use_id_pointer_fails_binding`
- [x] Tampered `nonce_digest` fails — `tampered_use_nonce_digest_fails_binding`
- [x] Rewritten package chain fails — `dangling_previous_record_digest_fails_chain_continuity`
- [x] Strict mode escalates all four blockers to failure (matcher widened in `commands/package.rs`)
- [x] Default mode never overclaims (action-binding "not asserted" warn for pre-v0.9.10 packages instead of silent pass)
- [x] No global/Hub/org replay claim unless a real Hub checkpoint exists (PR #55 logic intact, regression tests still green)

## Verification

- ✅ `cargo test -p treeship-core` — 250 unit + 12 new binding integration + 7 hub-checkpoint + every other suite green
- ✅ `cargo test --workspace` — every suite green
- ✅ `cargo build -p treeship-core-wasm --target wasm32-unknown-unknown`
- ✅ `bash tests/acceptance/trust-fabric.sh` — smoke pass

## Test plan

- [ ] CI green on every check (`version-consistency`, `test`, `hub`, cross-SDK matrix, Vercel)
- [ ] **Targeted Codex re-check** scoped to these four fixes only — confirm no remaining bypass on the same threat model. Re-run findings get saved as a delta in `docs/release-adversarial/v0.9.9.md`.
- [ ] Confirm `--strict` against an unmodified v0.9.9 package now fails `approval-use-action-binding` (pre-v0.9.10 packages can't assert binding) — that's the intended upgrade signal
- [ ] Confirm a v0.9.10 package round-trips: `build_package_with_approvals` writes envelopes; `read_approvals_bundle` reads them back; `verify_package` passes binding check
- [ ] No new behavior visible to users without consumed approvals — pre-v0.9.10 sessions without approvals produce identical packages

## After this merges

PR B opens immediately: boring v0.9.10 cutover (21 version sites 0.9.9 → 0.9.10, CHANGELOG entry under "Approval Authority — Patch" theme, no product code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)