### PR TITLE
fix(sdk-python): v0.10.1 PR 2 — correctness and validation

### DIFF
--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -1,0 +1,280 @@
+"""Unit tests for treeship_sdk.client.
+
+Run with: python -m unittest discover -s packages/sdk-python/tests
+
+Tests stub subprocess.run so they pass without a real treeship CLI.
+"""
+
+import json
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from treeship_sdk import (
+    SessionReportResult,
+    Treeship,
+    TreeshipError,
+)
+from treeship_sdk.client import _OPTION_LIKE, _reject_option_like
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Helper to build a mock subprocess.CompletedProcess."""
+    cp = subprocess.CompletedProcess(
+        args=["treeship"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+    return cp
+
+
+class VersionDerivationTests(unittest.TestCase):
+    def test_version_resolves_from_metadata_or_fallback(self) -> None:
+        from treeship_sdk import __version__
+
+        self.assertIsInstance(__version__, str)
+        self.assertTrue(__version__)
+        # Either a real semver-ish string from the installed package, or
+        # the explicit fallback when running from an uninstalled source.
+        self.assertTrue(
+            __version__[0].isdigit() or __version__ == "0.0.0+unknown",
+            f"unexpected version shape: {__version__!r}",
+        )
+
+
+class OptionInjectionTests(unittest.TestCase):
+    def test_rejects_dash_dash_format(self) -> None:
+        with self.assertRaises(TreeshipError):
+            _reject_option_like("actor", "--format")
+
+    def test_rejects_short_option(self) -> None:
+        with self.assertRaises(TreeshipError):
+            _reject_option_like("actor", "-x")
+
+    def test_allows_uri_with_dashes_inside(self) -> None:
+        # Common actor URI: agent://my-agent
+        self.assertEqual(
+            _reject_option_like("actor", "agent://my-agent"),
+            "agent://my-agent",
+        )
+
+    def test_allows_artifact_id(self) -> None:
+        self.assertEqual(
+            _reject_option_like("artifact_id", "art_abc123"),
+            "art_abc123",
+        )
+
+    def test_attest_action_rejects_option_like_actor(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.attest_action(actor="--format", action="x")
+
+    def test_verify_rejects_option_like_artifact(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.verify("--help")
+
+
+class WrapBehaviorTests(unittest.TestCase):
+    def test_wrap_str_preserves_quoted_args_via_shlex(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1"}),
+            )
+            ts.wrap("python -c 'print(1)'")
+
+            argv = mock_run.call_args.args[0]
+            # Find the position after "--" -- everything after is the wrapped argv.
+            split_at = argv.index("--")
+            wrapped = argv[split_at + 1:]
+            self.assertEqual(wrapped, ["python", "-c", "print(1)"])
+
+    def test_wrap_sequence_passes_argv_exactly(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1"}),
+            )
+            ts.wrap(["python", "-c", "print('hi mom')"])
+
+            argv = mock_run.call_args.args[0]
+            split_at = argv.index("--")
+            wrapped = argv[split_at + 1:]
+            self.assertEqual(wrapped, ["python", "-c", "print('hi mom')"])
+
+    def test_wrap_empty_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.wrap("")
+        with self.assertRaises(TreeshipError):
+            ts.wrap([])
+
+
+class BinaryResolutionTests(unittest.TestCase):
+    def test_default_uses_treeship_on_path(self) -> None:
+        ts = Treeship()
+        self.assertEqual(ts.binary, "treeship")
+
+    def test_cli_path_overrides(self) -> None:
+        ts = Treeship(cli_path="/opt/treeship/bin/treeship")
+        self.assertEqual(ts.binary, "/opt/treeship/bin/treeship")
+
+    def test_explicit_cli_path_threaded_through_to_subprocess(self) -> None:
+        ts = Treeship(cli_path="/opt/treeship/bin/treeship")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1"}),
+            )
+            ts.attest_action(actor="agent://test", action="x")
+
+            argv = mock_run.call_args.args[0]
+            self.assertEqual(argv[0], "/opt/treeship/bin/treeship")
+
+    def test_timeout_override_threaded_through(self) -> None:
+        ts = Treeship(cli_path="/treeship", timeout=42)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1"}),
+            )
+            ts.attest_action(actor="agent://t", action="x")
+            self.assertEqual(mock_run.call_args.kwargs["timeout"], 42)
+
+
+class ArtifactIdHandlingTests(unittest.TestCase):
+    def test_empty_artifact_id_raises(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json.dumps({}))
+            with self.assertRaises(TreeshipError) as ctx:
+                ts.attest_action(actor="agent://t", action="x")
+            self.assertIn("no artifact id", str(ctx.exception))
+
+    def test_artifact_id_under_id_key(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json.dumps({"id": "art_aaa"}))
+            r = ts.attest_action(actor="agent://t", action="x")
+            self.assertEqual(r.artifact_id, "art_aaa")
+
+    def test_artifact_id_under_artifact_id_key(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"artifact_id": "art_bbb"}),
+            )
+            r = ts.attest_action(actor="agent://t", action="x")
+            self.assertEqual(r.artifact_id, "art_bbb")
+
+
+class SessionReportTests(unittest.TestCase):
+    def test_session_report_uses_json_format(self) -> None:
+        ts = Treeship()
+        json_payload = json.dumps({
+            "schema": "treeship/share-result/v1",
+            "session_id": "ssn_01",
+            "receipt_url": "https://treeship.dev/r/abc",
+            "verification_status": "ok",
+            "warnings": [],
+        })
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json_payload)
+            r = ts.session_report()
+
+            argv = mock_run.call_args.args[0]
+            self.assertIn("--format", argv)
+            self.assertIn("json", argv)
+            self.assertEqual(r.session_id, "ssn_01")
+            self.assertEqual(r.receipt_url, "https://treeship.dev/r/abc")
+
+    def test_session_report_falls_back_to_text_when_json_missing(self) -> None:
+        ts = Treeship()
+        # First call: simulate older CLI returning non-JSON text.
+        # Second call (text fallback): regex-parsed text.
+        text_output = (
+            "session: ssn_old\n"
+            "receipt: https://treeship.dev/r/legacy\n"
+            "agents: 2\n"
+            "events: 17\n"
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                _completed(stdout="not json", returncode=0),
+                _completed(stdout=text_output, returncode=0),
+            ]
+            r = ts.session_report()
+            self.assertEqual(r.session_id, "ssn_old")
+            self.assertEqual(r.receipt_url, "https://treeship.dev/r/legacy")
+            self.assertEqual(r.agents, 2)
+            self.assertEqual(r.events, 17)
+
+    def test_session_report_raises_when_neither_format_works(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                _completed(stdout="not json", returncode=0),
+                _completed(stdout="garbage", returncode=0),
+            ]
+            with self.assertRaises(TreeshipError):
+                ts.session_report()
+
+
+class LengthAndRangeValidationTests(unittest.TestCase):
+    def test_actor_too_long_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError) as ctx:
+            ts.attest_action(actor="a" * 257, action="x")
+        self.assertIn("actor", str(ctx.exception))
+        self.assertIn("max is 256", str(ctx.exception))
+
+    def test_summary_too_long_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError) as ctx:
+            ts.attest_decision(actor="agent://t", summary="x" * 4097)
+        self.assertIn("summary", str(ctx.exception))
+
+    def test_confidence_out_of_range_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError) as ctx:
+            ts.attest_decision(actor="agent://t", confidence=1.5)
+        self.assertIn("confidence", str(ctx.exception))
+
+        with self.assertRaises(TreeshipError):
+            ts.attest_decision(actor="agent://t", confidence=-0.1)
+
+    def test_confidence_nan_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.attest_decision(actor="agent://t", confidence=float("nan"))
+
+    def test_confidence_in_range_passes(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json.dumps({"id": "art_1"}))
+            # All four boundary values must pass.
+            for c in (0.0, 0.5, 1.0):
+                ts.attest_decision(actor="agent://t", confidence=c)
+
+    def test_negative_tokens_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.attest_decision(actor="agent://t", tokens_in=-1)
+        with self.assertRaises(TreeshipError):
+            ts.attest_decision(actor="agent://t", tokens_out=-5)
+
+    def test_artifact_id_too_long_raises(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.verify("a" * 257)
+
+
+class CLIMissingErrorTests(unittest.TestCase):
+    def test_file_not_found_carries_actionable_message(self) -> None:
+        ts = Treeship(cli_path="/does/not/exist/treeship")
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            with self.assertRaises(TreeshipError) as ctx:
+                ts.attest_action(actor="agent://t", action="x")
+            self.assertIn("/does/not/exist/treeship", str(ctx.exception))
+            self.assertIn("bot_mode=True", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/sdk-python/treeship_sdk/__init__.py
+++ b/packages/sdk-python/treeship_sdk/__init__.py
@@ -33,4 +33,26 @@ __all__ = [
     "TreeshipError",
     "ensure_cli",
 ]
-__version__ = "0.10.0"
+
+
+def _resolve_version() -> str:
+    # Single source of truth: the package metadata. Hardcoding the
+    # string here forced two parallel version sites (this file and
+    # pyproject.toml) and the version-bump script regularly missed one
+    # of them, producing the v0.10 dogfood smoke where pip installed
+    # 0.10.0 but reported 0.9.x. importlib.metadata.version reads
+    # whichever metadata the active install came with.
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:  # Python < 3.8 -- not supported, but defensive.
+        return "0.0.0+unknown"
+    try:
+        return version("treeship-sdk")
+    except PackageNotFoundError:
+        # Source checkout without an installed dist (`pip install -e .`
+        # not run yet, or a sys.path tweak). Returning a sentinel beats
+        # raising on import.
+        return "0.0.0+unknown"
+
+
+__version__ = _resolve_version()

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -1,10 +1,15 @@
 """Treeship SDK client. Wraps the treeship CLI binary."""
 
+from __future__ import annotations
+
 import json
+import os
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 from treeship_sdk.bootstrap import (
     BootstrapResult,
@@ -16,9 +21,9 @@ from treeship_sdk.bootstrap import (
 class TreeshipError(Exception):
     """Error from the treeship CLI."""
 
-    def __init__(self, message: str, args: List[str]):
+    def __init__(self, message: str, args: Sequence[str]):
         super().__init__(message)
-        self.args_used = args
+        self.args_used = list(args)
 
 
 @dataclass
@@ -53,8 +58,9 @@ class SessionReportResult:
     receipt_url -- the permanent public URL where the receipt is served;
                    safe to share, no auth required to fetch
     agents      -- number of distinct agents the hub extracted from the
-                   receipt's agent_graph.nodes
-    events      -- number of timeline events in the receipt
+                   receipt's agent_graph.nodes (0 if not reported by CLI)
+    events      -- number of timeline events in the receipt (0 if not
+                   reported by CLI)
     """
 
     session_id: str
@@ -63,38 +69,77 @@ class SessionReportResult:
     events: int = 0
 
 
-def _run(args: List[str], timeout: int = 10, *, binary: str = "treeship") -> Dict[str, Any]:
-    """Run a treeship CLI command and return parsed JSON.
+# Single source of truth for option-injection rejection. Any user-facing
+# argument that becomes a CLI value must clear this. The SDK never
+# enables shell expansion (subprocess shell=False), so the only attack
+# surface is option *parsing* -- a value like "--format" or "--config"
+# that the CLI would interpret as a flag instead of a value.
+_OPTION_LIKE = re.compile(r"^-{1,2}[A-Za-z0-9]")
 
-    `binary` lets the caller override which executable is invoked --
-    used by the agent-native bootstrap path (Treeship(bot_mode=True))
-    so the SDK can shell out to a CLI it resolved itself rather than
-    relying on PATH.
+# Length limits at the SDK boundary. Numbers chosen to fit comfortably
+# inside the CLI's own caps and to keep receipts human-readable. Any
+# breach raises in the SDK so the caller sees the failure at the call
+# site, not as a confusing CLI parse error.
+_MAX_ACTOR_LEN = 256        # actor URIs are short identifiers
+_MAX_ACTION_LEN = 256       # action labels (e.g., mcp.tool.read.intent)
+_MAX_DESCRIPTION_LEN = 4096 # human-readable approval description
+_MAX_SUMMARY_LEN = 4096     # decision summary (LLM reasoning blurb)
+_MAX_MODEL_LEN = 256        # model identifier
+_MAX_NONCE_LEN = 256        # approval nonce
+_MAX_ARTIFACT_ID_LEN = 256  # art_<hex>
+_MAX_TOKEN_COUNT = 100_000_000  # 100M tokens — well past any single decision
+
+
+def _check_length(name: str, value: str, limit: int) -> str:
+    if len(value) > limit:
+        raise TreeshipError(
+            f"{name} is {len(value)} chars; max is {limit}. "
+            f"Trim the value before passing it to the SDK.",
+            [name],
+        )
+    return value
+
+
+def _check_int_range(name: str, value: int, low: int, high: int) -> int:
+    if value < low or value > high:
+        raise TreeshipError(
+            f"{name}={value} is outside the allowed range [{low}, {high}]",
+            [name],
+        )
+    return value
+
+
+def _check_float_range(name: str, value: float, low: float, high: float) -> float:
+    # NaN check first — NaN compares False to everything, so a naive
+    # range check would pass it through.
+    if value != value:  # NaN
+        raise TreeshipError(f"{name}={value} is NaN", [name])
+    if value < low or value > high:
+        raise TreeshipError(
+            f"{name}={value} is outside the allowed range [{low}, {high}]",
+            [name],
+        )
+    return value
+
+
+def _reject_option_like(name: str, value: str) -> str:
+    """Raise TreeshipError if `value` could be parsed as a CLI option.
+
+    Treeship's argument parser is strict (clap), so a value beginning
+    with `-` or `--` followed by a letter would silently be claimed as a
+    flag. This guard catches that at the SDK boundary so the error
+    appears at the SDK call site, not as a confusing CLI-side parse
+    failure.
     """
-    try:
-        result = subprocess.run(
-            [binary] + args,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        if result.returncode != 0:
-            raise TreeshipError(
-                f"treeship {' '.join(args[:2])} failed: {result.stderr.strip()}",
-                args,
-            )
-        return json.loads(result.stdout)
-    except FileNotFoundError:
+    if not isinstance(value, str):
+        return value
+    if _OPTION_LIKE.match(value):
         raise TreeshipError(
-            "treeship CLI not found. Install: curl -fsSL treeship.dev/install | sh\n"
-            "  Or in a Python program: ts = Treeship(bot_mode=True)  # auto-resolves the CLI",
-            args,
+            f"{name}={value!r} looks like a CLI option; refusing to pass it. "
+            f"This guards against option-injection in user-facing values.",
+            [value],
         )
-    except json.JSONDecodeError:
-        raise TreeshipError(
-            f"treeship returned invalid JSON: {result.stdout[:200]}",
-            args,
-        )
+    return value
 
 
 class Treeship:
@@ -103,17 +148,25 @@ class Treeship:
 
     Wraps the treeship CLI binary for signing, verification, and Hub operations.
 
-    Two construction modes:
+    Construction modes::
 
-      Treeship()
-        Default — assumes ``treeship`` is on PATH. Raises
-        :class:`TreeshipError` if the binary isn't found at call time.
+        Treeship()
+            Default — assumes ``treeship`` is on ``PATH``. Raises
+            :class:`TreeshipError` if the binary isn't found at call time.
 
-      Treeship(bot_mode=True)
-        Agent-native — calls :func:`ensure_cli` at construction time to
-        resolve the binary via env / PATH / cache / npm / GitHub Release
-        in that order. AI agents on a fresh machine should use this so
-        they don't have to ask a human "is the CLI installed?".
+        Treeship(bot_mode=True)
+            Agent-native — calls :func:`ensure_cli` at construction time
+            to resolve the binary via ``$TREESHIP_BIN`` / ``PATH`` /
+            cache / npm / GitHub Release in that order. AI agents on a
+            fresh machine should use this so they don't have to ask a
+            human "is the CLI installed?".
+
+        Treeship(cli_path="/path/to/treeship", timeout=30, cwd=..., env={...})
+            Fully explicit. ``cli_path`` overrides PATH lookup; ``timeout``
+            becomes the default per-call timeout in seconds; ``cwd`` is
+            the subprocess working directory; ``env`` is the full
+            subprocess environment (or pass ``env={"FOO": "bar"}`` to
+            extend the inherited environment).
 
     Usage::
 
@@ -123,16 +176,36 @@ class Treeship:
 
         # agent-native bootstrap
         ts = Treeship(bot_mode=True)
-        # CLI resolved + ready, even on a fresh sandbox
+
+        # explicit config
+        ts = Treeship(cli_path="/opt/treeship/bin/treeship", timeout=30)
     """
 
-    def __init__(self, *, bot_mode: bool = False) -> None:
-        # Default: use whatever's on PATH. The CLI lookup happens at
-        # call time inside _run(), so an unresolved binary fails on the
-        # first method call (with a recovery hint pointing at bot_mode).
-        self._binary: str = "treeship"
+    DEFAULT_TIMEOUT_S: int = 10
+    WRAP_DEFAULT_TIMEOUT_S: int = 300
+    SESSION_REPORT_DEFAULT_TIMEOUT_S: int = 60
+
+    def __init__(
+        self,
+        *,
+        bot_mode: bool = False,
+        cli_path: Optional[Union[str, Path]] = None,
+        timeout: Optional[int] = None,
+        cwd: Optional[Union[str, Path]] = None,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        # Resolve the binary in priority order:
+        #   explicit cli_path > bot_mode bootstrap > PATH ("treeship")
+        #
+        # Prior versions resolved a path in bot_mode but never threaded
+        # it through to subprocess calls -- bot_mode silently dropped
+        # back to PATH. The fix: store the resolved path and require
+        # every subprocess invocation to go through `_run_cli`.
         self._bootstrap: Optional[BootstrapResult] = None
-        if bot_mode:
+
+        if cli_path is not None:
+            self._binary: str = str(cli_path)
+        elif bot_mode:
             try:
                 self._bootstrap = ensure_cli()
                 self._binary = self._bootstrap.binary
@@ -141,30 +214,122 @@ class Treeship:
                     f"agent-native bootstrap failed: {exc} (reason={exc.reason})",
                     [],
                 ) from exc
+        else:
+            self._binary = "treeship"
+
+        self._timeout: int = timeout if timeout is not None else self.DEFAULT_TIMEOUT_S
+        self._cwd: Optional[str] = str(cwd) if cwd is not None else None
+        self._env: Optional[Dict[str, str]] = dict(env) if env is not None else None
 
     @classmethod
     def ensure_cli(cls) -> BootstrapResult:
-        """Resolve a working CLI binary without instantiating the SDK.
-
-        Sugar around :func:`treeship_sdk.bootstrap.ensure_cli` so a
-        caller can do::
-
-            from treeship_sdk import Treeship
-            Treeship.ensure_cli()
-
-        without importing the bootstrap submodule.
-        """
+        """Resolve a working CLI binary without instantiating the SDK."""
         return ensure_cli()
 
     @property
     def binary(self) -> str:
-        """Path to the resolved CLI binary. ``"treeship"`` when not bot-mode."""
+        """Path to the resolved CLI binary."""
         return self._binary
 
     @property
     def bootstrap(self) -> Optional[BootstrapResult]:
         """The resolution result when bot_mode=True; ``None`` otherwise."""
         return self._bootstrap
+
+    # ---- subprocess helpers --------------------------------------------------
+
+    def _run_cli_raw(
+        self,
+        args: Sequence[str],
+        *,
+        timeout: Optional[int] = None,
+    ) -> "subprocess.CompletedProcess[str]":
+        """Invoke the CLI without parsing output. Returns the
+        CompletedProcess so callers can inspect returncode + stdout +
+        stderr independently.
+
+        Raises :class:`TreeshipError` only when the binary is missing
+        (FileNotFoundError) or the call times out -- structured CLI
+        errors (non-zero exit with content) are returned as-is for the
+        caller to interpret.
+        """
+        env: Optional[Dict[str, str]] = None
+        if self._env is not None:
+            env = {**os.environ, **self._env} if self._env_is_extension() else dict(self._env)
+
+        try:
+            return subprocess.run(
+                [self._binary, *args],
+                capture_output=True,
+                text=True,
+                timeout=timeout if timeout is not None else self._timeout,
+                cwd=self._cwd,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise TreeshipError(
+                f"treeship CLI not found at {self._binary!r}. "
+                f"Install: curl -fsSL treeship.dev/install | sh\n"
+                f"  Or in a Python program: ts = Treeship(bot_mode=True)  # auto-resolves the CLI\n"
+                f"  Or pass cli_path explicitly: Treeship(cli_path=...)",
+                args,
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TreeshipError(
+                f"treeship {' '.join(args[:2])} timed out after {exc.timeout}s",
+                args,
+            ) from exc
+
+    def _env_is_extension(self) -> bool:
+        # Heuristic: callers passing a tiny env dict almost always mean
+        # "extend the inherited env." Callers passing a full env (PATH +
+        # HOME + ...) mean "replace." 5 keys is the cutoff -- a real
+        # full env has dozens.
+        return self._env is not None and len(self._env) <= 5
+
+    def _run_cli_json(
+        self,
+        args: Sequence[str],
+        *,
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Run the CLI and parse stdout as JSON. Raises on non-zero exit
+        or unparseable output."""
+        result = self._run_cli_raw(args, timeout=timeout)
+        if result.returncode != 0:
+            raise TreeshipError(
+                f"treeship {' '.join(args[:2])} failed (exit={result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip() or '<no output>'}",
+                args,
+            )
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise TreeshipError(
+                f"treeship {' '.join(args[:2])} returned invalid JSON: "
+                f"{result.stdout[:200]}",
+                args,
+            ) from exc
+
+    @staticmethod
+    def _artifact_id(payload: Mapping[str, Any], args: Sequence[str]) -> str:
+        """Pull `id` or `artifact_id` out of a CLI JSON payload.
+
+        Raises :class:`TreeshipError` when both are missing or empty —
+        prior versions silently returned ``""``, which masked CLI
+        regressions and produced confusing downstream NoneType-style
+        errors when a caller fed the empty id back into ``parent_id``.
+        """
+        raw = payload.get("id") or payload.get("artifact_id")
+        if not raw or not isinstance(raw, str):
+            raise TreeshipError(
+                f"treeship returned no artifact id (keys: {sorted(payload.keys())}); "
+                f"the CLI may have changed shape — file an issue with the args.",
+                args,
+            )
+        return raw
+
+    # ---- attestations --------------------------------------------------------
 
     def attest_action(
         self,
@@ -175,15 +340,31 @@ class Treeship:
         meta: Optional[Dict[str, Any]] = None,
     ) -> ActionResult:
         """Create a signed action receipt."""
-        args = ["attest", "action", "--actor", actor, "--action", action, "--format", "json"]
-        if parent_id:
+        _reject_option_like("actor", actor)
+        _check_length("actor", actor, _MAX_ACTOR_LEN)
+        _reject_option_like("action", action)
+        _check_length("action", action, _MAX_ACTION_LEN)
+        if parent_id is not None:
+            _reject_option_like("parent_id", parent_id)
+            _check_length("parent_id", parent_id, _MAX_ARTIFACT_ID_LEN)
+        if approval_nonce is not None:
+            _reject_option_like("approval_nonce", approval_nonce)
+            _check_length("approval_nonce", approval_nonce, _MAX_NONCE_LEN)
+
+        args: List[str] = [
+            "attest", "action",
+            "--actor", actor,
+            "--action", action,
+            "--format", "json",
+        ]
+        if parent_id is not None:
             args += ["--parent", parent_id]
-        if approval_nonce:
+        if approval_nonce is not None:
             args += ["--approval-nonce", approval_nonce]
-        if meta:
+        if meta is not None:
             args += ["--meta", json.dumps(meta)]
-        result = _run(args)
-        return ActionResult(artifact_id=result.get("id") or result.get("artifact_id", ""))
+        result = self._run_cli_json(args)
+        return ActionResult(artifact_id=self._artifact_id(result, args))
 
     def attest_approval(
         self,
@@ -191,19 +372,24 @@ class Treeship:
         description: str,
         expires_in: Optional[str] = None,
     ) -> ApprovalResult:
-        """Create a signed approval receipt with a binding nonce.
+        """Create a signed approval receipt with a binding nonce."""
+        _reject_option_like("approver", approver)
+        _check_length("approver", approver, _MAX_ACTOR_LEN)
+        _check_length("description", description, _MAX_DESCRIPTION_LEN)
+        if expires_in is not None:
+            _reject_option_like("expires_in", expires_in)
 
-        v0.9.6 enforces binding + scope (when set on the underlying CLI)
-        statelessly; replay enforcement is package-local. Cross-package
-        and distributed replay enforcement land in v0.10 (local
-        Approval Use Journal) and v0.11+ (Hub-backed checkpoints).
-        """
-        args = ["attest", "approval", "--approver", approver, "--description", description, "--format", "json"]
-        if expires_in:
+        args: List[str] = [
+            "attest", "approval",
+            "--approver", approver,
+            "--description", description,
+            "--format", "json",
+        ]
+        if expires_in is not None:
             args += ["--expires", expires_in]
-        result = _run(args)
+        result = self._run_cli_json(args)
         return ApprovalResult(
-            artifact_id=result.get("id") or result.get("artifact_id", ""),
+            artifact_id=self._artifact_id(result, args),
             nonce=result.get("nonce", ""),
         )
 
@@ -215,7 +401,18 @@ class Treeship:
         approvals: Optional[List[str]] = None,
     ) -> ActionResult:
         """Create a signed handoff receipt between agents."""
-        args = [
+        _reject_option_like("from_actor", from_actor)
+        _check_length("from_actor", from_actor, _MAX_ACTOR_LEN)
+        _reject_option_like("to_actor", to_actor)
+        _check_length("to_actor", to_actor, _MAX_ACTOR_LEN)
+        for a in artifacts:
+            _reject_option_like("artifact_id", a)
+            _check_length("artifact_id", a, _MAX_ARTIFACT_ID_LEN)
+        for a in approvals or []:
+            _reject_option_like("approval_id", a)
+            _check_length("approval_id", a, _MAX_ARTIFACT_ID_LEN)
+
+        args: List[str] = [
             "attest", "handoff",
             "--from", from_actor,
             "--to", to_actor,
@@ -224,8 +421,8 @@ class Treeship:
         ]
         if approvals:
             args += ["--approvals", ",".join(approvals)]
-        result = _run(args)
-        return ActionResult(artifact_id=result.get("id") or result.get("artifact_id", ""))
+        result = self._run_cli_json(args)
+        return ActionResult(artifact_id=self._artifact_id(result, args))
 
     def attest_decision(
         self,
@@ -238,21 +435,40 @@ class Treeship:
         parent_id: Optional[str] = None,
     ) -> ActionResult:
         """Create a signed decision receipt (LLM reasoning context)."""
-        args = ["attest", "decision", "--actor", actor, "--format", "json"]
-        if model:
+        _reject_option_like("actor", actor)
+        _check_length("actor", actor, _MAX_ACTOR_LEN)
+        if model is not None:
+            _reject_option_like("model", model)
+            _check_length("model", model, _MAX_MODEL_LEN)
+        if parent_id is not None:
+            _reject_option_like("parent_id", parent_id)
+            _check_length("parent_id", parent_id, _MAX_ARTIFACT_ID_LEN)
+        if tokens_in is not None:
+            _check_int_range("tokens_in", tokens_in, 0, _MAX_TOKEN_COUNT)
+        if tokens_out is not None:
+            _check_int_range("tokens_out", tokens_out, 0, _MAX_TOKEN_COUNT)
+        if summary is not None:
+            _check_length("summary", summary, _MAX_SUMMARY_LEN)
+        if confidence is not None:
+            _check_float_range("confidence", confidence, 0.0, 1.0)
+
+        args: List[str] = ["attest", "decision", "--actor", actor, "--format", "json"]
+        if model is not None:
             args += ["--model", model]
         if tokens_in is not None:
             args += ["--tokens-in", str(tokens_in)]
         if tokens_out is not None:
             args += ["--tokens-out", str(tokens_out)]
-        if summary:
+        if summary is not None:
             args += ["--summary", summary]
         if confidence is not None:
             args += ["--confidence", str(confidence)]
-        if parent_id:
+        if parent_id is not None:
             args += ["--parent", parent_id]
-        result = _run(args)
-        return ActionResult(artifact_id=result.get("id") or result.get("artifact_id", ""))
+        result = self._run_cli_json(args)
+        return ActionResult(artifact_id=self._artifact_id(result, args))
+
+    # ---- verification --------------------------------------------------------
 
     def verify(self, artifact_id: str) -> VerifyResult:
         """Verify an artifact and its chain.
@@ -269,18 +485,11 @@ class Treeship:
         even be attempted: missing CLI binary, malformed JSON output,
         keystore inaccessible.
         """
-        try:
-            result = subprocess.run(
-                ["treeship", "verify", artifact_id, "--format", "json"],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-        except FileNotFoundError:
-            raise TreeshipError(
-                "treeship CLI not found. Install: curl -fsSL treeship.dev/install | sh",
-                ["verify", artifact_id],
-            )
+        _reject_option_like("artifact_id", artifact_id)
+        _check_length("artifact_id", artifact_id, _MAX_ARTIFACT_ID_LEN)
+
+        args: List[str] = ["verify", artifact_id, "--format", "json"]
+        result = self._run_cli_raw(args)
 
         # Empty stdout means the binary couldn't even attempt verification
         # (config missing, keystore broken, etc.) -- that's a real error.
@@ -288,22 +497,21 @@ class Treeship:
             raise TreeshipError(
                 f"treeship verify produced no output (exit={result.returncode}): "
                 f"{result.stderr.strip() or '<empty stderr>'}",
-                ["verify", artifact_id],
+                args,
             )
 
         try:
             parsed = json.loads(result.stdout)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
             raise TreeshipError(
-                f"treeship verify returned invalid JSON: {result.stdout[:200]}",
-                ["verify", artifact_id],
-            )
+                f"treeship verify returned invalid JSON (exit={result.returncode}): "
+                f"{result.stdout[:200]}",
+                args,
+            ) from exc
 
         # `chain` semantics match the TypeScript SDK contract:
         #   - on outcome=pass: number of artifacts that passed (== total)
         #   - on outcome=fail: number of artifacts that failed
-        # The two SDKs MUST agree here -- the cross-SDK contract suite
-        # asserts equality on every vector.
         outcome = parsed.get("outcome", "error")
         if outcome == "pass":
             chain = parsed.get("passed") or parsed.get("total") or 1
@@ -314,78 +522,156 @@ class Treeship:
 
         return VerifyResult(outcome=outcome, chain=chain, target=artifact_id)
 
-    def hub_push(self, artifact_id: str) -> PushResult:
-        """Push an artifact to Hub.
+    # ---- hub -----------------------------------------------------------------
 
-        Returns the public URL where the artifact can be fetched and
-        verified. The CLI subcommand is `treeship hub push` -- prior
-        versions of this SDK called the now-removed `treeship dock`
-        subcommand, which silently failed against any v0.7+ binary.
-        """
-        result = _run(["hub", "push", artifact_id, "--format", "json"])
+    def hub_push(self, artifact_id: str) -> PushResult:
+        """Push an artifact to Hub."""
+        _reject_option_like("artifact_id", artifact_id)
+        _check_length("artifact_id", artifact_id, _MAX_ARTIFACT_ID_LEN)
+
+        args: List[str] = ["hub", "push", artifact_id, "--format", "json"]
+        result = self._run_cli_json(args)
         return PushResult(
             hub_url=result.get("hub_url", result.get("url", "")),
             rekor_index=result.get("rekor_index"),
         )
 
-    def wrap(self, command: str, actor: Optional[str] = None) -> ActionResult:
-        """Wrap a shell command with a signed receipt."""
-        args = ["wrap"]
-        if actor:
+    # ---- wrap ----------------------------------------------------------------
+
+    def wrap(
+        self,
+        command: Union[str, Sequence[str]],
+        actor: Optional[str] = None,
+        *,
+        timeout: Optional[int] = None,
+    ) -> ActionResult:
+        """Wrap a shell command with a signed receipt.
+
+        ``command`` accepts either:
+
+        * **Sequence[str]** (preferred): exact argv. Quoted arguments
+          and embedded spaces are preserved without ambiguity.
+          Example: ``ts.wrap(["python", "-c", "print('hi mom')"])``
+        * **str** (legacy): split with :func:`shlex.split` so quoted
+          arguments survive. Earlier versions of this SDK used naive
+          ``str.split()``, which silently broke commands like
+          ``python -c 'print(1)'``.
+
+        ``timeout`` overrides the SDK's default wrap timeout (5 minutes)
+        for this single call.
+        """
+        if actor is not None:
+            _reject_option_like("actor", actor)
+
+        if isinstance(command, str):
+            argv = shlex.split(command)
+        else:
+            argv = list(command)
+
+        if not argv:
+            raise TreeshipError(
+                "wrap() requires a non-empty command",
+                ["wrap"],
+            )
+
+        args: List[str] = ["wrap"]
+        if actor is not None:
             args += ["--actor", actor]
-        args += ["--format", "json", "--"] + command.split()
-        result = _run(args, timeout=300)  # longer timeout for wrapped commands
-        return ActionResult(artifact_id=result.get("id") or result.get("artifact_id", ""))
+        args += ["--format", "json", "--", *argv]
+        result = self._run_cli_json(
+            args,
+            timeout=timeout if timeout is not None else self.WRAP_DEFAULT_TIMEOUT_S,
+        )
+        return ActionResult(artifact_id=self._artifact_id(result, args))
+
+    # ---- sessions ------------------------------------------------------------
 
     def session_report(
         self,
         session_id: Optional[str] = None,
+        *,
+        timeout: Optional[int] = None,
     ) -> SessionReportResult:
         """Upload a closed session's receipt to the configured hub.
 
-        Reads the .treeship package generated by `treeship session close`
-        and PUTs the receipt to the configured hub. Prints the permanent
-        public URL where anyone can fetch the receipt without auth.
+        Reads the .treeship package generated by ``treeship session
+        close`` and PUTs the receipt to the configured hub. Returns the
+        permanent public URL where anyone can fetch the receipt without
+        auth.
 
-        If session_id is None, the most recently closed session is used.
+        If ``session_id`` is None, the most recently closed session is used.
 
-        Usage:
-            ts = Treeship()
-            result = ts.session_report()
-            print(result.receipt_url)
+        Uses ``--format json`` (CLI schema ``treeship/share-result/v1``)
+        so URL/session_id/digests come from a stable JSON contract,
+        not regex-parsed text. The text-output regex path was a
+        repeated source of release-time breakage when the text format
+        was tweaked.
         """
-        args = ["session", "report"]
-        if session_id:
+        if session_id is not None:
+            _reject_option_like("session_id", session_id)
+
+        args: List[str] = ["session", "report", "--format", "json"]
+        if session_id is not None:
             args.append(session_id)
 
         try:
-            result = subprocess.run(
-                ["treeship"] + args,
-                capture_output=True,
-                text=True,
-                timeout=60,
+            parsed = self._run_cli_json(
+                args,
+                timeout=timeout if timeout is not None else self.SESSION_REPORT_DEFAULT_TIMEOUT_S,
             )
-        except FileNotFoundError:
+        except TreeshipError:
+            # Older CLIs (pre-0.10.x) may not emit JSON for session
+            # report. Fall back to the text-parse path so existing
+            # users don't break on SDK upgrade.
+            return self._session_report_text_fallback(session_id, args[:2], timeout)
+
+        receipt_url = parsed.get("receipt_url") or ""
+        sid = parsed.get("session_id") or session_id or ""
+        if not receipt_url:
             raise TreeshipError(
-                "treeship CLI not found. Install: curl -fsSL treeship.dev/install | sh",
+                f"session report JSON missing receipt_url "
+                f"(keys: {sorted(parsed.keys())}); error={parsed.get('error')!r}",
                 args,
             )
 
+        # agents/events counts aren't in the share-result/v1 JSON schema
+        # today. Default to 0; a future schema bump can populate them.
+        return SessionReportResult(
+            session_id=sid,
+            receipt_url=receipt_url,
+            agents=int(parsed.get("agents", 0) or 0),
+            events=int(parsed.get("events", 0) or 0),
+        )
+
+    def _session_report_text_fallback(
+        self,
+        session_id: Optional[str],
+        args_for_error: Sequence[str],
+        timeout: Optional[int],
+    ) -> SessionReportResult:
+        # Pre-JSON path: parse the text output. Kept for compatibility
+        # with CLIs older than v0.10.x.
+        text_args: List[str] = ["session", "report"]
+        if session_id is not None:
+            text_args.append(session_id)
+        result = self._run_cli_raw(
+            text_args,
+            timeout=timeout if timeout is not None else self.SESSION_REPORT_DEFAULT_TIMEOUT_S,
+        )
         if result.returncode != 0:
-            err = result.stderr.strip() or result.stdout.strip()
             raise TreeshipError(
-                f"treeship session report failed: {err}",
-                args,
+                f"treeship session report failed (exit={result.returncode}): "
+                f"{result.stderr.strip() or result.stdout.strip()}",
+                args_for_error,
             )
 
-        # session report prints a text summary, not JSON. Pull the
-        # session_id, receipt URL, and counts out of the stdout block.
         stdout = result.stdout
         url_match = re.search(r"receipt:\s*(https?://\S+)", stdout)
         if not url_match:
             raise TreeshipError(
-                f"could not parse receipt URL from session report output",
-                args,
+                "could not parse receipt URL from session report output "
+                "(neither --format json nor text-format matched)",
+                args_for_error,
             )
 
         session_match = re.search(r"session:\s*(\S+)", stdout)

--- a/scripts/check-release-versions.py
+++ b/scripts/check-release-versions.py
@@ -110,11 +110,70 @@ def pyproject_version(rel: str) -> str | None:
 
 
 def py_dunder_version(rel: str) -> str | None:
+    """Extract the version that ``__version__`` will resolve to at runtime.
+
+    Three accepted forms:
+
+      __version__ = "0.10.1"
+        Literal string. Returned as-is.
+
+      __version__ = _resolve_version()
+        v0.10.1+ pattern: runtime resolution from
+        importlib.metadata.version("treeship-sdk"). The metadata is
+        whatever pip / build wrote into the installed dist's
+        package metadata, which on every release pipeline is
+        synthesized from pyproject.toml's [project] version. So
+        when we see this pattern, treat pyproject.toml as
+        authoritative and return that version.
+
+      __version__ = importlib.metadata.version("treeship-sdk")
+        Same intent, inline. Treated identically.
+
+    Anything else (including absence of __version__) returns None,
+    which the caller reports as "not found" and the release blocks.
+
+    The check exists to catch drift across version sites; switching
+    __init__.py to a metadata-derived form removes the drift class
+    by construction (one source of truth, evaluated at runtime), so
+    this function honors that contract by reading pyproject.toml's
+    version when the metadata pattern is detected.
+    """
     text = read_text(rel)
     if text is None:
         return None
+
+    # Form 1: literal string.
     m = re.search(r'__version__\s*=\s*"([^"]+)"', text)
-    return m.group(1) if m else None
+    if m:
+        return m.group(1)
+
+    # Form 2 / Form 3: metadata-derived. Detect by name heuristic and
+    # fall back to pyproject.toml in the same package directory. The
+    # match is conservative -- we want a clear positive signal that
+    # the file is using the metadata pattern rather than e.g. a stray
+    # comment that mentions the words.
+    metadata_pattern = re.search(
+        r'__version__\s*=\s*('
+        r'_resolve_version\s*\(\s*\)'
+        r'|importlib\.metadata\.version\s*\('
+        r'|version\s*\(\s*"treeship-sdk"\s*\)'
+        r')',
+        text,
+    )
+    if metadata_pattern:
+        # Walk up to find the matching pyproject.toml. The Python SDK
+        # is the only consumer of this codepath today; the layout is
+        # packages/sdk-python/treeship_sdk/__init__.py and
+        # packages/sdk-python/pyproject.toml.
+        from pathlib import Path
+        rel_path = Path(rel)
+        for parent in rel_path.parents:
+            candidate = parent / "pyproject.toml"
+            if candidate.exists():
+                return pyproject_version(str(candidate))
+        return None
+
+    return None
 
 
 # ---------- site discovery ----------


### PR DESCRIPTION
## What changed

Folds the v0.10.0-review SDK findings into one coherent pass. **Combines what was originally planned as PR 2 (correctness) and PR 3 (input validation)** because the validators sit alongside the methods they guard; splitting them required two passes through every method and produced PR diffs that were less readable than this combined form.

### Correctness

1. `__version__` derived from `importlib.metadata.version("treeship-sdk")` instead of a hand-edited string. Removes the version-skew class of bug where `pyproject.toml` says 0.10.0 but `treeship_sdk.__version__` reports 0.9.x.
2. **`Treeship(cli_path=..., timeout=..., cwd=..., env=...)` constructor parameters.** Prior versions only accepted `bot_mode` and silently discarded any resolved binary at call time — `_run` (a free function) hardcoded `"treeship"`, so `Treeship(bot_mode=True)` would resolve a path then never use it. **This was a real bug:** every SDK user with `bot_mode=True` was actually still depending on PATH. Now `_run_cli_raw`/`_run_cli_json` are methods on `Treeship` and always call `self._binary`.
3. `wrap()` accepts both `str` (legacy, `shlex.split` for backwards compat with quoted args like `python -c 'print(1)'`) and `Sequence[str]` (new, exact argv passthrough). The previous naive `command.split()` silently broke quoted commands.
4. `verify()` returns a structured `VerifyResult` on `outcome=fail` rather than raising; raises only on missing-binary, malformed-JSON, or inaccessible keystore. Matches the TypeScript SDK contract.
5. `session_report()` uses `--format json` (CLI schema `treeship/share-result/v1`). Falls back to text-format regex parse only if JSON parsing fails (older CLIs).
6. **Empty `artifact_id` raises `TreeshipError`** instead of returning the empty string. The old `result.get("id") or result.get("artifact_id", "")` silently swallowed CLI-shape regressions and produced confusing downstream errors when the empty id was fed back as a `parent_id`.

### Input validation

7. `_reject_option_like(name, value)` rejects values that look like CLI flags (`--format`, `-x`) before they reach subprocess. Without shell expansion this isn't an injection vulnerability per se, but clap would silently parse such a value as a flag and produce a confusing CLI-side parse error far from the SDK call site.
8. `_check_length` / `_check_int_range` / `_check_float_range` enforce sensible bounds at the SDK boundary:
    - actor / approver / model / nonce / artifact_id: max 256 chars
    - description / summary: max 4096 chars
    - tokens_in / tokens_out: 0 .. 100M
    - confidence: 0.0 .. 1.0 (NaN-safe)

## v0.10.0 review findings closed

> "Python SDK correctness: stale `__version__`, naive `wrap()` splitting, `verify()` not checking return code, no CLI path configurability, hardcoded timeouts, fragile `session_report()` regex parsing, falsy-value bugs."

> "SDK input validation: actor/action/artifact_id are not validated and can confuse CLI option parsing. Reject option-like inputs before subprocess. Add length limits and range checks."

> "Bot mode silently broken: bootstrap resolves a path but every subprocess call hardcodes `treeship`."

## Tests run

**28 unit tests** in `packages/sdk-python/tests/test_client.py` covering `__version__` resolution, option-injection rejection (with allowed substring patterns like `agent://my-agent`), wrap behavior for both str and argv, binary resolution including `cli_path` threading, artifact id handling, session report JSON path + text fallback, length/range validators including NaN.

Run:
```
PYTHONPATH=packages/sdk-python python3 -m unittest discover -s packages/sdk-python/tests
```

Result: **28/28 pass.** No external dependencies; uses stdlib `unittest` so no pip install required to run the suite.

## What is intentionally out of scope

- Async API. The SDK stays sync; the wrapped CLI is the unit of work.
- Streaming / chunked response parsing for `wrap()`.

## Independent or stacked

**Independent.** Branched off main; no dependencies on other v0.10.1 PRs.

## Part of v0.10.1 — Platform, SDK, Supply Chain, and MCP Hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)