### PR TITLE
fix(mcp): v0.10.1 PR 0 — real stdio MCP server

### DIFF
--- a/bridges/mcp/ATTACHING.md
+++ b/bridges/mcp/ATTACHING.md
@@ -6,6 +6,15 @@ Treeship is a **trust fabric**, not an agent. The product promise is:
 
 This document shows how to attach any MCP-compatible coding agent so its tool calls flow into a Treeship session and end up on a shareable receipt at `treeship.dev/receipt/<id>`.
 
+## What ships today (v0.10)
+
+`@treeship/mcp` ships in two modes:
+
+1. **MCP server mode** (new in 0.10.1) — add `npx -y @treeship/mcp` as an MCP server in your agent's config. The server exposes Treeship tools (`treeship_session_status`, `treeship_session_event`, `treeship_attest_action`, `treeship_verify`, `treeship_session_report`) so any MCP client can read/write the active session.
+2. **Library mode** — `import { Client } from '@treeship/mcp'` to drop-in replace your `@modelcontextprotocol/sdk` client; every `callTool()` it makes is signed and recorded automatically.
+
+The **transparent forwarder** model described below — where the bridge proxies every call to an upstream MCP server and attests in between — is roadmap (target v0.11). The diagram and "what the agent sees" sections describe that future shape, not today's behavior. If you need every MCP tool call attested today, use library mode.
+
 ## How it works (one diagram)
 
 ```

--- a/bridges/mcp/README.md
+++ b/bridges/mcp/README.md
@@ -32,7 +32,27 @@ treeship package verify <path-to-receipt.treeship>
 
 The verify command is pure WASM — it does not phone home and does not require the hub. So once you have a receipt (your own or someone else's), you can confirm exactly what was captured, by whom, and that the signatures hold, entirely offline.
 
-## Usage
+## Two ways to use it
+
+**As an MCP server** (new in 0.10.1) — add it to your agent's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "treeship": {
+      "command": "npx",
+      "args": ["-y", "@treeship/mcp"],
+      "env": { "TREESHIP_ACTOR": "agent://your-agent" }
+    }
+  }
+}
+```
+
+The server exposes 5 tools your agent can call: `treeship_session_status`, `treeship_session_event`, `treeship_attest_action`, `treeship_verify`, `treeship_session_report`. Use these to read or write the active Treeship session from any MCP-compatible client.
+
+**As a library** — wrap your existing MCP client. Every `callTool()` gets signed automatically.
+
+## Library usage
 
 Change one import. Everything else stays the same.
 

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -9,7 +9,12 @@
       "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@treeship/core-wasm": "0.10.0",
+        "zod": "^3.25.76"
+      },
+      "bin": {
+        "treeship-mcp": "dist/server.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -867,6 +872,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@treeship/core-wasm": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.10.0.tgz",
+      "integrity": "sha512-aFzJ26hzD2b4gMGCDv14XXc3EguT9ojECGFakFP9//WGxfmY8ojnz75RaKwCweZPNYeB56G/IaBODyksrcAVZg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2699,9 +2710,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -22,15 +22,22 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "treeship-mcp": "./dist/server.js"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server.js"
     }
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.10.0"
+    "@treeship/core-wasm": "0.10.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/src/server.ts
+++ b/bridges/mcp/src/server.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { z } from 'zod';
+
+const exec = promisify(execFile);
+
+const TREESHIP_BIN = process.env.TREESHIP_BIN || 'treeship';
+const ACTOR = process.env.TREESHIP_ACTOR || 'agent://mcp';
+const TIMEOUT_MS = 10_000;
+
+type ExecResult = { stdout: string; stderr: string; code: number };
+
+async function runTreeship(args: string[]): Promise<ExecResult> {
+  try {
+    const { stdout, stderr } = await exec(TREESHIP_BIN, args, { timeout: TIMEOUT_MS });
+    return { stdout, stderr, code: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e?.stdout ?? '',
+      stderr: e?.stderr ?? String(e?.message ?? e),
+      code: typeof e?.code === 'number' ? e.code : 1,
+    };
+  }
+}
+
+function textResult(text: string, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text }],
+    isError,
+  };
+}
+
+function formatExec({ stdout, stderr, code }: ExecResult): { content: any[]; isError: boolean } {
+  if (code === 0) {
+    return textResult(stdout.trim() || stderr.trim() || 'ok');
+  }
+  const msg = (stderr || stdout || `treeship exited with code ${code}`).trim();
+  return textResult(msg, true);
+}
+
+const server = new McpServer(
+  { name: 'treeship', version: '0.10.0' },
+  { capabilities: { tools: {} } },
+);
+
+server.registerTool(
+  'treeship_session_status',
+  {
+    title: 'Treeship session status',
+    description:
+      'Show the active Treeship session: id, name, started_at, event count, and the current actor. Returns JSON.',
+    inputSchema: {},
+  },
+  async () => formatExec(await runTreeship(['session', 'status', '--format', 'json'])),
+);
+
+server.registerTool(
+  'treeship_session_event',
+  {
+    title: 'Append a session event',
+    description:
+      'Append a structured event to the active Treeship session. Use type=agent.note for free-form notes the agent wants on the receipt timeline.',
+    inputSchema: {
+      type: z.string().describe('Event type, e.g. agent.note, agent.decision, agent.handoff'),
+      tool: z.string().optional().describe('Tool name, when applicable'),
+      durationMs: z.number().int().optional(),
+      exitCode: z.number().int().optional(),
+      meta: z.record(z.unknown()).optional().describe('Free-form metadata (no secrets)'),
+    },
+  },
+  async ({ type, tool, durationMs, exitCode, meta }) => {
+    const args = [
+      'session', 'event',
+      '--type', type,
+      '--actor', ACTOR,
+      '--agent-name', ACTOR.replace(/^agent:\/\//, ''),
+    ];
+    if (tool) args.push('--tool', tool);
+    if (durationMs != null) args.push('--duration-ms', String(durationMs));
+    if (exitCode != null) args.push('--exit-code', String(exitCode));
+    if (meta && Object.keys(meta).length > 0) {
+      args.push('--meta', JSON.stringify(meta));
+    }
+    return formatExec(await runTreeship(args));
+  },
+);
+
+server.registerTool(
+  'treeship_attest_action',
+  {
+    title: 'Sign an action attestation',
+    description:
+      'Sign a Treeship action artifact recording that the agent is about to do something. Returns the artifact id as JSON.',
+    inputSchema: {
+      action: z.string().describe('Action label, e.g. mcp.fetch.intent or git.commit.intent'),
+      parentId: z.string().optional().describe('Parent artifact id for chaining'),
+      meta: z.record(z.unknown()).optional(),
+    },
+  },
+  async ({ action, parentId, meta }) => {
+    const args = [
+      'attest', 'action',
+      '--actor', ACTOR,
+      '--action', action,
+      '--format', 'json',
+    ];
+    if (parentId) args.push('--parent', parentId);
+    if (meta && Object.keys(meta).length > 0) {
+      args.push('--meta', JSON.stringify(meta));
+    }
+    return formatExec(await runTreeship(args));
+  },
+);
+
+server.registerTool(
+  'treeship_verify',
+  {
+    title: 'Verify an artifact or chain',
+    description:
+      'Verify a Treeship artifact id and its parent chain. Returns the verification result.',
+    inputSchema: {
+      artifactId: z.string().describe('Artifact id (e.g. art_...) or path to a .treeship file'),
+      chain: z.boolean().optional().describe('Walk the full parent chain (default true)'),
+    },
+  },
+  async ({ artifactId, chain }) => {
+    const args = ['verify', artifactId];
+    if (chain !== false) args.push('--chain');
+    return formatExec(await runTreeship(args));
+  },
+);
+
+server.registerTool(
+  'treeship_session_report',
+  {
+    title: 'Publish session report',
+    description:
+      'Close-and-publish the active session as a shareable report on the configured hub. Returns the report URL.',
+    inputSchema: {
+      summary: z.string().optional().describe('Headline summary for the report'),
+    },
+  },
+  async ({ summary }) => {
+    const args = ['session', 'report'];
+    if (summary) args.push('--summary', summary);
+    return formatExec(await runTreeship(args));
+  },
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(err => {
+  process.stderr.write(`[treeship-mcp] fatal: ${err?.stack ?? err}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What changed

Adds a real stdio MCP server to `@treeship/mcp` so `npx -y @treeship/mcp` actually boots when configured as an MCP server in Claude Code, Codex CLI, Cursor, etc.

- **NEW** `bridges/mcp/src/server.ts` — stdio MCP server exposing five Treeship tools:
  - `treeship_session_status`
  - `treeship_session_event`
  - `treeship_attest_action`
  - `treeship_verify`
  - `treeship_session_report`
- `bridges/mcp/package.json` — declares `bin: { "treeship-mcp": "./dist/server.js" }` so npm can resolve the executable. Adds `zod` for tool input schemas. Adds `./server` export path.
- `bridges/mcp/README.md` — adds "MCP server mode" section so users know there are two distinct ways to use the package.
- `bridges/mcp/ATTACHING.md` — adds a "What ships today (v0.10.1)" callout that distinguishes server mode (this PR), library mode (existing `TreeshipMCPClient`), and the **transparent forwarder** model that was previously documented but never built.

## v0.10.0 review finding closed

> "@treeship/mcp v0.10.0 was a Client wrapper class only — no stdio server, no `bin` entry. Configuring it as an MCP server (`npx -y @treeship/mcp`) silently failed because npm could not resolve a binary to run."

This was discovered during multi-agent onboarding work (Claude / Codex / Kimi attaching to a shared Treeship session). The MCP route was a hard blocker; without a real server, every agent integration via MCP returned `Failed to connect`.

## Tests run

Verified end-to-end against the locally-built server:

- **JSON-RPC handshake** — `initialize` → `notifications/initialized` → `tools/list` returns the five tools.
- **`tools/call treeship_session_status`** — forwards to the `treeship` CLI, returns the active session state, structured response.
- **`tools/call treeship_attest_action`** — signs an action via the CLI, returns the artifact id.
- **Claude Code integration** — after pointing the plugin's `.mcp.json` at the local `dist/server.js`, `claude mcp list` reports `plugin:treeship:treeship — ✓ Connected`.

The library-mode tests (`TreeshipMCPClient`) still pass; this PR is additive.

## What is intentionally out of scope

- **Transparent forwarder model.** `ATTACHING.md` previously promised that the bridge would proxy every `callTool` to an upstream MCP server and attest in between. That model is non-trivial (needs upstream-server config, schema for which servers to attest, etc.) and has no users today. It stays roadmap.
- **Auto-instrumentation of every Claude tool call.** That's covered by the existing native PostToolUse hook in the claude-code plugin, not by the MCP server.

## Independent or stacked

**Independent.** Branched off main; no dependencies on other v0.10.1 PRs.

## Part of v0.10.1 — Platform, SDK, Supply Chain, and MCP Hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)