### PR TITLE
chore(ci): pin GitHub Actions to SHAs + scope release write perms (audit lane C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,10 @@ jobs:
       # workspace, not whatever was last published to npm). wasm-pack is
       # required.
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        # Pinned crates.io install with a locked dependency graph,
+        # replacing the previous `curl … | sh` which executed whatever
+        # the rustwasm.github.io CDN served at job runtime.
+        run: cargo install wasm-pack --version 0.14.0 --locked
 
       - name: Install tsx
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   version-consistency:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Check internal version consistency
@@ -32,8 +32,8 @@ jobs:
   docs-route-health:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Check docs route health
@@ -42,8 +42,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
 
       - name: Run tests
         run: cargo test -p treeship-core
@@ -64,8 +64,8 @@ jobs:
   hub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.22'
 
@@ -83,14 +83,14 @@ jobs:
         python: ['3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
         with:
           targets: wasm32-unknown-unknown
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Check every release-version site against the tag
@@ -52,9 +52,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
         with:
           targets: ${{ matrix.target }}
 
@@ -90,7 +90,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/treeship ${{ matrix.artifact }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -121,10 +121,10 @@ jobs:
           - { nick: ubuntu24, image: 'ubuntu:24.04',  pm: apt }
           - { nick: alpine,   image: 'alpine:3.20',   pm: apk }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download Linux binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: treeship-linux-x86_64
           path: artifact
@@ -184,7 +184,7 @@ jobs:
       sha256_darwin_x86_64:   ${{ steps.checksums.outputs.sha256_darwin_x86_64 }}
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
       # Compute SHA-256 of every binary that's about to be published.
       # The hashes are:
@@ -215,7 +215,7 @@ jobs:
           echo "sha256_darwin_x86_64=$(  awk '/treeship-darwin-x86_64/   {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             treeship-linux-x86_64/treeship-linux-x86_64
@@ -236,8 +236,8 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -284,7 +284,7 @@ jobs:
             exit 1
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
         with:
           targets: wasm32-unknown-unknown
 
@@ -420,8 +420,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
 
       - name: Publish treeship-core
         run: |
@@ -472,8 +472,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   # Preflight: fail the entire release if any package manifest, version file, or
@@ -177,6 +176,13 @@ jobs:
   release:
     needs: smoke
     runs-on: ubuntu-latest
+
+    # Only `release` creates the GitHub Release and uploads assets to it.
+    # `contents: write` is scoped here instead of workflow-wide so a
+    # compromised step in preflight/build/smoke/publish-* cannot push
+    # commits, move tags, or rewrite the release.
+    permissions:
+      contents: write
 
     outputs:
       sha256_linux_x86_64:    ${{ steps.checksums.outputs.sha256_linux_x86_64 }}
@@ -470,6 +476,15 @@ jobs:
     # Linux, treeship-sdk is unusable for those users anyway.
     needs: [smoke, release]
     runs-on: ubuntu-latest
+
+    # `id-token: write` preserves the ability to switch to PyPI OIDC
+    # trusted publishing without re-granting workflow-wide write. The
+    # current step uses TWINE_PASSWORD (a long-lived token); keeping
+    # the permission scoped here means migrating to OIDC is a one-line
+    # change in `steps:` and not a permissions audit.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,7 +295,12 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        # `cargo install --locked` builds wasm-pack from a pinned crates.io
+        # version with a locked dependency graph. Replaces the previous
+        # `curl … | sh` which executed whatever the rustwasm.github.io
+        # CDN served at job runtime — a real supply-chain hole in a job
+        # that holds `id-token: write` for npm trusted publishing.
+        run: cargo install wasm-pack --version 0.14.0 --locked
 
       - name: Install wasm-opt (binaryen)
         run: |


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to commit SHAs (no more floating `@v3`/`@v4` refs that can be force-pushed under us).
- Scope the `contents: write` permission to the release job only, instead of granting it to the whole workflow.
- Replace the `wasm-pack` `curl | sh` install with a pinned `cargo install` to remove a supply-chain hole.

## Audit context

This PR is part of a pre-launch audit covering 11 P0 findings + supporting hardening. The full audit branched into 8 independent lanes (A-H) that compose without conflicts.

**Lane C:** GitHub Actions workflow hardening (no runtime code changes).

**Pre-merge verification:** all 8 lanes were merged into `audit/integration-verify` and the full test suite passed:

- Rust workspace: 297 lib + 412 integration tests
- TypeScript SDK: 11 vitest cases (incl. real CLI round-trip + tamper test)
- Python SDK: 44 unittest cases
- YAML workflow parse: OK
- Version preflight script: 23/23 sites consistent

**Commits in this PR:** 3 on top of `main` (`c6802d3`).

## Test plan

- [ ] CI green
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` succeeds