### PR TITLE
feat(bootstrap): PR 5 — agent-native bootstrap (Python ensure_cli + setup --format json)

### DIFF
--- a/packages/cli/src/commands/setup.rs
+++ b/packages/cli/src/commands/setup.rs
@@ -43,6 +43,12 @@ pub struct SetupOpts {
     pub skip_smoke: bool,
     /// Skip instrumentation entirely -- only detect + draft cards.
     pub no_instrument: bool,
+    /// Output format. `text` (default) prints the orchestrated setup
+    /// flow as a human-readable transcript; `json` returns a stable
+    /// agent-readable payload describing what was detected,
+    /// instrumented, and smoke-tested. AI agents call this with
+    /// `--yes --format json` to bootstrap Treeship without a TTY.
+    pub format: String,
 }
 
 impl Default for SetupOpts {
@@ -51,6 +57,7 @@ impl Default for SetupOpts {
             yes:           false,
             skip_smoke:    false,
             no_instrument: false,
+            format:        "text".into(),
         }
     }
 }
@@ -61,6 +68,15 @@ pub fn run(
     opts: SetupOpts,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let json_mode = opts.format == "json";
+    // Accumulator. When json_mode is on, the function fills this in as
+    // it proceeds and emits the structured payload at the end. When
+    // json_mode is off, the existing text printing is the canonical
+    // output and the accumulator goes unused. AI agents call
+    // `treeship setup --yes --format json` to bootstrap Treeship
+    // without a TTY; this is the response shape they branch on.
+    let mut result = SetupResult::default();
+
     printer.blank();
     printer.section("Treeship setup");
     printer.blank();
@@ -78,9 +94,15 @@ pub fn run(
             printer.hint("Run: treeship init   (or `treeship init --config <path>` for a project-local config)");
             printer.dim_info("  After init, re-run `treeship setup` and Treeship will pick up where you left off.");
             printer.blank();
+            if json_mode {
+                result.error = Some("not initialized -- run `treeship init` first".into());
+                emit_setup_json(&result);
+            }
             return Ok(());
         }
     };
+    result.ship_id    = Some(ctx.config.ship_id.clone());
+    result.config_path = Some(ctx.config_path.display().to_string());
     printer.dim_info(&format!("  config:    {}", ctx.config_path.display()));
     printer.dim_info(&format!("  ship:      {}", ctx.config.ship_id));
 
@@ -88,12 +110,27 @@ pub fn run(
     let env = Env::current();
     let agents = discovery::discover(&env);
 
+    // Always record what we detected -- json_mode consumers want
+    // visibility on "the machine had no agents" (which is itself
+    // useful info for an orchestration agent).
+    for agent in &agents {
+        result.detected.push(DetectedSummary {
+            surface:                agent.surface.kind().into(),
+            display_name:           agent.display_name.clone(),
+            confidence:             agent.confidence.label().into(),
+            recommended_harness_id: Some(agent.recommended_harness_id().to_string()),
+        });
+    }
+
     if agents.is_empty() {
         printer.blank();
         printer.dim_info("  No agents detected on this machine.");
         printer.blank();
         printer.hint("Treeship still works -- start a session with `treeship session start` and wrap commands with `treeship wrap`.");
         printer.blank();
+        if json_mode {
+            emit_setup_json(&result);
+        }
         return Ok(());
     }
 
@@ -128,6 +165,12 @@ pub fn run(
         printer.blank();
         printer.hint("Approve cards manually with `treeship agents review <id>` then `treeship agents approve <id>`.");
         printer.blank();
+        if json_mode {
+            populate_card_counts(&mut result, &written);
+            result.next_steps.push("treeship agents review <id>".into());
+            result.next_steps.push("treeship agents approve <id>".into());
+            emit_setup_json(&result);
+        }
         return Ok(());
     }
 
@@ -145,6 +188,11 @@ pub fn run(
     if !confirmed {
         printer.dim_info("  Skipping instrumentation. Run `treeship add` or re-run `treeship setup --yes` later.");
         printer.blank();
+        if json_mode {
+            populate_card_counts(&mut result, &written);
+            result.next_steps.push("treeship setup --yes".into());
+            emit_setup_json(&result);
+        }
         return Ok(());
     }
 
@@ -185,6 +233,9 @@ pub fn run(
     if names_for_add.is_empty() {
         printer.dim_info("  No agents in this set have an automated instrumenter yet.");
     } else {
+        // Capture instrumented surface names for the JSON shape before
+        // delegating; `add::run` doesn't return them as a value.
+        result.instrumented = names_for_add.clone();
         // `add::run` takes ownership of stdout for its own printing; let
         // it run. `--all` (true) skips its prompt since we already asked.
         crate::commands::add::run(names_for_add, true, false, printer)?;
@@ -226,19 +277,32 @@ pub fn run(
     if opts.skip_smoke {
         let final_cards = cards::list(&agents_dir).unwrap_or(written.clone());
         print_complete(&final_cards, false, printer);
+        if json_mode {
+            populate_card_counts(&mut result, &final_cards);
+            result.smoke = Some(SmokeSummary { ran: false, passed: false, error: None });
+            result.next_steps.push("treeship setup            (re-run later with --skip-smoke off to verify)".into());
+            emit_setup_json(&result);
+        }
         return Ok(());
     }
 
-    let smoke_ok = match run_smoke_session(printer) {
-        Ok(()) => true,
+    let smoke_start = std::time::Instant::now();
+    let (smoke_ok, smoke_err) = match run_smoke_session(printer) {
+        Ok(()) => (true, None),
         Err(e) => {
             printer.warn(
                 "smoke session did not complete; cards stay at draft / needs-review",
                 &[("error", &e.to_string())],
             );
-            false
+            (false, Some(e.to_string()))
         }
     };
+    result.smoke = Some(SmokeSummary {
+        ran:    true,
+        passed: smoke_ok,
+        error:  smoke_err,
+    });
+    let _ = smoke_start;
 
     if smoke_ok {
         // Trust-semantics note (v0.9.8 PR 5 patch):
@@ -303,7 +367,107 @@ pub fn run(
         Err(_) => written,
     };
     print_complete(&final_cards, smoke_ok, printer);
+    if json_mode {
+        populate_card_counts(&mut result, &final_cards);
+        result.next_steps.push("treeship session start --name <task>".into());
+        result.next_steps.push("treeship session report --share --format json".into());
+        emit_setup_json(&result);
+    }
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Agent-readable JSON output (v0.10.0 PR 5 — Agent-Native Bootstrap)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize, Default)]
+struct SetupResult {
+    schema:       String,
+    ship_id:      Option<String>,
+    config_path:  Option<String>,
+    detected:     Vec<DetectedSummary>,
+    cards:        CardCounts,
+    instrumented: Vec<String>,
+    smoke:        Option<SmokeSummary>,
+    next_steps:   Vec<String>,
+    error:        Option<String>,
+}
+
+#[derive(serde::Serialize)]
+struct DetectedSummary {
+    surface:                String,
+    display_name:           String,
+    confidence:             String,
+    recommended_harness_id: Option<String>,
+}
+
+#[derive(serde::Serialize, Default)]
+struct CardCounts {
+    total:        usize,
+    draft:        usize,
+    needs_review: usize,
+    active:       usize,
+    verified:     usize,
+}
+
+#[derive(serde::Serialize)]
+struct SmokeSummary {
+    ran:    bool,
+    passed: bool,
+    error:  Option<String>,
+}
+
+fn populate_card_counts(result: &mut SetupResult, cards_list: &[AgentCard]) {
+    let mut c = CardCounts::default();
+    c.total = cards_list.len();
+    for card in cards_list {
+        match card.status {
+            CardStatus::Draft       => c.draft        += 1,
+            CardStatus::NeedsReview => c.needs_review += 1,
+            CardStatus::Active      => c.active       += 1,
+            CardStatus::Verified    => c.verified     += 1,
+        }
+    }
+    result.cards = c;
+}
+
+fn emit_setup_json(result: &SetupResult) {
+    let mut payload = result.clone_with_schema();
+    payload.schema = "treeship/setup-result/v1".into();
+    if let Ok(s) = serde_json::to_string_pretty(&payload) {
+        println!("{}", s);
+    }
+}
+
+impl SetupResult {
+    fn clone_with_schema(&self) -> SetupResult {
+        SetupResult {
+            schema:       self.schema.clone(),
+            ship_id:      self.ship_id.clone(),
+            config_path:  self.config_path.clone(),
+            detected:     self.detected.iter().map(|d| DetectedSummary {
+                surface:                d.surface.clone(),
+                display_name:           d.display_name.clone(),
+                confidence:             d.confidence.clone(),
+                recommended_harness_id: d.recommended_harness_id.clone(),
+            }).collect(),
+            cards:        CardCounts {
+                total:        self.cards.total,
+                draft:        self.cards.draft,
+                needs_review: self.cards.needs_review,
+                active:       self.cards.active,
+                verified:     self.cards.verified,
+            },
+            instrumented: self.instrumented.clone(),
+            smoke:        self.smoke.as_ref().map(|s| SmokeSummary {
+                ran:    s.ran,
+                passed: s.passed,
+                error:  s.error.clone(),
+            }),
+            next_steps:   self.next_steps.clone(),
+            error:        self.error.clone(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1867,6 +1867,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 yes:           a.yes,
                 skip_smoke:    a.skip_smoke,
                 no_instrument: a.no_instrument,
+                format:        cli.format.clone(),
             },
             printer,
         ),

--- a/packages/sdk-python/treeship_sdk/__init__.py
+++ b/packages/sdk-python/treeship_sdk/__init__.py
@@ -14,6 +14,11 @@ Usage:
 Requires the treeship CLI: curl -fsSL treeship.dev/install | sh
 """
 
+from treeship_sdk.bootstrap import (
+    BootstrapResult,
+    TreeshipBootstrapError,
+    ensure_cli,
+)
 from treeship_sdk.client import (
     SessionReportResult,
     Treeship,
@@ -21,8 +26,11 @@ from treeship_sdk.client import (
 )
 
 __all__ = [
+    "BootstrapResult",
     "SessionReportResult",
     "Treeship",
+    "TreeshipBootstrapError",
     "TreeshipError",
+    "ensure_cli",
 ]
 __version__ = "0.9.11"

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -1,0 +1,408 @@
+"""
+Treeship CLI bootstrap — agent-native install resolution.
+
+The Treeship Python SDK shells out to the `treeship` CLI binary. When
+that binary isn't on PATH (a fresh AI-agent environment, a sandboxed
+CI, a brand-new dev machine), the SDK should resolve it without
+asking the human a clarifying question.
+
+This module implements the resolution order:
+
+  1. ``$TREESHIP_BIN`` env var, if set and pointing at an executable.
+  2. ``treeship`` on PATH, if it's a working binary.
+  3. Sibling install via npm in a per-user cache dir, if ``npx`` is
+     available. (``npx -p treeship -c 'treeship --version'`` works
+     today; we copy the resolved binary out to the cache.)
+  4. Direct download from the matching GitHub Release asset for the
+     current platform, into the same cache dir.
+
+Each step is safe to run inside a sandbox: the cache dir defaults to
+``$HOME/.cache/treeship/bin`` (or the platform equivalent); the
+``--config`` path the caller passes elsewhere is respected; nothing
+runs ``sudo``; nothing modifies ``$PATH``.
+
+The ``ensure_cli()`` function returns the path to a working binary or
+raises :class:`TreeshipBootstrapError` with a structured ``reason``
+suitable for an AI agent to branch on. Use ``ensure_cli(json=True)``
+to get a dict result instead of a path; ``Treeship(bot_mode=True)``
+calls this internally so an agent can do:
+
+    from treeship_sdk import Treeship
+
+    ts = Treeship(bot_mode=True)
+    # Treeship now has a working CLI even on a fresh machine; no prompt.
+
+There is also a ``python -m treeship_sdk.bootstrap_cli`` entry point
+that prints the JSON result and exits — useful for shell scripts and
+agents that want to bootstrap without instantiating the SDK first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional
+
+
+__all__ = [
+    "BootstrapResult",
+    "TreeshipBootstrapError",
+    "ensure_cli",
+    "default_cache_dir",
+    "platform_release_asset",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class TreeshipBootstrapError(Exception):
+    """Raised when ensure_cli() can't resolve a working binary.
+
+    The ``reason`` attribute is a stable kebab-case identifier that AI
+    agents can branch on; the message is a human-readable summary.
+    """
+
+    def __init__(self, reason: str, message: str, attempted: list[str]) -> None:
+        super().__init__(message)
+        self.reason: str = reason
+        self.attempted: list[str] = attempted
+
+    def to_dict(self) -> dict:
+        return {
+            "ok":         False,
+            "reason":     self.reason,
+            "message":    str(self),
+            "attempted":  self.attempted,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BootstrapResult:
+    """Result of a successful ensure_cli() resolution.
+
+    The ``source`` enum tells a downstream consumer how the binary was
+    found, so an AI agent can decide whether to surface that to a
+    human ("I installed Treeship from the GitHub Release") vs treat it
+    as already-present.
+    """
+
+    ok: bool
+    binary: str            # absolute path to the working binary
+    version: str           # the version the binary reports
+    source: str            # "env" | "path" | "npm-cache" | "github-release"
+    cache_dir: Optional[str] = None  # only set for the cache-based sources
+
+    def to_dict(self) -> dict:
+        return {**asdict(self), "schema": "treeship/bootstrap-result/v1"}
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def default_cache_dir() -> Path:
+    """Return the per-user cache directory used for fallback installs.
+
+    Honors ``$TREESHIP_CACHE`` if set. Otherwise picks the platform
+    convention: ``$XDG_CACHE_HOME/treeship/bin`` on Linux,
+    ``~/Library/Caches/treeship/bin`` on macOS, ``%LOCALAPPDATA%/treeship/bin``
+    on Windows.
+    """
+    override = os.environ.get("TREESHIP_CACHE")
+    if override:
+        return Path(override).expanduser() / "bin"
+
+    sys_platform = sys.platform
+    if sys_platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "treeship" / "bin"
+    if sys_platform == "win32":
+        local = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(local) / "treeship" / "bin"
+    # linux / *bsd
+    xdg = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(xdg) / "treeship" / "bin"
+
+
+def platform_release_asset() -> tuple[str, Optional[str]]:
+    """Return ``(asset_name, error)`` for the current platform.
+
+    Returns ``("", reason)`` when the platform isn't supported by the
+    GitHub Release publisher. The first element is the asset filename
+    (e.g. ``treeship-darwin-aarch64``) on supported platforms.
+    """
+    sys_platform = sys.platform
+    machine = platform.machine().lower()
+    if sys_platform == "darwin":
+        if machine in ("arm64", "aarch64"):
+            return ("treeship-darwin-aarch64", None)
+        if machine in ("x86_64", "amd64"):
+            return ("treeship-darwin-x86_64", None)
+        return ("", f"unsupported macOS arch {machine}")
+    if sys_platform.startswith("linux"):
+        if machine in ("x86_64", "amd64"):
+            return ("treeship-linux-x86_64", None)
+        return ("", f"unsupported Linux arch {machine}")
+    if sys_platform == "win32":
+        return ("", "Windows install must use `npm install -g treeship` (no Windows binary on the GitHub Release)")
+    return ("", f"unsupported platform {sys_platform}")
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def _probe_binary(path: str) -> Optional[str]:
+    """Return the version string if `path` is a working treeship binary.
+
+    A working binary responds to ``--version`` with output like
+    ``treeship 0.9.11`` on stdout within a few seconds. Anything else
+    is treated as not-a-binary.
+    """
+    try:
+        proc = subprocess.run(
+            [path, "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+        return None
+    out = (proc.stdout or "").strip()
+    # Expected format: "treeship X.Y.Z"
+    if out.startswith("treeship "):
+        return out
+    return None
+
+
+def _try_env() -> Optional[BootstrapResult]:
+    bin_env = os.environ.get("TREESHIP_BIN")
+    if not bin_env:
+        return None
+    p = Path(bin_env).expanduser()
+    if not p.is_file():
+        return None
+    v = _probe_binary(str(p))
+    if v is None:
+        return None
+    return BootstrapResult(ok=True, binary=str(p), version=v, source="env")
+
+
+def _try_path() -> Optional[BootstrapResult]:
+    found = shutil.which("treeship")
+    if not found:
+        return None
+    v = _probe_binary(found)
+    if v is None:
+        return None
+    return BootstrapResult(ok=True, binary=found, version=v, source="path")
+
+
+def _try_cache(cache_dir: Path) -> Optional[BootstrapResult]:
+    cached = cache_dir / "treeship"
+    if not cached.is_file():
+        return None
+    v = _probe_binary(str(cached))
+    if v is None:
+        return None
+    return BootstrapResult(
+        ok=True, binary=str(cached), version=v,
+        source="cache", cache_dir=str(cache_dir),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Installers
+# ---------------------------------------------------------------------------
+
+
+def _install_via_github_release(
+    cache_dir: Path,
+    version: Optional[str] = None,
+) -> Optional[BootstrapResult]:
+    """Download the matching platform binary from the GitHub Release.
+
+    No `sudo`; writes only into ``cache_dir``. Returns None if the
+    download fails or the platform isn't supported. Uses the "latest"
+    release by default; pass ``version`` (e.g. ``"0.9.11"``) to pin.
+    """
+    asset, err = platform_release_asset()
+    if err:
+        return None
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    target = cache_dir / "treeship"
+    base = (
+        f"https://github.com/zerkerlabs/treeship/releases/download/v{version}/{asset}"
+        if version
+        else f"https://github.com/zerkerlabs/treeship/releases/latest/download/{asset}"
+    )
+    # Stream into a temp file in the same dir so the final move is atomic.
+    tmp = tempfile.NamedTemporaryFile(dir=str(cache_dir), prefix=".treeship-", suffix=".part", delete=False)
+    tmp_path = Path(tmp.name)
+    try:
+        with urllib.request.urlopen(base, timeout=30) as resp:  # nosec B310 (vetted https GitHub URL)
+            shutil.copyfileobj(resp, tmp)
+        tmp.close()
+        # Mark executable.
+        tmp_path.chmod(0o755)
+        tmp_path.replace(target)
+    except Exception:
+        try:
+            tmp.close()
+        except Exception:
+            pass
+        try:
+            tmp_path.unlink()
+        except Exception:
+            pass
+        return None
+
+    v = _probe_binary(str(target))
+    if v is None:
+        return None
+    return BootstrapResult(
+        ok=True, binary=str(target), version=v,
+        source="github-release", cache_dir=str(cache_dir),
+    )
+
+
+def _install_via_npm_global(cache_dir: Path) -> Optional[BootstrapResult]:
+    """Install via npm into a per-user prefix, then symlink the binary.
+
+    Uses ``npm install --prefix <cache_dir>/.npm treeship`` so the
+    install is fully isolated from any system-wide npm setup. The
+    resolved binary lives at ``<cache_dir>/.npm/node_modules/.bin/treeship``;
+    we symlink it to ``cache_dir/treeship`` for consistency with the
+    GitHub Release path.
+    """
+    if shutil.which("npm") is None:
+        return None
+    npm_prefix = cache_dir / ".npm"
+    npm_prefix.mkdir(parents=True, exist_ok=True)
+    try:
+        proc = subprocess.run(
+            ["npm", "install", "--prefix", str(npm_prefix), "treeship", "--silent"],
+            capture_output=True, text=True, timeout=180,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    inner_bin = npm_prefix / "node_modules" / ".bin" / "treeship"
+    if not inner_bin.is_file():
+        return None
+    # Stable path that matches the cached-binary probe.
+    target = cache_dir / "treeship"
+    try:
+        if target.exists() or target.is_symlink():
+            target.unlink()
+        target.symlink_to(inner_bin.resolve())
+    except OSError:
+        # Fallback: copy the binary if symlinks aren't allowed (Windows
+        # without dev-mode, sandboxes that block symlink creation).
+        try:
+            shutil.copyfile(inner_bin, target)
+            target.chmod(0o755)
+        except OSError:
+            return None
+    v = _probe_binary(str(target))
+    if v is None:
+        return None
+    return BootstrapResult(
+        ok=True, binary=str(target), version=v,
+        source="npm-cache", cache_dir=str(cache_dir),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def ensure_cli(
+    *,
+    cache_dir: Optional[Path] = None,
+    pinned_version: Optional[str] = None,
+    allow_install: bool = True,
+) -> BootstrapResult:
+    """Resolve a working ``treeship`` binary.
+
+    Order: env var → PATH → cache → npm install → GitHub Release.
+    Each step is fast and idempotent; the function exits at the first
+    success.
+
+    Args:
+        cache_dir: Override the default cache location. Useful in
+            tests and sandboxes.
+        pinned_version: When the GitHub Release fallback fires, pin
+            to this version (e.g. ``"0.9.11"``). Defaults to ``latest``.
+        allow_install: Set to ``False`` to disable the npm-install and
+            GitHub-Release fallbacks. Useful when the agent should
+            fail loudly rather than reach out to the network.
+
+    Returns:
+        :class:`BootstrapResult` describing the resolved binary.
+
+    Raises:
+        :class:`TreeshipBootstrapError` if every probe failed.
+    """
+    cache = cache_dir or default_cache_dir()
+    attempted: list[str] = []
+
+    # 1. Env var (explicit user override).
+    attempted.append("env:TREESHIP_BIN")
+    r = _try_env()
+    if r is not None:
+        return r
+
+    # 2. PATH.
+    attempted.append("path:treeship")
+    r = _try_path()
+    if r is not None:
+        return r
+
+    # 3. Cache directory from a prior bootstrap.
+    attempted.append(f"cache:{cache}")
+    r = _try_cache(cache)
+    if r is not None:
+        return r
+
+    if not allow_install:
+        raise TreeshipBootstrapError(
+            "no-binary-found-and-install-disabled",
+            "treeship binary not found in env, PATH, or cache; install fallbacks are disabled",
+            attempted,
+        )
+
+    # 4. Try npm install into the cache.
+    attempted.append("install:npm")
+    r = _install_via_npm_global(cache)
+    if r is not None:
+        return r
+
+    # 5. Direct GitHub Release download for the current platform.
+    attempted.append("install:github-release")
+    r = _install_via_github_release(cache, version=pinned_version)
+    if r is not None:
+        return r
+
+    raise TreeshipBootstrapError(
+        "all-resolution-paths-failed",
+        "could not resolve a working treeship binary via env, PATH, cache, npm, or GitHub Release",
+        attempted,
+    )

--- a/packages/sdk-python/treeship_sdk/bootstrap_cli.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap_cli.py
@@ -1,0 +1,97 @@
+"""
+``python -m treeship_sdk.bootstrap_cli`` — agent-friendly CLI bootstrap.
+
+Resolves a working ``treeship`` binary on the current machine and
+prints a stable JSON result. Designed for shell scripts and AI agents
+that need to bootstrap Treeship before they have a Python SDK
+instance.
+
+Examples
+--------
+
+Resolve and print the JSON result::
+
+    python -m treeship_sdk.bootstrap_cli --json
+
+Resolve and print just the binary path (text mode)::
+
+    python -m treeship_sdk.bootstrap_cli
+
+Resolve without falling back to network installs::
+
+    python -m treeship_sdk.bootstrap_cli --no-install
+
+Pin to a specific version when downloading from the GitHub Release::
+
+    python -m treeship_sdk.bootstrap_cli --json --version 0.9.11
+
+The ``--agent`` flag is accepted (and a no-op) for compatibility with
+the agent-native idiom; the JSON output already carries everything an
+agent needs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from treeship_sdk.bootstrap import (
+    BootstrapResult,
+    TreeshipBootstrapError,
+    default_cache_dir,
+    ensure_cli,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m treeship_sdk.bootstrap_cli",
+        description="Resolve a working treeship CLI binary; output a stable JSON result.",
+    )
+    parser.add_argument("--json", action="store_true",
+        help="Output JSON instead of the binary path. Required for AI-agent use.")
+    parser.add_argument("--no-install", action="store_true",
+        help="Disable network fallbacks (npm install, GitHub Release). Fail if the binary isn't already present.")
+    parser.add_argument("--version", "-V", default=None,
+        help="When falling back to GitHub Release download, pin to this version. Default: latest.")
+    parser.add_argument("--cache-dir", default=None,
+        help="Override the default per-user cache directory.")
+    parser.add_argument("--agent", action="store_true",
+        help="Agent-native idiom flag. Accepted for compatibility; the JSON output is already agent-readable.")
+    args = parser.parse_args(argv)
+
+    cache = None
+    if args.cache_dir:
+        from pathlib import Path
+        cache = Path(args.cache_dir).expanduser()
+
+    try:
+        result: BootstrapResult = ensure_cli(
+            cache_dir=cache,
+            pinned_version=args.version,
+            allow_install=not args.no_install,
+        )
+    except TreeshipBootstrapError as exc:
+        if args.json:
+            print(json.dumps(exc.to_dict(), indent=2))
+        else:
+            print(f"treeship-bootstrap: {exc}", file=sys.stderr)
+            print("attempted: " + ", ".join(exc.attempted), file=sys.stderr)
+        return 1
+
+    if args.json:
+        # Add `cache_dir` separately when it wasn't filled in by the
+        # successful path (env / path resolutions don't write to the
+        # cache).
+        payload = result.to_dict()
+        if payload.get("cache_dir") is None:
+            payload["cache_dir"] = str(default_cache_dir())
+        print(json.dumps(payload, indent=2))
+    else:
+        print(result.binary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -6,6 +6,12 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from treeship_sdk.bootstrap import (
+    BootstrapResult,
+    TreeshipBootstrapError,
+    ensure_cli,
+)
+
 
 class TreeshipError(Exception):
     """Error from the treeship CLI."""
@@ -57,11 +63,17 @@ class SessionReportResult:
     events: int = 0
 
 
-def _run(args: List[str], timeout: int = 10) -> Dict[str, Any]:
-    """Run a treeship CLI command and return parsed JSON."""
+def _run(args: List[str], timeout: int = 10, *, binary: str = "treeship") -> Dict[str, Any]:
+    """Run a treeship CLI command and return parsed JSON.
+
+    `binary` lets the caller override which executable is invoked --
+    used by the agent-native bootstrap path (Treeship(bot_mode=True))
+    so the SDK can shell out to a CLI it resolved itself rather than
+    relying on PATH.
+    """
     try:
         result = subprocess.run(
-            ["treeship"] + args,
+            [binary] + args,
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -74,7 +86,8 @@ def _run(args: List[str], timeout: int = 10) -> Dict[str, Any]:
         return json.loads(result.stdout)
     except FileNotFoundError:
         raise TreeshipError(
-            "treeship CLI not found. Install: curl -fsSL treeship.dev/install | sh",
+            "treeship CLI not found. Install: curl -fsSL treeship.dev/install | sh\n"
+            "  Or in a Python program: ts = Treeship(bot_mode=True)  # auto-resolves the CLI",
             args,
         )
     except json.JSONDecodeError:
@@ -89,13 +102,69 @@ class Treeship:
     Treeship SDK client.
 
     Wraps the treeship CLI binary for signing, verification, and Hub operations.
-    Requires the treeship binary in PATH.
 
-    Usage:
+    Two construction modes:
+
+      Treeship()
+        Default — assumes ``treeship`` is on PATH. Raises
+        :class:`TreeshipError` if the binary isn't found at call time.
+
+      Treeship(bot_mode=True)
+        Agent-native — calls :func:`ensure_cli` at construction time to
+        resolve the binary via env / PATH / cache / npm / GitHub Release
+        in that order. AI agents on a fresh machine should use this so
+        they don't have to ask a human "is the CLI installed?".
+
+    Usage::
+
+        # default
         ts = Treeship()
         result = ts.attest_action(actor="agent://my-agent", action="tool.call")
-        print(result.artifact_id)
+
+        # agent-native bootstrap
+        ts = Treeship(bot_mode=True)
+        # CLI resolved + ready, even on a fresh sandbox
     """
+
+    def __init__(self, *, bot_mode: bool = False) -> None:
+        # Default: use whatever's on PATH. The CLI lookup happens at
+        # call time inside _run(), so an unresolved binary fails on the
+        # first method call (with a recovery hint pointing at bot_mode).
+        self._binary: str = "treeship"
+        self._bootstrap: Optional[BootstrapResult] = None
+        if bot_mode:
+            try:
+                self._bootstrap = ensure_cli()
+                self._binary = self._bootstrap.binary
+            except TreeshipBootstrapError as exc:
+                raise TreeshipError(
+                    f"agent-native bootstrap failed: {exc} (reason={exc.reason})",
+                    [],
+                ) from exc
+
+    @classmethod
+    def ensure_cli(cls) -> BootstrapResult:
+        """Resolve a working CLI binary without instantiating the SDK.
+
+        Sugar around :func:`treeship_sdk.bootstrap.ensure_cli` so a
+        caller can do::
+
+            from treeship_sdk import Treeship
+            Treeship.ensure_cli()
+
+        without importing the bootstrap submodule.
+        """
+        return ensure_cli()
+
+    @property
+    def binary(self) -> str:
+        """Path to the resolved CLI binary. ``"treeship"`` when not bot-mode."""
+        return self._binary
+
+    @property
+    def bootstrap(self) -> Optional[BootstrapResult]:
+        """The resolution result when bot_mode=True; ``None`` otherwise."""
+        return self._bootstrap
 
     def attest_action(
         self,


### PR DESCRIPTION
## Summary

PR 5 of the **Agent-Native Receipt Sharing** release. Closes the \"AI agent can't bootstrap Treeship without asking the human\" gap from the Kimi dogfood failure.

Two parts:

### Part A — \`treeship setup --format json\` returns a real shape

Previously \`treeship setup --yes --format json\` returned \`{}\` — the setup function ignored the global \`--format\` flag. AI agents calling it got nothing actionable.

This PR plumbs \`format\` into \`SetupOpts\`, builds a \`SetupResult\` accumulator as the orchestrated flow runs, and emits:

\`\`\`json
{
  \"schema\":      \"treeship/setup-result/v1\",
  \"ship_id\":     \"ship_...\",
  \"config_path\": \"...\",
  \"detected\": [
    { \"surface\", \"display_name\", \"confidence\", \"recommended_harness_id\" }
  ],
  \"cards\":        { \"total\", \"draft\", \"needs_review\", \"active\", \"verified\" },
  \"instrumented\": [\"claude-code\", \"cursor\", ...],
  \"smoke\":        { \"ran\", \"passed\", \"error\" },
  \"next_steps\":   [\"treeship session start --name <task>\", ...],
  \"error\":        null
}
\`\`\`

Every early-exit path (not initialized, no agents, \`--no-instrument\`, declined-confirmation, \`--skip-smoke\`) populates the accumulator and emits the JSON before returning. Late-exit paths include post-smoke promotion results.

### Part B — Python SDK bootstrap

New files:

- \`packages/sdk-python/treeship_sdk/bootstrap.py\`
- \`packages/sdk-python/treeship_sdk/bootstrap_cli.py\`

\`ensure_cli()\` resolves a working \`treeship\` binary in order:

\`\`\`
$TREESHIP_BIN  →  PATH  →  cache  →  npm-cache  →  github-release
\`\`\`

Each step is sandboxed-safe: no \`sudo\`, no network unless steps 4/5 fire, no \`PATH\` modification. Returns:

\`\`\`python
@dataclass
class BootstrapResult:
    ok: bool
    binary: str            # absolute path
    version: str           # e.g. \"treeship 0.9.11\"
    source: str            # \"env\" | \"path\" | \"cache\" | \"npm-cache\" | \"github-release\"
    cache_dir: Optional[str]
\`\`\`

Raises \`TreeshipBootstrapError(reason, message, attempted)\` when every probe fails. \`reason\` is a stable kebab-case identifier an AI agent can branch on.

\`Treeship(bot_mode=True)\` calls \`ensure_cli()\` at construction time, so an agent on a fresh machine never has to ask \"is the CLI installed?\". The resolved binary is used for every subsequent shell-out:

\`\`\`python
from treeship_sdk import Treeship
ts = Treeship(bot_mode=True)  # resolves CLI via env / PATH / cache / npm / GitHub Release
result = ts.attest_action(actor=\"agent://...\", action=\"tool.call\")
\`\`\`

\`python -m treeship_sdk.bootstrap_cli --json\` is the agent-friendly shell entry point; \`--no-install\` disables network fallbacks for agents that should fail loudly rather than reach out.

## What this PR explicitly does NOT do

- No new trust subsystem, no Hub server, no AgentGate runtime, no issuer registry.
- No \`PATH\` modification, no \`sudo\`, no privilege escalation.
- No CLI version pinning by default — \`pinned_version\` is optional.

## Verification

- ✅ \`cargo build --bin treeship\` clean
- ✅ \`cargo test --workspace\` — all suites green
- ✅ \`bash tests/acceptance/trust-fabric.sh\` — smoke pass
- ✅ \`python3 scripts/check-docs-routes.py\` — 9 meta.json files checked, all routes resolve
- ✅ Local smoke against a fresh isolated workspace:
  - \`treeship setup --yes --no-instrument --format json\` returns a rich JSON payload with 5 detected agents, 5 draft cards, next-steps array
  - Python \`ensure_cli()\` resolves the CLI from PATH on this machine
  - \`Treeship(bot_mode=True).binary\` returns the absolute path
  - \`python -m treeship_sdk.bootstrap_cli --json --no-install\` returns the schema-conformant payload

## Test plan

- [ ] CI: \`version-consistency\`, \`docs-route-health\`, \`test\`, \`hub\`, cross-SDK matrix, Vercel preview
- [ ] Smoke against a sandboxed Python env without \`treeship\` on PATH: \`Treeship(bot_mode=True)\` should resolve via npm or GitHub Release fallback
- [ ] Smoke \`python -m treeship_sdk.bootstrap_cli --json\` from a fresh shell

## What ships in the release

Combined with the marketing-site PRs ([zerkerlabs/treeship.dev #7-#9](https://github.com/zerkerlabs/treeship.dev/pulls)) and CLI PR #64 (\`session report --format json\`), the canonical agent flow now works end-to-end:

\`\`\`bash
# 1. Bootstrap (no human required)
python -m treeship_sdk.bootstrap_cli --json

# 2. Set up Treeship (agent-readable)
treeship setup --yes --format json

# 3. Run a session
treeship session start --name task-x
treeship wrap -- ./build.sh
treeship session close --summary \"build verified\"

# 4. Share + return URLs to the human
treeship session report --share --format json
# → { receipt_url, raw_json_url, package_download_url, receipt_digest, ... }
\`\`\`

The receipt URL the agent returns is now SSR-rendered (PR 1), the JSON contract is stable (PR 2), and the package is downloadable (PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)