### PR TITLE
feat(docs): PR 3 — SDK/install docs (TypeScript page + registry topology)

### DIFF
--- a/docs/content/docs/guides/install.mdx
+++ b/docs/content/docs/guides/install.mdx
@@ -1,0 +1,125 @@
+---
+title: Install & registry topology
+description: How Treeship is distributed across npm, PyPI, crates.io, and GitHub Releases — what's on each, why, and what's intentionally not.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Treeship's release pipeline publishes to four registries. Each one carries a deliberate slice of the codebase; **what's *not* on a registry is as load-bearing as what is**. AI agents inspecting the project — Codex, Claude, Kimi, Gemini — sometimes flag the absence of `treeship-cli` from crates.io as a missing artifact. It isn't: the CLI is a Rust binary with native dependencies that don't ship cleanly through cargo, so the binary lives on npm and GitHub Releases instead. This page documents that decision so it stops being surprising.
+
+## What goes where
+
+| Registry | Package | What it is |
+|---|---|---|
+| **npm** | `treeship` | The CLI wrapper. `npm install -g treeship` installs the platform binary for your OS via `optionalDependencies`. |
+| **npm** | `@treeship/cli-darwin-arm64`, `@treeship/cli-darwin-x64`, `@treeship/cli-linux-x64` | Per-platform CLI binaries. Selected automatically by the wrapper based on `process.platform`. |
+| **npm** | `@treeship/sdk` | TypeScript / Node SDK. Wraps the CLI. |
+| **npm** | `@treeship/mcp` | MCP server bridge. Drop-in for Claude Code, Cursor, Cline, Codex. |
+| **npm** | `@treeship/a2a` | A2A bridge. |
+| **npm** | `@treeship/verify` | Browser/WASM verifier. No CLI required. |
+| **npm** | `@treeship/core-wasm` | Core verification logic compiled to WebAssembly. Used by `@treeship/verify`. |
+| **PyPI** | `treeship-sdk` | Python SDK. Wraps the CLI. |
+| **crates.io** | `treeship-core` | Rust library. The trust primitives (signing, verification, Merkle, journal) — *not* the CLI. |
+| **GitHub Releases** | `treeship-darwin-aarch64`, `treeship-darwin-x86_64`, `treeship-linux-x86_64` | Raw, signed CLI binaries. Direct download for systems without npm. |
+
+## What's intentionally NOT on each registry
+
+This is the part agents sometimes get wrong. Each absence is deliberate:
+
+### Not on crates.io
+- **`treeship-cli`** — the CLI binary. Reasoning: cargo install builds from source, which requires every native dep present (libssl, etc.) and pulls in the full Rust toolchain. The CLI's distribution story is "fast install, no toolchain required," which `npm install -g treeship` and the GitHub Release binaries deliver in seconds. cargo install of `treeship-cli` would take several minutes and fail on systems missing build dependencies.
+- **`treeship-core-wasm`** — the WASM crate. Reasoning: WASM-only crates aren't useful as cargo dependencies; consumers want them as npm packages where the WASM is bundled with JS glue. Lives at `@treeship/core-wasm` on npm.
+
+### Not on PyPI
+- **`treeship`** (binary). Reasoning: same as crates.io — pip install of a package containing a Rust binary is brittle and slow. The Python SDK shells out to the CLI installed separately via npm or GitHub Release.
+
+### Not on npm
+- **`treeship-core` (Rust library).** Reasoning: it's a Rust library; consumers in the Rust ecosystem use cargo. Embedding via WASM isn't necessary because the JS path uses `@treeship/core-wasm` (a different artifact).
+
+## Install commands by language
+
+```bash
+# CLI binary (any system with npm)
+npm install -g treeship
+treeship --version
+
+# CLI binary (no npm)
+# https://github.com/zerkerlabs/treeship/releases
+curl -L -o /usr/local/bin/treeship \
+  https://github.com/zerkerlabs/treeship/releases/latest/download/treeship-linux-x86_64
+chmod +x /usr/local/bin/treeship
+
+# Python SDK
+pip install treeship-sdk
+
+# TypeScript / Node SDK
+npm install @treeship/sdk
+
+# Browser/WASM verifier
+npm install @treeship/verify @treeship/core-wasm
+
+# MCP bridge
+npm install @treeship/mcp
+
+# A2A bridge
+npm install @treeship/a2a
+
+# Rust library (NOT the CLI)
+cargo add treeship-core
+```
+
+## For AI agents
+
+If an AI agent is bootstrapping Treeship on behalf of a human, the most reliable single command is:
+
+```bash
+npm install -g treeship && treeship init --name my-workspace
+```
+
+That covers the CLI, its keystore, and the artifact store in one step. From there:
+
+- Python users: `pip install treeship-sdk` (uses the same CLI; no additional binary).
+- Browser verifiers: `npm install @treeship/verify`.
+- Anything else: pull from the [GitHub Release](https://github.com/zerkerlabs/treeship/releases) directly.
+
+<Callout type="info">
+**`treeship-cli` 404 on crates.io is not a release failure.** AI scanners and automated tools sometimes flag this as a missing artifact. The CLI is intentionally distributed via npm and GitHub Releases, not crates.io. Only the Rust *library* (`treeship-core`) is on crates.io.
+</Callout>
+
+## Sandbox / agent-friendly install
+
+For AI agents running in a sandboxed environment without persistent installation:
+
+```bash
+# Per-session install — node available
+npx -p treeship -c 'treeship init && treeship status'
+```
+
+Or pull a binary directly into a tmpdir:
+
+```bash
+TMPDIR=$(mktemp -d)
+curl -sL -o "$TMPDIR/treeship" \
+  "https://github.com/zerkerlabs/treeship/releases/latest/download/treeship-linux-x86_64"
+chmod +x "$TMPDIR/treeship"
+"$TMPDIR/treeship" --version
+```
+
+Both paths avoid touching the system PATH. The CLI is fully functional from a non-PATH location; pass `--config` to point at a tmpdir keystore if you need full isolation:
+
+```bash
+"$TMPDIR/treeship" --config "$TMPDIR/.treeship/config.json" init
+"$TMPDIR/treeship" --config "$TMPDIR/.treeship/config.json" session start --name probe
+```
+
+## Version consistency
+
+Every release bumps 21 version sites in one preflight pass (`scripts/check-release-versions.py`). If you see different versions reported by different SDKs against the same Treeship version tag, that's a bug — file an issue with the version table. The release machinery refuses to publish if any of the 21 sites disagree, so cross-registry drift shouldn't happen in normal operation.
+
+For the current set of 21 sites, see `scripts/check-release-versions.py` in the repo. Any new package added to a registry must be wired into that script in the same PR.
+
+## See also
+
+- [Quickstart](/guides/quickstart) — first install through first verified receipt
+- [SDK overview](/sdk/overview) — pick the right SDK for your stack
+- [`treeship setup`](/cli/setup) — first-run orchestration after install

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Get started",
-  "pages": ["introduction", "quickstart", "first-run", "coverage-levels", "replay-levels", "how-it-works", "templates", "approvals", "handoffs", "workflows", "merkle-proofs", "edge-runtime"]
+  "pages": ["introduction", "quickstart", "install", "first-run", "coverage-levels", "replay-levels", "how-it-works", "templates", "approvals", "handoffs", "workflows", "merkle-proofs", "edge-runtime"]
 }

--- a/docs/content/docs/sdk/meta.json
+++ b/docs/content/docs/sdk/meta.json
@@ -2,8 +2,9 @@
   "title": "SDK",
   "pages": [
     "overview",
-    "verify",
+    "typescript",
     "python",
+    "verify",
     "mcp"
   ]
 }

--- a/docs/content/docs/sdk/overview.mdx
+++ b/docs/content/docs/sdk/overview.mdx
@@ -1,363 +1,70 @@
 ---
-title: "@treeship/sdk"
-description: TypeScript SDK for Treeship. Wraps the CLI binary for signing, verification, and hub connections.
+title: SDK overview
+description: Treeship's SDKs — pick the language that matches your stack. Every SDK shells out to the same signed CLI binary.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
-## Install
-
-```bash
-npm install @treeship/sdk
-```
+Treeship ships an SDK for the languages most agent stacks are built in. **Every SDK is a thin wrapper over the same `treeship` CLI binary** — the binary does the signing, verification, and Hub I/O; the SDK just gives you idiomatic types and async ergonomics in your language. That keeps the trust surface (Ed25519 signing, canonical PAE, Merkle compose) in one place across every language and platform.
 
 <Callout type="info">
-The SDK shells out to the `treeship` CLI binary. The CLI must be installed and initialized (`treeship init`) before using the SDK. WASM-based signing is planned for a future version.
+**Install the CLI first.** Every SDK requires the `treeship` binary on PATH and a `treeship init` workspace. See [install + registry topology](/guides/install) for the full picture of which package goes on which registry, and what's intentionally not on each one.
 </Callout>
 
-## Quick start
-
-```ts
-import { ship } from '@treeship/sdk';
-
-const s = ship();
-
-// Attest an action
-const { artifactId } = await s.attest.action({
-  actor: 'agent://my-agent',
-  action: 'tool.call',
-});
-
-// Verify it
-const result = await s.verify.verify(artifactId);
-console.log(result.outcome); // "pass"
-
-// Push to Hub
-const { hubUrl } = await s.hub.push(artifactId);
-console.log(hubUrl); // https://treeship.dev/verify/art_xxx
-```
-
-## Ship class
-
-### `Ship.checkCli()`
-
-Static method that checks whether the `treeship` CLI binary is installed and available on PATH. Returns the version string (e.g. `"0.4.1"`). Throws a descriptive error if the binary is not found.
-
-```ts
-import { Ship } from '@treeship/sdk';
-
-const version = await Ship.checkCli();
-console.log(`Treeship CLI version: ${version}`);
-```
-
-Call this early in your startup sequence to fail fast if the CLI is missing, rather than getting a confusing error on the first attestation call.
-
-### Instance properties
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `attest` | `AttestModule` | Attestation methods (action, decision, approval, handoff) |
-| `verify` | `VerifyModule` | Verification methods |
-| `hub` | `HubModule` | Hub push/pull and connection status |
-
-## Attest module
-
-All attestation methods live under `s.attest`.
-
-### `s.attest.action(params)`
-
-Record that an actor performed an action.
-
-```ts
-const { artifactId } = await s.attest.action({
-  actor: 'agent://my-agent',
-  action: 'tool.call',
-  meta: { model: 'gpt-4o', tokens: 1247 },
-});
-```
-
-**Params: `ActionParams`**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `actor` | `string` | Yes | Actor URI, e.g. `agent://my-agent` |
-| `action` | `string` | Yes | Label for the action performed |
-| `parentId` | `string` | No | Parent artifact ID for chain linking |
-| `approvalNonce` | `string` | No | Nonce from an existing approval |
-| `meta` | `Record<string, unknown>` | No | Arbitrary metadata attached to the artifact |
-
-**Returns: `ActionResult`** -- `{ artifactId: string }`
-
-### `s.attest.decision(params)`
-
-Record an LLM inference decision with token usage and confidence scoring.
-
-```ts
-await s.attest.decision({
-  actor: 'agent://analyst',
-  model: 'claude-opus-4',
-  tokensIn: 8432,
-  tokensOut: 1247,
-  summary: 'Contract looks standard.',
-  confidence: 0.91,
-});
-```
-
-**Params: `DecisionParams`**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `actor` | `string` | Yes | Actor URI |
-| `model` | `string` | No | Model identifier |
-| `tokensIn` | `number` | No | Input token count |
-| `tokensOut` | `number` | No | Output token count |
-| `promptDigest` | `string` | No | SHA-256 digest of the prompt |
-| `summary` | `string` | No | Plain-text summary of the decision |
-| `confidence` | `number` | No | Confidence score between 0 and 1 |
-| `parentId` | `string` | No | Parent artifact ID for chain linking |
-
-Note: The `modelVersion` field exists in the TypeScript type but is not currently forwarded to the CLI. Use the `model` field to identify the model and version together (e.g., `"claude-opus-4-20260301"`).
-
-**Returns: `ActionResult`** -- `{ artifactId: string }`
-
-### `s.attest.approval(params)`
-
-Record that an approver authorized an intent. Returns a nonce that can be echoed back when attesting the approved action.
-
-```ts
-const { artifactId, nonce } = await s.attest.approval({
-  approver: 'human://alice',
-  description: 'approve payment max $500',
-});
-```
-
-**Params: `ApprovalParams`**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `approver` | `string` | Yes | Approver identity URI |
-| `description` | `string` | Yes | Plain-text description of what is authorized |
-| `expires` | `string` | No | ISO-8601 timestamp when the approval expires, e.g. `"2026-12-31T00:00:00Z"` |
-| `subject` | `string` | No | Artifact ID being approved -- maps to the CLI `--subject` flag |
-
-**Returns: `ApprovalResult`** -- `{ artifactId: string, nonce: string }`
-
-### `s.attest.handoff(params)`
-
-Record a transfer of work between actors.
-
-```ts
-await s.attest.handoff({
-  from: 'agent://researcher',
-  to: 'agent://executor',
-  artifacts: ['art_abc123'],
-});
-```
-
-**Params: `HandoffParams`**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `from` | `string` | Yes | Source actor URI |
-| `to` | `string` | Yes | Destination actor URI |
-| `artifacts` | `string[]` | Yes | Artifact IDs being transferred |
-| `approvals` | `string[]` | No | Approval IDs the receiver inherits |
-| `obligations` | `string[]` | No | Obligations the receiver must satisfy |
-
-**Returns: `ActionResult`** -- `{ artifactId: string }`
-
-## Verify module
-
-### `s.verify.verify(artifactId)`
-
-Verify an artifact and walk its chain.
-
-```ts
-const result = await s.verify.verify('art_abc123');
-// { outcome: 'pass', chain: 3, target: 'art_abc123' }
-```
-
-**Returns: `VerifyResult`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `outcome` | `'pass' \| 'fail' \| 'error'` | Verification result |
-| `chain` | `number` | Number of artifacts in the chain |
-| `target` | `string` | The artifact ID that was verified |
-
-## Hub module
-
-### `s.hub.push(artifactId)`
-
-Push an artifact to the Treeship Hub.
-
-```ts
-const { hubUrl } = await s.hub.push('art_abc123');
-// https://treeship.dev/verify/art_abc123
-```
-
-**Returns: `PushResult`**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `hubUrl` | `string` | Public URL for the artifact on the Hub |
-| `rekorIndex` | `number \| undefined` | Rekor transparency log index, if available |
-
-### `s.hub.pull(id)`
-
-Pull an artifact from the Treeship Hub to the local store.
-
-```ts
-await s.hub.pull('art_abc123');
-```
-
-Returns `void`. Throws if the artifact is not found or the network request fails.
-
-### `s.hub.status()`
-
-Check the current hub connection status.
-
-```ts
-const status = await s.hub.status();
-if (status.attached) {
-  console.log(`Connected to ${status.endpoint}`);
-}
-```
-
-**Returns:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `attached` | `boolean` | Whether the hub connection is currently active |
-| `endpoint` | `string \| undefined` | Hub endpoint URL, if connected |
-| `hubId` | `string \| undefined` | Hub connection identifier, if connected |
-
-If the status check fails for any reason (CLI not installed, no config), returns `{ attached: false }` instead of throwing.
-
-## Exported types
-
-All types are re-exported from the top-level `@treeship/sdk` import.
-
-### `ActionParams`
-
-```ts
-interface ActionParams {
-  actor: string;
-  action: string;
-  parentId?: string;
-  approvalNonce?: string;
-  meta?: Record<string, unknown>;
-}
-```
-
-### `ApprovalParams`
-
-```ts
-interface ApprovalParams {
-  approver: string;
-  description: string;
-  expires?: string;   // ISO-8601 timestamp
-  subject?: string;   // artifact ID being approved
-}
-```
-
-### `HandoffParams`
-
-```ts
-interface HandoffParams {
-  from: string;
-  to: string;
-  artifacts: string[];
-  approvals?: string[];
-  obligations?: string[];
-}
-```
-
-### `DecisionParams`
-
-```ts
-interface DecisionParams {
-  actor: string;
-  model?: string;
-  modelVersion?: string;
-  tokensIn?: number;
-  tokensOut?: number;
-  promptDigest?: string;
-  summary?: string;
-  confidence?: number;
-  parentId?: string;
-}
-```
-
-### `ActionResult`
-
-```ts
-interface ActionResult {
-  artifactId: string;
-}
-```
-
-### `ApprovalResult`
-
-```ts
-interface ApprovalResult {
-  artifactId: string;
-  nonce: string;
-}
-```
-
-### `VerifyResult`
-
-```ts
-interface VerifyResult {
-  outcome: "pass" | "fail" | "error";
-  chain: number;
-  target: string;
-}
-```
-
-### `PushResult`
-
-```ts
-interface PushResult {
-  hubUrl: string;
-  rekorIndex?: number;
-}
-```
-
-## Error handling
-
-The SDK throws `TreeshipError` when the CLI exits with a non-zero code.
-
-### `TreeshipError`
-
-```ts
-class TreeshipError extends Error {
-  readonly args: string[];  // the CLI arguments that were passed
-  readonly name: "TreeshipError";
-}
-```
-
-`TreeshipError` extends the standard `Error` class. The `args` property contains the exact CLI arguments that were passed, which is useful for debugging. The `message` property contains the stderr output from the CLI.
-
-```ts
-import { TreeshipError } from '@treeship/sdk';
-
-try {
-  await s.attest.action({ actor: 'agent://x', action: 'test' });
-} catch (e) {
-  if (e instanceof TreeshipError) {
-    console.error('CLI failed:', e.message);
-    console.error('Args:', e.args);
-  }
-}
-```
-
-## Design rules
+## Pick your SDK
 
 <Cards>
-<Card title="CLI-backed" description="Shells out to the treeship binary. No native crypto in the SDK yet." />
-<Card title="Never stores sensitive content" description="Hash payloads, not content." />
-<Card title="Explicit errors" description="CLI failures throw TreeshipError. Verify returns a typed VerifyResult with an outcome field instead of throwing." />
+  <Card title="TypeScript / Node.js" href="/sdk/typescript" description="@treeship/sdk on npm. Full attest, verify, hub. The primary SDK for Node, Bun, Deno." />
+  <Card title="Python" href="/sdk/python" description="treeship-sdk on PyPI. Full attest, verify, session reporting, hub." />
+  <Card title="Browser / WASM verifier" href="/sdk/verify" description="@treeship/verify and @treeship/core-wasm. Verify receipts entirely in the browser; no CLI required." />
+  <Card title="MCP / A2A bridges" href="/sdk/mcp" description="@treeship/mcp and @treeship/a2a — drop-in instrumenters for any MCP-speaking agent." />
 </Cards>
+
+## Common shape
+
+Every SDK exposes the same three modules, with the same method names mapped to the language's conventions:
+
+| Module | Methods | What it does |
+|---|---|---|
+| `attest` | `action`, `decision`, `approval`, `handoff`, `endorsement`, `receipt` | Sign one of the six attestation types |
+| `verify` | `verify`, `verifyChain`, `verifyPackage` | Recompute Merkle, recheck signatures, walk parent chain |
+| `hub` | `push`, `pull`, `share` | Upload to the Hub, get a shareable URL, pull a remote receipt |
+
+The TypeScript SDK is the reference implementation; new methods land there first and propagate to Python and the bridges.
+
+## Install topology
+
+| Stack | Install |
+|---|---|
+| Node / TypeScript | `npm install @treeship/sdk` |
+| Python | `pip install treeship-sdk` |
+| Rust (library, not the CLI) | `cargo add treeship-core` |
+| Browser verifier | `npm install @treeship/verify @treeship/core-wasm` |
+| MCP bridge | `npm install @treeship/mcp` |
+| A2A bridge | `npm install @treeship/a2a` |
+| CLI binary (native) | `npm install -g treeship` *or* download a [GitHub Release](https://github.com/zerkerlabs/treeship/releases) binary |
+
+The CLI is **not** on crates.io. `treeship-cli` is a binary distributed via npm + GitHub Releases; only the `treeship-core` library is on crates.io. See [install + registry topology](/guides/install) for the full rationale (Rust binaries with native deps don't ship cleanly on crates.io; native deps shell out from the SDK boundary anyway).
+
+## Agent-mode shape
+
+Every SDK supports a JSON output mode the underlying CLI inherits via `--format json`. AI agents calling the SDK can:
+
+```ts
+const result = await s.attest.action({ actor: 'agent://x', action: 'tool.call' });
+//   ^? { artifactId: string, digest: string, signedAt: string }
+```
+
+```python
+result = ts.attest_action(actor="agent://x", action="tool.call")
+print(result.artifact_id, result.digest)
+```
+
+The shape is stable across SDKs — agents that orchestrate Treeship through one language can hand the same JSON to a verifier in another.
+
+## See also
+
+- [install + registry topology](/guides/install) — what's on each registry and why
+- [Quickstart](/guides/quickstart) — the fastest path from `treeship init` to a verified receipt
+- [CLI reference](/cli/overview) — every command the SDKs wrap

--- a/docs/content/docs/sdk/typescript.mdx
+++ b/docs/content/docs/sdk/typescript.mdx
@@ -1,0 +1,363 @@
+---
+title: "@treeship/sdk"
+description: TypeScript SDK for Treeship. Wraps the CLI binary for signing, verification, and hub connections.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+
+## Install
+
+```bash
+npm install @treeship/sdk
+```
+
+<Callout type="info">
+The SDK shells out to the `treeship` CLI binary. The CLI must be installed and initialized (`treeship init`) before using the SDK. WASM-based signing is planned for a future version.
+</Callout>
+
+## Quick start
+
+```ts
+import { ship } from '@treeship/sdk';
+
+const s = ship();
+
+// Attest an action
+const { artifactId } = await s.attest.action({
+  actor: 'agent://my-agent',
+  action: 'tool.call',
+});
+
+// Verify it
+const result = await s.verify.verify(artifactId);
+console.log(result.outcome); // "pass"
+
+// Push to Hub
+const { hubUrl } = await s.hub.push(artifactId);
+console.log(hubUrl); // https://treeship.dev/verify/art_xxx
+```
+
+## Ship class
+
+### `Ship.checkCli()`
+
+Static method that checks whether the `treeship` CLI binary is installed and available on PATH. Returns the version string (e.g. `"0.4.1"`). Throws a descriptive error if the binary is not found.
+
+```ts
+import { Ship } from '@treeship/sdk';
+
+const version = await Ship.checkCli();
+console.log(`Treeship CLI version: ${version}`);
+```
+
+Call this early in your startup sequence to fail fast if the CLI is missing, rather than getting a confusing error on the first attestation call.
+
+### Instance properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `attest` | `AttestModule` | Attestation methods (action, decision, approval, handoff) |
+| `verify` | `VerifyModule` | Verification methods |
+| `hub` | `HubModule` | Hub push/pull and connection status |
+
+## Attest module
+
+All attestation methods live under `s.attest`.
+
+### `s.attest.action(params)`
+
+Record that an actor performed an action.
+
+```ts
+const { artifactId } = await s.attest.action({
+  actor: 'agent://my-agent',
+  action: 'tool.call',
+  meta: { model: 'gpt-4o', tokens: 1247 },
+});
+```
+
+**Params: `ActionParams`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `actor` | `string` | Yes | Actor URI, e.g. `agent://my-agent` |
+| `action` | `string` | Yes | Label for the action performed |
+| `parentId` | `string` | No | Parent artifact ID for chain linking |
+| `approvalNonce` | `string` | No | Nonce from an existing approval |
+| `meta` | `Record<string, unknown>` | No | Arbitrary metadata attached to the artifact |
+
+**Returns: `ActionResult`** -- `{ artifactId: string }`
+
+### `s.attest.decision(params)`
+
+Record an LLM inference decision with token usage and confidence scoring.
+
+```ts
+await s.attest.decision({
+  actor: 'agent://analyst',
+  model: 'claude-opus-4',
+  tokensIn: 8432,
+  tokensOut: 1247,
+  summary: 'Contract looks standard.',
+  confidence: 0.91,
+});
+```
+
+**Params: `DecisionParams`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `actor` | `string` | Yes | Actor URI |
+| `model` | `string` | No | Model identifier |
+| `tokensIn` | `number` | No | Input token count |
+| `tokensOut` | `number` | No | Output token count |
+| `promptDigest` | `string` | No | SHA-256 digest of the prompt |
+| `summary` | `string` | No | Plain-text summary of the decision |
+| `confidence` | `number` | No | Confidence score between 0 and 1 |
+| `parentId` | `string` | No | Parent artifact ID for chain linking |
+
+Note: The `modelVersion` field exists in the TypeScript type but is not currently forwarded to the CLI. Use the `model` field to identify the model and version together (e.g., `"claude-opus-4-20260301"`).
+
+**Returns: `ActionResult`** -- `{ artifactId: string }`
+
+### `s.attest.approval(params)`
+
+Record that an approver authorized an intent. Returns a nonce that can be echoed back when attesting the approved action.
+
+```ts
+const { artifactId, nonce } = await s.attest.approval({
+  approver: 'human://alice',
+  description: 'approve payment max $500',
+});
+```
+
+**Params: `ApprovalParams`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `approver` | `string` | Yes | Approver identity URI |
+| `description` | `string` | Yes | Plain-text description of what is authorized |
+| `expires` | `string` | No | ISO-8601 timestamp when the approval expires, e.g. `"2026-12-31T00:00:00Z"` |
+| `subject` | `string` | No | Artifact ID being approved -- maps to the CLI `--subject` flag |
+
+**Returns: `ApprovalResult`** -- `{ artifactId: string, nonce: string }`
+
+### `s.attest.handoff(params)`
+
+Record a transfer of work between actors.
+
+```ts
+await s.attest.handoff({
+  from: 'agent://researcher',
+  to: 'agent://executor',
+  artifacts: ['art_abc123'],
+});
+```
+
+**Params: `HandoffParams`**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `from` | `string` | Yes | Source actor URI |
+| `to` | `string` | Yes | Destination actor URI |
+| `artifacts` | `string[]` | Yes | Artifact IDs being transferred |
+| `approvals` | `string[]` | No | Approval IDs the receiver inherits |
+| `obligations` | `string[]` | No | Obligations the receiver must satisfy |
+
+**Returns: `ActionResult`** -- `{ artifactId: string }`
+
+## Verify module
+
+### `s.verify.verify(artifactId)`
+
+Verify an artifact and walk its chain.
+
+```ts
+const result = await s.verify.verify('art_abc123');
+// { outcome: 'pass', chain: 3, target: 'art_abc123' }
+```
+
+**Returns: `VerifyResult`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `outcome` | `'pass' \| 'fail' \| 'error'` | Verification result |
+| `chain` | `number` | Number of artifacts in the chain |
+| `target` | `string` | The artifact ID that was verified |
+
+## Hub module
+
+### `s.hub.push(artifactId)`
+
+Push an artifact to the Treeship Hub.
+
+```ts
+const { hubUrl } = await s.hub.push('art_abc123');
+// https://treeship.dev/verify/art_abc123
+```
+
+**Returns: `PushResult`**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hubUrl` | `string` | Public URL for the artifact on the Hub |
+| `rekorIndex` | `number \| undefined` | Rekor transparency log index, if available |
+
+### `s.hub.pull(id)`
+
+Pull an artifact from the Treeship Hub to the local store.
+
+```ts
+await s.hub.pull('art_abc123');
+```
+
+Returns `void`. Throws if the artifact is not found or the network request fails.
+
+### `s.hub.status()`
+
+Check the current hub connection status.
+
+```ts
+const status = await s.hub.status();
+if (status.attached) {
+  console.log(`Connected to ${status.endpoint}`);
+}
+```
+
+**Returns:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `attached` | `boolean` | Whether the hub connection is currently active |
+| `endpoint` | `string \| undefined` | Hub endpoint URL, if connected |
+| `hubId` | `string \| undefined` | Hub connection identifier, if connected |
+
+If the status check fails for any reason (CLI not installed, no config), returns `{ attached: false }` instead of throwing.
+
+## Exported types
+
+All types are re-exported from the top-level `@treeship/sdk` import.
+
+### `ActionParams`
+
+```ts
+interface ActionParams {
+  actor: string;
+  action: string;
+  parentId?: string;
+  approvalNonce?: string;
+  meta?: Record<string, unknown>;
+}
+```
+
+### `ApprovalParams`
+
+```ts
+interface ApprovalParams {
+  approver: string;
+  description: string;
+  expires?: string;   // ISO-8601 timestamp
+  subject?: string;   // artifact ID being approved
+}
+```
+
+### `HandoffParams`
+
+```ts
+interface HandoffParams {
+  from: string;
+  to: string;
+  artifacts: string[];
+  approvals?: string[];
+  obligations?: string[];
+}
+```
+
+### `DecisionParams`
+
+```ts
+interface DecisionParams {
+  actor: string;
+  model?: string;
+  modelVersion?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  promptDigest?: string;
+  summary?: string;
+  confidence?: number;
+  parentId?: string;
+}
+```
+
+### `ActionResult`
+
+```ts
+interface ActionResult {
+  artifactId: string;
+}
+```
+
+### `ApprovalResult`
+
+```ts
+interface ApprovalResult {
+  artifactId: string;
+  nonce: string;
+}
+```
+
+### `VerifyResult`
+
+```ts
+interface VerifyResult {
+  outcome: "pass" | "fail" | "error";
+  chain: number;
+  target: string;
+}
+```
+
+### `PushResult`
+
+```ts
+interface PushResult {
+  hubUrl: string;
+  rekorIndex?: number;
+}
+```
+
+## Error handling
+
+The SDK throws `TreeshipError` when the CLI exits with a non-zero code.
+
+### `TreeshipError`
+
+```ts
+class TreeshipError extends Error {
+  readonly args: string[];  // the CLI arguments that were passed
+  readonly name: "TreeshipError";
+}
+```
+
+`TreeshipError` extends the standard `Error` class. The `args` property contains the exact CLI arguments that were passed, which is useful for debugging. The `message` property contains the stderr output from the CLI.
+
+```ts
+import { TreeshipError } from '@treeship/sdk';
+
+try {
+  await s.attest.action({ actor: 'agent://x', action: 'test' });
+} catch (e) {
+  if (e instanceof TreeshipError) {
+    console.error('CLI failed:', e.message);
+    console.error('Args:', e.args);
+  }
+}
+```
+
+## Design rules
+
+<Cards>
+<Card title="CLI-backed" description="Shells out to the treeship binary. No native crypto in the SDK yet." />
+<Card title="Never stores sensitive content" description="Hash payloads, not content." />
+<Card title="Explicit errors" description="CLI failures throw TreeshipError. Verify returns a typed VerifyResult with an outcome field instead of throwing." />
+</Cards>


### PR DESCRIPTION
## Summary

PR 3 of the **Agent-Native Bootstrap + Share + Docs Reliability** release.

Closes two findings:
1. **No canonical `/sdk/typescript` URL.** The TypeScript SDK is the primary SDK but shared the `/sdk/overview` slot with the section landing — Kimi flagged this as a meaningful gap.
2. **No registry topology page.** Codex / Kimi / any AI scanner that inspects a Treeship release sees `treeship-cli` 404 on crates.io and flags it as a missing artifact — when it's actually a deliberate distribution choice. There was nowhere in the docs to point at the right answer.

## Changes

### Renamed
- **`/sdk/overview` → `/sdk/typescript`** (363 lines of TypeScript SDK reference, content unchanged). Now the canonical TypeScript SDK page parallel to `/sdk/python`.

### New: `/sdk/overview` (true section landing)
- Short intro + Cards linking to `/sdk/typescript`, `/sdk/python`, `/sdk/verify`, `/sdk/mcp`.
- Documents the common shape every SDK exposes (attest/verify/hub modules with parallel method names).
- Install topology table covering every SDK + the CLI binary.

### New: `/guides/install` — registry topology
The page AI agents should read before flagging "missing artifact":

- **What's on each registry** (npm, PyPI, crates.io, GitHub Release) with every package named.
- **What's intentionally NOT on each registry** with the explicit reasoning:
  - `treeship-cli` not on crates.io (cargo install builds from source; brittle on systems without native deps; ships via npm + GitHub Releases for fast install).
  - `treeship-core-wasm` not on crates.io (WASM-only crates aren't useful as cargo deps; lives at `@treeship/core-wasm` on npm).
  - `treeship` binary not on PyPI (Python SDK shells out to the CLI installed separately).
  - `treeship-core` not on npm (it's a Rust library; cargo consumers).
- Per-language install commands, including direct GitHub Release download.
- Sandbox / agent-friendly install paths (`npx`, tmpdir + `--config`).
- Explicit callout: **"treeship-cli 404 on crates.io is not a release failure."**

### Sidebar wiring
- `sdk/meta.json`: added `"typescript"` between `"overview"` and `"python"`.
- `guides/meta.json`: added `"install"` between `"quickstart"` and `"first-run"`.

## Verification

- ✅ `python3 scripts/check-docs-routes.py` — 9 meta.json files checked, all routes resolve
- ✅ Every link in the new pages points at an existing route on this branch
- ✅ The renamed file's URL stays available: `/sdk` redirect → `/sdk/overview` → the new section landing

## Out of scope (later PRs)

- `/receipt/<id>` SSR + raw JSON endpoints — PR 4
- Python SDK `ensure_cli` runtime — PR 5
- Dogfood checklist — PR 6

## Test plan

- [ ] CI: `version-consistency`, `docs-route-health`, `test`, `hub`, cross-SDK matrix, Vercel preview
- [ ] After Vercel preview deploys, visit `/sdk` and confirm the new section landing renders with cards
- [ ] Visit `/sdk/typescript` and confirm the full TypeScript SDK reference renders (it's the same content as the old `/sdk/overview`)
- [ ] Visit `/guides/install` and confirm the registry topology page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)