### PR TITLE
fix(attribution): wire model+provider through attest decision into session timeline

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -12,6 +12,7 @@ use treeship_core::{
 
 use crate::commands::verify::{check_scope_violation, find_approval_by_nonce, now_rfc3339};
 use crate::{ctx, printer::Printer};
+use treeship_core::session::event::EventType;
 
 // --- action -----------------------------------------------------------------
 
@@ -379,6 +380,7 @@ pub struct DecisionArgs {
     pub actor:         String,
     pub model:         Option<String>,
     pub model_version: Option<String>,
+    pub provider:      Option<String>,
     pub tokens_in:     Option<u64>,
     pub tokens_out:    Option<u64>,
     pub prompt_digest: Option<String>,
@@ -395,6 +397,7 @@ pub fn decision(args: DecisionArgs, printer: &Printer) -> Result<(), Box<dyn std
     let mut stmt = DecisionStatement::new(&args.actor);
     stmt.model = args.model.clone();
     stmt.model_version = args.model_version.clone();
+    stmt.provider = args.provider.clone();
     stmt.tokens_in = args.tokens_in;
     stmt.tokens_out = args.tokens_out;
     stmt.prompt_digest = args.prompt_digest.clone();
@@ -422,6 +425,20 @@ pub fn decision(args: DecisionArgs, printer: &Printer) -> Result<(), Box<dyn std
     // Write .last for auto-chaining
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
+    // v0.10.2: also emit a SessionEvent::AgentDecision into the active
+    // session's event log (best-effort). Without this, model/provider
+    // attribution lived only on the signed artifact -- the session
+    // receipt's agent_graph saw the actor but had no idea what
+    // model/provider they were running. Now `treeship attest decision
+    // --actor agent://x --model kimi-k2 --provider moonshot` flows
+    // through to the session timeline and `agents` array directly.
+    //
+    // Best-effort: failure to emit (no active session, lock contention,
+    // missing .treeship dir) MUST NOT fail the action. The signed
+    // artifact and storage write above already succeeded; the session
+    // event is a derived view, not the source of truth.
+    emit_decision_session_event(&args, &result.artifact_id);
+
     printer.success("decision attested", &[
         ("id",    &result.artifact_id),
         ("actor", &args.actor),
@@ -436,6 +453,60 @@ pub fn decision(args: DecisionArgs, printer: &Printer) -> Result<(), Box<dyn std
     printer.hint(&format!("treeship verify {}", result.artifact_id));
     printer.blank();
     Ok(())
+}
+
+/// v0.10.2 helper: mirror a freshly-signed `attest decision` into the
+/// active session's event log so the receipt composer / agent_graph
+/// can attribute model + provider + tokens. Best-effort -- a missing
+/// session, lock contention, or write failure must not bubble up to
+/// fail the artifact path.
+///
+/// Without this, model/provider attribution lives only on the signed
+/// artifact and the session report says "agent X did N decisions"
+/// with the model/provider columns empty. Wiring it here closes the
+/// gap that v0.10.1's compatibility audit flagged.
+fn emit_decision_session_event(args: &DecisionArgs, artifact_id: &str) {
+    // Resolve env-var fallbacks so an integration that exports
+    // TREESHIP_MODEL once at session start still gets attribution
+    // even if the per-call --model isn't passed. Mirrors the logic
+    // in commands/session.rs::event for agent.decision.
+    let model = args.model.clone()
+        .or_else(|| std::env::var("TREESHIP_MODEL").ok());
+    let provider = args.provider.clone()
+        .or_else(|| std::env::var("TREESHIP_PROVIDER").ok());
+    let tokens_in = args.tokens_in
+        .or_else(|| std::env::var("TREESHIP_TOKENS_IN").ok().and_then(|s| s.parse().ok()));
+    let tokens_out = args.tokens_out
+        .or_else(|| std::env::var("TREESHIP_TOKENS_OUT").ok().and_then(|s| s.parse().ok()));
+
+    // If the operator gave us nothing about the inference (no model,
+    // no provider, no tokens, no summary, no confidence), there's
+    // nothing useful to put in the session event. The signed artifact
+    // already exists; skip the empty event.
+    if model.is_none() && provider.is_none() && tokens_in.is_none() && tokens_out.is_none()
+        && args.summary.is_none() && args.confidence.is_none()
+    {
+        return;
+    }
+
+    let et = EventType::AgentDecision {
+        model,
+        tokens_in,
+        tokens_out,
+        provider,
+        summary: args.summary.clone(),
+        confidence: args.confidence,
+    };
+
+    // Best-effort: ignore all errors. The artifact path already
+    // succeeded; this is a derived view.
+    let _ = crate::commands::session::append_active_session_event(
+        et,
+        Some(&args.actor),
+        Some(&args.actor.replace("agent://", "")),
+        Some(artifact_id),
+        "attest-cli",
+    );
 }
 
 // --- endorsement -----------------------------------------------------------

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -983,6 +983,70 @@ pub fn close(
 // session event -- append a structured event to the active session's log
 // ---------------------------------------------------------------------------
 
+/// Append a fully-typed `EventType` into the active session's event log.
+///
+/// Best-effort: returns `Ok(false)` (not an error) when there is no
+/// active session. Callers like `attest::decision` use this to mirror
+/// a signed artifact into the session timeline without forcing the
+/// caller to first check for an active session.
+///
+/// Returns `Ok(true)` on a successful append, `Ok(false)` if there is
+/// no active session, and `Err(_)` for actual I/O / lock failures.
+///
+/// `actor` should be the agent URI (e.g. `agent://kimi-1`); the
+/// session manifest's actor is used as a fallback when None. `agent_name`
+/// is the human-readable name shown in agent_graph nodes.
+///
+/// The event's source is tagged `attest-cli` in meta so the receipt
+/// composer can distinguish artifact-derived events from
+/// `session-event-cli` (manual operator) and `wrap`-emitted ones.
+pub fn append_active_session_event(
+    event_type: EventType,
+    actor: Option<&str>,
+    agent_name: Option<&str>,
+    artifact_ref: Option<&str>,
+    source: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let manifest = match load_session() {
+        Some(m) => m,
+        None => return Ok(false),
+    };
+    let ts_dir = match session_dir() {
+        Some(d) => d,
+        None => return Ok(false),
+    };
+    let evt_dir = ts_dir.join("sessions").join(&manifest.session_id);
+    let event_log = EventLog::open(&evt_dir)?;
+
+    let actor_uri = actor.unwrap_or(&manifest.actor);
+    let a_name = agent_name.unwrap_or("external");
+
+    let mut meta_obj = serde_json::Map::new();
+    meta_obj.insert("source".into(), serde_json::json!(source));
+    let meta = Some(serde_json::Value::Object(meta_obj));
+
+    let mut evt = SessionEvent {
+        session_id: manifest.session_id.clone(),
+        event_id: generate_event_id(),
+        timestamp: now_rfc3339(),
+        sequence_no: 0,
+        trace_id: generate_trace_id(),
+        span_id: generate_span_id(),
+        parent_span_id: None,
+        agent_id: actor_uri.into(),
+        agent_instance_id: a_name.into(),
+        agent_name: a_name.into(),
+        agent_role: Some("agent".into()),
+        host_id: local_host_id(),
+        tool_runtime_id: None,
+        event_type,
+        artifact_ref: artifact_ref.map(|s| s.into()),
+        meta,
+    };
+    event_log.append(&mut evt)?;
+    Ok(true)
+}
+
 pub fn event(
     event_type: &str,
     tool: Option<&str>,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1269,13 +1269,22 @@ struct AttestDecisionArgs {
     #[arg(long, required = true, value_name = "URI")]
     actor: String,
 
-    /// Model used for inference (e.g. claude-opus-4)
+    /// Model used for inference. Examples:
+    /// claude-opus-4-7, kimi-k2, gpt-5, gemini-3-pro.
     #[arg(long, value_name = "MODEL")]
     model: Option<String>,
 
     /// Model version if known
     #[arg(long, value_name = "VERSION")]
     model_version: Option<String>,
+
+    /// Provider that hosts the model. Examples:
+    /// anthropic, moonshot, openai, google, meta, mistral, ollama.
+    /// Decoupled from --model so attribution is correct when the
+    /// same model name lives behind multiple providers (e.g.
+    /// Bedrock vs Anthropic native, OpenRouter vs OpenAI).
+    #[arg(long, value_name = "NAME")]
+    provider: Option<String>,
 
     /// Number of input tokens consumed
     #[arg(long, value_name = "N")]
@@ -2029,6 +2038,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     actor:         a.actor.clone(),
                     model:         a.model.clone(),
                     model_version: a.model_version.clone(),
+                    provider:      a.provider.clone(),
                     tokens_in:     a.tokens_in,
                     tokens_out:    a.tokens_out,
                     prompt_digest: a.prompt_digest.clone(),

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -365,13 +365,29 @@ pub struct DecisionStatement {
     #[serde(rename = "parentId", skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<String>,
 
-    /// Model used for inference. e.g. "claude-opus-4"
+    /// Model used for inference. e.g. "claude-opus-4-7", "kimi-k2", "gpt-5"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 
     /// Model version if known.
     #[serde(rename = "modelVersion", skip_serializing_if = "Option::is_none")]
     pub model_version: Option<String>,
+
+    /// Provider that hosts the model. e.g. "anthropic", "moonshot",
+    /// "openai", "google", "meta", "mistral", "ollama".
+    ///
+    /// Distinct from `model`: a "surface" (the runtime that runs the
+    /// agent loop -- Claude Code, Cursor, Codex, OpenClaw, Hermes,
+    /// Cline) can be paired with any provider/model. Kimi for
+    /// example is `model = "kimi-k2"` with `provider = "moonshot"`,
+    /// runnable from any surface that speaks OpenAI-compatible APIs.
+    /// Attributing both lets a downstream auditor reason about
+    /// surface, model, and provider independently.
+    ///
+    /// Defaulted on deserialization so pre-v0.10.2 artifacts that
+    /// were signed without provider still parse cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
 
     /// Number of input tokens consumed.
     #[serde(rename = "tokensIn", skip_serializing_if = "Option::is_none")]
@@ -490,6 +506,7 @@ impl DecisionStatement {
             parent_id: None,
             model: None,
             model_version: None,
+            provider: None,
             tokens_in: None,
             tokens_out: None,
             prompt_digest: None,
@@ -762,6 +779,45 @@ mod tests {
         assert_eq!(decoded.summary, Some("Contract looks standard.".into()));
         assert_eq!(decoded.confidence, Some(0.91));
         assert_eq!(decoded.type_, TYPE_DECISION);
+    }
+
+    #[test]
+    fn decision_statement_provider_roundtrips() {
+        // v0.10.2 added `provider` so Kimi (model=kimi-k2 / provider=moonshot)
+        // and similar split-model/provider attributions land on the
+        // signed artifact, not just on the unsigned session event.
+        let signer   = Ed25519Signer::generate("key_test").unwrap();
+        let verifier = Verifier::from_signer(&signer);
+
+        let mut stmt = DecisionStatement::new("agent://researcher");
+        stmt.model    = Some("kimi-k2".into());
+        stmt.provider = Some("moonshot".into());
+
+        let pt = payload_type("decision");
+        let result = sign(&pt, &stmt, &signer).unwrap();
+        verifier.verify(&result.envelope).unwrap();
+
+        let decoded: DecisionStatement = result.envelope.unmarshal_statement().unwrap();
+        assert_eq!(decoded.model,    Some("kimi-k2".into()));
+        assert_eq!(decoded.provider, Some("moonshot".into()));
+    }
+
+    #[test]
+    fn decision_statement_legacy_payload_without_provider_decodes() {
+        // Pre-v0.10.2 artifacts were signed without `provider`. The
+        // field MUST default to None on deserialize so an old receipt
+        // verifying against a fresh CLI doesn't fail with
+        // "missing field provider". Defaulting is configured via
+        // `#[serde(default)]` -- this test pins that contract.
+        let raw = serde_json::json!({
+            "type": TYPE_DECISION,
+            "timestamp": "2026-04-30T12:00:00Z",
+            "actor": "agent://legacy",
+            "model": "claude-opus-4",
+        });
+        let parsed: DecisionStatement = serde_json::from_value(raw).unwrap();
+        assert_eq!(parsed.model, Some("claude-opus-4".into()));
+        assert_eq!(parsed.provider, None);
     }
 
     #[test]


### PR DESCRIPTION
## What this PR does

First in a series of v0.10.2 compatibility fixes — closing gaps the v0.10.1 audit found between earlier-version features and the v0.10.x session/receipt architecture.

This one closes **Kimi attribution**:

- `DecisionStatement` (the signed artifact) gains an optional \`provider\` field. Pre-v0.10.2 artifacts without it still parse via \`#[serde(default)]\`.
- \`treeship attest decision\` accepts \`--provider\` and threads it through to the signed artifact AND the session event.
- New \`commands::session::append_active_session_event\` helper lets the artifact-producing path mirror itself into the active session's timeline. Best-effort — no active session is not an error.
- \`attest decision\` now emits a \`SessionEvent::AgentDecision\` into the active session log, populating \`model\` / \`provider\` / \`tokens_in\` / \`tokens_out\` / \`summary\` / \`confidence\` from the same CLI args.

## Why

Pre-PR, this command:

\`\`\`
treeship attest decision --actor agent://researcher \\
  --model kimi-k2 --provider moonshot \\
  --tokens-in 1024 --tokens-out 512
\`\`\`

did three things that should have happened:
1. ❌ Rejected by clap because \`--provider\` wasn't a flag on the decision command.
2. (If \`--provider\` had been accepted): silently dropped because \`DecisionStatement\` had no provider field.
3. (If both above had worked): never appeared in the active session's event log because \`attest decision\` only signed an artifact and didn't emit a session event.

Net: the receipt's \`agent_graph\` carried \`model: null, provider: null\` for any agent attributed via \`attest decision\`, even when both were specified. Session reports could not surface "this agent ran on Kimi via Moonshot." That made the entire model/provider attribution surface — which is documented in \`bridges/mcp/ATTACHING.md\` and \`packages/cli/src/main.rs\`'s help text — a no-op for the artifact-producing path.

## Verification (local smoke)

Tmpdir keystore, run \`session start\` then \`attest decision\` then inspect the events.jsonl + receipt:

| Check | Result |
|---|---|
| events.jsonl contains \`type: agent.decision\` with model + provider + tokens + summary + confidence | ✓ |
| event \`artifact_ref\` chains back to the signed artifact id | ✓ |
| event \`meta.source\` = \`attest-cli\` (distinguishes from session-event-cli / wrap) | ✓ |
| receipt \`agent_graph\` node carries model + provider + tokens_in + tokens_out | ✓ |
| \`session report --share --format json --no-upload\` returns \`verification_status: pass\` | ✓ |

## Tests

Two new unit tests in \`packages/core/src/statements/mod.rs\`:
- \`decision_statement_provider_roundtrips\` — sign+verify preserves provider
- \`decision_statement_legacy_payload_without_provider_decodes\` — pins backwards-compat for pre-v0.10.2 artifacts

Workspace test suite: 270+ pass. CLI: 86/86. Statements: 30/30 (incl. 2 new).

## Out of scope

Other gaps from the compatibility audit that need their own PRs:
- Agent cards into receipt (slot exists, never populated)
- Harnesses into receipt (same shape)
- A2A bridge → session events (currently signs artifacts only, no session integration)
- ZK proofs → receipt linkage (artifacts only, no event-attribution)
- Daemon stand-alone mode (currently requires active session)
- OTel session-event subscription (artifact-only export today)
- Templates → session policy binding

I'll open these as separate focused PRs.

## Independent or stacked

**Independent.** Branched off main; no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)