### PR TITLE
release: v0.9.11 cutover (docs reliability + agent install clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.9.11 (2026-04-30)
+
+The Docs Reliability + Agent Install Clarity release. **No product code.** Closes the docs-side findings from a third-party scan (Kimi) of the live docs surface and from the v0.9.6→v0.9.10 cadence's accumulated drift. Four PRs land on top of v0.9.10's trust-fix; this release wraps them into a versioned cutover so installs and the docs site move in lockstep.
+
+The connective theme: **make Treeship legible to the next AI agent that has to bootstrap it on a strange machine.** Every gap this release closes was something a human or AI would only see at install/inspection time — section roots that 404, CLI commands without reference pages, missing TypeScript SDK page, no single page documenting the registry topology, no post-ship review template. None of these were trust bugs (the v0.9.10 hotfix already closed those); they were UX-of-trust bugs.
+
+### Added (docs reliability)
+
+- **Three new section-root redirects + one alias** in `docs/next.config.mjs` — `/guides → /guides/introduction`, `/concepts → /concepts/trust-fabric`, `/integrations → /integrations/claude-code`, `/hub-api → /api/overview` (alias since the api/ section is titled "Hub API" in nav). The five existing redirects (`/cli`, `/sdk`, `/api`, `/commerce`, `/reference`) were already in production; these three were the genuine gaps.
+- **`scripts/check-docs-routes.py` + `docs-route-health` CI gate.** Static check, no network. Walks every `meta.json` under `docs/content/docs/` and asserts: every advertised page resolves to a real `.mdx` file or sub-section, every section root has either an `index.mdx` or a redirect, every redirect destination resolves to an existing page. Wired into `.github/workflows/ci.yml` as a sibling to `version-consistency`. PRs that delete a doc without updating its `meta.json` — or add a section without a redirect — now fail fast.
+
+### Added (CLI reference catch-up)
+
+- **`/cli/setup`** — `treeship setup [--yes] [--skip-smoke] [--no-instrument] [--format json]`. The orchestrated first-run flow (detect → draft cards → confirm → instrument → smoke). Documents the `Active` vs `Verified` status distinction (smoke promotes Draft → Active; only per-harness smokes write Verified).
+- **`/cli/add`** — `treeship add [agents]... [--all] [--dry-run] [--discover] [--format json]`. The focused instrumenter. Documents the `--discover` read-only mode AI agents use to inspect a machine, with the actual JSON shape the binary emits today.
+- **`/cli/agents`** — `treeship agents {list, review, approve, remove}`. Documents the four-stage status lifecycle (`Draft → NeedsReview → Active → Verified`) and the deterministic `agent_id` derivation. Honest callout that `--format json` returns `{}` today and points readers at the on-disk `~/.treeship/agents/<id>.json` files (which are stable schema-versioned JSON).
+- **`/cli/harness`** — `treeship harness {list, inspect, smoke}`. Documents the manifest/state split that prevents `PotentialCaptures` vs `VerifiedCaptures` confusion, and the privacy posture (record paths, never content).
+- **`/cli/attest`** — replaced the v0.9.6 deferred-Hub callout with the actual v0.9.10 surface: every replay row (`replay-package-local`, `replay-local-journal`, `replay-included-checkpoint`, `replay-hub-org`) and the four bundle-level binding rows (`approval-use-record-digest`, `approval-use-nonce-binding`, `approval-use-action-binding`, `approval-use-chain-continuity`).
+- **`/cli/verify`** — added an Approval Authority replay rows section. What each row proves, the honesty rule (`✓` only when evidence present and verified, `✗` only when present and failed, `-` when absent — never silent pass), and the `--strict` promotion list.
+- **CLI sidebar reordered** so the first-run flow comes first: `init → setup → add → agents → harness → wrap → attest → verify → ...`.
+
+### Added (SDK + install topology)
+
+- **`/sdk/typescript`** at its canonical URL parallel to `/sdk/python`. Previous content of `/sdk/overview` (363 lines of TypeScript SDK reference) renamed without losing material; the new `/sdk/overview` is a true section landing with cards linking to TypeScript, Python, Verify, and MCP.
+- **`/guides/install`** — registry topology page. Documents what's on each registry (npm, PyPI, crates.io, GitHub Releases) **and what's intentionally NOT** with explicit reasoning. AI agents (Codex, Claude, Kimi) sometimes flag `treeship-cli` 404 on crates.io as a release failure; the page has the explicit "this is not a release failure" callout so the next scanner that hits it gets the right answer. Also documents the sandbox / agent-friendly install paths (`npx`, tmpdir + `--config`).
+
+### Added (process)
+
+- **`/guides/dogfood-checklist`** — post-ship review template. Sibling to the release-adversarial discipline at `docs/release-adversarial/README.md` (which itself landed in v0.9.10). The two cover different failure modes: adversarial review hunts trust bypasses an attacker would exploit; dogfood hunts UX gaps a real user would hit. A release passes both gates before it's done. Saves under `docs/dogfood/<version>.md` parallel to `docs/release-adversarial/<version>.md`.
+- **`docs(cli) JSON-shape honesty fix`** baked into PR #60. Where the binary returns `{}` today (`treeship setup --format json`, `treeship agents list --format json`), the docs say so and point at the per-component commands that DO emit rich JSON (`treeship add --discover --format json`, `treeship harness list --format json`). Truth-in-advertising before the agent-mode shape stabilizes.
+
+### Intentionally deferred to a later release
+
+- **Agent-readable receipt page (`/receipt/<id>` SSR + `/receipt/<id>.json` + package download).** Requires the marketing-site (`treeship.dev`) repo, which lives separately from this codebase. Tracked for the next product release.
+- **Python SDK `ensure_cli` / bootstrap helper.** Substantive product work. Tracked for the next product release.
+- **`treeship setup --agent --yes --format json` rich-shape implementation.** Today it returns `{}`; the v0.9.11 docs flag this honestly. The richer shape lands in the next product release.
+- **`treeship session report --share --format json`** returning `{receipt_url, raw_json_url, package_url, receipt_digest, verification_status, warnings}`. Same release.
+
+The next product release theme will be **Agent-Native Bootstrap + Share** — the deferred items above. v0.9.11 makes Treeship's existing surface legible; the next release makes a fresh AI agent able to install, run, share, and verify it without asking a human a clarifying question.
+
+### Verification
+
+This is a docs-only release. Per the release-adversarial cadence policy at `docs/release-adversarial/README.md`, no targeted Codex pass is required — adversarial review is reserved for trust-semantics changes. The release machinery's own gates apply:
+
+- ✅ `python3 scripts/check-release-versions.py 0.9.11` — 21/21 sites at 0.9.11
+- ✅ `python3 scripts/check-docs-routes.py` — 9 meta.json files checked, all routes resolve (the new gate this release adds)
+- ✅ `cargo test --workspace` — every suite green (251 core unit + 17 binding integration + 7 hub-checkpoint integration + everything else, identical to v0.9.10 since no product code changed)
+- ✅ `bash tests/acceptance/trust-fabric.sh` — smoke pass
+
 ## 0.9.10 (2026-04-30)
 
 The Approval Authority patch release. Closes four trust-bypass paths and three adjacent hardenings that a targeted Codex adversarial review of v0.9.9 found in the new approval-evidence surface. **Verifiers running v0.9.9 should upgrade.** v0.9.9 packages still verify under v0.9.10, but the binding rows that v0.9.9 silently passed now report honestly: a v0.9.9 package's `approval-use-action-binding` row will read `not asserted by package` because v0.9.9 didn't ship the action envelopes the binding check needs. Under `--strict`, that's a fail — the intended upgrade signal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "base64",
  "clap",
@@ -3926,7 +3926,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.10"
+    "@treeship/core-wasm": "0.9.11"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.9.10"
+    "@treeship/core-wasm": "0.9.11"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.9.10",
-    "@treeship/cli-darwin-arm64": "0.9.10",
-    "@treeship/cli-darwin-x64": "0.9.10"
+    "@treeship/cli-linux-x64": "0.9.11",
+    "@treeship/cli-darwin-arm64": "0.9.11",
+    "@treeship/cli-darwin-x64": "0.9.11"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.9.10", path = "../core" }
+treeship-core = { version = "0.9.11", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.9.10"
+version = "0.9.11"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-python/treeship_sdk/__init__.py
+++ b/packages/sdk-python/treeship_sdk/__init__.py
@@ -25,4 +25,4 @@ __all__ = [
     "Treeship",
     "TreeshipError",
 ]
-__version__ = "0.9.10"
+__version__ = "0.9.11"

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "^0.9.4"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.10"
+    "@treeship/core-wasm": "0.9.11"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.9.2"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.9.10"
+    "@treeship/core-wasm": "0.9.11"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

The boring v0.9.11 cutover. **Version bump + CHANGELOG only — no product code.** Wraps four docs PRs (#59, #60, #61, #62) that landed on top of v0.9.10's trust-fix into a versioned release so installs and the docs site move in lockstep.

### v0.9.11 — Docs Reliability + Agent Install Clarity

The connective theme: **make Treeship legible to the next AI agent that has to bootstrap it on a strange machine.** Every gap this release closes was something a human or AI would only see at install/inspection time. None are trust bugs (v0.9.10 already closed those); they're UX-of-trust bugs.

### What's in scope

- **Docs route health** (#59) — three new section-root redirects + `/hub-api` alias + new `docs-route-health` CI gate that catches sidebar drift before it ships
- **CLI reference catch-up** (#60) — four new pages (`/cli/setup`, `/cli/add`, `/cli/agents`, `/cli/harness`), updated `/cli/attest` and `/cli/verify` for the v0.9.10 surface, sidebar reordered for first-run flow, and an honest JSON-shape callout where the binary returns `{}` today
- **SDK + install topology** (#61) — `/sdk/typescript` at its canonical URL, true SDK section landing, and `/guides/install` with the explicit "what's NOT on each registry and why" page so AI scanners stop flagging `treeship-cli` 404 on crates.io as a release failure
- **Process** (#62) — `/guides/dogfood-checklist` (sibling to release-adversarial review)

### Intentionally deferred

- Agent-readable receipt page (`/receipt/<id>` SSR + raw JSON + package download) — needs marketing-site repo
- Python SDK `ensure_cli` / bootstrap helper — substantive product work
- `treeship setup --agent --yes --format json` rich-shape implementation — today it returns `{}`, docs flag this honestly
- `treeship session report --share --format json` — same release

These compose into the next product release: **Agent-Native Bootstrap + Share**.

## Verification

- ✅ `python3 scripts/check-release-versions.py 0.9.11` — 21/21 sites at 0.9.11
- ✅ `python3 scripts/check-docs-routes.py` — 9 meta.json files checked, all routes resolve
- ✅ `cargo test --workspace` — every suite green (251 core unit + 17 binding integration + 7 hub-checkpoint integration + everything else; identical to v0.9.10 since no product code changed)
- ✅ `bash tests/acceptance/trust-fabric.sh` — smoke pass

Per the cadence policy at `docs/release-adversarial/README.md`: this is a docs-only release, so no targeted Codex pass is required. Adversarial review is reserved for trust-semantics changes.

## Diff scope

19 files: `CHANGELOG.md` + `Cargo.lock` + 17 version-bearing manifests. Zero source/test changes.

## Test plan

- [ ] CI: `version-consistency`, `docs-route-health`, `test`, `hub`, cross-SDK matrix, Vercel preview
- [ ] Confirm zero source/test changes (only CHANGELOG + version manifests + Cargo.lock)
- [ ] Read the CHANGELOG entry top-to-bottom — does it accurately describe what shipped in #59–#62?

## After merge

Same release discipline as v0.9.10:

1. Post-merge CI checks on main
2. Capture merged-main SHA
3. Run `python3 scripts/check-release-versions.py 0.9.11` + `--consistency`, `bash tests/acceptance/trust-fabric.sh`, `cargo test --workspace`
4. Confirm no local or remote v0.9.11 tag exists
5. Explicit user approval for local tag creation (Gate 1)
6. `scripts/release.sh tag 0.9.11 --sha <merged-sha>`
7. Show tag
8. Explicit user approval to push tag (Gate 2)
9. `git push origin v0.9.11` triggers `release.yml`
10. Report registry + install smokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)