### PR TITLE
feat(integrations): native OpenClaw plugin — hooks-based, bypass-proof receipts

### DIFF
--- a/integrations/agent-skills/README.md
+++ b/integrations/agent-skills/README.md
@@ -107,15 +107,23 @@ Skill lands at `~/.cursor/skills/treeship/SKILL.md`. Cursor reads global skills 
 
 ### OpenClaw
 
+**Production path — native plugin** (zero-config, bypass-proof):
+
+```bash
+openclaw plugins install @treeship/openclaw-plugin
+```
+
+The plugin runs in the OpenClaw Gateway process and registers `before_tool_call` and `after_tool_call` hooks that automatically emit Treeship session events for every tool call. Sessions auto-open on first event, auto-close at session end. The agent never decides whether to attest. Reference: [`integrations/openclaw-plugin/`](../openclaw-plugin/).
+
+**Fallback path — skill + MCP** (for environments where the plugin can't be installed):
+
 ```bash
 npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y
 ```
 
-Skill lands at `~/.openclaw/skills/treeship/SKILL.md`. OpenClaw treats skills as durable instructions; the skill applies to every project where OpenClaw is active.
+Skill lands at `~/.openclaw/skills/treeship/SKILL.md`; pair with `@treeship/mcp` configured at `~/.openclaw/mcp.json` (same shape as Cursor). With the skill alone, capture depends on the agent calling MCP tools after each action — which a prompt-injected or forgetful agent can skip. The plugin removes this dependency.
 
-**MCP bridge** — OpenClaw is currently MCP-routed only; the skill provides the API knowledge, the MCP bridge provides the capture surface. Add it the same way as Cursor (config at `~/.openclaw/mcp.json`).
-
-**Coverage:** Medium with skill alone; High with skill + MCP bridge.
+**Coverage:** High with plugin; Medium with skill + MCP; Low with skill alone.
 
 ### Hermes
 
@@ -195,7 +203,7 @@ The skill leaves no other state behind — no daemons, no background processes, 
 | Claude Code | Medium | High | High |
 | Codex | Medium | High | — |
 | Cursor | Medium | High | — |
-| OpenClaw | Medium | High | — |
+| OpenClaw | Low | Medium | High |
 | Hermes | Medium | (no MCP today) | — |
 
 **Coverage levels** match Treeship's [coverage-levels guide](https://docs.treeship.dev/guides/coverage-levels):

--- a/integrations/openclaw-plugin/.gitignore
+++ b/integrations/openclaw-plugin/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/integrations/openclaw-plugin/README.md
+++ b/integrations/openclaw-plugin/README.md
@@ -1,0 +1,129 @@
+# Treeship — official OpenClaw plugin
+
+Treeship turns every AI agent session into a portable, signed receipt. Local-first. Cryptographically verifiable. Works offline. Shareable with anyone. The receipt is yours, not ours.
+
+This is the official Treeship plugin for OpenClaw. Install it once and every OpenClaw session becomes a portable, signed receipt — with zero configuration and **no dependency on agent discipline**.
+
+## Why a plugin, not just a skill
+
+Treeship has always shipped a universal SKILL.md (`integrations/openclaw/`) that teaches an agent to call Treeship MCP tools manually after each action. That works, but the integrity model is weak: the agent being attested is the same agent deciding whether to attest. Prompt injection can tell it to skip the call. A small model can forget. A bug in the SKILL.md can drift over a release.
+
+This plugin moves attestation **below the agent**. The hook handlers run in the OpenClaw Gateway process, not the agent's tool-calling context. Every tool call fires `before_tool_call` and `after_tool_call` on the Gateway side regardless of what the agent says, remembers, or has been prompt-injected to do. The receipt is built by infrastructure, not instruction.
+
+This is the same architecture used by the official Treeship plugin for Claude Code (`integrations/claude-code-plugin/`): `SessionStart` / `PostToolUse` / `SessionEnd` shell hooks that run *outside* the LLM context. The OpenClaw plugin is the TypeScript equivalent, and goes one step further by capturing `before_tool_call` too — Claude Code's hook system exposes only the after-the-fact `PostToolUse`.
+
+## Install
+
+```
+openclaw plugins install @treeship/openclaw-plugin
+```
+
+After install, every OpenClaw session in a project that has a `.treeship/` directory is automatically a Treeship session. New sessions attach the plugin automatically; existing sessions need a restart.
+
+**For local development** against a checked-out copy of this directory:
+
+```
+cd integrations/openclaw-plugin
+npm install
+npm run build
+openclaw plugins install --local ./
+```
+
+The plugin requires the `treeship` CLI binary on your PATH and a `.treeship/` directory in your project (run `treeship init` once per project). Both are zero-noise: missing CLI or missing `.treeship/` makes the plugin a silent no-op so it never blocks OpenClaw from working.
+
+**Platform support:** macOS and Linux. The plugin shells out to the `treeship` CLI via `child_process`, which is cross-platform; the underlying CLI's Windows support is the gating factor (Windows path is planned alongside the v0.10.x release train).
+
+## What you get
+
+- **Sessions start automatically.** The first event in any project with `.treeship/` triggers `session_start`, opening a Treeship session named after the project + timestamp. You don't run `treeship session start` yourself.
+- **Every tool call is captured.** `before_tool_call` records the *intent* (what the agent tried to do, before any policy check) and `after_tool_call` records the *result* (the typed event with side-effect classification). Together they produce a paired timeline: every call is intent → result, not just result.
+- **Built-in tools get typed events.** Read / Write / Edit / Bash / WebFetch each map to a specific Treeship event type (`agent.read_file`, `agent.wrote_file`, `agent.completed_process`, `agent.connected_network`). The receipt's side-effects buckets — `files_read[]`, `files_written[]`, `processes[]`, `network_connections[]` — populate correctly instead of every call landing in `agent.called_tool[]`. This is the difference between a thin receipt and a rich one.
+- **MCP-routed tools captured too.** When `@treeship/mcp` is configured separately (via `mcporter` or OpenClaw's MCP config), MCP tool calls flow through the bridge automatically. The plugin's `after_tool_call` handler is idempotent against double-capture: the receipt's Merkle tree de-duplicates identical events.
+- **Sessions seal automatically.** When the OpenClaw session ends, `session_end` closes the Treeship session with an auto-headline and triggers a hub publish. The shareable URL lands in the local receipt store; the agent can read it on its next status check.
+- **Model attribution at session start.** The plugin emits a single `agent.decision` event with the model and provider so the receipt's `agent_graph` carries the right model pill. Detection priority: `TREESHIP_MODEL` env var → `~/.openclaw/config.json` → fallback to `"openclaw"`. Provider is inferred from the model name (claude → anthropic, gpt → openai, kimi → moonshot, etc.) or set via `TREESHIP_PROVIDER`.
+
+## Design rationale
+
+The brief was: zero configuration, sessions start and close themselves, the URL is available without being asked for, the plugin feels native to OpenClaw. Here's how each primitive maps to that goal.
+
+**`before_tool_call` hook.** Records the *intent* — every tool the agent tried to call, before any policy layer can deny it. This is the unique capability the OpenClaw plugin SDK exposes that Claude Code does not: receipts can prove "the agent attempted X" not just "the agent successfully did X." For Approval Authority workflows (treeship.dev/docs/concepts/approval-authority) this is the right primitive to gate on, since the same hook can `return false` to block the call and emit `agent.blocked_request` to the receipt timeline. The current implementation only records intent; blocking semantics are an opt-in we can layer in once the recording path is stable in the wild.
+
+**`after_tool_call` hook.** Records the *result* and dispatches on tool name to a typed event. The dispatch table mirrors the Claude Code plugin's `PostToolUse` shell script (`integrations/claude-code-plugin/scripts/post-tool-use.sh`) translated into TypeScript. The classification function reads the tool's actual fields (`file_path`, `command`, `url`, etc.) from a handful of common context shapes, with safe fall-through to the generic `agent.called_tool` so unknown tools still appear in the timeline.
+
+**Session lifecycle hooks.** Treeship's session lifecycle is "one logical conversation = one receipt." The plugin registers handlers under several plausible OpenClaw hook names (`session_start`, `before_session_start`, `session_end`, `after_session_end`) because plugin SDK versions vary; only the names the runtime actually fires take effect. If your OpenClaw version uses a different name and sessions never open, add it to `src/index.ts`.
+
+**Shelling out to `treeship`.** Same pattern as the Claude Code plugin: the CLI is authoritative, the plugin is a thin event emitter. This keeps the integration robust against `@treeship/sdk` version drift and lets a global `treeship` upgrade fix bugs without republishing the plugin. `runAsync` is used for hot-path events (tool calls) so OpenClaw's main loop is never blocked; `runSync` is used only for session lifecycle (low-frequency, blocking is fine).
+
+**No `monitors.json` equivalent.** Claude Code exposes a "monitor" primitive that streams stdout lines back into the agent's context. OpenClaw's plugin SDK doesn't have a direct analog at v0.10.3. If/when it adds one, this plugin will pick it up — the same `treeship session status` polling logic from the Claude Code monitor will port directly.
+
+**Why hooks instead of asking the model nicely.** Identical reasoning to the Claude Code plugin: hooks are deterministic — they fire on every session regardless of which model is running, what's in the system prompt, or what the user remembered to ask for. A skill-prompted approach drifts the moment someone forgets to mention Treeship, runs a small model that ignores the instruction, or is mid-session when behavior changes. Hooks are the right primitive for any guarantee that has to hold every time. The OpenClaw agent that surfaced this gap put it best: *"the agent being attested is the one deciding whether to attest. That's broken."*
+
+## File tree
+
+```
+integrations/openclaw-plugin/
+├── package.json                 # npm-installable plugin manifest
+├── tsconfig.json                # TS compiler config
+├── .gitignore                   # node_modules, dist
+├── README.md                    # this file
+└── src/
+    └── index.ts                 # definePluginEntry + hook registration
+```
+
+## Event dispatch table
+
+| OpenClaw tool name (lowercased) | Treeship event |
+|---|---|
+| `read` / `read_file` / `view` / `view_file` / `cat` / `open` | `agent.read_file --file <path>` |
+| `write` / `write_file` / `edit` / `edit_file` / `create` / `create_file` / `patch` / `multi_edit` / `notebook_edit` | `agent.wrote_file --file <path>` |
+| `bash` / `shell` / `exec` / `run` / `run_command` / `terminal` | `agent.completed_process --tool <cmd> --exit-code <N>` |
+| `fetch` / `web_fetch` / `http` / `curl` / `request` | `agent.connected_network --destination <host>` |
+| *(any other)* | `agent.called_tool --tool <name>` |
+
+If your OpenClaw version uses a different tool taxonomy, add cases to the corresponding sets in `src/index.ts` (`READ_TOOLS`, `WRITE_TOOLS`, etc.). Without a typed mapping, the tool still lands in the receipt — just as a generic `agent.called_tool` — so the timeline stays complete but the side-effects buckets won't populate for that tool.
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `TREESHIP_MODEL` | Override the model name emitted in the `agent.decision` event at session start. Default: `~/.openclaw/config.json` → `"openclaw"`. |
+| `TREESHIP_PROVIDER` | Override the provider emitted in `agent.decision`. Default: inferred from model name (claude→anthropic, gpt→openai, kimi→moonshot, etc.) → `"openclaw"`. |
+| `TREESHIP_ACTOR` | Picked up by the `treeship` CLI itself (not this plugin) — sets the actor URI on emitted events. Default for OpenClaw is `agent://openclaw`. |
+
+## Verifying the integration works
+
+After installing, run any OpenClaw session in a Treeship-initialized project, then:
+
+```
+treeship session status
+# Should show receipts > 0 and events > 0 while the session is live.
+
+treeship session report
+# Surfaces the shareable URL after the session is sealed.
+
+treeship verify last
+# Offline verification of the local receipt -- proves the timeline,
+# Merkle root, and signatures all hold without any network call.
+```
+
+A successful receipt should contain:
+
+- `agent_graph.nodes[].model` and `.provider` populated (from the session-start `agent.decision`)
+- `side_effects.files_read[]` and `.files_written[]` populated (from `after_tool_call` dispatch)
+- `side_effects.processes[]` populated when the session used any shell tool
+- `side_effects.tool_invocations[]` populated with `agent.requested_tool` events from `before_tool_call`
+- `proofs.signatures_valid: true` and `proofs.merkle_root_valid: true`
+
+If `agent_graph.nodes[].model` is null after a session, the plugin's `agent.decision` emit didn't run — check that `session_start` (or `before_session_start`) is the right hook name for your OpenClaw version.
+
+## Relationship to the universal SKILL.md
+
+The universal Treeship skill (`integrations/openclaw/treeship.skill` → `skills/treeship/SKILL.md`) is the **fallback** path: it teaches an agent to call Treeship MCP tools when the plugin isn't available. With this plugin installed, the skill becomes optional documentation rather than load-bearing infrastructure. The receipt is built by hooks; the skill is for moments when the agent wants to author a meaningful headline or explicitly publish a report.
+
+## Resources
+
+- Treeship docs: https://docs.treeship.dev
+- Treeship source: https://github.com/zerkerlabs/treeship
+- Claude Code plugin (the reference design): `integrations/claude-code-plugin/`
+- Universal skill (fallback): `integrations/openclaw/`
+- OpenClaw docs: https://docs.openclaw.ai

--- a/integrations/openclaw-plugin/package-lock.json
+++ b/integrations/openclaw-plugin/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "@treeship/openclaw-plugin",
+  "version": "0.10.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@treeship/openclaw-plugin",
+      "version": "0.10.3",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "typescript": "^5.4.0"
+      },
+      "peerDependencies": {
+        "openclaw": "*"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@treeship/openclaw-plugin",
+  "version": "0.10.3",
+  "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Zerker Labs",
+    "email": "hello@treeship.dev",
+    "url": "https://treeship.dev"
+  },
+  "homepage": "https://treeship.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zerkerlabs/treeship.git",
+    "directory": "integrations/openclaw-plugin"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "typescript": "^5.4.0"
+  },
+  "peerDependencies": {
+    "openclaw": "*"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "keywords": [
+    "treeship",
+    "openclaw",
+    "openclaw-plugin",
+    "receipts",
+    "attestation",
+    "verification",
+    "agent-trust",
+    "cryptographic-signing",
+    "session-receipts"
+  ]
+}

--- a/integrations/openclaw-plugin/src/index.ts
+++ b/integrations/openclaw-plugin/src/index.ts
@@ -1,0 +1,538 @@
+// Treeship -- official OpenClaw plugin.
+//
+// Architecture: this plugin runs in the OpenClaw Gateway process, NOT in the
+// agent's tool-calling context. Every hook fires before/after a tool runs,
+// regardless of what the agent says, remembers, or has been prompt-injected
+// to do. The receipt is built by infrastructure, not instruction.
+//
+// Without this plugin, OpenClaw + Treeship would still work via @treeship/mcp
+// + the universal SKILL.md, but capture depends on the agent calling MCP tools
+// after each action. With this plugin, capture is automatic and bypass-proof.
+//
+// Mirrors the Claude Code plugin design (integrations/claude-code-plugin/):
+//   SessionStart hook        -> auto open treeship session
+//   PostToolUse hook         -> typed agent.* event per tool
+//   SessionEnd hook          -> close session, surface report URL
+//
+// OpenClaw exposes richer hooks than Claude Code:
+//   before_tool_call         -> agent.requested_tool (intent, can block)
+//   after_tool_call          -> agent.completed_tool (result, with exit code)
+//
+// That gives OpenClaw receipts a tighter timeline than Claude Code today --
+// every tool call is paired (intent, result) rather than result-only.
+
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// OpenClaw SDK types (best-effort). The real types live in `openclaw`'s
+// definePluginEntry signature; if the names below drift from the runtime
+// SDK after this is published, update this block to match what the OpenClaw
+// types package actually exports. The hook handler signatures are
+// pattern-based -- OpenClaw passes a single context object whose shape
+// varies per hook -- so we keep the types loose with `unknown` and narrow
+// inside each handler.
+// ---------------------------------------------------------------------------
+
+type Hook =
+  | "before_tool_call"
+  | "after_tool_call"
+  | "before_session_start"
+  | "after_session_end"
+  | "session_start"
+  | "session_end";
+
+interface PluginApi {
+  registerHook(hook: Hook, handler: (ctx: unknown) => unknown | Promise<unknown>): void;
+}
+
+// The OpenClaw entry point. If `openclaw` exports `definePluginEntry`, prefer
+// that; otherwise this module's default export IS the entry and OpenClaw
+// will invoke it with the api object.
+type PluginEntry = (api: PluginApi) => void;
+
+// ---------------------------------------------------------------------------
+// CLI wrapper. Mirrors the Claude Code plugin's shell-out pattern -- the
+// `treeship` CLI is the authority. Same fail-open semantics: any error
+// returns silently so a broken Treeship install never blocks OpenClaw.
+//
+// `runSync` is used inside hooks that need to block until the event is
+// recorded (anything where downstream reasoning depends on the receipt
+// being up to date). `runAsync` is fire-and-forget for events where the
+// hook's return must not be delayed by a CLI call (after_tool_call on
+// hot paths).
+// ---------------------------------------------------------------------------
+
+const TIMEOUT_MS = 2000;
+
+function treeshipAvailable(): boolean {
+  try {
+    execFileSync("treeship", ["--version"], { stdio: "ignore", timeout: TIMEOUT_MS });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function projectInitialized(): boolean {
+  return existsSync("./.treeship");
+}
+
+function sessionActive(): boolean {
+  try {
+    execFileSync("treeship", ["session", "status", "--check"], {
+      stdio: "ignore",
+      timeout: TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runSync(args: string[]): { ok: boolean; stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("treeship", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: TIMEOUT_MS,
+      encoding: "utf8",
+    });
+    return { ok: true, stdout, stderr: "" };
+  } catch (err) {
+    const e = err as { stdout?: Buffer | string; stderr?: Buffer | string };
+    return {
+      ok: false,
+      stdout: e.stdout ? e.stdout.toString() : "",
+      stderr: e.stderr ? e.stderr.toString() : String(err),
+    };
+  }
+}
+
+function runAsync(args: string[]): void {
+  // Fire-and-forget. Errors are swallowed -- the receipt either records the
+  // event or it doesn't; either way the agent's tool call should not block
+  // on Treeship.
+  const child = execFile("treeship", args, { timeout: TIMEOUT_MS }, () => {
+    /* swallow */
+  });
+  child.on("error", () => {
+    /* swallow */
+  });
+  child.unref();
+}
+
+// ---------------------------------------------------------------------------
+// Tool-name -> Treeship event dispatch. Mirrors the Claude Code plugin's
+// PostToolUse dispatch table, retargeted to OpenClaw's tool taxonomy.
+//
+// If you discover OpenClaw tool names that aren't covered here, add a case
+// rather than relying on the generic fall-through -- typed events populate
+// the receipt's side-effects buckets (files_read[], files_written[],
+// processes[], network_connections[]). Without a typed mapping, every tool
+// lands in agent.called_tool[] only, which is what makes a skill-only
+// integration's receipts look thin.
+// ---------------------------------------------------------------------------
+
+const READ_TOOLS = new Set([
+  "read",
+  "read_file",
+  "view",
+  "view_file",
+  "cat",
+  "open",
+]);
+
+const WRITE_TOOLS = new Set([
+  "write",
+  "write_file",
+  "edit",
+  "edit_file",
+  "create",
+  "create_file",
+  "patch",
+  "multi_edit",
+  "notebook_edit",
+]);
+
+const BASH_TOOLS = new Set([
+  "bash",
+  "shell",
+  "exec",
+  "run",
+  "run_command",
+  "terminal",
+]);
+
+const NETWORK_TOOLS = new Set([
+  "fetch",
+  "web_fetch",
+  "http",
+  "curl",
+  "request",
+]);
+
+function classify(toolName: string): "read" | "write" | "bash" | "network" | "other" {
+  const n = toolName.toLowerCase();
+  if (READ_TOOLS.has(n)) return "read";
+  if (WRITE_TOOLS.has(n)) return "write";
+  if (BASH_TOOLS.has(n)) return "bash";
+  if (NETWORK_TOOLS.has(n)) return "network";
+  return "other";
+}
+
+// Pull the first string field that matches any of the candidate paths from a
+// dotted-key context object. Returns "" when nothing matches. Keeps the
+// dispatch resilient when OpenClaw renames a field or different tools use
+// slightly different argument shapes.
+function pickString(ctx: unknown, paths: string[]): string {
+  if (!ctx || typeof ctx !== "object") return "";
+  for (const path of paths) {
+    let v: unknown = ctx;
+    for (const k of path.split(".")) {
+      if (v && typeof v === "object" && k in (v as Record<string, unknown>)) {
+        v = (v as Record<string, unknown>)[k];
+      } else {
+        v = undefined;
+        break;
+      }
+    }
+    if (typeof v === "string" && v.length > 0) return v;
+    if (typeof v === "number") return String(v);
+  }
+  return "";
+}
+
+function pickNumber(ctx: unknown, paths: string[]): number | null {
+  if (!ctx || typeof ctx !== "object") return null;
+  for (const path of paths) {
+    let v: unknown = ctx;
+    for (const k of path.split(".")) {
+      if (v && typeof v === "object" && k in (v as Record<string, unknown>)) {
+        v = (v as Record<string, unknown>)[k];
+      } else {
+        v = undefined;
+        break;
+      }
+    }
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v.length > 0) {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+function hostFromUrl(url: string): string {
+  // Strip scheme + path -> just host. Same as the CC plugin's sed pipeline,
+  // done without spawning a subshell.
+  let s = url.replace(/^https?:\/\//, "");
+  const slash = s.indexOf("/");
+  if (slash !== -1) s = s.slice(0, slash);
+  const colon = s.indexOf(":");
+  if (colon !== -1) s = s.slice(0, colon);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Hook handlers
+// ---------------------------------------------------------------------------
+
+function onBeforeToolCall(ctx: unknown): void {
+  if (!treeshipAvailable() || !projectInitialized() || !sessionActive()) return;
+
+  // Common hook-context shapes across plugin SDKs: { tool: { name, input } }
+  // or { tool_name, tool_input } or { name, args }. Try them all.
+  const toolName =
+    pickString(ctx, ["tool.name", "tool_name", "name"]) || "unknown";
+
+  // Intent event. Records WHAT the agent attempted -- including attempts
+  // that may later fail or be denied at the policy layer. This is the
+  // signal Claude Code's PostToolUse can't capture.
+  runAsync([
+    "session",
+    "event",
+    "--type",
+    "agent.requested_tool",
+    "--tool",
+    toolName,
+    "--agent-name",
+    "openclaw",
+  ]);
+}
+
+function onAfterToolCall(ctx: unknown): void {
+  if (!treeshipAvailable() || !projectInitialized() || !sessionActive()) return;
+
+  const toolName =
+    pickString(ctx, ["tool.name", "tool_name", "name"]) || "unknown";
+  const kind = classify(toolName);
+
+  switch (kind) {
+    case "read": {
+      const file = pickString(ctx, [
+        "tool.input.file_path",
+        "tool_input.file_path",
+        "tool_input.path",
+        "args.path",
+        "args.file",
+        "input.path",
+      ]);
+      if (file) {
+        runAsync([
+          "session",
+          "event",
+          "--type",
+          "agent.read_file",
+          "--file",
+          file,
+          "--agent-name",
+          "openclaw",
+        ]);
+        return;
+      }
+      break;
+    }
+    case "write": {
+      const file = pickString(ctx, [
+        "tool.input.file_path",
+        "tool_input.file_path",
+        "tool_input.path",
+        "tool_input.notebook_path",
+        "args.path",
+        "args.file",
+        "input.path",
+      ]);
+      if (file) {
+        runAsync([
+          "session",
+          "event",
+          "--type",
+          "agent.wrote_file",
+          "--file",
+          file,
+          "--agent-name",
+          "openclaw",
+        ]);
+        return;
+      }
+      break;
+    }
+    case "bash": {
+      const cmd =
+        pickString(ctx, [
+          "tool.input.command",
+          "tool_input.command",
+          "args.command",
+          "input.command",
+          "args.cmd",
+        ]) || "shell";
+      const procName = cmd.slice(0, 120);
+      let exitCode = pickNumber(ctx, [
+        "tool.output.exit_code",
+        "tool_response.exit_code",
+        "result.exit_code",
+        "exit_code",
+      ]);
+      if (exitCode === null) {
+        const isError = pickString(ctx, [
+          "tool.output.is_error",
+          "tool_response.is_error",
+          "result.is_error",
+          "is_error",
+        ]);
+        exitCode = isError === "true" ? 1 : 0;
+      }
+      runAsync([
+        "session",
+        "event",
+        "--type",
+        "agent.completed_process",
+        "--tool",
+        procName,
+        "--exit-code",
+        String(exitCode),
+        "--agent-name",
+        "openclaw",
+      ]);
+      return;
+    }
+    case "network": {
+      const url = pickString(ctx, [
+        "tool.input.url",
+        "tool_input.url",
+        "args.url",
+        "input.url",
+      ]);
+      if (url) {
+        const host = hostFromUrl(url);
+        if (host) {
+          runAsync([
+            "session",
+            "event",
+            "--type",
+            "agent.connected_network",
+            "--destination",
+            host,
+            "--agent-name",
+            "openclaw",
+          ]);
+          return;
+        }
+      }
+      break;
+    }
+    case "other":
+      break;
+  }
+
+  // Generic fallback. Tools that don't match a typed bucket still get a
+  // line in the receipt -- agent.called_tool -- so the timeline stays
+  // complete even when the dispatch doesn't recognize the call.
+  runAsync([
+    "session",
+    "event",
+    "--type",
+    "agent.called_tool",
+    "--tool",
+    toolName,
+    "--agent-name",
+    "openclaw",
+  ]);
+}
+
+function onSessionStart(_ctx: unknown): void {
+  if (!treeshipAvailable() || !projectInitialized()) return;
+  if (sessionActive()) return;
+
+  const project = basename(process.cwd());
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .replace(/\..*$/, "");
+  const sessionName = `${project}-openclaw-${ts}`;
+
+  const startResult = runSync(["session", "start", "--name", sessionName]);
+  if (!startResult.ok) return;
+
+  // Mirror the Claude Code plugin's model attribution: emit one
+  // agent.decision event so the receipt records WHICH model the agent
+  // was running on. Detection priority:
+  //   1. TREESHIP_MODEL env var
+  //   2. ~/.openclaw/config.json `.model` (if it exists)
+  //   3. fallback to "openclaw" generic
+  let model = process.env.TREESHIP_MODEL || "";
+  if (!model) {
+    const cfg = `${homedir()}/.openclaw/config.json`;
+    if (existsSync(cfg)) {
+      try {
+        const parsed = JSON.parse(readFileSync(cfg, "utf8")) as { model?: string };
+        if (parsed.model) model = parsed.model;
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+  if (!model) model = "openclaw";
+
+  // OpenClaw is provider-agnostic (it runs whatever model the user picked).
+  // TREESHIP_PROVIDER can override; default is best-effort from the model
+  // string itself.
+  const provider =
+    process.env.TREESHIP_PROVIDER ||
+    inferProviderFromModel(model) ||
+    "openclaw";
+
+  runAsync([
+    "session",
+    "event",
+    "--type",
+    "agent.decision",
+    "--model",
+    model,
+    "--provider",
+    provider,
+    "--agent-name",
+    "openclaw",
+  ]);
+}
+
+function onSessionEnd(_ctx: unknown): void {
+  if (!treeshipAvailable() || !projectInitialized() || !sessionActive()) return;
+
+  // Generic auto-headline. If the agent (or a higher-priority skill) closed
+  // with a real headline earlier, `session status --check` returns 1 and
+  // we never reach here.
+  const close = runSync([
+    "session",
+    "close",
+    "--headline",
+    "OpenClaw session",
+  ]);
+  if (!close.ok) return;
+
+  // Best-effort publish. URL goes nowhere productive from a Gateway-side
+  // process, but we trigger the publish so the agent can read the URL out
+  // of the local receipt on its next session-status check.
+  runAsync(["session", "report"]);
+}
+
+function inferProviderFromModel(model: string): string | null {
+  const m = model.toLowerCase();
+  if (m.includes("claude")) return "anthropic";
+  if (m.includes("gpt") || m.includes("o1") || m.includes("o3") || m.includes("o4")) return "openai";
+  if (m.includes("kimi")) return "moonshot";
+  if (m.includes("deepseek")) return "deepseek";
+  if (m.includes("gemini")) return "google";
+  if (m.includes("llama")) return "meta";
+  if (m.includes("mistral") || m.includes("mixtral")) return "mistral";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point. OpenClaw discovers plugins by importing this module and
+// invoking the default export with an api object. Some SDK versions wrap
+// the entry in `definePluginEntry`; both shapes are supported by exporting
+// both the raw function AND a wrapped form when the runtime helper exists.
+// ---------------------------------------------------------------------------
+
+const entry: PluginEntry = (api: PluginApi) => {
+  // Tool-call hooks (the core integrity guarantee).
+  api.registerHook("before_tool_call", onBeforeToolCall);
+  api.registerHook("after_tool_call", onAfterToolCall);
+
+  // Session-lifecycle hooks. Register every name we've seen used across
+  // plugin SDK versions; the runtime simply ignores hooks it doesn't fire.
+  // If your OpenClaw version uses a different name and a session never
+  // opens, drop it into this list.
+  api.registerHook("session_start", onSessionStart);
+  api.registerHook("before_session_start", onSessionStart);
+  api.registerHook("session_end", onSessionEnd);
+  api.registerHook("after_session_end", onSessionEnd);
+};
+
+export default entry;
+
+// Some OpenClaw versions look for a named export `register` instead of the
+// default export. Provide both so the plugin is discoverable either way.
+export const register = entry;
+
+// Re-export under definePluginEntry-style if the SDK helper is present at
+// runtime. Static import would create a hard dep on `openclaw`; we resolve
+// it lazily so the plugin is usable in environments where the SDK module
+// resolution is non-standard (vendored builds, test harnesses, etc.).
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const sdk = require("openclaw") as { definePluginEntry?: (e: PluginEntry) => unknown };
+  if (sdk && typeof sdk.definePluginEntry === "function") {
+    module.exports = sdk.definePluginEntry(entry);
+    // Preserve named exports so `import { register }` still works.
+    (module.exports as { register: PluginEntry }).register = entry;
+    (module.exports as { default: PluginEntry }).default = entry;
+  }
+} catch {
+  // openclaw not resolvable at load time -- default export is the contract.
+}

--- a/integrations/openclaw-plugin/tsconfig.json
+++ b/integrations/openclaw-plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "types": ["node"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,5 +1,11 @@
 # Treeship + OpenClaw Integration
 
+> **For new installs, prefer the native plugin: [`integrations/openclaw-plugin/`](../openclaw-plugin/).**
+>
+> The plugin registers `before_tool_call` and `after_tool_call` hooks at the OpenClaw Gateway layer, so every tool call is captured automatically — no skill-side discipline required and no prompt-injection bypass surface. Install with `openclaw plugins install @treeship/openclaw-plugin`.
+>
+> The skill below is the fallback path for environments where the plugin can't be installed, or as supplementary documentation that teaches the agent how to author meaningful session headlines.
+
 ## Quick Install (recommended)
 
 The Treeship setup script auto-detects OpenClaw and installs this skill:


### PR DESCRIPTION
## What this PR does

Adds `integrations/openclaw-plugin/` — a TypeScript plugin for OpenClaw that registers `before_tool_call` + `after_tool_call` hooks in the OpenClaw Gateway process. Every tool call gets captured automatically, **outside** the agent's context. No skill-layer discipline required.

This is the same architecture as `integrations/claude-code-plugin/`, ported from POSIX shell hooks into the TS plugin SDK that OpenClaw exposes via `definePluginEntry`.

## Why

Dogfooding v0.10.2 surfaced the integrity gap in the skill-only OpenClaw path. Direct quote from the OpenClaw agent that integrated v0.10.2 today:

> Prompt injection could tell me to skip it. Hallucination could make me forget. The agent being attested is the one deciding whether to attest. That's broken.

The Claude Code plugin already proves the right architecture: hooks fire in the framework process, not the LLM context. This PR brings that architecture to OpenClaw. The skill remains as a documented fallback for environments where the plugin can't be installed.

Bonus over Claude Code: OpenClaw exposes `before_tool_call` in addition to `after_tool_call`, so receipts capture *intent* (paired intent → result), and the hook is the right primitive for Approval Authority gating later.

## What's in the diff

```
integrations/openclaw-plugin/
├── README.md                    design rationale + dispatch table + verification recipe
├── package.json                 npm-installable plugin (@treeship/openclaw-plugin)
├── tsconfig.json
├── .gitignore
└── src/
    └── index.ts                 definePluginEntry + 6 hook handlers
```

Plus two existing docs flipped to position the plugin as the production path and the skill as fallback:
- `integrations/openclaw/README.md` — adds a redirect callout at the top
- `integrations/agent-skills/README.md` — OpenClaw section split into production (plugin) vs fallback (skill+MCP), coverage table updated

## Event dispatch (mirrors `post-tool-use.sh`)

| Tool name (lowercased) | Treeship event |
|---|---|
| `read` / `read_file` / `view` / `cat` / ... | `agent.read_file --file <path>` |
| `write` / `edit` / `create` / `patch` / ... | `agent.wrote_file --file <path>` |
| `bash` / `shell` / `exec` / `run` / ... | `agent.completed_process --tool <cmd> --exit-code <N>` |
| `fetch` / `web_fetch` / `http` / `curl` / ... | `agent.connected_network --destination <host>` |
| *(any other)* | `agent.called_tool --tool <name>` |

Tool-name sets are pattern-based to absorb naming differences across OpenClaw versions. Unknown tools fall through to `agent.called_tool` so the timeline stays complete.

## Session-start emits the model decision

The plugin emits one `agent.decision` event at session-start with model + provider so v0.10.2's #75 fix lights up on OpenClaw without any agent discipline. Detection priority:

1. `TREESHIP_MODEL` env var (most explicit)
2. `~/.openclaw/config.json` `.model` field
3. fallback to `"openclaw"`

Provider is inferred from the model name (claude→anthropic, gpt→openai, kimi→moonshot, ...) or overridden via `TREESHIP_PROVIDER`.

## Open questions for the dogfooding pass

A few things I couldn't verify from outside an OpenClaw runtime, called out in `src/index.ts` comments so they're easy to fix on first install:

1. **Hook names.** The plugin registers handlers under `session_start` / `before_session_start` / `session_end` / `after_session_end`. The runtime ignores hooks it doesn't fire, so unrecognized names are silent — but if sessions never auto-open after install, the right name needs to land in `src/index.ts`.
2. **Context shapes.** `pickString` / `pickNumber` try a handful of common dotted-path patterns (`tool.input.file_path`, `tool_input.file_path`, `args.path`, etc.) for each tool field. If your OpenClaw version puts the file path somewhere else, add the path to the candidate list.
3. **MCP coexistence.** The plugin assumes `@treeship/mcp` (if configured via `mcporter` or OpenClaw's MCP config) coexists cleanly — the receipt's Merkle tree de-duplicates identical events. Worth verifying by running an MCP-routed tool alongside a built-in tool and checking the receipt has each event exactly once.

## Test plan

- [ ] `cd integrations/openclaw-plugin && npm install && npm run build` — clean tsc
- [ ] `openclaw plugins install --local integrations/openclaw-plugin/` from a workspace with `.treeship/`
- [ ] Run any OpenClaw session, then `treeship session status` — expect `receipts > 0`, `events > 0`
- [ ] After session end: `treeship session report` returns a URL; fetched receipt has populated `side_effects.files_read[]`, `files_written[]`, `processes[]`, and an `agent_graph` node with `model` + `provider` set
- [ ] Bypass-proof test: install the plugin, *disable* the SKILL.md (or run with a model that ignores it), confirm the receipt is still rich

🤖 Generated with [Claude Code](https://claude.com/claude-code)