### PR TITLE
release: v0.9.10 cutover (bump + CHANGELOG + cadence policy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.9.10 (2026-04-30)
+
+The Approval Authority patch release. Closes four trust-bypass paths and three adjacent hardenings that a targeted Codex adversarial review of v0.9.9 found in the new approval-evidence surface. **Verifiers running v0.9.9 should upgrade.** v0.9.9 packages still verify under v0.9.10, but the binding rows that v0.9.9 silently passed now report honestly: a v0.9.9 package's `approval-use-action-binding` row will read `not asserted by package` because v0.9.9 didn't ship the action envelopes the binding check needs. Under `--strict`, that's a fail — the intended upgrade signal.
+
+The release-adversarial discipline that surfaced these gaps is now durable policy. `docs/release-adversarial/README.md` writes down the rule: **trust-semantics releases run a targeted adversarial review; bump-only releases don't.** Findings are saved per-version in `docs/release-adversarial/<version>.md`. The v0.9.9 file records every blocker with file:line + repro + verification step, and includes the round-2 / round-3 re-check verdicts that gated the v0.9.10 hotfix merge. Running adversarial review on every CHANGELOG bump would be wasted budget; running it on every receipt-format / approval-semantics / replay-behavior change is the discipline that catches the bugs CI doesn't.
+
+What v0.9.10 does NOT add: any new trust subsystem. Hub server, issuer/registry identity, AgentGate runtime enforcement, and mobile/desktop approval apps remain out of scope, carried over from v0.9.9's deferred list. The next product release (Agent-Native Bootstrap + Share + Docs Reliability) will pick up where v0.9.9 left off; v0.9.10 is purely the boring-but-correct patch in front of it.
+
+### Fixed (Approval Authority blockers — #57)
+
+- **TOCTOU race in `reserve_in_journal` bypassed `max_uses`** — `packages/core/src/journal/mod.rs`, `packages/cli/src/commands/attest.rs`. v0.9.9's `reserve_in_journal` ran `check_replay` and `list_uses_for_grant` *outside* `with_lock`, then called `append_use` which took the lock only for the write. Two parallel `treeship attest` invocations against a `max_uses=1` grant could both pass replay-check pre-lock, then queue serially through the lock, and both write — exceeding `max_uses`. Closed by a new `journal::reserve_use` that runs `check_replay` and `use_number` derivation *inside* `with_lock` and stamps `use_number` from the count observed at lock-acquire time. The CLI consume path now calls `reserve_use`; `append_use` is preserved for tests and trusted callers. Pinned by `journal::tests::reserve_use_concurrent_max_uses_1_only_one_succeeds` (8 threads contend; exactly one wins; on-disk record count is 1) and `reserve_use_retry_after_lock_busy_does_not_bypass_max_uses` (idempotency-retry safety).
+- **Action↔use binding ignored at verify time** — `packages/core/src/session/package.rs`, `packages/cli/src/commands/session.rs`. v0.9.9's `collect_approval_evidence` pulled every use for the grant and `verify_package` resolved by `(grant_id, nonce_digest)` only. Worse, the package format never shipped action envelopes, so the verifier could not see `meta.approval_use_id` even if it had wanted to. Closed by extending `ApprovalsBundle` with `action_envelopes: Vec<(String, Vec<u8>)>`, populating it during session close, writing each consuming action envelope to `pkg_dir/artifacts/<artifact_id>.json` (the directory existed but was empty pre-v0.9.10), and adding a new `approval-use-action-binding` verify row. The row PASSes only when every consuming action's `meta.approval_use_id` resolves to a use_id in the bundle AND the action's `approval_nonce` hashes to that use's `nonce_digest`. Round 2 added a content-addressing gate: the envelope's `artifact_id_from_pae(pae(payload_type, payload))` must equal the filename stem before any field is trusted. Without this gate an attacker controlling the package could write any forged unsigned action JSON to `artifacts/<id>.json` and the binding row would trust it.
+- **`nonce_digest` in ApprovalUse not cross-checked** — `packages/core/src/session/package.rs`. v0.9.9's package replay path read each use's `nonce_digest` verbatim and never compared it to `nonce_digest(grant.nonce)`. An attacker who controlled the package could mutate `nonce_digest` to claim consumption of any grant whose nonce they hadn't actually used — recompute the use's `record_digest` and the per-record check still passed. Closed by a new `approval-use-nonce-binding` verify row: for each use, find the matching grant in `bundle.grants`, parse its envelope, compute `nonce_digest(grant.nonce)`, compare. Round 2 added the same content-addressing gate to grant envelopes; a forged grant payload with any nonce now fails before the row's signed-nonce extraction runs.
+- **Embedded chain not walked in package replay** — `packages/core/src/session/package.rs`. v0.9.9's `replay-included-checkpoint` and per-use `record_digest` checks both recomputed individual digests, but neither walked the `previous_record_digest` chain across embedded records. An attacker could rewrite a chain consistently — recomputing each digest along the way — and every per-record check still passed. Closed by a new `approval-use-chain-continuity` verify row. Round 2 tightened the algorithm: requires exactly one record with `previous_record_digest == ""` (one genesis), no two records sharing a non-empty prev (no forks), no cycles detected during the walk from genesis, and every record reachable from the genesis (no disconnected subchains). Pinned by `multiple_genesis_records_fail_chain_continuity`, `forked_chain_two_records_share_prev_fails_chain_continuity`, `disconnected_subchain_fails_chain_continuity`, plus the original `dangling_previous_record_digest_fails_chain_continuity`.
+
+### Fixed (label hygiene — #57)
+
+- **Renamed `approval-use-integrity` → `approval-use-record-digest`** — `packages/core/src/session/package.rs`, `packages/cli/src/commands/package.rs`. The old label suggested the row covered nonce/action binding; it didn't, and Codex's review flagged the over-claim. The strict-mode promotion matcher keeps the old label too for backward compatibility with downstream tooling, but the live emitter uses the new name. Three new verify rows (`approval-use-nonce-binding`, `approval-use-action-binding`, `approval-use-chain-continuity`) carry the responsibilities the old label implied.
+- **Strict-mode promotion widened.** `--strict` now promotes every new approval-evidence row from warn → fail alongside the existing `replay-*` rows.
+
+### Added (release-adversarial cadence policy)
+
+- **`docs/release-adversarial/README.md`** — durable policy. Trust-semantics releases (receipt format, approval semantics, replay/journal, package verification, Hub checkpoint verification, MCP/A2A bridges, tool authorization, agent identity, harness coverage, public sharing, installer security) run a targeted Codex adversarial pass before or immediately after release. Bump-only releases don't. Findings save to `docs/release-adversarial/<version>.md`. Triage is a fixed scale: replay/signature bypass or secret leak → hotfix; docs overclaim → docs patch; missing test → next hardening PR. Codex output is verified against the actual code before being recorded as a confirmed blocker — file-path hallucinations don't become release-blocking findings.
+- **`docs/release-adversarial/v0.9.9.md`** — first instance. Records the four blockers, three round-2 sub-blockers, round-3 ship verdict, and the two non-blocking secondaries (duplicate grant_id last-wins, missing 3-cycle and self-loop chain test cases) deferred to the next hardening pass.
+
+### Tests
+
+- `journal::tests::reserve_use_first_call_succeeds_and_stamps_use_number`
+- `journal::tests::reserve_use_max_uses_1_serial_second_call_rejects`
+- `journal::tests::reserve_use_max_uses_2_two_uses_pass_third_rejects`
+- `journal::tests::reserve_use_concurrent_max_uses_1_only_one_succeeds`
+- `journal::tests::reserve_use_retry_after_lock_busy_does_not_bypass_max_uses`
+- 17 new integration tests in `packages/core/tests/approval_evidence_binding.rs` covering action-binding pass/fail/missing-pointer/no-envelopes/forged-envelope, nonce-binding pass/tamper/unknown-grant/forged-grant, chain-continuity pass/dangling/multiple-genesis/fork/disconnected, label rename, action-envelope round trip.
+- All 246+ pre-existing core tests still pass; the 7 `hub_checkpoint_verify` integration tests still pass; acceptance smoke (`tests/acceptance/trust-fabric.sh`) still passes.
+
+### Known follow-ups (non-blocking, deferred)
+
+- Duplicate `grant_id` entries in `bundle.grants` silently last-wins in the nonce-binding HashMap. Real packages produced by `build_package_with_approvals` deduplicate by sanitized filename, so this is hard to trigger in production, but a defensive explicit-failure check would harden the row.
+- Test coverage for 3-cycle (a→b→c→a) and self-loop (`record_digest == previous_record_digest`) chain shapes. The current algorithm should reject both via the visited-set walk; a regression test would pin that explicitly.
+
+### Intentionally NOT changed
+
+- Hub server / issuer registry / AgentGate runtime / mobile-desktop apps remain out of scope (carried over from v0.9.9 deferred list).
+- v0.9.9 packages still verify under v0.9.10. The new binding rows report honestly when the package doesn't ship the evidence; verifiers calling `--strict` against pre-v0.9.10 packages will fail `approval-use-action-binding`. That's the intended upgrade signal.
+
 ## 0.9.9 (2026-04-30)
 
 The Approval Authority release. v0.9.6 made the receipt trustworthy. v0.9.7 made the release process trustworthy. v0.9.8 made the agent experience legible. v0.9.9 makes **temporary authority** itself a first-class trust object: a human approves an agent for a bounded action; the agent consumes that approval at runtime; the receipt records the consumption; offline verifiers can replay the chain on any machine; and where a signed Hub checkpoint is embedded, the same verify run can attest to non-replay across machines. Six PRs (#50–#55) compose into the core trust answer for v0.9.9.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "base64",
  "clap",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.9"
+    "@treeship/core-wasm": "0.9.10"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.9.9"
+    "@treeship/core-wasm": "0.9.10"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/docs/release-adversarial/README.md
+++ b/docs/release-adversarial/README.md
@@ -1,0 +1,100 @@
+# Release adversarial review — policy
+
+Treeship's release discipline distinguishes **trust-semantics releases** from **bump-only releases**. The two get different treatment.
+
+## When to run a targeted Codex adversarial review
+
+**Run** the targeted Codex pass before or immediately after release for any change to:
+
+- receipt composition
+- approval semantics (grants, scope, nonce binding)
+- replay / journal behavior
+- package verification
+- Hub checkpoint verification
+- MCP / A2A bridges (sanitization, command privacy)
+- tool authorization
+- agent identity / cards
+- harness coverage semantics
+- public sharing / raw receipt exposure
+- installer / bootstrap security
+
+**Skip** the broad Codex pass for:
+
+- CHANGELOG-only changes
+- VERSION-only bumps
+- package manifest pin updates
+- release tag pushes that don't carry product code
+- pure docs / website edits that don't change exported claims
+
+For the skip cases, the existing release machinery is enough: `scripts/check-release-versions.py` (preflight + `--consistency`), CI (`version-consistency`, `test`, `hub`, cross-SDK matrix), and post-tag registry install smokes.
+
+## How to run a targeted pass
+
+The pass is **scoped to the actual diff**, not "find anything." The reviewer (Codex CLI in adversarial / "challenge" mode) gets:
+
+1. The exact commit range (e.g. `git diff v0.9.8..v0.9.9 -- packages/ docs/` minus version-bump files).
+2. A list of invariants the diff is supposed to maintain.
+3. Specific attacks to try against each invariant.
+4. A required output shape: BLOCKERS / IMPORTANT NON-BLOCKERS / COPY ISSUES / TESTS TO ADD / FILES / REPRO COMMANDS.
+
+The threat-model template lives in `docs/release-adversarial/<version>.md` for every release that ran one. Reuse the template for the next release; tighten it as new attack classes are found.
+
+## What to do with findings
+
+Findings get triaged on the same scale every time:
+
+| Finding | Severity | Action |
+|---|---|---|
+| Replay bypass | Blocker | Cut a `vX.Y.Z+1` patch immediately |
+| Signature bypass | Blocker | Cut a patch |
+| Secret leak (raw nonces, commands, prompts, file contents, bearer tokens) | Blocker | Cut a patch |
+| Docs overclaim of a guarantee the code doesn't deliver | Copy issue | Docs patch (can ride next release) |
+| Missing test that pins an existing invariant | Tests-to-add | Add in next hardening PR |
+| Installer / agent-native UX issue | UX | Fold into next product release |
+
+**Verify before treating as truth.** Codex tools sometimes hallucinate file paths or misread context. Every cited file:line gets independently read and the gap reproduced against the actual code before being recorded as a confirmed blocker. The triage doc should explicitly call out this verification step.
+
+## Save the findings
+
+Every targeted pass that finds anything (or even confirms a clean bill of health) is saved as `docs/release-adversarial/<version>.md`. The file follows the structure the v0.9.9 doc established:
+
+- threat model used
+- list of confirmed blockers, each with file:line + repro command + suggested fix
+- non-blockers and copy issues
+- tests to add post-fix
+- triage decision (ship / docs patch / hotfix)
+- attestation of the Codex run (CLI version, mode, verification approach)
+
+This is the durable record. New releases reference prior findings to avoid regressing the same invariant twice.
+
+## Re-check on the fix PR
+
+When a hotfix lands the fixes for an adversarial-found blocker, run a **second** targeted Codex pass scoped to the fix diff alone:
+
+1. Did each fix actually close the finding the original repro pinned?
+2. Did the fix introduce a new bypass adjacent to the same surface?
+3. Are there test coverage gaps that should land before the cutover?
+
+The re-check is appended to the same `docs/release-adversarial/<version>.md` file, not a new file. The re-check is the merge gate for the fix PR.
+
+## Why this exists
+
+The v0.9.9 release published with four real trust-bypass paths in the new Approval Authority surface — a TOCTOU race in the consume path, ignored action↔use binding, an unbound `nonce_digest` field, and an unwalked embedded chain. Each one was a *replay* or *binding* bypass. None of them were caught by CI or by the version-consistency machinery, because none of those were the kind of bug those tools catch. The targeted Codex pass found all four.
+
+The lesson: **trust semantics need an adversarial reader, not just tests.** Tests pin invariants you remembered to write tests for. An adversarial review hunts the invariant you forgot.
+
+The lesson does NOT extend to bump-only releases. Running a broad Codex pass on a CHANGELOG-only PR is wasted budget and noise; that's why the policy is *targeted* and *gated by what changed*.
+
+## Schedule
+
+| Trigger | Adversarial pass? | Notes |
+|---|---|---|
+| New trust subsystem (e.g. v0.9.9 Approval Authority) | Yes | Pre-cutover or immediately post-tag |
+| New bridge / sanitizer / authorization surface | Yes | Same |
+| Receipt format change | Yes | Same |
+| Package format extension (new fields, new sections) | Yes | Even if "just additive" |
+| Bump-only cutover PR | No | Preflight + CI + smokes |
+| Pure docs PR | No | Unless docs claim something the code doesn't deliver — then a copy review |
+| Hotfix PR for previously-found blockers | Yes (re-check) | Scoped to the fix diff |
+
+Update this table when a release category surfaces that doesn't fit either bucket.

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.9.9",
-    "@treeship/cli-darwin-arm64": "0.9.9",
-    "@treeship/cli-darwin-x64": "0.9.9"
+    "@treeship/cli-linux-x64": "0.9.10",
+    "@treeship/cli-darwin-arm64": "0.9.10",
+    "@treeship/cli-darwin-x64": "0.9.10"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.9.9", path = "../core" }
+treeship-core = { version = "0.9.10", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.9.9"
+version = "0.9.10"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-python/treeship_sdk/__init__.py
+++ b/packages/sdk-python/treeship_sdk/__init__.py
@@ -25,4 +25,4 @@ __all__ = [
     "Treeship",
     "TreeshipError",
 ]
-__version__ = "0.9.9"
+__version__ = "0.9.10"

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "^0.9.4"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.9"
+    "@treeship/core-wasm": "0.9.10"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.9.2"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.9"
+    "@treeship/core-wasm": "0.9.10"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

The v0.9.10 cutover. Version bump (21 sites 0.9.9 → 0.9.10), CHANGELOG entry under "Approval Authority — Patch" theme, and a new durable `docs/release-adversarial/README.md` capturing the cadence policy that surfaced the bugs PR #57 fixed. **No product code in this PR** — every fix already landed in #57.

### v0.9.10 — Approval Authority — Patch

Closes four trust-bypass paths (TOCTOU race, action↔use binding ignored, unbound `nonce_digest`, unwalked embedded chain) plus three round-2 hardenings (content-addressing on action and grant envelopes, tightened chain continuity), plus the rename `approval-use-integrity` → `approval-use-record-digest`. Three rounds of targeted Codex adversarial review gated the merge of #57. Findings recorded in `docs/release-adversarial/v0.9.9.md`.

**Verifiers running v0.9.9 should upgrade.** v0.9.9 packages still verify under v0.9.10, but the binding rows that v0.9.9 silently passed now report honestly: a v0.9.9 package's `approval-use-action-binding` row reads `not asserted by package` because v0.9.9 didn't ship the action envelopes the binding check needs. Under `--strict`, that's a fail — the intended upgrade signal.

## Out of scope (carried over from v0.9.9 deferred list)

- Full Hub server / signing service
- Issuer / registry identity (trusted-key pinning)
- AgentGate runtime enforcement
- Mobile/desktop approval apps

## What this PR contains

- 21 version sites bumped 0.9.9 → 0.9.10. Confirmed by `scripts/check-release-versions.py 0.9.10` (21 ok, 0 wrong, 0 not-found).
- Substantive `CHANGELOG.md` entry under the **Approval Authority — Patch** theme with explicit "v0.9.9 verifiers should upgrade" note.
- New `docs/release-adversarial/README.md` (durable policy: trust-semantics releases get a targeted adversarial pass; bump-only releases don't).
- `docs/release-adversarial/v0.9.9.md` already landed in PR #57 — no change here.
- No source files outside version-bearing manifests + Cargo.lock + CHANGELOG + the new policy doc.

## Verification

- ✅ `python3 scripts/check-release-versions.py 0.9.10` — 21/21 sites at 0.9.10
- ✅ `cargo test --workspace` — every suite green (251 core unit + 17 binding integration + 7 hub-checkpoint integration + everything else)
- ✅ `bash tests/acceptance/trust-fabric.sh` — smoke pass

## Test plan

- [ ] CI: `version-consistency`, `test`, `hub`, cross-SDK matrix (ubuntu + macOS), Vercel preview, acceptance smoke
- [ ] Confirm zero source/test changes (only CHANGELOG, version manifests, Cargo.lock, and the new policy doc)
- [ ] Read the CHANGELOG entry top-to-bottom — does it accurately describe what shipped in #57?

## After merge

Same release discipline as v0.9.9:

1. Post-merge CI checks on main
2. Capture merged-main SHA
3. Run `python3 scripts/check-release-versions.py 0.9.10` + `--consistency`, `bash tests/acceptance/trust-fabric.sh`, `cargo test --workspace`
4. Confirm no local or remote v0.9.10 tag exists
5. Explicit user approval for local tag creation (Gate 1)
6. `scripts/release.sh tag 0.9.10 --sha <merged-sha>` (creates annotated tag locally only — never pushes)
7. Show tag (`git show --no-patch --decorate --oneline v0.9.10`)
8. Explicit user approval to push tag (Gate 2)
9. `git push origin v0.9.10` triggers `release.yml` publish pipeline
10. Report registry + install smokes (npm, pip, cargo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)