### PR TITLE
feat(docs): PR 1 — docs route health (section-root redirects + CI smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,24 @@ jobs:
       - name: Check internal version consistency
         run: python3 scripts/check-release-versions.py --consistency
 
+  # Static check that every page advertised in a docs `meta.json`
+  # resolves to a real `.mdx` file (or a sub-section), every section
+  # root has either an index.mdx or a redirect in `next.config.mjs`,
+  # and every redirect points at a destination that exists. Catches
+  # the failure mode where a renamed/deleted doc leaves a sidebar
+  # entry pointing at a 404, or where a new section ships without a
+  # root redirect so `/cli` works but `/concepts` doesn't. Cheap; no
+  # network, no build.
+  docs-route-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Check docs route health
+        run: python3 scripts/check-docs-routes.py
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -12,12 +12,25 @@ const config = {
         destination: '/:path*',
         permanent: true,
       },
-      { source: '/cli', destination: '/cli/overview', permanent: false },
-      { source: '/sdk', destination: '/sdk/overview', permanent: false },
-      { source: '/api', destination: '/api/overview', permanent: false },
-      { source: '/commerce', destination: '/commerce/overview', permanent: false },
-      { source: '/reference', destination: '/reference/schema', permanent: false },
-      { source: '/cli/dock', destination: '/cli/hub', permanent: true },
+      // Section-root redirects. Every section listed in
+      // `docs/content/docs/meta.json` should resolve at its bare root URL --
+      // a section that 404s when typed without the trailing page slug
+      // looks broken to a human reader and (more importantly) to AI
+      // agents/scrapers that treat /cli as canonical. The static
+      // route-health check at scripts/check-docs-routes.py asserts each
+      // entry below maps to a real first page.
+      { source: '/cli',          destination: '/cli/overview',            permanent: false },
+      { source: '/sdk',          destination: '/sdk/overview',            permanent: false },
+      { source: '/api',          destination: '/api/overview',            permanent: false },
+      { source: '/commerce',     destination: '/commerce/overview',       permanent: false },
+      { source: '/reference',    destination: '/reference/schema',        permanent: false },
+      { source: '/guides',       destination: '/guides/introduction',     permanent: false },
+      { source: '/concepts',     destination: '/concepts/trust-fabric',   permanent: false },
+      { source: '/integrations', destination: '/integrations/claude-code', permanent: false },
+      // Friendly alias: the api/ section's title is "Hub API"; agents
+      // crawling the sidebar often try /hub-api as the canonical URL.
+      { source: '/hub-api',      destination: '/api/overview',            permanent: false },
+      { source: '/cli/dock',     destination: '/cli/hub',                 permanent: true  },
     ];
   },
 };

--- a/scripts/check-docs-routes.py
+++ b/scripts/check-docs-routes.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Static route-health check for the Treeship docs site.
+
+Walks every `meta.json` under `docs/content/docs/` and asserts:
+
+  1. Every page listed in a section's `pages` array resolves to a real
+     `.mdx` file in the same folder, or to a sub-folder with its own
+     `meta.json`. Catches the failure mode where a sidebar entry points
+     at a renamed/deleted file -- the page 404s the moment a user clicks
+     it.
+
+  2. Every section root (the URL `/<section>` without a page slug) has
+     a way to resolve. Either:
+       - the folder contains an `index.mdx` (fumadocs treats this as the
+         section's root page), OR
+       - `docs/next.config.mjs` declares a redirect from `/<section>` to
+         a real first page.
+     Catches the failure mode where typing `/cli` directly returns 404
+     because no index page exists and no redirect was wired.
+
+  3. Every redirect in `docs/next.config.mjs` points at a destination
+     that exists on disk. A redirect to a deleted page is a hidden
+     404 -- the redirect itself returns 308, but the user lands on
+     a missing page.
+
+Exits non-zero on any failure. Designed to run in CI on every PR; see
+`.github/workflows/ci.yml` for the wiring.
+
+Run locally:
+    python3 scripts/check-docs-routes.py
+
+Run with extra detail:
+    python3 scripts/check-docs-routes.py --verbose
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT       = Path(__file__).resolve().parents[1]
+DOCS_CONTENT    = REPO_ROOT / "docs" / "content" / "docs"
+NEXT_CONFIG     = REPO_ROOT / "docs" / "next.config.mjs"
+
+
+class Failure:
+    __slots__ = ("kind", "where", "detail")
+
+    def __init__(self, kind: str, where: str, detail: str) -> None:
+        self.kind   = kind
+        self.where  = where
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"  ✗ [{self.kind}] {self.where}\n      {self.detail}"
+
+
+def load_meta(meta_path: Path) -> dict:
+    with meta_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_redirects(config_path: Path) -> list[tuple[str, str]]:
+    """Pull `(source, destination)` pairs out of next.config.mjs.
+
+    The config is JS, not JSON, so we use a regex tolerant of the
+    file's known shape (object literal entries inside the redirects()
+    return). Each pair is recorded; flags like `permanent` are
+    ignored. If the parser misses a redirect it surfaces as a
+    "destination not found" failure during the section-root check,
+    which is loud enough to debug.
+    """
+    text = config_path.read_text(encoding="utf-8")
+    pattern = re.compile(
+        r"\{\s*source:\s*'([^']+)'\s*,\s*destination:\s*'([^']+)'",
+        re.MULTILINE,
+    )
+    return [(m.group(1), m.group(2)) for m in pattern.finditer(text)]
+
+
+def page_resolves(folder: Path, page: str) -> bool:
+    """A page name listed in meta.json resolves when:
+
+      - `<folder>/<page>.mdx` exists (a leaf doc), OR
+      - `<folder>/<page>/meta.json` exists (a sub-section).
+    """
+    if (folder / f"{page}.mdx").is_file():
+        return True
+    if (folder / page / "meta.json").is_file():
+        return True
+    return False
+
+
+def section_path_from_meta(meta_path: Path) -> str:
+    """Convert a meta.json path on disk into the URL-style section
+    path (e.g. `docs/content/docs/cli/meta.json` -> `cli`,
+    `docs/content/docs/meta.json` -> `` (root)).
+    """
+    rel = meta_path.parent.relative_to(DOCS_CONTENT)
+    return str(rel) if str(rel) != "." else ""
+
+
+def collect_failures() -> list[Failure]:
+    failures: list[Failure] = []
+
+    # Walk every meta.json in content/docs.
+    metas = sorted(DOCS_CONTENT.rglob("meta.json"))
+    if not metas:
+        failures.append(Failure(
+            "structure", str(DOCS_CONTENT),
+            "no meta.json files found -- docs content directory missing or empty",
+        ))
+        return failures
+
+    redirects = parse_redirects(NEXT_CONFIG) if NEXT_CONFIG.is_file() else []
+    redirect_sources = {src.lstrip("/") for src, _ in redirects}
+
+    for meta_path in metas:
+        folder = meta_path.parent
+        try:
+            meta = load_meta(meta_path)
+        except json.JSONDecodeError as e:
+            failures.append(Failure(
+                "json", str(meta_path.relative_to(REPO_ROOT)),
+                f"invalid JSON: {e}",
+            ))
+            continue
+
+        pages = meta.get("pages", [])
+        if not isinstance(pages, list):
+            failures.append(Failure(
+                "schema", str(meta_path.relative_to(REPO_ROOT)),
+                "`pages` is not an array",
+            ))
+            continue
+
+        # 1. Every listed page resolves to a real file or sub-section.
+        for page in pages:
+            if not isinstance(page, str):
+                failures.append(Failure(
+                    "schema", str(meta_path.relative_to(REPO_ROOT)),
+                    f"page entry is not a string: {page!r}",
+                ))
+                continue
+            if not page_resolves(folder, page):
+                section = section_path_from_meta(meta_path)
+                full = f"/{section}/{page}".replace("//", "/").rstrip("/") or "/"
+                failures.append(Failure(
+                    "missing-page", str(meta_path.relative_to(REPO_ROOT)),
+                    f"page '{page}' listed in meta.json has no .mdx file or sub-meta -- {full} would 404",
+                ))
+
+        # 2. Section root resolution. Skip the top-level meta (the docs
+        #    landing redirects to /guides/introduction in
+        #    `app/[[...slug]]/page.tsx`, which is correct).
+        section = section_path_from_meta(meta_path)
+        if section == "":
+            continue
+
+        has_index   = (folder / "index.mdx").is_file()
+        has_redirect = section in redirect_sources or f"{section}/" in redirect_sources
+
+        # First page in `pages` -- if it resolves to an .mdx in this
+        # folder, the user could have intended it as the implicit
+        # section root.
+        first_page  = pages[0] if pages else None
+        first_resolves = bool(first_page and (folder / f"{first_page}.mdx").is_file())
+
+        if not has_index and not has_redirect:
+            if first_resolves:
+                detail = (
+                    f"section /{section} has no index.mdx and no "
+                    f"redirect in next.config.mjs. Add: "
+                    f"{{ source: '/{section}', destination: '/{section}/{first_page}', permanent: false }}"
+                )
+            else:
+                detail = (
+                    f"section /{section} has no index.mdx and no "
+                    f"redirect in next.config.mjs (and the first page "
+                    f"in meta.json does not resolve either)"
+                )
+            failures.append(Failure(
+                "section-root", str(meta_path.relative_to(REPO_ROOT)),
+                detail,
+            ))
+
+    # 3. Every redirect destination resolves to a real page.
+    for src, dst in redirects:
+        # Skip the broad `/docs/:path*` rewrite (path-passthrough).
+        if ":path" in dst or ":path" in src:
+            continue
+        rel = dst.lstrip("/")
+        # The destination is a URL; map it back to a file. URL "cli/overview"
+        # -> docs/content/docs/cli/overview.mdx.
+        target_mdx  = DOCS_CONTENT / f"{rel}.mdx"
+        target_meta = DOCS_CONTENT / rel / "meta.json"
+        if not target_mdx.is_file() and not target_meta.is_file():
+            failures.append(Failure(
+                "broken-redirect", str(NEXT_CONFIG.relative_to(REPO_ROOT)),
+                f"redirect {src} -> {dst} but neither {target_mdx.relative_to(REPO_ROOT)} "
+                f"nor {target_meta.relative_to(REPO_ROOT)} exists",
+            ))
+
+    return failures
+
+
+def main(argv: Iterable[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Print every section/page checked, not just failures.",
+    )
+    args = parser.parse_args(list(argv))
+
+    if not DOCS_CONTENT.is_dir():
+        print(f"::error::{DOCS_CONTENT} not found", file=sys.stderr)
+        return 2
+
+    failures = collect_failures()
+
+    if args.verbose:
+        metas = sorted(DOCS_CONTENT.rglob("meta.json"))
+        print(f"checked {len(metas)} meta.json file(s)")
+
+    if failures:
+        print(f"\nDocs route health: {len(failures)} failure(s)\n", file=sys.stderr)
+        for f in failures:
+            print(str(f), file=sys.stderr)
+        print("\nFix these before merging. Each failure represents a route a", file=sys.stderr)
+        print("user (or AI agent) hitting the docs site would see as a 404.\n", file=sys.stderr)
+        return 1
+
+    metas = sorted(DOCS_CONTENT.rglob("meta.json"))
+    print(f"  ✓ docs route health: {len(metas)} meta.json file(s) checked, all routes resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

PR 1 of the **Agent-Native Bootstrap + Share + Docs Reliability** release.

Closes the broken-section-root failure mode found in Kimi's scan: typing `/guides`, `/concepts`, `/integrations`, or `/hub-api` on docs.treeship.dev returned 404 because no redirect was wired and no `index.mdx` existed. Direct probes against the live deploy confirmed exactly which paths were broken (full table in commit message). PR adds three new redirects, one alias, and a static CI check that prevents the same class of bug from regressing.

## What's in the PR

1. **Three new section-root redirects + one alias** in `docs/next.config.mjs`:
   - `/guides → /guides/introduction`
   - `/concepts → /concepts/trust-fabric`
   - `/integrations → /integrations/claude-code`
   - `/hub-api → /api/overview` (alias — sidebar titles the api/ section "Hub API"; agents typing the natural URL got 404)
2. **`scripts/check-docs-routes.py`** — static route-health check. Walks every `meta.json` and asserts: (a) every advertised page exists, (b) every section root has a redirect or an `index.mdx`, (c) every redirect destination is a real page.
3. **New `docs-route-health` CI job** wired into `.github/workflows/ci.yml`, sibling to `version-consistency`. No network, no build; runs in seconds.

## Out of scope (later PRs in the release)

- `/cli/setup`, `/cli/harness`, `/cli/agents` — PR 2 (CLI reference sync)
- `/sdk/typescript` — PR 3 (SDK/install docs)
- `/receipt/<id>` SSR endpoints — PR 4 (agent-readable receipt page)
- Python SDK `ensure_cli` / `setup --agent --yes --format json` — PR 5 (agent-native bootstrap)
- Dogfood checklist — PR 6

## Verification

- ✅ `python3 scripts/check-docs-routes.py` — 9 meta.json file(s) checked, all routes resolve
- ✅ Deliberately broke a meta.json to confirm the script flags missing pages and exits 1; restored
- ✅ Each redirect destination probed against the live `docs.treeship.dev` deploy and confirmed 200 before being added

## Test plan

- [ ] CI green: `version-consistency`, **`docs-route-health` (new)**, `test`, `hub`, cross-SDK matrix, Vercel preview
- [ ] After Vercel preview deploys, manually probe `/guides`, `/concepts`, `/integrations`, `/hub-api` and confirm they redirect to a real page
- [ ] Confirm the Vercel preview's existing redirects still work (`/cli`, `/sdk`, `/api`, `/commerce`, `/reference`)

## Notes on Kimi's findings vs reality

Kimi's scan flagged `/cli`, `/sdk`, `/reference`, `/commerce` as 404, but probing the live deploy at PR-author time showed all four returning 200 — the existing redirects (added in `9799e69`, 2026-04-24) were already in production. The genuine gaps were the three sections without redirects + the `/hub-api` alias gap. This PR fixes those four paths and adds the CI gate to keep them fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)