### PR TITLE
fix(cli): v0.10.1 PR 4 — config/init/json correctness

### DIFF
--- a/packages/cli/src/commands/init.rs
+++ b/packages/cli/src/commands/init.rs
@@ -6,7 +6,7 @@ use treeship_core::rules::ProjectConfig;
 use treeship_core::storage::Store as ArtifactStore;
 
 use crate::{
-    config::{self, default_config_path},
+    config::{self, default_config_path, global_config_path},
     printer::Printer,
 };
 
@@ -14,14 +14,51 @@ pub fn run(
     name:        Option<String>,
     config_path: Option<String>,
     force:       bool,
+    global:      bool,
     template:    Option<String>,
     printer:     &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
 
+    // Resolve target. Order:
+    //   1. --config <path>  (explicit user override; we never second-guess it)
+    //   2. --global         (forces user-level path even when a project
+    //                        stub would otherwise be discovered)
+    //   3. default          (walks up cwd for project-local; falls back to global)
     let config_path: PathBuf = match config_path {
         Some(p) => PathBuf::from(p),
+        None if global => global_config_path()?,
         None    => default_config_path()?,
     };
+
+    // Guard: refuse to clobber the global keystore unless the operator
+    // explicitly opted in with --global. The footgun: a user runs
+    // `treeship init --force` from a non-project cwd, default_config_path
+    // returns the global, --force happily regenerates the keys, and
+    // every previously-signed receipt the user produced is no longer
+    // signed by their default key. Past dogfooding sessions hit exactly
+    // this. Now we hard-stop unless --global is passed.
+    if force && !global && config_path.exists() {
+        let resolved_global = global_config_path().ok();
+        let is_global_target = resolved_global
+            .as_deref()
+            .map(|g| config_path == g)
+            .unwrap_or(false);
+        if is_global_target {
+            return Err(format!(
+                "refusing to overwrite the global keystore at {}.\n\n\
+                 --force without --global will not regenerate the user-level keystore.\n\
+                 Pick one:\n\
+                   • Project-local init:  cd <project> && treeship init --force\n\
+                   • Different path:      treeship init --config <path> --force\n\
+                   • Really regenerate the global keystore (DESTRUCTIVE):\n\
+                       treeship init --global --force\n\
+                 \n  This guard exists because earlier versions silently rotated the\n\
+                 global default_key_id under --force, breaking signature continuity\n\
+                 for every receipt that referenced the old key.",
+                config_path.display()
+            ).into());
+        }
+    }
 
     if config_path.exists() && !force {
         return Err(format!(
@@ -357,9 +394,23 @@ fn write_project_config(
         return Ok(());
     }
 
-    let global_config = crate::config::default_config_path()
+    // Use the GLOBAL path explicitly. default_config_path() walks up
+    // for project-local configs first, which here would resolve to the
+    // very file we're about to write -- producing a self-referencing
+    // `extends:` cycle that silently breaks every subsequent command
+    // until the file is hand-edited.
+    let global_config = crate::config::global_config_path()
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_default();
+
+    // Defense in depth: if the resolved global path somehow equals the
+    // marker we're about to write (e.g., a non-standard $HOME setup
+    // where the cwd is literally the home dir), refuse to write a stub
+    // that would self-reference.
+    if marker_path == std::path::Path::new(&global_config) {
+        return Ok(());
+    }
+
     let marker = serde_json::json!({
         "extends": global_config,
         "project": true,

--- a/packages/cli/src/commands/quickstart.rs
+++ b/packages/cli/src/commands/quickstart.rs
@@ -25,7 +25,7 @@ pub fn run(
     let needs_init = crate::ctx::open(config).is_err();
     if needs_init {
         // Run init non-interactively
-        let result = super::init::run(None, None, false, None, printer);
+        let result = super::init::run(None, None, false, false, None, printer);
         if let Err(e) = result {
             // Already initialized is fine
             if !e.to_string().contains("already initialized") {

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, path::{Path, PathBuf}};
+use std::{collections::{HashMap, HashSet}, fs, path::{Path, PathBuf}};
 use serde::{Deserialize, Serialize};
 
 // -- v0.4.0 Config ------------------------------------------------------------
@@ -187,6 +187,24 @@ pub fn default_config_path() -> Result<PathBuf, ConfigError> {
     Ok(resolve_config_path()?.0)
 }
 
+/// Returns ONLY the global config path (`~/.treeship/config.json`),
+/// ignoring any project-local `.treeship/config.json` in the cwd
+/// chain.
+///
+/// Use this when you specifically need the user-level config — most
+/// notably from `init`'s project-stub writer, which would otherwise
+/// resolve `default_config_path()` to the project stub it is about to
+/// create and produce a self-referencing `extends:` value.
+pub fn global_config_path() -> Result<PathBuf, ConfigError> {
+    if let Some(env) = std::env::var_os("TREESHIP_CONFIG") {
+        if !env.is_empty() {
+            return Ok(PathBuf::from(env));
+        }
+    }
+    let home = home::home_dir().ok_or(ConfigError::NoHome)?;
+    Ok(home.join(".treeship").join("config.json"))
+}
+
 /// Like `default_config_path` but also returns where the path came from.
 /// `doctor` uses the source label to explain unexpected resolution.
 pub fn resolve_config_path() -> Result<(PathBuf, ConfigSource), ConfigError> {
@@ -296,21 +314,242 @@ mod tests {
         );
         assert_eq!(found, Some(PathBuf::from("/a/b/.treeship/config.json")));
     }
+
+    // --- extends-chain handling (PR 5.B) ------------------------------------
+
+    fn write_real_config(dir: &Path, ship_id: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join("config.json");
+        let json = serde_json::json!({
+            "ship_id":        ship_id,
+            "name":           null,
+            "storage_dir":    dir.join("artifacts").to_string_lossy(),
+            "keys_dir":       dir.join("keys").to_string_lossy(),
+            "default_key_id": "key_test",
+            "hub_connections": {},
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+        path
+    }
+
+    fn write_stub(dir: &Path, extends_path: &Path) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let path = dir.join("config.json");
+        let json = serde_json::json!({
+            "extends": extends_path.to_string_lossy(),
+            "project": true,
+        });
+        std::fs::write(&path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+        path
+    }
+
+    fn temp_dir() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let mut b = [0u8; 8];
+        use rand::RngCore;
+        rand::thread_rng().fill_bytes(&mut b);
+        p.push(format!("treeship-cfgtest-{}", hex::encode(b)));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn extends_resolves_parent_ship_id() {
+        let root = temp_dir();
+        let parent_dir = root.join("global");
+        let parent = write_real_config(&parent_dir, "ship_parent_xyz");
+
+        let project_dir = root.join("project");
+        let stub = write_stub(&project_dir, &parent);
+
+        let cfg = load(&stub).expect("stub with extends should resolve");
+        assert_eq!(cfg.ship_id, "ship_parent_xyz");
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn extends_self_reference_caught_by_cycle_detection() {
+        let root = temp_dir();
+        let project_dir = root.join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let stub = project_dir.join("config.json");
+        // Self-reference: extends path == own path.
+        std::fs::write(
+            &stub,
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "extends": stub.to_string_lossy(),
+                "project": true,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let err = load(&stub).expect_err("self-referential stub must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cycle") || msg.contains("loops back"),
+            "expected cycle error, got: {msg}",
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn extends_chain_too_deep_caught() {
+        let root = temp_dir();
+        // Build a chain longer than EXTENDS_MAX_DEPTH.
+        let mut paths: Vec<PathBuf> = Vec::new();
+        // Innermost: a real Config so the chain has a proper terminal.
+        let real_dir = root.join("real");
+        let real = write_real_config(&real_dir, "ship_terminal");
+        paths.push(real);
+
+        for i in 0..(EXTENDS_MAX_DEPTH as usize + 2) {
+            let dir = root.join(format!("stub-{}", i));
+            let stub = write_stub(&dir, paths.last().unwrap());
+            paths.push(stub);
+        }
+
+        let outermost = paths.last().unwrap();
+        let err = load(outermost).expect_err("over-deep chain must error");
+        assert!(err.to_string().contains("chain exceeded"));
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    // --- global_config_path (PR 5.C) ----------------------------------------
+
+    #[test]
+    fn global_config_path_ignores_project_local_walk() {
+        // Even when cwd has a project-local stub, global_config_path
+        // must return the user-level path. The test relies on the
+        // function ignoring cwd entirely; we don't actually need to
+        // chdir to confirm that.
+        let p = global_config_path().expect("home should be resolvable in CI");
+        assert!(
+            p.ends_with(".treeship/config.json"),
+            "expected ~/.treeship/config.json, got {}",
+            p.display(),
+        );
+    }
 }
 
+/// Maximum depth of `extends:` chain. Caught separately from the
+/// visited-set cycle check: a chain of distinct paths longer than this
+/// is almost certainly a misconfiguration rather than legitimate use.
+const EXTENDS_MAX_DEPTH: u8 = 5;
+
 pub fn load(path: &Path) -> Result<Config, ConfigError> {
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    load_with_depth(path, 0, &mut visited)
+}
+
+fn load_with_depth(
+    path: &Path,
+    depth: u8,
+    visited: &mut HashSet<PathBuf>,
+) -> Result<Config, ConfigError> {
+    if depth > EXTENDS_MAX_DEPTH {
+        return Err(ConfigError::Json(serde_json::Error::io(
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "config `extends:` chain exceeded {} levels at {}",
+                    EXTENDS_MAX_DEPTH,
+                    path.display(),
+                ),
+            ),
+        )));
+    }
     if !path.exists() {
         return Err(ConfigError::NotFound(path.to_path_buf()));
     }
-    let bytes = fs::read(path)?;
-    let mut cfg: Config = serde_json::from_slice(&bytes)?;
 
-    // Auto-migrate v0.1/v0.2 hub config to v0.4 hub_connections format.
+    // Canonicalize to detect cycles even when paths are written with
+    // different shapes (relative vs absolute, /Users/... vs ~/, etc.).
+    // Falls back to the as-given path on canonicalize failure -- the
+    // visited check still works against either shape consistently.
+    let canon = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canon.clone()) {
+        return Err(ConfigError::Json(serde_json::Error::io(
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "config `extends:` cycle: {} extends a file that loops back to it. \
+                     Edit the file and remove the self-reference, or run `treeship init --force` \
+                     in a directory that should be project-local.",
+                    canon.display(),
+                ),
+            ),
+        )));
+    }
+
+    let bytes = fs::read(path)?;
+
+    // Project-local stub configs use the shape:
+    //   {"extends": "/abs/or/relative/path", "project": true, "<override>": ...}
+    // We resolve that by loading the parent first, then layering this
+    // file's other fields on top. The keystore and storage stay where
+    // the parent points unless the project explicitly overrides them.
+    //
+    // Detect the stub by parsing as a generic Value first -- the full
+    // Config deserializer requires ship_id, which is absent in stubs.
+    let raw: serde_json::Value = serde_json::from_slice(&bytes)?;
+    if let Some(extends_value) = raw.get("extends") {
+        let extends_path = extends_value
+            .as_str()
+            .ok_or_else(|| ConfigError::Json(serde_json::Error::io(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "config `extends` must be a string path",
+                ),
+            )))?;
+        let parent_path = resolve_extends(path, extends_path);
+        let mut cfg = load_with_depth(&parent_path, depth + 1, visited)?;
+        apply_overrides(&mut cfg, &raw);
+
+        if migrate_legacy_hub(&mut cfg) {
+            // Don't write back into the project stub; only the parent.
+            let _ = save(&cfg, &parent_path);
+        }
+        return Ok(cfg);
+    }
+
+    let mut cfg: Config = serde_json::from_slice(&bytes)?;
     if migrate_legacy_hub(&mut cfg) {
         let _ = save(&cfg, path);
     }
-
     Ok(cfg)
+}
+
+/// Resolve an `extends` path. Absolute paths are returned as-is;
+/// relative paths are joined against the *directory* containing the
+/// referring config so `{"extends": "../base.json"}` works the way an
+/// editor user expects.
+fn resolve_extends(referrer: &Path, extends: &str) -> PathBuf {
+    let p = Path::new(extends);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        referrer
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(p)
+    }
+}
+
+/// Layer non-empty / non-default fields from the project stub onto the
+/// resolved parent. Today only `name` is overridable from a stub; the
+/// keystore-pointing fields (`storage_dir`, `keys_dir`,
+/// `default_key_id`) intentionally stay with the parent so two
+/// projects sharing a parent don't accidentally fork keystores.
+fn apply_overrides(cfg: &mut Config, raw: &serde_json::Value) {
+    if let Some(name) = raw.get("name").and_then(|v| v.as_str()) {
+        if !name.is_empty() {
+            cfg.name = Some(name.to_string());
+        }
+    }
 }
 
 pub fn save(cfg: &Config, path: &Path) -> Result<(), ConfigError> {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -559,9 +559,23 @@ struct InitArgs {
     #[arg(long, value_name = "TEMPLATE")]
     template: Option<String>,
 
-    /// Overwrite an existing config
+    /// Overwrite an existing config.
+    ///
+    /// On its own, --force will not regenerate the global
+    /// (`~/.treeship/config.json`) keystore — that requires --global
+    /// --force. Without --global the operation is scoped to the
+    /// project-local config (the path passed via --config, or a fresh
+    /// `.treeship/` in the cwd).
     #[arg(long, default_value_t = false)]
     force: bool,
+
+    /// Explicitly target the user-global keystore (`~/.treeship/`).
+    ///
+    /// Required to overwrite the global config when combined with
+    /// --force. Without this flag, --force will refuse to clobber the
+    /// global keystore and recommend a project-local target instead.
+    #[arg(long, default_value_t = false)]
+    global: bool,
 }
 
 // --- hook -------------------------------------------------------------------
@@ -1720,7 +1734,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
         ),
 
         Command::Init(a) => commands::init::run(
-            a.name.clone(), cli.config.clone(), a.force, a.template.clone(), printer,
+            a.name.clone(), cli.config.clone(), a.force, a.global, a.template.clone(), printer,
         ),
 
         Command::Status => commands::status::run(cli.config.as_deref(), printer),

--- a/packages/cli/src/printer.rs
+++ b/packages/cli/src/printer.rs
@@ -23,14 +23,33 @@ impl Printer {
     /// ✓ green success header + aligned key:value fields
     pub fn success(&self, msg: &str, fields: &[(&str, &str)]) {
         if self.quiet { return; }
-        if self.format == Format::Json { self.print_json(fields); return; }
+        if self.format == Format::Json {
+            self.print_json_with_status("ok", Some(msg), fields);
+            return;
+        }
         println!("{}", self.green(&format!("✓ {msg}")));
         self.print_fields(fields);
     }
 
-    /// ✗ red failure to stderr -- always shows
+    /// ✗ red failure to stderr -- always shows.
+    ///
+    /// In JSON mode emits a structured error envelope:
+    ///   {"status": "error", "error": "<msg>", "<field>": "<v>", ...}
+    /// to stderr. Prior versions called print_json with only the
+    /// fields slice, which dropped `msg` entirely -- callers
+    /// (especially the @treeship/mcp bridge) saw an empty `{}` body
+    /// with a non-zero exit code and no error text. The MCP bridge
+    /// then surfaced that as a generic isError on every tool call.
     pub fn failure(&self, msg: &str, fields: &[(&str, &str)]) {
-        if self.format == Format::Json { self.print_json(fields); return; }
+        if self.format == Format::Json {
+            // Errors go to stderr in JSON mode too -- callers parsing
+            // the success path's stdout shouldn't have to demux a
+            // fail-shaped object from a success-shaped object on the
+            // same stream. Keep stdout clean for happy-path callers.
+            let body = self.json_envelope("error", Some(msg), fields);
+            eprintln!("{body}");
+            return;
+        }
         eprintln!("{}", self.red(&format!("✗ {msg}")));
         for (k, v) in fields { eprintln!("  {k}: {v}"); }
     }
@@ -38,7 +57,10 @@ impl Printer {
     /// ⚠ amber warning
     pub fn warn(&self, msg: &str, fields: &[(&str, &str)]) {
         if self.quiet { return; }
-        if self.format == Format::Json { self.print_json(fields); return; }
+        if self.format == Format::Json {
+            self.print_json_with_status("warning", Some(msg), fields);
+            return;
+        }
         println!("{}", self.yellow(&format!("⚠ {msg}")));
         self.print_fields(fields);
     }
@@ -101,6 +123,41 @@ impl Printer {
         println!("{}", serde_json::to_string(&m).unwrap_or_default());
     }
 
+    fn print_json_with_status(
+        &self,
+        status: &str,
+        message: Option<&str>,
+        fields: &[(&str, &str)],
+    ) {
+        println!("{}", self.json_envelope(status, message, fields));
+    }
+
+    /// Build the JSON envelope used for success / warning / error in
+    /// --format json mode. Backwards-compatible with the previous
+    /// success shape: every field that used to be a top-level key is
+    /// still a top-level key. We just *also* add `status` and `error`
+    /// (when applicable) so callers can branch on them.
+    fn json_envelope(
+        &self,
+        status: &str,
+        message: Option<&str>,
+        fields: &[(&str, &str)],
+    ) -> String {
+        let mut m = serde_json::Map::new();
+        m.insert("status".into(), serde_json::Value::String(status.to_string()));
+        if let Some(msg) = message {
+            // success/warning use `message`; error uses `error`. Both
+            // are present so callers don't have to read `status` to
+            // know which key carries the human text.
+            let key = if status == "error" { "error" } else { "message" };
+            m.insert(key.into(), serde_json::Value::String(msg.to_string()));
+        }
+        for (k, v) in fields {
+            m.insert(k.to_string(), serde_json::Value::String(v.to_string()));
+        }
+        serde_json::to_string(&m).unwrap_or_default()
+    }
+
     fn use_color(&self) -> bool {
         !self.no_color
             && std::env::var("NO_COLOR").is_err()
@@ -118,4 +175,57 @@ impl Printer {
     pub fn dim(&self, s: &str)    -> String { self.code(s, "\x1b[2m")  }
     pub fn bold(&self, s: &str)   -> String { self.code(s, "\x1b[1m")  }
     pub fn cyan(&self, s: &str)   -> String { self.code(s, "\x1b[36m") }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn json_printer() -> Printer {
+        Printer::new(Format::Json, /* quiet */ false, /* no_color */ true)
+    }
+
+    fn parse(s: &str) -> Value {
+        serde_json::from_str(s).expect("envelope must be valid JSON")
+    }
+
+    #[test]
+    fn error_envelope_carries_message() {
+        // Regression for the v0.10.0 bug: failure(msg, &[]) in JSON
+        // mode emitted `{}` and dropped the message, so the @treeship/mcp
+        // bridge surfaced every CLI error as an empty isError object.
+        let p = json_printer();
+        let body = p.json_envelope("error", Some("keys crypto: MAC failed"), &[]);
+        let v = parse(&body);
+        assert_eq!(v["status"], "error");
+        assert_eq!(v["error"], "keys crypto: MAC failed");
+        // No spurious "message" key on errors -- only "error".
+        assert!(v.get("message").is_none());
+    }
+
+    #[test]
+    fn success_envelope_keeps_existing_fields() {
+        let p = json_printer();
+        let body = p.json_envelope(
+            "ok",
+            Some("action attested"),
+            &[("id", "art_abc"), ("actor", "agent://t")],
+        );
+        let v = parse(&body);
+        assert_eq!(v["status"], "ok");
+        assert_eq!(v["message"], "action attested");
+        assert_eq!(v["id"], "art_abc");
+        assert_eq!(v["actor"], "agent://t");
+    }
+
+    #[test]
+    fn warning_envelope_uses_message_key() {
+        let p = json_printer();
+        let body = p.json_envelope("warning", Some("clock skew detected"), &[]);
+        let v = parse(&body);
+        assert_eq!(v["status"], "warning");
+        assert_eq!(v["message"], "clock skew detected");
+        assert!(v.get("error").is_none());
+    }
 }


### PR DESCRIPTION
## What changed

Three bugs surfaced during MCP-bridge dogfooding earlier in this session. All silent or destructive in v0.10.0; this PR makes each visible.

### 1. Project-level `extends:` honored

`.treeship/config.json` containing `{"extends": "/path/to/parent", "project": true}` now resolves the parent and inherits its `ship_id` / `keys_dir` / `default_key_id`. Prior versions tried to deserialize the stub directly and crashed with `missing field ship_id`.

Cycle and depth protection: visited `HashSet` (canonicalized paths) catches a config that extends itself (we found one such file in the wild during this session, autogenerated by an old `treeship init` run), and a depth cap of 5 catches chains longer than any sensible project layout.

New `global_config_path()` returns ONLY `~/.treeship/config.json`, never walking up for a project-local match. Used by init's stub writer (was the root cause of the self-referencing `extends:` bug — `default_config_path()` walked up and found the very file `init` was about to create).

### 2. `init --force` does not clobber the global keystore

**Prior behavior:** `treeship init --force` from any cwd would silently regenerate `~/.treeship/config.json` with a fresh `ship_id` and `default_key_id`, breaking signature continuity for every receipt that referenced the old key. We hit this twice during this session.

**New behavior:** `--force` alone, when the resolved config_path is the global path, refuses with an actionable error pointing at:

- `cd <project> && treeship init --force` for project-local
- `treeship init --config <path> --force` for an explicit path
- `treeship init --global --force` to truly regenerate (DESTRUCTIVE; explicit opt-in)

### 3. `attest action --format json` returns structured success/failure

**Prior behavior:** when the CLI errored in JSON mode, `printer.failure` emitted `{}` to stderr and exited 1. The error message was dropped entirely. The `@treeship/mcp` bridge then surfaced every CLI error as a generic `isError` with no actionable content.

**New behavior:** JSON mode emits `{"status": "error", "error": "<full message>", ...}` envelopes. Success keeps existing keys + adds `status: "ok"` and `message`. Backwards compatible with consumers that only read the existing keys.

## v0.10.0 review findings closed

These three bugs were not in the v0.10.0 review (they were discovered post-review during MCP integration). All three are listed in the v0.10.1 hardening release notes as PR 5 in the original numbering / "CLI correctness" in the renumbered scheme.

## Tests run

7 new unit tests; full CLI suite **86/86 pass**:

- `config::tests::extends_resolves_parent_ship_id`
- `config::tests::extends_self_reference_caught_by_cycle_detection`
- `config::tests::extends_chain_too_deep_caught`
- `config::tests::global_config_path_ignores_project_local_walk`
- `printer::tests::error_envelope_carries_message`
- `printer::tests::success_envelope_keeps_existing_fields`
- `printer::tests::warning_envelope_uses_message_key`

## What is intentionally out of scope

- A general-purpose JSON output schema for every CLI command. The envelope is for `success`/`failure`/`warning` paths via `printer`. Commands that already emit specific schemas (e.g. `session report --format json` returning `treeship/share-result/v1`) are unchanged.

## Independent or stacked

**Independent.** Branched off main; no dependencies on other v0.10.1 PRs.

## Part of v0.10.1 — Platform, SDK, Supply Chain, and MCP Hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)