### PR TITLE
fix(release): v0.10.1 PR 5 — npm binary integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,38 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    outputs:
+      sha256_linux_x86_64:    ${{ steps.checksums.outputs.sha256_linux_x86_64 }}
+      sha256_darwin_aarch64:  ${{ steps.checksums.outputs.sha256_darwin_aarch64 }}
+      sha256_darwin_x86_64:   ${{ steps.checksums.outputs.sha256_darwin_x86_64 }}
+
     steps:
       - uses: actions/download-artifact@v4
+
+      # Compute SHA-256 of every binary that's about to be published.
+      # The hashes are:
+      #   1. uploaded to the GitHub Release as SHA256SUMS (auditors can
+      #      cross-check what the release actually contains).
+      #   2. surfaced as job outputs so the publish-npm job below can
+      #      embed each per-platform hash into its npm package without
+      #      re-downloading the binary.
+      # The npm postinstall verifies binary against the embedded hash;
+      # because the hash arrives via npm and the binary arrives via
+      # GitHub, an attacker would have to compromise both trust roots
+      # to slip a tampered binary past install.
+      - name: Compute SHA256SUMS
+        id: checksums
+        run: |
+          set -e
+          (
+            cd treeship-linux-x86_64    && sha256sum treeship-linux-x86_64
+            cd ../treeship-darwin-aarch64  && sha256sum treeship-darwin-aarch64
+            cd ../treeship-darwin-x86_64   && sha256sum treeship-darwin-x86_64
+          ) | sort > SHA256SUMS
+          cat SHA256SUMS
+          echo "sha256_linux_x86_64=$(   awk '/treeship-linux-x86_64/    {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
+          echo "sha256_darwin_aarch64=$( awk '/treeship-darwin-aarch64/  {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
+          echo "sha256_darwin_x86_64=$(  awk '/treeship-darwin-x86_64/   {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -77,6 +107,7 @@ jobs:
             treeship-linux-x86_64/treeship-linux-x86_64
             treeship-darwin-aarch64/treeship-darwin-aarch64
             treeship-darwin-x86_64/treeship-darwin-x86_64
+            SHA256SUMS
           generate_release_notes: true
 
   publish-npm:
@@ -206,6 +237,32 @@ jobs:
 
       - name: Verify @treeship/verify version landed
         run: .github/scripts/wait-for-npm-version.sh @treeship/verify "${GITHUB_REF_NAME#v}"
+
+      # Embed the SHA-256 of each per-platform binary into the npm
+      # package being published, so the postinstall script can verify
+      # the binary it downloads from GitHub against the hash that
+      # arrived via npm.
+      #
+      # Without this step the postinstall would refuse to install
+      # ("expected-checksum.txt missing or malformed"). That refusal
+      # is the desired behavior — better to fail noisily here than to
+      # silently ship an unverifiable binary.
+      - name: Embed expected SHA-256 into platform npm packages
+        run: |
+          set -e
+          for slug in linux-x86_64 darwin-aarch64 darwin-x86_64; do
+            case "$slug" in
+              linux-x86_64)   pkg=cli-linux-x64    sha='${{ needs.release.outputs.sha256_linux_x86_64 }}';;
+              darwin-aarch64) pkg=cli-darwin-arm64 sha='${{ needs.release.outputs.sha256_darwin_aarch64 }}';;
+              darwin-x86_64)  pkg=cli-darwin-x64   sha='${{ needs.release.outputs.sha256_darwin_x86_64 }}';;
+            esac
+            if [ -z "$sha" ] || ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "::error::Missing or malformed SHA-256 for $pkg ($slug). Refusing to publish."
+              exit 1
+            fi
+            printf '%s\n' "$sha" > "npm/@treeship/$pkg/expected-checksum.txt"
+            echo "  $pkg → $sha"
+          done
 
       - name: Publish @treeship/cli-linux-x64
         working-directory: npm/@treeship/cli-linux-x64

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ tests/cross-sdk/corpus.json
 tests/cross-sdk/.ts-output.jsonl
 tests/cross-sdk/.py-output.jsonl
 tests/cross-sdk/.roundtrip-output.jsonl
+
+# Per-platform binary checksum populated by the release pipeline
+# (see .github/workflows/release.yml). Never committed; written only
+# at npm-publish time so the postinstall can verify the GitHub Release
+# binary against an npm-delivered hash.
+npm/@treeship/cli-*/expected-checksum.txt

--- a/npm/@treeship/cli-darwin-arm64/README.md
+++ b/npm/@treeship/cli-darwin-arm64/README.md
@@ -10,6 +10,19 @@ npm install -g treeship
 
 The main `treeship` package detects your platform and pulls the correct binary.
 
+## Binary integrity
+
+The package ships a single-line `expected-checksum.txt` with the SHA-256 of the binary it downloads from the matching GitHub Release. The postinstall script:
+
+1. Reads the expected hash from the package (delivered via npm).
+2. Downloads the binary from `https://github.com/zerkerlabs/treeship/releases/download/v<version>/treeship-darwin-aarch64`.
+3. Verifies the downloaded bytes match the expected hash.
+4. Atomically renames the partial download into place only on match. On mismatch, the partial file is deleted and install fails (exit 1).
+
+Because the hash is delivered via npm and the binary is delivered via GitHub Releases, an attacker would need to compromise *both* trust roots simultaneously to slip a tampered binary past install. A compromise of either alone produces a verification failure.
+
+If the package was published without `expected-checksum.txt`, the postinstall refuses to install. That's intentional: a binary with no published checksum is unverifiable.
+
 ## Repository
 
-[github.com/nicholasgriffintn/treeship](https://github.com/nicholasgriffintn/treeship)
+[github.com/zerkerlabs/treeship](https://github.com/zerkerlabs/treeship)

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -9,6 +9,12 @@
     "arm64"
   ],
   "license": "Apache-2.0",
+  "files": [
+    "postinstall.js",
+    "binary.js",
+    "expected-checksum.txt",
+    "README.md"
+  ],
   "scripts": {
     "postinstall": "node postinstall.js"
   },

--- a/npm/@treeship/cli-darwin-arm64/postinstall.js
+++ b/npm/@treeship/cli-darwin-arm64/postinstall.js
@@ -1,41 +1,138 @@
-const https = require('https');
+// @treeship/cli-darwin-arm64 -- platform binary postinstall.
+//
+// Downloads the Treeship CLI binary from the matching GitHub Release
+// and verifies its SHA-256 against the expected hash that ships
+// inside this npm package. Both halves of the trust path matter:
+//
+//   1. The expected hash arrives via npm (signed by npm's package
+//      integrity, separate trust root from GitHub).
+//   2. The binary arrives via GitHub Releases.
+//   3. If either is tampered, the hashes don't match and we abort.
+//
+// Earlier versions (<= 0.10.0) downloaded the binary, chmod +x'd it,
+// and exited 0 -- no integrity check, and an install failure also
+// exited 0 (claiming success). This file is the v0.10.1 hardening.
+
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
 
 const VERSION = require('./package.json').version;
 const BINARY_NAME = 'treeship-darwin-aarch64';
 const URL = 'https://github.com/zerkerlabs/treeship/releases/download/v' + VERSION + '/' + BINARY_NAME;
-const DEST = path.join(__dirname, 'bin', 'treeship');
+const BIN_DIR = path.join(__dirname, 'bin');
+const DEST = path.join(BIN_DIR, 'treeship');
+const PARTIAL = DEST + '.partial';
+const CHECKSUM_FILE = path.join(__dirname, 'expected-checksum.txt');
 
-if (fs.existsSync(DEST)) process.exit(0);
+// Read the expected SHA-256 that the release pipeline embedded in this
+// package. Format: a single line, lowercase hex, 64 chars. If absent
+// or malformed, refuse to install -- a binary without a published
+// checksum is an unverifiable binary.
+function readExpectedChecksum() {
+  let raw;
+  try {
+    raw = fs.readFileSync(CHECKSUM_FILE, 'utf8');
+  } catch (e) {
+    return null;
+  }
+  const hex = raw.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  return hex;
+}
 
-fs.mkdirSync(path.join(__dirname, 'bin'), { recursive: true });
+function abort(reason, code) {
+  // Always delete the partial download so a retry doesn't think it
+  // already has the binary.
+  try { if (fs.existsSync(PARTIAL)) fs.unlinkSync(PARTIAL); } catch {}
+  console.error('treeship: install failed -- ' + reason);
+  console.error('  Recover:');
+  console.error('    1. Re-run the install (transient network/CDN issues clear up):');
+  console.error('       npm install -g treeship');
+  console.error('    2. Or download the binary directly and place it on PATH:');
+  console.error('       https://github.com/zerkerlabs/treeship/releases/tag/v' + VERSION);
+  console.error('    3. Or build from source:');
+  console.error('       git clone https://github.com/zerkerlabs/treeship');
+  console.error('       cd treeship && cargo build --release -p treeship-cli');
+  process.exit(code || 1);
+}
 
-console.log('treeship: downloading ' + BINARY_NAME + '...');
+const expected = readExpectedChecksum();
+if (!expected) {
+  abort(
+    'expected-checksum.txt missing or malformed in ' + path.basename(__dirname) +
+    '. This npm package was published without a binary integrity hash and ' +
+    'cannot be installed safely. File an issue at ' +
+    'https://github.com/zerkerlabs/treeship/issues so we can re-publish it.',
+    1,
+  );
+}
 
-function download(url) {
-  https.get(url, (res) => {
-    if (res.statusCode === 302 || res.statusCode === 301) {
-      download(res.headers.location);
-      return;
+if (fs.existsSync(DEST)) {
+  // Already installed and verified previously -- nothing to do.
+  process.exit(0);
+}
+
+fs.mkdirSync(BIN_DIR, { recursive: true });
+console.log('treeship: downloading ' + BINARY_NAME + ' v' + VERSION + ' ...');
+
+function download(url, redirects) {
+  if (redirects > 5) return abort('too many redirects', 1);
+
+  const req = https.get(url, (res) => {
+    if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
+      res.resume();
+      return download(res.headers.location, redirects + 1);
     }
     if (res.statusCode !== 200) {
-      console.error('treeship: download failed (' + res.statusCode + ')');
-      console.error('Install manually: cargo install treeship-cli');
-      process.exit(0);
+      res.resume();
+      return abort('download HTTP ' + res.statusCode + ' from ' + url, 1);
     }
-    const file = fs.createWriteStream(DEST);
-    res.pipe(file);
-    file.on('finish', () => {
-      file.close();
-      fs.chmodSync(DEST, 0o755);
-      console.log('treeship: installed');
+
+    const hash = crypto.createHash('sha256');
+    const file = fs.createWriteStream(PARTIAL);
+
+    res.on('data', (chunk) => {
+      hash.update(chunk);
+      file.write(chunk);
     });
-  }).on('error', () => {
-    console.error('treeship: download failed');
-    console.error('Install manually: cargo install treeship-cli');
-    process.exit(0);
+    res.on('end', () => {
+      file.end(() => {
+        const got = hash.digest('hex');
+        if (got !== expected) {
+          // Delete the partial file before aborting so a retry can't
+          // pick up the bad bytes.
+          try { fs.unlinkSync(PARTIAL); } catch {}
+          return abort(
+            'SHA-256 mismatch.\n' +
+            '       expected: ' + expected + '\n' +
+            '       got:      ' + got + '\n' +
+            '       This means either the GitHub Release was tampered with, ' +
+            'a CDN cached a stale or malicious binary, or the npm package ' +
+            'and the release are out of sync. Do not run the binary.',
+            1,
+          );
+        }
+        try {
+          fs.renameSync(PARTIAL, DEST);
+          fs.chmodSync(DEST, 0o755);
+        } catch (e) {
+          return abort('could not finalize binary: ' + e.message, 1);
+        }
+        console.log('treeship: installed (sha256 verified)');
+      });
+    });
+    res.on('error', (e) => abort('stream error: ' + e.message, 1));
+    file.on('error', (e) => abort('write error: ' + e.message, 1));
+  });
+  req.on('error', (e) => abort('connection error: ' + e.message, 1));
+  req.setTimeout(60_000, () => {
+    req.destroy();
+    abort('download timed out after 60s', 1);
   });
 }
 
-download(URL);
+download(URL, 0);

--- a/npm/@treeship/cli-darwin-x64/README.md
+++ b/npm/@treeship/cli-darwin-x64/README.md
@@ -1,6 +1,6 @@
 # @treeship/cli-darwin-x64
 
-Platform-specific binary for the Treeship CLI on Intel Mac (macOS x64).
+Platform-specific binary for the Treeship CLI on Intel Macs (macOS x86_64).
 
 This package is **not meant to be installed directly**. It is automatically downloaded when you run:
 
@@ -10,6 +10,19 @@ npm install -g treeship
 
 The main `treeship` package detects your platform and pulls the correct binary.
 
+## Binary integrity
+
+The package ships a single-line `expected-checksum.txt` with the SHA-256 of the binary it downloads from the matching GitHub Release. The postinstall script:
+
+1. Reads the expected hash from the package (delivered via npm).
+2. Downloads the binary from `https://github.com/zerkerlabs/treeship/releases/download/v<version>/treeship-darwin-x86_64`.
+3. Verifies the downloaded bytes match the expected hash.
+4. Atomically renames the partial download into place only on match. On mismatch, the partial file is deleted and install fails (exit 1).
+
+Because the hash is delivered via npm and the binary is delivered via GitHub Releases, an attacker would need to compromise *both* trust roots simultaneously to slip a tampered binary past install. A compromise of either alone produces a verification failure.
+
+If the package was published without `expected-checksum.txt`, the postinstall refuses to install. That's intentional: a binary with no published checksum is unverifiable.
+
 ## Repository
 
-[github.com/nicholasgriffintn/treeship](https://github.com/nicholasgriffintn/treeship)
+[github.com/zerkerlabs/treeship](https://github.com/zerkerlabs/treeship)

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -9,6 +9,12 @@
     "x64"
   ],
   "license": "Apache-2.0",
+  "files": [
+    "postinstall.js",
+    "binary.js",
+    "expected-checksum.txt",
+    "README.md"
+  ],
   "scripts": {
     "postinstall": "node postinstall.js"
   },

--- a/npm/@treeship/cli-darwin-x64/postinstall.js
+++ b/npm/@treeship/cli-darwin-x64/postinstall.js
@@ -1,41 +1,138 @@
-const https = require('https');
+// @treeship/cli-darwin-arm64 -- platform binary postinstall.
+//
+// Downloads the Treeship CLI binary from the matching GitHub Release
+// and verifies its SHA-256 against the expected hash that ships
+// inside this npm package. Both halves of the trust path matter:
+//
+//   1. The expected hash arrives via npm (signed by npm's package
+//      integrity, separate trust root from GitHub).
+//   2. The binary arrives via GitHub Releases.
+//   3. If either is tampered, the hashes don't match and we abort.
+//
+// Earlier versions (<= 0.10.0) downloaded the binary, chmod +x'd it,
+// and exited 0 -- no integrity check, and an install failure also
+// exited 0 (claiming success). This file is the v0.10.1 hardening.
+
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
 
 const VERSION = require('./package.json').version;
 const BINARY_NAME = 'treeship-darwin-x86_64';
 const URL = 'https://github.com/zerkerlabs/treeship/releases/download/v' + VERSION + '/' + BINARY_NAME;
-const DEST = path.join(__dirname, 'bin', 'treeship');
+const BIN_DIR = path.join(__dirname, 'bin');
+const DEST = path.join(BIN_DIR, 'treeship');
+const PARTIAL = DEST + '.partial';
+const CHECKSUM_FILE = path.join(__dirname, 'expected-checksum.txt');
 
-if (fs.existsSync(DEST)) process.exit(0);
+// Read the expected SHA-256 that the release pipeline embedded in this
+// package. Format: a single line, lowercase hex, 64 chars. If absent
+// or malformed, refuse to install -- a binary without a published
+// checksum is an unverifiable binary.
+function readExpectedChecksum() {
+  let raw;
+  try {
+    raw = fs.readFileSync(CHECKSUM_FILE, 'utf8');
+  } catch (e) {
+    return null;
+  }
+  const hex = raw.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  return hex;
+}
 
-fs.mkdirSync(path.join(__dirname, 'bin'), { recursive: true });
+function abort(reason, code) {
+  // Always delete the partial download so a retry doesn't think it
+  // already has the binary.
+  try { if (fs.existsSync(PARTIAL)) fs.unlinkSync(PARTIAL); } catch {}
+  console.error('treeship: install failed -- ' + reason);
+  console.error('  Recover:');
+  console.error('    1. Re-run the install (transient network/CDN issues clear up):');
+  console.error('       npm install -g treeship');
+  console.error('    2. Or download the binary directly and place it on PATH:');
+  console.error('       https://github.com/zerkerlabs/treeship/releases/tag/v' + VERSION);
+  console.error('    3. Or build from source:');
+  console.error('       git clone https://github.com/zerkerlabs/treeship');
+  console.error('       cd treeship && cargo build --release -p treeship-cli');
+  process.exit(code || 1);
+}
 
-console.log('treeship: downloading ' + BINARY_NAME + '...');
+const expected = readExpectedChecksum();
+if (!expected) {
+  abort(
+    'expected-checksum.txt missing or malformed in ' + path.basename(__dirname) +
+    '. This npm package was published without a binary integrity hash and ' +
+    'cannot be installed safely. File an issue at ' +
+    'https://github.com/zerkerlabs/treeship/issues so we can re-publish it.',
+    1,
+  );
+}
 
-function download(url) {
-  https.get(url, (res) => {
-    if (res.statusCode === 302 || res.statusCode === 301) {
-      download(res.headers.location);
-      return;
+if (fs.existsSync(DEST)) {
+  // Already installed and verified previously -- nothing to do.
+  process.exit(0);
+}
+
+fs.mkdirSync(BIN_DIR, { recursive: true });
+console.log('treeship: downloading ' + BINARY_NAME + ' v' + VERSION + ' ...');
+
+function download(url, redirects) {
+  if (redirects > 5) return abort('too many redirects', 1);
+
+  const req = https.get(url, (res) => {
+    if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
+      res.resume();
+      return download(res.headers.location, redirects + 1);
     }
     if (res.statusCode !== 200) {
-      console.error('treeship: download failed (' + res.statusCode + ')');
-      console.error('Install manually: cargo install treeship-cli');
-      process.exit(0);
+      res.resume();
+      return abort('download HTTP ' + res.statusCode + ' from ' + url, 1);
     }
-    const file = fs.createWriteStream(DEST);
-    res.pipe(file);
-    file.on('finish', () => {
-      file.close();
-      fs.chmodSync(DEST, 0o755);
-      console.log('treeship: installed');
+
+    const hash = crypto.createHash('sha256');
+    const file = fs.createWriteStream(PARTIAL);
+
+    res.on('data', (chunk) => {
+      hash.update(chunk);
+      file.write(chunk);
     });
-  }).on('error', () => {
-    console.error('treeship: download failed');
-    console.error('Install manually: cargo install treeship-cli');
-    process.exit(0);
+    res.on('end', () => {
+      file.end(() => {
+        const got = hash.digest('hex');
+        if (got !== expected) {
+          // Delete the partial file before aborting so a retry can't
+          // pick up the bad bytes.
+          try { fs.unlinkSync(PARTIAL); } catch {}
+          return abort(
+            'SHA-256 mismatch.\n' +
+            '       expected: ' + expected + '\n' +
+            '       got:      ' + got + '\n' +
+            '       This means either the GitHub Release was tampered with, ' +
+            'a CDN cached a stale or malicious binary, or the npm package ' +
+            'and the release are out of sync. Do not run the binary.',
+            1,
+          );
+        }
+        try {
+          fs.renameSync(PARTIAL, DEST);
+          fs.chmodSync(DEST, 0o755);
+        } catch (e) {
+          return abort('could not finalize binary: ' + e.message, 1);
+        }
+        console.log('treeship: installed (sha256 verified)');
+      });
+    });
+    res.on('error', (e) => abort('stream error: ' + e.message, 1));
+    file.on('error', (e) => abort('write error: ' + e.message, 1));
+  });
+  req.on('error', (e) => abort('connection error: ' + e.message, 1));
+  req.setTimeout(60_000, () => {
+    req.destroy();
+    abort('download timed out after 60s', 1);
   });
 }
 
-download(URL);
+download(URL, 0);

--- a/npm/@treeship/cli-linux-x64/README.md
+++ b/npm/@treeship/cli-linux-x64/README.md
@@ -1,6 +1,6 @@
 # @treeship/cli-linux-x64
 
-Platform-specific binary for the Treeship CLI on Linux x86_64.
+Platform-specific binary for the Treeship CLI on Linux x86_64 (GNU).
 
 This package is **not meant to be installed directly**. It is automatically downloaded when you run:
 
@@ -10,6 +10,19 @@ npm install -g treeship
 
 The main `treeship` package detects your platform and pulls the correct binary.
 
+## Binary integrity
+
+The package ships a single-line `expected-checksum.txt` with the SHA-256 of the binary it downloads from the matching GitHub Release. The postinstall script:
+
+1. Reads the expected hash from the package (delivered via npm).
+2. Downloads the binary from `https://github.com/zerkerlabs/treeship/releases/download/v<version>/treeship-linux-x86_64`.
+3. Verifies the downloaded bytes match the expected hash.
+4. Atomically renames the partial download into place only on match. On mismatch, the partial file is deleted and install fails (exit 1).
+
+Because the hash is delivered via npm and the binary is delivered via GitHub Releases, an attacker would need to compromise *both* trust roots simultaneously to slip a tampered binary past install. A compromise of either alone produces a verification failure.
+
+If the package was published without `expected-checksum.txt`, the postinstall refuses to install. That's intentional: a binary with no published checksum is unverifiable.
+
 ## Repository
 
-[github.com/nicholasgriffintn/treeship](https://github.com/nicholasgriffintn/treeship)
+[github.com/zerkerlabs/treeship](https://github.com/zerkerlabs/treeship)

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -9,6 +9,12 @@
     "x64"
   ],
   "license": "Apache-2.0",
+  "files": [
+    "postinstall.js",
+    "binary.js",
+    "expected-checksum.txt",
+    "README.md"
+  ],
   "scripts": {
     "postinstall": "node postinstall.js"
   },

--- a/npm/@treeship/cli-linux-x64/postinstall.js
+++ b/npm/@treeship/cli-linux-x64/postinstall.js
@@ -1,41 +1,138 @@
-const https = require('https');
+// @treeship/cli-darwin-arm64 -- platform binary postinstall.
+//
+// Downloads the Treeship CLI binary from the matching GitHub Release
+// and verifies its SHA-256 against the expected hash that ships
+// inside this npm package. Both halves of the trust path matter:
+//
+//   1. The expected hash arrives via npm (signed by npm's package
+//      integrity, separate trust root from GitHub).
+//   2. The binary arrives via GitHub Releases.
+//   3. If either is tampered, the hashes don't match and we abort.
+//
+// Earlier versions (<= 0.10.0) downloaded the binary, chmod +x'd it,
+// and exited 0 -- no integrity check, and an install failure also
+// exited 0 (claiming success). This file is the v0.10.1 hardening.
+
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
 
 const VERSION = require('./package.json').version;
 const BINARY_NAME = 'treeship-linux-x86_64';
 const URL = 'https://github.com/zerkerlabs/treeship/releases/download/v' + VERSION + '/' + BINARY_NAME;
-const DEST = path.join(__dirname, 'bin', 'treeship');
+const BIN_DIR = path.join(__dirname, 'bin');
+const DEST = path.join(BIN_DIR, 'treeship');
+const PARTIAL = DEST + '.partial';
+const CHECKSUM_FILE = path.join(__dirname, 'expected-checksum.txt');
 
-if (fs.existsSync(DEST)) process.exit(0);
+// Read the expected SHA-256 that the release pipeline embedded in this
+// package. Format: a single line, lowercase hex, 64 chars. If absent
+// or malformed, refuse to install -- a binary without a published
+// checksum is an unverifiable binary.
+function readExpectedChecksum() {
+  let raw;
+  try {
+    raw = fs.readFileSync(CHECKSUM_FILE, 'utf8');
+  } catch (e) {
+    return null;
+  }
+  const hex = raw.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  return hex;
+}
 
-fs.mkdirSync(path.join(__dirname, 'bin'), { recursive: true });
+function abort(reason, code) {
+  // Always delete the partial download so a retry doesn't think it
+  // already has the binary.
+  try { if (fs.existsSync(PARTIAL)) fs.unlinkSync(PARTIAL); } catch {}
+  console.error('treeship: install failed -- ' + reason);
+  console.error('  Recover:');
+  console.error('    1. Re-run the install (transient network/CDN issues clear up):');
+  console.error('       npm install -g treeship');
+  console.error('    2. Or download the binary directly and place it on PATH:');
+  console.error('       https://github.com/zerkerlabs/treeship/releases/tag/v' + VERSION);
+  console.error('    3. Or build from source:');
+  console.error('       git clone https://github.com/zerkerlabs/treeship');
+  console.error('       cd treeship && cargo build --release -p treeship-cli');
+  process.exit(code || 1);
+}
 
-console.log('treeship: downloading ' + BINARY_NAME + '...');
+const expected = readExpectedChecksum();
+if (!expected) {
+  abort(
+    'expected-checksum.txt missing or malformed in ' + path.basename(__dirname) +
+    '. This npm package was published without a binary integrity hash and ' +
+    'cannot be installed safely. File an issue at ' +
+    'https://github.com/zerkerlabs/treeship/issues so we can re-publish it.',
+    1,
+  );
+}
 
-function download(url) {
-  https.get(url, (res) => {
-    if (res.statusCode === 302 || res.statusCode === 301) {
-      download(res.headers.location);
-      return;
+if (fs.existsSync(DEST)) {
+  // Already installed and verified previously -- nothing to do.
+  process.exit(0);
+}
+
+fs.mkdirSync(BIN_DIR, { recursive: true });
+console.log('treeship: downloading ' + BINARY_NAME + ' v' + VERSION + ' ...');
+
+function download(url, redirects) {
+  if (redirects > 5) return abort('too many redirects', 1);
+
+  const req = https.get(url, (res) => {
+    if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
+      res.resume();
+      return download(res.headers.location, redirects + 1);
     }
     if (res.statusCode !== 200) {
-      console.error('treeship: download failed (' + res.statusCode + ')');
-      console.error('Install manually: cargo install treeship-cli');
-      process.exit(0);
+      res.resume();
+      return abort('download HTTP ' + res.statusCode + ' from ' + url, 1);
     }
-    const file = fs.createWriteStream(DEST);
-    res.pipe(file);
-    file.on('finish', () => {
-      file.close();
-      fs.chmodSync(DEST, 0o755);
-      console.log('treeship: installed');
+
+    const hash = crypto.createHash('sha256');
+    const file = fs.createWriteStream(PARTIAL);
+
+    res.on('data', (chunk) => {
+      hash.update(chunk);
+      file.write(chunk);
     });
-  }).on('error', () => {
-    console.error('treeship: download failed');
-    console.error('Install manually: cargo install treeship-cli');
-    process.exit(0);
+    res.on('end', () => {
+      file.end(() => {
+        const got = hash.digest('hex');
+        if (got !== expected) {
+          // Delete the partial file before aborting so a retry can't
+          // pick up the bad bytes.
+          try { fs.unlinkSync(PARTIAL); } catch {}
+          return abort(
+            'SHA-256 mismatch.\n' +
+            '       expected: ' + expected + '\n' +
+            '       got:      ' + got + '\n' +
+            '       This means either the GitHub Release was tampered with, ' +
+            'a CDN cached a stale or malicious binary, or the npm package ' +
+            'and the release are out of sync. Do not run the binary.',
+            1,
+          );
+        }
+        try {
+          fs.renameSync(PARTIAL, DEST);
+          fs.chmodSync(DEST, 0o755);
+        } catch (e) {
+          return abort('could not finalize binary: ' + e.message, 1);
+        }
+        console.log('treeship: installed (sha256 verified)');
+      });
+    });
+    res.on('error', (e) => abort('stream error: ' + e.message, 1));
+    file.on('error', (e) => abort('write error: ' + e.message, 1));
+  });
+  req.on('error', (e) => abort('connection error: ' + e.message, 1));
+  req.setTimeout(60_000, () => {
+    req.destroy();
+    abort('download timed out after 60s', 1);
   });
 }
 
-download(URL);
+download(URL, 0);


### PR DESCRIPTION
## What changed

v0.10.0's npm postinstall downloaded the CLI binary from GitHub Releases, `chmod +x`'d it, and exited 0. There was no integrity check. A network MITM, GitHub-Releases compromise, or CDN cache poisoning could substitute a tampered binary and the install would silently succeed.

This PR closes the gap with a **two-trust-root model**:

1. The expected SHA-256 ships in the npm package as `expected-checksum.txt` (delivered via npm registry, signed by npm's package integrity — separate trust root from GitHub).
2. The binary ships on GitHub Releases (independent trust root).
3. The postinstall verifies the downloaded bytes match the embedded hash. Mismatch → `exit 1`, partial download deleted, actionable error pointing at retry / direct-download / build-from-source.

To slip a tampered binary past install, an attacker now has to compromise **both** npm AND GitHub simultaneously. A compromise of either alone fails closed.

### Concrete changes

- Each platform package's `postinstall.js` (`cli-darwin-arm64`, `cli-darwin-x64`, `cli-linux-x64`) replaced with the hardened version: read `expected-checksum.txt`, atomic `.partial` → final, fail-closed on every error path (timeout, redirects > 5, HTTP non-200, hash mismatch, missing checksum file). `exit(0)`-on-failure is gone; npm now sees real failures.
- Each `package.json` adds `files:` so `expected-checksum.txt` is packed into the npm tarball.
- `.gitignore` excludes `npm/@treeship/cli-*/expected-checksum.txt` so the file is never committed — it is populated only at npm-publish time by the release pipeline.
- `.github/workflows/release.yml` computes `SHA256SUMS` in the release job, uploads it to the GitHub Release, and surfaces per-platform hashes as job outputs. The publish-npm job has a new "Embed expected SHA-256" step that writes each hash into its matching npm package before `npm publish`. Refuses to publish if any hash is missing or malformed.
- Per-package READMEs document the two-trust-root integrity model so the contract is discoverable from `npm view`.

## v0.10.0 review finding closed

> "npm binary integrity verification: this is the most serious supply-chain issue. The security review flags npm postinstall downloading binaries from GitHub without checksum/signature verification as critical. Preferred fix: include the binary inside each platform npm package. If download-on-install remains: publish SHA256SUMS, embed expected checksum in npm package, verify downloaded binary before chmod/use, fail closed on mismatch."

## Tests run

Verified locally:
- **Missing `expected-checksum.txt`** → exit 1 with clear error pointing at retry/direct-download/build-from-source paths
- **Malformed `expected-checksum.txt`** → exit 1
- **Well-formed but wrong checksum** → SHA mismatch detected, exit 1, partial deleted
- All 3 postinstall files parse-check OK (`node -c`)

End-to-end (download → hash → atomic install) will exercise on the first 0.10.1 publish via the new release CI step.

## What is intentionally out of scope

- **Sigstore / cosign signatures** of the binary. The two-trust-root SHA-256 model is the v0.10.1 hardening floor; full signature-based attestation is future work.
- **In-package binaries** (the alternative to download-on-install). Considered and rejected for v0.10.1 because per-platform npm tarballs would balloon to ~5MB each. The download path with verification is the v0.10.x answer.

## Independent or stacked

**Independent.** Branched off main; no dependencies on other v0.10.1 PRs. **Note:** PR 6 (Linux musl) stacks on this PR because both touch `release.yml`. Merge order: PR 5 first, then rebase/merge PR 6.

## Part of v0.10.1 — Platform, SDK, Supply Chain, and MCP Hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)