### PR TITLE
feat: Add Treeship Agent Skills — One skill, every agent

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,90 @@
+# feat: Add Treeship Agent Skills — One skill, every agent
+
+Adds a single `SKILL.md` that teaches Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, and Hermes how to use Treeship — CLI commands, both SDKs, MCP bridge wiring, approval-gated workflows, multi-agent handoffs, Hub API. The skill is declarative (just text); the agent decides when to apply it. One file, every supported agent.
+
+The skill is the missing piece in the agent-native experience: pair it with the [v0.10.0 receipt-sharing release](https://github.com/zerkerlabs/treeship/releases) and an agent on a fresh machine can install Treeship, run a session, share a receipt, and hand the human a verifiable URL — all without re-explaining the API.
+
+## What's Added
+
+```
+treeship/
+├── skills/
+│   └── treeship/
+│       └── SKILL.md                         (new — the universal skill)
+├── integrations/
+│   └── agent-skills/
+│       └── README.md                        (new — multi-agent setup guide)
+└── docs/
+    └── content/
+        ├── docs/integrations/
+        │   └── agent-skills.mdx             (new — docs page)
+        └── blog/
+            └── multi-agent-skills.mdx       (new — launch post)
+```
+
+Total: 4 new files (5 if you count this PR description).
+
+## Supported Agents
+
+| Agent | Install Command |
+|---|---|
+| Kimi Code CLI | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` |
+| Claude Code | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` |
+| Codex | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` |
+| Cursor | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` |
+| OpenClaw | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` |
+| Hermes | `mkdir -p ~/.hermes/skills/treeship && curl -fsSL <SKILL.md raw url> -o ~/.hermes/skills/treeship/SKILL.md` |
+
+`-g` installs globally (every project on the machine sees it). `-y` skips the confirm prompt — useful in CI / scripted setup.
+
+## What the Skill Teaches
+
+- **Every Treeship CLI command** — `wrap`, `verify`, `session report`, `approve`, `hub push`, plus the v0.9.x setup / harness / agents surface.
+- **Python SDK shape** — `Treeship().attest_action()`, `attest_approval()`, `attest_decision()`, `verify()`, `dock_push()`, `session_report()`.
+- **TypeScript SDK shape** — `Ship.init()`, `attestAction()`, `attestHandoff()`, `createCheckpoint()`, `createBundle()`.
+- **Approval-gated workflows** — the create-approval / consume-with-nonce / verify-with-replay-checks pattern.
+- **Chained workflows** — multi-agent handoffs linked by `parent_id`, the chain walk `treeship verify` runs.
+- **MCP bridge wiring per agent** — `claude mcp add`, `kimi mcp add`, Cursor `mcp.json`, Codex `config.toml` snippets.
+- **Hub API surface** — DPoP auth, public verification URLs, Merkle inclusion proofs.
+- **Standards reference** — Ed25519 (RFC 8032), DSSE, SHA-256, RFC 8785 canonicalization.
+
+The skill is **declarative, not procedural**: it doesn't run anything itself. It teaches the agent the API and the right shape for each use case. The agent decides when to call the CLI or SDK based on what the user actually asked for. That keeps the skill safe (it's just text) and portable (same file, every agent).
+
+## MCP Bridge
+
+The skill teaches the agent what to do. The optional MCP bridge ([`@treeship/mcp`](https://www.npmjs.com/package/@treeship/mcp)) captures whatever the agent does. Together they give High coverage without prompting — every Read, Write, Bash, and MCP tool call gets attested automatically.
+
+```bash
+claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
+kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
+# Cursor / Codex / OpenClaw — add to their respective MCP config (see integration guide)
+```
+
+Hermes uses skill-driven `treeship wrap` calls (no MCP today); coverage stays Medium.
+
+## Files to Review
+
+- `skills/treeship/SKILL.md` — the skill content. The frontmatter `description` is what the agent matches against the user's intent; verify the trigger phrases cover the cases you care about.
+- `integrations/agent-skills/README.md` — the per-agent setup guide. Verify the install path table and per-agent MCP wiring.
+- `docs/content/docs/integrations/agent-skills.mdx` — the docs site page (Fumadocs format). Wired into `docs/content/docs/integrations/meta.json` as the first entry under "Integrations" so it surfaces ahead of the per-agent pages.
+- `docs/content/blog/multi-agent-skills.mdx` — the launch post.
+
+## After Merging
+
+- The skill is publishable to the [`skills add`](https://github.com/anthropics/skills) registry under `zerkerlabs/treeship` so the install commands above resolve. Coordinate with the skills registry team or run the publish step out-of-band; this PR doesn't gate on it.
+- Update [docs.treeship.dev](https://docs.treeship.dev/integrations/agent-skills) homepage / landing if you want to surface the skill as a top-level "first thing every agent should install" CTA.
+- Announce on the Treeship blog (the launch post in this PR is ready to go live as soon as the merge lands — it's wired into `docs/content/blog/`).
+- Consider versioning the skill content with each release: each `treeship` release that changes the CLI surface or SDK shape should push a matching `SKILL.md` update. The "Updating" section of the integration guide already tells users how to pin (`npx skills add zerkerlabs/treeship@v0.10.0 ...`).
+
+## Testing Checklist
+
+- [ ] `SKILL.md` frontmatter parses (YAML head + Markdown body)
+- [ ] All install commands in the integration guide and docs page reference the right agent flag and path
+- [ ] Every link in the docs page resolves to an existing route (`/integrations/claude-code`, `/guides/coverage-levels`, `/guides/install`)
+- [ ] Blog post date is correct and `tags` field matches the existing blog format
+
+## Related
+
+- [v0.10.0 — Agent-Native Receipt Sharing](../../releases) — the receipt-side companion to this skill (server-rendered receipt pages, agent-native JSON contract, downloadable `.treeship` packages)
+- [Coverage levels](https://docs.treeship.dev/guides/coverage-levels) — what High / Medium / Basic actually mean
+- [Anthropic Skills docs](https://github.com/anthropics/skills) — the SKILL.md format spec

--- a/docs/content/blog/multi-agent-skills.mdx
+++ b/docs/content/blog/multi-agent-skills.mdx
@@ -1,0 +1,176 @@
+---
+title: "Treeship Agent Skills: One Skill, Every Agent"
+description: "Install Treeship on Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, and Hermes. One skill file teaches every agent how to create cryptographically signed trust receipts."
+date: 2026-05-01
+tags: ["skills", "integrations", "multi-agent", "release"]
+readTime: "5 min read"
+---
+
+# Treeship Agent Skills: One Skill, Every Agent
+
+Today we're shipping the Treeship Agent Skill: one Markdown file that teaches any coding agent — Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, or Hermes — how to create cryptographically signed trust receipts.
+
+Install it once, and the agent can sign actions, verify chains, manage approvals, and push receipts to the Hub without you re-explaining the API every conversation.
+
+---
+
+## The Problem
+
+Agent conversations are not evidence. A chat log is a record of what an agent said, not what it did. When the agent runs `npm test` and reports "all green," the only thing you have is a sentence in a transcript. When the agent applies a database migration on your behalf, the only thing you have is a sentence in a transcript. When the agent claims a deployment succeeded, the only thing you have is a sentence in a transcript.
+
+Treeship turns those moments into receipts. `treeship wrap -- npm test` produces a signed Ed25519 attestation of the exact command, exit code, and outputs. `treeship verify last` checks the chain offline. `treeship hub push last` gives you a public URL anyone can verify without an account, an API key, or a browser extension.
+
+The catch was always the same: *the agent has to know about it*. If you have to explain the API every time you start a conversation, you'll stop using it. If the agent doesn't know which command to run when you say "deploy the staging service," it'll fall back to the chat-log answer — "I'll run the deploy script" — and the trust receipt never gets produced.
+
+The Agent Skill closes that gap.
+
+---
+
+## One Skill, Every Agent
+
+The skill is a single `SKILL.md` file. It teaches the agent the full Treeship surface: every CLI command, both SDKs, the MCP bridge wiring, the Hub API, the approval-gated workflow pattern, and the multi-agent handoff pattern. Drop it into the agent's skills directory and the agent treats it as durable knowledge — same as a long-lived `CLAUDE.md` or a system prompt, but loaded automatically by the agent's runtime.
+
+```bash
+# Kimi Code CLI
+npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y
+
+# Claude Code
+npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y
+
+# Codex
+npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
+
+# Cursor
+npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y
+
+# OpenClaw
+npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y
+
+# Hermes (manual install — Hermes loads from ~/.hermes/skills/<name>/)
+mkdir -p ~/.hermes/skills/treeship
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/skills/treeship/SKILL.md \
+  -o ~/.hermes/skills/treeship/SKILL.md
+```
+
+The `-g` flag installs globally (every project on the machine sees the skill), `-y` skips the confirmation prompt. Drop both for an interactive install scoped to a single project.
+
+---
+
+## How It Works
+
+Once the skill is installed, the agent stops needing the API explained to it. A typical conversation:
+
+> **You:** I'm about to deploy the staging service. Can you run the deploy and give me a verifiable receipt?
+>
+> **Agent:** I'll wrap the deploy with Treeship so you get a signed receipt:
+>
+> ```bash
+> treeship wrap --action deploy.staging -- ./scripts/deploy.sh staging
+> treeship session report
+> ```
+>
+> The first command runs the deploy and signs the result. The second uploads the receipt to the Hub and returns a public URL you can share. Want me to run them now?
+
+The agent didn't guess. The skill told it that `treeship wrap` is the right shape for "run a command and produce a signed receipt," and that `treeship session report` produces a shareable URL. It also knows the alternative paths — `treeship hub push last`, `treeship session start --name "..."`, the Python and TypeScript SDKs — and picks based on what fits your stack.
+
+When you ask "can you also have someone approve this first?", the skill knows the answer:
+
+```python
+# 1. Human creates approval
+approval = ts.attest_approval(
+    approver="human://alice",
+    description="approve staging deploy",
+    expires_in=3600
+)
+
+# 2. Agent uses the approval nonce
+result = ts.attest_action(
+    actor="agent://deployer",
+    action="deploy.staging",
+    approval_nonce=approval.nonce,
+    meta={"target": "staging"}
+)
+```
+
+The agent doesn't have to invent that flow. The skill spells it out, including the v0.9.9 replay-check semantics that make sure an approval can't be reused.
+
+---
+
+## MCP Bridge: Automatic Attestation
+
+The skill teaches the agent what to do. The MCP bridge ([`@treeship/mcp`](https://www.npmjs.com/package/@treeship/mcp)) captures whatever the agent does. Together they give High coverage without prompting — every Read, Write, Bash, and MCP tool call gets attested into the active session, no matter what the user asked for.
+
+```bash
+# Claude Code
+claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
+
+# Kimi Code CLI
+kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
+```
+
+For Cursor, Codex, and OpenClaw, the wiring is in their respective MCP config files (the [agent-skills integration guide](https://github.com/zerkerlabs/treeship/blob/main/integrations/agent-skills/README.md) has the per-agent snippets). For Hermes, the skill is the bridge — Hermes routes commands through `treeship wrap` per the skill's guidance, capturing every wrapped command at Medium coverage.
+
+---
+
+## Coverage Levels
+
+| Level | What Treeship sees | When |
+|---|---|---|
+| **High** | Every Read, Write, Bash, MCP tool call | Skill + MCP bridge, or Claude Code plugin |
+| **Medium** | Commands the agent explicitly wraps with `treeship wrap` | Skill alone |
+| **Basic** | Explicit user-requested wraps | Fallback (no skill, no MCP) |
+
+The skill's job is to lift any agent from Basic to at least Medium. Adding the MCP bridge — or installing the [Claude Code plugin](https://docs.treeship.dev/integrations/claude-code) where available — lifts coverage to High.
+
+See the [coverage levels guide](https://docs.treeship.dev/guides/coverage-levels) for the full ladder, including how `verified_captures` differs from `potential_captures` (the v0.9.8 trust-semantics distinction that keeps "what a harness *could* observe if attached and working" separate from "what's actually been *proven* by a smoke run on this machine").
+
+---
+
+## What's in the Skill
+
+- **Every Treeship CLI command** — `wrap`, `verify`, `session report`, `approve`, `hub push`, `setup`, `add --discover`, `harness list`, and more.
+- **Python SDK shape** — `Treeship().attest_action()`, `attest_approval()`, `attest_decision()`, `verify()`, `dock_push()`, `session_report()`.
+- **TypeScript SDK shape** — `Ship.init()`, `attestAction()`, `attestHandoff()`, `createCheckpoint()`, `createBundle()`.
+- **Approval-gated workflows** — the create-approval / consume-with-nonce / verify-with-replay-checks pattern.
+- **Chained workflows** — multi-agent handoffs linked by `parent_id`, the chain walk that `treeship verify` runs.
+- **MCP bridge wiring per agent** — exact `claude mcp add`, `kimi mcp add`, Cursor `mcp.json`, Codex `config.toml` snippets.
+- **Hub API surface** — DPoP auth, public verification URLs, Merkle inclusion proofs.
+- **Standards reference** — Ed25519 (RFC 8032), DSSE, SHA-256, RFC 8785 canonicalization.
+
+The skill is **declarative, not procedural**: it doesn't run anything itself. It teaches the agent the API and the right shape for each use case. The agent decides when to call the CLI or SDK based on what the user actually asked for. That keeps the skill safe (it's just text) and portable (the same file lands on every agent).
+
+---
+
+## Try It Now
+
+Three steps:
+
+```bash
+# 1. Install Treeship itself (one-liner; idempotent)
+curl -fsSL treeship.dev/setup | sh
+
+# 2. Install the skill on your agent (pick yours)
+npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y
+
+# 3. Open your agent and ask:
+#    "wrap my next command with Treeship"
+```
+
+The agent now knows the API. Ask it to verify a chain, push a receipt, or set up an approval workflow — it'll pick the right command without you spelling it out.
+
+---
+
+## What's Next
+
+The skill is the first half of the agent-native experience. The second half — published in the [v0.10.0 release](https://github.com/zerkerlabs/treeship/releases) — is the agent-readable receipt surface: server-rendered receipt pages a non-browser tool can read, a stable JSON contract at `/api/receipt/<id>/agent`, and downloadable `.treeship` packages anyone can verify offline. Together they close the loop: an agent can install Treeship, run a session, share a receipt, and hand back URLs that work for humans, AI agents, link unfurlers, and offline verifiers alike.
+
+The skill ships today. Try it on your agent of choice and tell us where it gets the answer wrong — that's the feedback loop that pulls the next API surface into the skill.
+
+---
+
+## Resources
+
+- [Agent Skills integration guide](https://github.com/zerkerlabs/treeship/blob/main/integrations/agent-skills/README.md) — full per-agent setup
+- [`SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship/SKILL.md) — the skill content itself
+- [Treeship docs](https://docs.treeship.dev) — full reference
+- [GitHub repository](https://github.com/zerkerlabs/treeship) — source, issues, contributions

--- a/docs/content/docs/integrations/agent-skills.mdx
+++ b/docs/content/docs/integrations/agent-skills.mdx
@@ -1,0 +1,120 @@
+---
+title: Agent Skills
+description: Install the Treeship skill on any coding agent — Kimi, Claude, Codex, Cursor, OpenClaw, Hermes. One skill, every agent.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Agent Skills
+
+<Callout type="info">
+**One skill, every agent.** The same `SKILL.md` works with Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, and Hermes. Install it once and the agent can sign actions, verify chains, manage approvals, and push receipts to the Hub without you re-explaining the API every conversation.
+</Callout>
+
+The Treeship Agent Skill is a single Markdown file the agent reads as durable knowledge: the CLI commands, the Python and TypeScript SDK shapes, when to attest action vs. approval vs. handoff vs. decision, the MCP bridge wiring, the Hub API surface, and the approval-gated workflow pattern. Drop it into any of the supported agents' skills directory and the agent stops needing the API explained to it.
+
+## Quick Install
+
+Pick your agent and run the matching command:
+
+```bash
+# Kimi Code CLI
+npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y
+
+# Claude Code
+npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y
+
+# Codex
+npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
+
+# Cursor
+npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y
+
+# OpenClaw
+npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y
+
+# Hermes (no skills installer; plain curl into the skill dir)
+mkdir -p ~/.hermes/skills/treeship
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/skills/treeship/SKILL.md \
+  -o ~/.hermes/skills/treeship/SKILL.md
+```
+
+`-g` installs globally (one copy on the machine, every project sees it). `-y` skips the confirmation prompt — useful in CI and scripted setup.
+
+## What the Skill Teaches Your Agent
+
+- **Every Treeship CLI command** — `wrap`, `verify`, `session report`, `approve`, `hub push`, plus the v0.9.x setup/harness/agents surface for first-run orchestration.
+- **The Python and TypeScript SDK shapes** — `Treeship().attest_action()`, `Ship.attestAction()`, full result types and exceptions.
+- **The MCP bridge wiring** — exact `claude mcp add`, `kimi mcp add`, `cursor mcp.json` snippets the agent can paste back to a user who asks "how do I attach Treeship to my agent?".
+- **Approval-gated workflows** — the create-approval / consume-with-nonce / verify-with-replay-checks pattern, with realistic examples (deployment, payment authorization, scoped tool grants).
+- **Chained workflows** — multi-agent handoffs linked by `parent_id`, the chain walk that `treeship verify` runs, what passes vs. fails.
+- **The Hub API and public verification URLs** — DPoP auth, `/v1/artifacts`, public `/verify/<id>` endpoints, no API keys needed for verification.
+
+## MCP Bridge (optional, recommended for full coverage)
+
+The skill teaches the agent what to do. The MCP bridge ([`@treeship/mcp`](https://www.npmjs.com/package/@treeship/mcp)) captures whatever the agent does. Together they give High coverage without prompting.
+
+```bash
+# Claude Code
+claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
+
+# Kimi Code CLI
+kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
+
+# Cursor — add to ~/.cursor/mcp.json
+{
+  "mcpServers": {
+    "treeship": { "command": "npx", "args": ["-y", "@treeship/mcp"] }
+  }
+}
+```
+
+Codex's MCP config lives at `~/.codex/config.toml`; Hermes routes commands through `treeship wrap` per the skill's guidance rather than via MCP today.
+
+## Coverage Levels
+
+| Level | What Treeship sees | When |
+|---|---|---|
+| **High** | Every Read, Write, Bash, and MCP tool call captured automatically | Skill + MCP bridge attached, or Claude Code plugin installed |
+| **Medium** | Commands the agent explicitly wraps with `treeship wrap` (the skill tells it when this matters) | Skill alone, no MCP bridge |
+| **Basic** | Explicit `treeship wrap` calls for commands the user asked the agent to attest | Fallback when neither skill nor MCP is wired |
+
+The skill's job is to lift any agent from "doesn't know about Treeship" to at least Medium. Adding the MCP bridge — or installing the [Claude Code plugin](/integrations/claude-code) where available — lifts coverage to High. See the [coverage levels guide](/guides/coverage-levels) for the full ladder.
+
+## How It Works
+
+`SKILL.md` is a [YAML-frontmatter Markdown file](https://github.com/anthropics/skills) the agent loads as durable instructions. The frontmatter has a `name` and a `description`; the description is what the agent matches against the user's intent to decide when the skill applies. The body is regular Markdown — code blocks, tables, headings — that the agent reads as authoritative reference for the API.
+
+The skill is **declarative, not procedural**: it doesn't run anything itself. It teaches the agent the API and the right shape for each use case. The agent decides when to call the CLI or SDK based on what the user actually asked for. That keeps the skill safe (it's just text) and portable (the same file lands on every agent).
+
+## Updating
+
+```bash
+# Same install command — `-y` overwrites without prompting
+npx skills add zerkerlabs/treeship --skill treeship --agent <agent> -g -y
+```
+
+For Hermes, re-run the curl one-liner. The skill content is versioned with the Treeship release; each release that changes the CLI surface or SDK shape pushes a matching skill update. Pin to a specific release tag if you need stability:
+
+```bash
+npx skills add zerkerlabs/treeship@v0.10.0 --skill treeship --agent <agent> -g -y
+```
+
+## Removing
+
+```bash
+npx skills remove --skill treeship --agent <agent> -g
+
+# Or manual removal (any agent)
+rm -rf ~/.<agent-config-dir>/skills/treeship/
+```
+
+The skill leaves no other state behind — no daemons, no background processes, no tracking. Removing the directory un-installs cleanly.
+
+## Resources
+
+- [`skills/treeship/SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship/SKILL.md) — the skill content
+- [`integrations/agent-skills/README.md`](https://github.com/zerkerlabs/treeship/blob/main/integrations/agent-skills/README.md) — full multi-agent integration guide
+- [Claude Code integration](/integrations/claude-code) — higher-coverage path for Claude Code (plugin)
+- [Coverage levels](/guides/coverage-levels) — what High / Medium / Basic mean
+- [Install + registry topology](/guides/install) — what's on each registry and how to install Treeship itself

--- a/docs/content/docs/integrations/meta.json
+++ b/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
+  "pages": ["agent-skills", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
 }

--- a/integrations/agent-skills/README.md
+++ b/integrations/agent-skills/README.md
@@ -1,0 +1,214 @@
+# Agent Skills — Multi-Agent Integration
+
+One [`SKILL.md`](../../skills/treeship/SKILL.md) file teaches every coding agent how to use Treeship. Install it on Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, or Hermes and the agent can sign actions, verify chains, manage approvals, and push receipts to the Hub — all without you re-explaining the API every conversation.
+
+The skill covers the full Treeship surface: CLI commands (`treeship wrap`, `treeship verify`, `treeship session report`, `treeship approve`, `treeship hub push`), Python SDK (`treeship-sdk`), TypeScript SDK (`@treeship/sdk`), MCP bridge (`@treeship/mcp`), Hub API (`api.treeship.dev`), approval-gated workflows, and chained multi-agent handoffs.
+
+## Quick Reference
+
+| Agent | Install Command | `--agent` flag | Skills Path |
+|---|---|---|---|
+| Kimi Code CLI | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` | `kimi-cli` | `~/.config/agents/skills/` |
+| Claude Code | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` | `claude-code` | `~/.claude/skills/` |
+| Codex | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` | `codex` | `~/.codex/skills/` |
+| Cursor | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` | `cursor` | `~/.cursor/skills/` |
+| OpenClaw | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` | `openclaw` | `~/.openclaw/skills/` |
+| Hermes | Manual curl (see below) | — | `~/.hermes/skills/` |
+
+The `-g` installs globally (one copy on the machine, every project sees it). `-y` skips the confirmation prompt — useful in CI and scripted setup. Drop both for an interactive install scoped to the current project.
+
+## Per-Agent Setup
+
+### Kimi Code CLI
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y
+```
+
+The skill lands at `~/.config/agents/skills/treeship/SKILL.md` and auto-loads on every Kimi session. Verify:
+
+```bash
+ls ~/.config/agents/skills/treeship/
+# SKILL.md
+```
+
+**MCP bridge (optional)** — for automatic attestation of every tool call without prompting Kimi to run `treeship wrap`:
+
+```bash
+kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
+```
+
+**Coverage:** High when the MCP bridge is attached (every MCP tool call is captured); Medium with the skill alone (the agent runs `treeship wrap` when prompted by the skill).
+
+### Claude Code
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y
+```
+
+The skill lands at `~/.claude/skills/treeship/SKILL.md`. Claude Code reads agent skills automatically — no restart required for new sessions.
+
+**MCP bridge (recommended for full coverage)** — pairs with the skill so Claude Code attests automatically as well as explaining attestation when asked:
+
+```bash
+claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
+```
+
+**Plugin alternative** — Claude Code also supports the [Treeship plugin](../claude-code-plugin), which bundles the skill, MCP bridge, and SessionStart/PostToolUse/SessionEnd hooks into one install. Use the plugin when you want zero-config session sealing. Use the skill alone when you want the agent to know the API without auto-attaching a session.
+
+**Coverage:** High with the plugin; High with skill + MCP; Medium with skill alone.
+
+### Codex
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
+```
+
+Skill lands at `~/.codex/skills/treeship/SKILL.md`. Codex picks up new skills on the next conversation; no restart required.
+
+**MCP bridge (optional)** — Codex's MCP config lives at `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.treeship]
+command = "npx"
+args = ["-y", "@treeship/mcp"]
+```
+
+Or use Codex's CLI to add it:
+
+```bash
+codex mcp add treeship npx -y @treeship/mcp
+```
+
+**Coverage:** High with skill + MCP; Medium with skill alone.
+
+### Cursor
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y
+```
+
+Skill lands at `~/.cursor/skills/treeship/SKILL.md`. Cursor reads global skills on startup; restart Cursor (or open a new chat session) for the skill to register.
+
+**MCP bridge (optional)** — Cursor's MCP config lives at `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "treeship": {
+      "command": "npx",
+      "args": ["-y", "@treeship/mcp"]
+    }
+  }
+}
+```
+
+**Coverage:** High with skill + MCP; Medium with skill alone.
+
+### OpenClaw
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y
+```
+
+Skill lands at `~/.openclaw/skills/treeship/SKILL.md`. OpenClaw treats skills as durable instructions; the skill applies to every project where OpenClaw is active.
+
+**MCP bridge** — OpenClaw is currently MCP-routed only; the skill provides the API knowledge, the MCP bridge provides the capture surface. Add it the same way as Cursor (config at `~/.openclaw/mcp.json`).
+
+**Coverage:** Medium with skill alone; High with skill + MCP bridge.
+
+### Hermes
+
+Hermes doesn't have an automated skill installer, so the skill goes in via plain `curl`:
+
+```bash
+mkdir -p ~/.hermes/skills/treeship
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/skills/treeship/SKILL.md \
+  -o ~/.hermes/skills/treeship/SKILL.md
+```
+
+Hermes loads skills from `~/.hermes/skills/<skill_name>/SKILL.md` automatically on its next conversation.
+
+**MCP bridge** — Hermes uses skill files rather than an MCP transport, so the skill is the canonical integration. Coverage stays Medium because Hermes routes commands through `treeship wrap` per the skill's guidance rather than through a passive observer.
+
+**Coverage:** Medium (skill-driven; agent runs `treeship wrap` when needed).
+
+## MCP Bridge (optional, all agents)
+
+For agents that speak MCP (every supported agent except Hermes today), the [`@treeship/mcp`](https://www.npmjs.com/package/@treeship/mcp) bridge captures every tool call automatically. The skill teaches the agent what to do; the bridge captures whatever the agent does. Together they give High coverage without prompting.
+
+Generic install:
+
+```bash
+npm install -g @treeship/mcp     # optional pre-install; npx pulls it lazily
+```
+
+Per-agent commands above show the wiring. The MCP bridge runs on stdio, talks to the local `treeship` CLI, and attests every tool call into the active session — the same way `treeship wrap` would for a single command, but applied to the agent's full tool surface.
+
+## What the Skill Provides
+
+- **API reference** — every CLI command, SDK method, and Hub API endpoint, with realistic examples
+- **Statement type vocabulary** — when to attest action vs. approval vs. handoff vs. decision
+- **Approval-gated workflows** — the create-approval / consume-with-nonce / verify pattern
+- **Chained workflows** — `parent_id`-linked attestation chains across multi-agent handoffs
+- **MCP bridge wiring** — per-agent setup snippets the agent can paste back to a user
+- **Hub API surface** — DPoP auth, public verification URLs, Merkle inclusion proofs
+- **Standards reference** — Ed25519, DSSE, SHA-256, RFC 8785 canonicalization
+- **Result types** — `ActionResult`, `ApprovalResult`, `VerifyResult`, `PushResult`, `SessionReportResult`
+
+The skill is **declarative, not procedural**: it doesn't run anything itself. It teaches the agent the API and the right shape for each use case. The agent decides when to call the CLI / SDK based on what the user asked for.
+
+## Updating
+
+To pull the latest skill content after an upstream change:
+
+```bash
+# Same install command — `-y` overwrites without prompting
+npx skills add zerkerlabs/treeship --skill treeship --agent <agent> -g -y
+```
+
+For Hermes (manual install), re-run the curl one-liner.
+
+The skill content is versioned with the Treeship release — each `treeship` release that changes the CLI surface or SDK shape pushes a matching skill update. Pin to a specific release tag if you need stability:
+
+```bash
+npx skills add zerkerlabs/treeship@v0.10.0 --skill treeship --agent <agent> -g -y
+```
+
+## Removing
+
+```bash
+# Skills installer removal
+npx skills remove --skill treeship --agent <agent> -g
+
+# Manual removal (any agent)
+rm -rf ~/.<agent-config-dir>/skills/treeship/
+```
+
+The skill leaves no other state behind — no daemons, no background processes, no tracking. Removing the directory un-installs cleanly.
+
+## Coverage Levels by Agent
+
+| Agent | Skill alone | Skill + MCP | Plugin (where available) |
+|---|---|---|---|
+| Kimi Code CLI | Medium | High | — |
+| Claude Code | Medium | High | High |
+| Codex | Medium | High | — |
+| Cursor | Medium | High | — |
+| OpenClaw | Medium | High | — |
+| Hermes | Medium | (no MCP today) | — |
+
+**Coverage levels** match Treeship's [coverage-levels guide](https://docs.treeship.dev/guides/coverage-levels):
+
+- **High** — Treeship sees every Read, Write, Bash, MCP tool call. The agent's full execution surface is captured.
+- **Medium** — Treeship sees the commands the agent explicitly wraps with `treeship wrap` (the skill teaches the agent when this matters); other tool calls aren't captured.
+- **Basic** — fallback. The agent knows about Treeship and runs `treeship wrap` for explicit commands the user asked it to attest, but no passive observation.
+
+The skill's job is to lift any agent from "doesn't know about Treeship" to at least Medium. Adding the MCP bridge (or installing the plugin where available) lifts coverage to High.
+
+## See Also
+
+- [`skills/treeship/SKILL.md`](../../skills/treeship/SKILL.md) — the skill content itself
+- [Claude Code plugin](../claude-code-plugin) — the higher-coverage path for Claude Code
+- [Treeship docs — integrations](https://docs.treeship.dev/integrations) — per-agent integration pages
+- [Treeship docs — coverage levels](https://docs.treeship.dev/guides/coverage-levels) — what High/Medium/Basic mean

--- a/skills/treeship/SKILL.md
+++ b/skills/treeship/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: treeship
+description: Create cryptographically signed, portable trust receipts for AI agent workflows using Treeship.dev. Use when the user wants to sign agent actions, create verifiable receipts, wrap commands with attestations, verify artifact chains, push artifacts to the Treeship Hub, manage approval-gated actions, or integrate Treeship into their agent workflow. Covers the Treeship CLI (treeship), Python SDK (treeship-sdk), TypeScript SDK (@treeship/sdk), MCP bridge (@treeship/mcp), and Hub API (api.treeship.dev). Trigger on any mention of attestation, verifiable receipts, signed receipts, agent trust, Treeship, action signing, cryptographic proof of agent work, portable receipts, approval workflows, session receipts, Merkle proofs, decision cards, or coverage levels.
+---
+
+# Treeship — Portable Trust Receipts for Agent Workflows
+
+Local-first. Cryptographically verifiable. Works offline. Ed25519 signatures. SHA-256 content hashing. Merkle proofs. The receipt is yours, not ours.
+
+## Quick Start
+
+```bash
+# Install Treeship
+curl -fsSL treeship.dev/setup | sh
+
+# Core loop
+treeship wrap -- npm test        # sign what happened
+treeship verify last             # verify offline
+treeship hub push last           # share verify URL
+```
+
+## When to Use Treeship
+
+- **Sign agent actions** — tamper-proof receipts of what an agent did
+- **Verify workflows** — cryptographically verify chains of actions
+- **Audit agent work** — evidence, not chat logs
+- **Gate sensitive actions** — human approval before execution
+- **Hand off between agents** — cryptographically signed transitions
+- **Share verification URLs** — publish to treeship.dev
+- **Comply with requirements** — auditable proof of behavior
+
+## Installation
+
+```bash
+# One-liner (setup + init + instrument)
+curl -fsSL treeship.dev/setup | sh
+
+# Step by step
+curl -fsSL treeship.dev/install | sh
+treeship init
+treeship setup
+
+# Python SDK
+pip install treeship-sdk
+
+# TypeScript SDK
+npm install -g treeship
+npm install @treeship/sdk
+npm install @treeship/mcp
+```
+
+## Core CLI Commands
+
+```bash
+treeship wrap -- <command>              # wrap with signed receipt
+treeship verify <id>                    # verify chain
+treeship verify last                    # verify most recent
+treeship session start --name "..."     # start session
+treeship session close                  # close session
+treeship session report                 # upload receipt
+treeship hub push last                  # push to Hub
+treeship approve --approver human://... # create approval
+treeship wrap --approval-nonce <n> --   # use approval
+treeship init                           # keypair generation
+treeship key show                       # show public key
+treeship inspect <id>                   # inspect artifact
+treeship doctor                         # check workspace
+treeship ui                             # TUI dashboard
+treeship setup                          # guided first-run
+treeship add --discover                 # discover agents
+treeship harness list                   # list harnesses
+treeship harness inspect <id>           # inspect harness
+treeship harness smoke <id>             # smoke test
+```
+
+## Actor URIs
+
+- `agent://<name>` — AI agent
+- `human://<name>` — Human operator
+- `agent://ci-pipeline` — CI/CD system
+
+## Statement Types
+
+| Type | Purpose | Method |
+|------|---------|--------|
+| `treeship/action/v1` | Agent did something | `attest_action()` / `wrap` |
+| `treeship/approval/v1` | Someone approved | `attest_approval()` / `approve` |
+| `treeship/handoff/v1` | Work moved between agents | `attest_handoff()` |
+| `treeship/decision/v1` | LLM made a decision | `attest_decision()` |
+| `treeship/use/v1` | Approval consumed | auto (v0.9.9+) |
+
+## Python SDK
+
+```python
+from treeship_sdk import Treeship
+
+ts = Treeship()
+
+# Attest action
+result = ts.attest_action(
+    actor="agent://my-agent",
+    action="tool.call",
+    parent_id="art_abc123",
+    approval_nonce="nonce_xyz",
+    meta={"tool": "read_file", "path": "src/main.rs"}
+)
+print(result.artifact_id)  # art_...
+
+# Attest approval
+approval = ts.attest_approval(
+    approver="human://alice",
+    description="approve deployment",
+    expires_in=3600
+)
+print(approval.artifact_id, approval.nonce)
+
+# Verify
+verified = ts.verify(result.artifact_id)
+# verified.outcome: "pass" | "fail" | "error"
+# verified.chain: number of linked artifacts
+
+# Push to Hub
+push = ts.dock_push(result.artifact_id)
+# push.hub_url: https://treeship.dev/verify/art_xxx
+
+# Wrap command
+result = ts.wrap("npm test", actor="agent://ci")
+
+# Session report
+report = ts.session_report()
+# report.receipt_url: permanent public URL
+```
+
+## TypeScript SDK
+
+```typescript
+import { Ship } from "@treeship/sdk";
+
+const ship = await Ship.init("./.treeship", "agent://my-agent");
+
+const { receipt } = ship.attestAction({
+  actor: { type: "agent", id: "agent://my-agent" },
+  actionType: "tool.call",
+  actionName: "search.web",
+  inputs: JSON.stringify({ query: "AI safety" }),
+  outputs: JSON.stringify({ results: ["paper1"] }),
+});
+
+ship.attestHandoff({
+  fromActor: { type: "agent", id: "agent://researcher" },
+  toActor: { type: "agent", id: "agent://writer" },
+  taskCommitment: "complete-report",
+});
+
+ship.createCheckpoint();
+const bundle = ship.createBundle("Workflow");
+await ship.save();
+```
+
+## Approval-Gated Actions
+
+```python
+# 1. Human creates approval
+approval = ts.attest_approval(
+    approver="human://alice",
+    description="approve payment up to $500",
+    expires_in=3600
+)
+
+# 2. Agent uses approval nonce
+result = ts.attest_action(
+    actor="agent://executor",
+    action="stripe.charge.create",
+    approval_nonce=approval.nonce,
+    meta={"amount": 299.00}
+)
+
+# 3. Verify (checks replay levels)
+verified = ts.verify(result.artifact_id)
+```
+
+## Chained Workflow
+
+```python
+prev_id = None
+for step in [
+    {"actor": "agent://researcher", "action": "search.web"},
+    {"actor": "agent://analyst", "action": "analyze.data"},
+    {"actor": "agent://writer", "action": "generate.report"},
+]:
+    result = ts.attest_action(
+        actor=step["actor"],
+        action=step["action"],
+        parent_id=prev_id
+    )
+    prev_id = result.artifact_id
+
+result = ts.verify(prev_id)
+print(f"Chain: {result.outcome}, {result.chain} steps")
+```
+
+## MCP Bridge
+
+For agents with MCP support, add Treeship as an MCP server:
+
+```bash
+# Claude Code
+claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
+
+# Kimi Code CLI
+kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
+
+# Cursor
+# Add to ~/.cursor/mcp.json:
+{
+  "mcpServers": {
+    "treeship": {
+      "command": "npx",
+      "args": ["-y", "@treeship/mcp"]
+    }
+  }
+}
+```
+
+## Hub API
+
+- Base: `https://api.treeship.dev/v1/`
+- Auth: DPoP (no API keys)
+- `POST /v1/artifacts` — push artifact
+- `GET /v1/verify/:id` — public verification (no auth)
+- `PUT /v1/receipt/{session_id}` — upload session receipt
+- `GET /v1/merkle/:id` — Merkle inclusion proof
+
+Public URLs: `https://treeship.dev/verify/{artifact_id}`
+
+## Result Types
+
+```python
+ActionResult(artifact_id: str)
+ApprovalResult(artifact_id: str, nonce: str)
+VerifyResult(outcome: str, chain: int, target: str)
+PushResult(hub_url: str, rekor_index: Optional[int])
+SessionReportResult(session_id, receipt_url, agents, events)
+```
+
+All methods raise `TreeshipError` on failure.
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `TREESHIP_API_KEY` | Hub API key (optional) |
+| `TREESHIP_AGENT` | Default agent slug |
+| `TREESHIP_HUB_ID` | Hub workspace ID |
+
+## Key Files
+
+- `~/.treeship/` — config, keys, local receipt store
+- `~/.treeship/sessions/` — session packages
+- `.treeship/` — project-local ship
+
+## Standards
+
+- **Ed25519** (RFC 8032) — signatures
+- **DSSE** — envelope format (Sigstore/in-toto compatible)
+- **SHA-256** — content addressing + Merkle tree
+- **RFC 8785** — JSON canonicalization
+
+## Resources
+
+- Docs: https://docs.treeship.dev
+- Hub: https://treeship.dev
+- GitHub: https://github.com/zerkerlabs/treeship


### PR DESCRIPTION
# feat: Add Treeship Agent Skills — One skill, every agent

Adds a single `SKILL.md` that teaches Kimi Code CLI, Claude Code, Codex, Cursor, OpenClaw, and Hermes how to use Treeship — CLI commands, both SDKs, MCP bridge wiring, approval-gated workflows, multi-agent handoffs, Hub API. The skill is declarative (just text); the agent decides when to apply it. One file, every supported agent.

The skill is the missing piece in the agent-native experience: pair it with the [v0.10.0 receipt-sharing release](https://github.com/zerkerlabs/treeship/releases) and an agent on a fresh machine can install Treeship, run a session, share a receipt, and hand the human a verifiable URL — all without re-explaining the API.

## What's Added

```
treeship/
├── skills/
│   └── treeship/
│       └── SKILL.md                         (new — the universal skill)
├── integrations/
│   └── agent-skills/
│       └── README.md                        (new — multi-agent setup guide)
└── docs/
    └── content/
        ├── docs/integrations/
        │   └── agent-skills.mdx             (new — docs page)
        └── blog/
            └── multi-agent-skills.mdx       (new — launch post)
```

Total: 4 new files (5 if you count this PR description).

## Supported Agents

| Agent | Install Command |
|---|---|
| Kimi Code CLI | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` |
| Claude Code | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` |
| Codex | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` |
| Cursor | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` |
| OpenClaw | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` |
| Hermes | `mkdir -p ~/.hermes/skills/treeship && curl -fsSL <SKILL.md raw url> -o ~/.hermes/skills/treeship/SKILL.md` |

`-g` installs globally (every project on the machine sees it). `-y` skips the confirm prompt — useful in CI / scripted setup.

## What the Skill Teaches

- **Every Treeship CLI command** — `wrap`, `verify`, `session report`, `approve`, `hub push`, plus the v0.9.x setup / harness / agents surface.
- **Python SDK shape** — `Treeship().attest_action()`, `attest_approval()`, `attest_decision()`, `verify()`, `dock_push()`, `session_report()`.
- **TypeScript SDK shape** — `Ship.init()`, `attestAction()`, `attestHandoff()`, `createCheckpoint()`, `createBundle()`.
- **Approval-gated workflows** — the create-approval / consume-with-nonce / verify-with-replay-checks pattern.
- **Chained workflows** — multi-agent handoffs linked by `parent_id`, the chain walk `treeship verify` runs.
- **MCP bridge wiring per agent** — `claude mcp add`, `kimi mcp add`, Cursor `mcp.json`, Codex `config.toml` snippets.
- **Hub API surface** — DPoP auth, public verification URLs, Merkle inclusion proofs.
- **Standards reference** — Ed25519 (RFC 8032), DSSE, SHA-256, RFC 8785 canonicalization.

The skill is **declarative, not procedural**: it doesn't run anything itself. It teaches the agent the API and the right shape for each use case. The agent decides when to call the CLI or SDK based on what the user actually asked for. That keeps the skill safe (it's just text) and portable (same file, every agent).

## MCP Bridge

The skill teaches the agent what to do. The optional MCP bridge ([`@treeship/mcp`](https://www.npmjs.com/package/@treeship/mcp)) captures whatever the agent does. Together they give High coverage without prompting — every Read, Write, Bash, and MCP tool call gets attested automatically.

```bash
claude mcp add --transport stdio treeship -- npx -y @treeship/mcp
kimi mcp add --transport stdio treeship -- npx -y @treeship/mcp
# Cursor / Codex / OpenClaw — add to their respective MCP config (see integration guide)
```

Hermes uses skill-driven `treeship wrap` calls (no MCP today); coverage stays Medium.

## Files to Review

- `skills/treeship/SKILL.md` — the skill content. The frontmatter `description` is what the agent matches against the user's intent; verify the trigger phrases cover the cases you care about.
- `integrations/agent-skills/README.md` — the per-agent setup guide. Verify the install path table and per-agent MCP wiring.
- `docs/content/docs/integrations/agent-skills.mdx` — the docs site page (Fumadocs format). Wired into `docs/content/docs/integrations/meta.json` as the first entry under "Integrations" so it surfaces ahead of the per-agent pages.
- `docs/content/blog/multi-agent-skills.mdx` — the launch post.

## After Merging

- The skill is publishable to the [`skills add`](https://github.com/anthropics/skills) registry under `zerkerlabs/treeship` so the install commands above resolve. Coordinate with the skills registry team or run the publish step out-of-band; this PR doesn't gate on it.
- Update [docs.treeship.dev](https://docs.treeship.dev/integrations/agent-skills) homepage / landing if you want to surface the skill as a top-level "first thing every agent should install" CTA.
- Announce on the Treeship blog (the launch post in this PR is ready to go live as soon as the merge lands — it's wired into `docs/content/blog/`).
- Consider versioning the skill content with each release: each `treeship` release that changes the CLI surface or SDK shape should push a matching `SKILL.md` update. The "Updating" section of the integration guide already tells users how to pin (`npx skills add zerkerlabs/treeship@v0.10.0 ...`).

## Testing Checklist

- [ ] `SKILL.md` frontmatter parses (YAML head + Markdown body)
- [ ] All install commands in the integration guide and docs page reference the right agent flag and path
- [ ] Every link in the docs page resolves to an existing route (`/integrations/claude-code`, `/guides/coverage-levels`, `/guides/install`)
- [ ] Blog post date is correct and `tags` field matches the existing blog format

## Related

- [v0.10.0 — Agent-Native Receipt Sharing](../../releases) — the receipt-side companion to this skill (server-rendered receipt pages, agent-native JSON contract, downloadable `.treeship` packages)
- [Coverage levels](https://docs.treeship.dev/guides/coverage-levels) — what High / Medium / Basic actually mean
- [Anthropic Skills docs](https://github.com/anthropics/skills) — the SKILL.md format spec
