### PR TITLE
feat(sdk-python): verify binary SHA-256 before exec (audit lane B)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -480,6 +480,38 @@ jobs:
       - name: Install build tools
         run: pip install build twine
 
+      # Embed the SHA-256 of each per-platform binary into the wheel
+      # being built, so treeship_sdk.bootstrap can verify the binary it
+      # downloads from GitHub against the hash that arrived via PyPI.
+      # Mirrors the equivalent step in publish-npm above — the hashes
+      # were computed in the `release` job (see its `Compute SHA256SUMS`
+      # step) and surfaced as job outputs.
+      #
+      # Without this step the bootstrap would refuse to install the CLI
+      # binary ("checksum-missing"). That refusal is the desired
+      # behavior — better to fail noisily here than to silently ship an
+      # unverifiable binary.
+      - name: Embed expected SHA-256 into treeship-sdk wheel
+        run: |
+          set -e
+          DATA_DIR="packages/sdk-python/treeship_sdk/_data"
+          mkdir -p "$DATA_DIR"
+          for slug in linux-x86_64 darwin-aarch64 darwin-x86_64; do
+            case "$slug" in
+              linux-x86_64)   asset=treeship-linux-x86_64    sha='${{ needs.release.outputs.sha256_linux_x86_64 }}';;
+              darwin-aarch64) asset=treeship-darwin-aarch64  sha='${{ needs.release.outputs.sha256_darwin_aarch64 }}';;
+              darwin-x86_64)  asset=treeship-darwin-x86_64   sha='${{ needs.release.outputs.sha256_darwin_x86_64 }}';;
+            esac
+            if [ -z "$sha" ] || ! printf '%s' "$sha" | grep -Eq '^[0-9a-f]{64}$'; then
+              echo "::error::Missing or malformed SHA-256 for $asset ($slug). Refusing to build wheel."
+              exit 1
+            fi
+            printf '%s\n' "$sha" > "$DATA_DIR/expected-checksum-${asset}.txt"
+            echo "  $asset → $sha"
+          done
+          echo "--- $DATA_DIR contents:"
+          ls -la "$DATA_DIR"
+
       - name: Build and publish treeship-sdk
         working-directory: packages/sdk-python
         run: |
@@ -536,6 +568,21 @@ jobs:
             echo "$UNEXPECTED"
             exit 1
           fi
+
+          # Verify the per-platform checksum files actually made it into
+          # the wheel. setuptools silently drops package-data entries
+          # when the directory layout disagrees with the manifest, which
+          # would ship an unverifiable wheel that fails install for
+          # every user. Catch it here instead.
+          for asset in treeship-linux-x86_64 treeship-darwin-aarch64 treeship-darwin-x86_64; do
+            if ! python -m zipfile -l "$EXPECTED_WHEEL" | grep -q "treeship_sdk/_data/expected-checksum-${asset}.txt"; then
+              echo "::error::built wheel is missing treeship_sdk/_data/expected-checksum-${asset}.txt"
+              echo "::error::wheel contents:"
+              python -m zipfile -l "$EXPECTED_WHEEL" || true
+              exit 1
+            fi
+          done
+          echo "  ✓ wheel contains all per-platform checksum files"
 
           # Validate package metadata (long-description rendering, required
           # fields, METADATA-Version compatibility) before upload. PyPI runs

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ tests/cross-sdk/.roundtrip-output.jsonl
 # at npm-publish time so the postinstall can verify the GitHub Release
 # binary against an npm-delivered hash.
 npm/@treeship/cli-*/expected-checksum.txt
+
+# Same trust model on the Python side: the wheel embeds per-platform
+# SHA-256 hashes for the CLI binary, written at wheel-build time so
+# the bootstrap can verify the GitHub Release download against a
+# PyPI-delivered hash. Never committed.
+packages/sdk-python/treeship_sdk/_data/expected-checksum-*.txt

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -22,3 +22,14 @@ classifiers = [
 Homepage = "https://treeship.dev"
 Repository = "https://github.com/zerkerlabs/treeship"
 Documentation = "https://docs.treeship.dev"
+
+[tool.setuptools.packages.find]
+include = ["treeship_sdk*"]
+
+# Ship the per-platform expected-checksum-*.txt files written by the
+# release pipeline (see .github/workflows/release.yml). These embed
+# the SHA-256 of each GitHub Release binary so the bootstrap can
+# verify the download before it's ever marked executable. The files
+# are gitignored — they exist only inside the published wheel.
+[tool.setuptools.package-data]
+"treeship_sdk._data" = ["expected-checksum-*.txt"]

--- a/packages/sdk-python/tests/test_bootstrap_checksum.py
+++ b/packages/sdk-python/tests/test_bootstrap_checksum.py
@@ -1,0 +1,315 @@
+"""Unit tests for the SHA-256 verification path in treeship_sdk.bootstrap.
+
+These tests exercise ``_install_via_github_release`` without ever
+touching the network: ``urllib.request.urlopen`` is patched to return a
+fake response whose bytes we control. ``platform_release_asset`` is
+patched so the test is deterministic across host OS/arch.
+
+The hardening contract under test:
+
+  1. Happy path: matching SHA-256 → target binary exists at
+     ``<cache>/treeship`` with mode 0755 and no ``.partial`` left over.
+  2. Hash mismatch: ``TreeshipBootstrapError`` raised, ``.partial``
+     is deleted, the final ``treeship`` path does NOT exist.
+  3. Missing checksum file: ``TreeshipBootstrapError`` raised with
+     reason ``checksum-missing`` BEFORE any network call.
+
+Each test isolates filesystem state under a ``tempfile.TemporaryDirectory``
+and never writes outside it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from treeship_sdk.bootstrap import (
+    TreeshipBootstrapError,
+    _install_via_github_release,
+)
+
+
+# Fake binary bytes — small enough to keep test fast, big enough to
+# exercise the streaming chunk loop (default chunk size is 64KiB).
+_FAKE_BINARY = b"#!/bin/sh\necho 'treeship 0.0.0-test'\n" * 4096
+_FAKE_SHA256 = hashlib.sha256(_FAKE_BINARY).hexdigest()
+
+# Asset name we'll pretend the host platform maps to. The
+# ``_install_via_github_release`` flow consults
+# ``platform_release_asset`` exactly once at the top; we override that.
+_ASSET = "treeship-test-asset"
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urllib.request.urlopen yields."""
+
+    def __init__(self, payload: bytes):
+        self._buf = io.BytesIO(payload)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._buf.close()
+        return False
+
+
+def _fake_urlopen_ok(_url, timeout=30):  # noqa: ARG001 — match urllib signature
+    return _FakeResponse(_FAKE_BINARY)
+
+
+def _fake_urlopen_mutated(_url, timeout=30):  # noqa: ARG001
+    # Returns different bytes than _FAKE_BINARY → hash will not match
+    # the expected _FAKE_SHA256.
+    return _FakeResponse(_FAKE_BINARY + b"tampered")
+
+
+class GithubReleaseChecksumTests(unittest.TestCase):
+    """Cover the verify-before-chmod contract."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = Path(self._tmp.name) / "cache"
+        # _install_via_github_release will mkdir this itself, but we
+        # leave the parent in place so cleanup is unambiguous.
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    def test_matching_hash_installs_binary_and_clears_partial(self) -> None:
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_ok,
+        ), patch(
+            "treeship_sdk.bootstrap._probe_binary",
+            return_value="treeship 0.0.0-test",
+        ):
+            result = _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+        self.assertIsNotNone(result)
+        assert result is not None  # narrow for type-checker
+        self.assertTrue(result.ok)
+        self.assertEqual(result.source, "github-release")
+
+        target = self.cache_dir / "treeship"
+        partial = self.cache_dir / "treeship.partial"
+
+        # The binary lives at the final path with the expected bytes.
+        self.assertTrue(target.is_file(), "expected target binary to exist")
+        self.assertEqual(target.read_bytes(), _FAKE_BINARY)
+
+        # No .partial leftover.
+        self.assertFalse(partial.exists(), "partial file should be cleaned up")
+
+        # Mode 0755 (or compatible) — we explicitly chmod'd it.
+        mode = target.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o755, f"expected mode 0755, got {oct(mode)}")
+
+    # ------------------------------------------------------------------
+    # Hash mismatch — the load-bearing security check
+    # ------------------------------------------------------------------
+
+    def test_hash_mismatch_raises_and_deletes_partial_and_target(self) -> None:
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,  # expected hash
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_mutated,  # different bytes → bad hash
+        ):
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+        err = ctx.exception
+        self.assertEqual(err.reason, "binary-checksum-mismatch")
+        # The error message must surface both hashes so an operator can
+        # diagnose without scraping debug logs.
+        self.assertIn(_FAKE_SHA256, str(err))
+        self.assertIn(
+            hashlib.sha256(_FAKE_BINARY + b"tampered").hexdigest(),
+            str(err),
+        )
+
+        target = self.cache_dir / "treeship"
+        partial = self.cache_dir / "treeship.partial"
+
+        # The final binary must NOT exist. If it did, a retry could run it.
+        self.assertFalse(target.exists(), "tampered binary must not land at final path")
+        # The partial must also be gone — bad bytes deleted, not stranded.
+        self.assertFalse(partial.exists(), "partial file must be removed on mismatch")
+
+    def test_hash_mismatch_does_not_chmod_partial(self) -> None:
+        """A stronger version of the above: prove we don't even touch chmod.
+
+        Patches ``os.chmod`` and asserts it is never called when the
+        hash doesn't match. Catches a regression where someone reorders
+        the steps and chmods before verify.
+        """
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_mutated,
+        ), patch(
+            "treeship_sdk.bootstrap.os.chmod",
+        ) as mock_chmod:
+            with self.assertRaises(TreeshipBootstrapError):
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+            mock_chmod.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Missing checksum file — fail before talking to the network
+    # ------------------------------------------------------------------
+
+    def test_missing_checksum_raises_with_clear_message(self) -> None:
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=None,  # simulates malformed/missing data file
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+        ) as mock_urlopen:
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+            # The download must never have been attempted.
+            mock_urlopen.assert_not_called()
+
+        err = ctx.exception
+        self.assertEqual(err.reason, "checksum-missing")
+        self.assertIn(_ASSET, str(err))
+        # Message guides the user toward a real recovery, not a vague error.
+        self.assertIn("reinstall", str(err).lower())
+
+    # ------------------------------------------------------------------
+    # Network failure mid-download — partial cleanup, fail-loud
+    # ------------------------------------------------------------------
+
+    def test_download_io_error_raises_and_cleans_up(self) -> None:
+        class _BoomResponse:
+            def __enter__(self): return self
+            def __exit__(self, *_a): return False
+            def read(self, _n=-1):
+                raise IOError("simulated network drop")
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            return_value=_BoomResponse(),
+        ):
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+        self.assertEqual(ctx.exception.reason, "binary-download-failed")
+        # No partial or target file stranded.
+        self.assertFalse((self.cache_dir / "treeship").exists())
+        self.assertFalse((self.cache_dir / "treeship.partial").exists())
+
+
+class ReadExpectedChecksumTests(unittest.TestCase):
+    """Direct tests of the checksum-loading helper."""
+
+    def test_returns_none_when_data_file_absent(self) -> None:
+        # Pick an asset name we know there is no data file for. The
+        # release pipeline writes specific ones; this is a made-up
+        # name that won't have a corresponding file.
+        from treeship_sdk.bootstrap import _read_expected_checksum
+
+        result = _read_expected_checksum("treeship-nonexistent-asset-xyz")
+        self.assertIsNone(result)
+
+    def test_rejects_malformed_hex(self) -> None:
+        # Stub the importlib.resources lookup so we can inject a
+        # malformed payload without writing a real file.
+        from treeship_sdk import bootstrap
+
+        class _StubResource:
+            def is_file(self): return True
+            def read_text(self, encoding="utf-8"):  # noqa: ARG002
+                return "not-hex-not-64-chars\n"
+
+        class _StubRoot:
+            def joinpath(self, _name): return _StubResource()
+
+        with patch(
+            "importlib.resources.files",
+            return_value=_StubRoot(),
+        ):
+            self.assertIsNone(bootstrap._read_expected_checksum("anything"))
+
+    def test_accepts_valid_lowercase_hex(self) -> None:
+        from treeship_sdk import bootstrap
+
+        good = "a" * 64
+
+        class _StubResource:
+            def is_file(self): return True
+            def read_text(self, encoding="utf-8"):  # noqa: ARG002
+                return good + "\n"
+
+        class _StubRoot:
+            def joinpath(self, _name): return _StubResource()
+
+        with patch(
+            "importlib.resources.files",
+            return_value=_StubRoot(),
+        ):
+            self.assertEqual(bootstrap._read_expected_checksum("anything"), good)
+
+    def test_normalizes_uppercase_hex_to_lowercase(self) -> None:
+        from treeship_sdk import bootstrap
+
+        upper = "A" * 64
+
+        class _StubResource:
+            def is_file(self): return True
+            def read_text(self, encoding="utf-8"):  # noqa: ARG002
+                return upper + "\n"
+
+        class _StubRoot:
+            def joinpath(self, _name): return _StubResource()
+
+        with patch(
+            "importlib.resources.files",
+            return_value=_StubRoot(),
+        ):
+            self.assertEqual(
+                bootstrap._read_expected_checksum("anything"),
+                "a" * 64,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/sdk-python/tests/test_bootstrap_checksum.py
+++ b/packages/sdk-python/tests/test_bootstrap_checksum.py
@@ -78,7 +78,15 @@ class GithubReleaseChecksumTests(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self.cache_dir = Path(self._tmp.name) / "cache"
         # _install_via_github_release will mkdir this itself, but we
-        # leave the parent in place so cleanup is unambiguous.
+        # leave the parent in place so cleanup is unambiguous. We
+        # pre-create with 0o700 so the F3 ownership check (which
+        # refuses group/world-writable cache dirs) passes regardless
+        # of the host umask. mkdir(exist_ok=True) inside the function
+        # is then a no-op.
+        import os as _os
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if hasattr(_os, "chmod"):
+            _os.chmod(self.cache_dir, 0o700)
 
     def tearDown(self) -> None:
         self._tmp.cleanup()
@@ -420,6 +428,14 @@ class UniquePartialFilenameTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         self.cache_dir = Path(self._tmp.name) / "cache"
+        # Pre-create cache_dir with 0o700 so the F3 ownership check
+        # (group/world-writable refusal) doesn't reject us on machines
+        # with a permissive umask. The function uses mkdir(exist_ok=
+        # True), so this is a no-op for it.
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        import os as _os
+        if hasattr(_os, "chmod"):
+            _os.chmod(self.cache_dir, 0o700)
 
     def tearDown(self) -> None:
         self._tmp.cleanup()
@@ -488,6 +504,13 @@ class UniquePartialFilenameTests(unittest.TestCase):
         # addresses. Even with the same cache_dir the fix should hold.
         cache_a = Path(self._tmp.name) / "cache-a"
         cache_b = Path(self._tmp.name) / "cache-b"
+        # Pre-create with 0o700 so the F3 ownership check passes
+        # regardless of host umask.
+        import os as _os
+        cache_a.mkdir(parents=True, exist_ok=True)
+        cache_b.mkdir(parents=True, exist_ok=True)
+        _os.chmod(cache_a, 0o700)
+        _os.chmod(cache_b, 0o700)
 
         results: dict[str, object] = {}
         errors: dict[str, BaseException] = {}

--- a/packages/sdk-python/tests/test_bootstrap_checksum.py
+++ b/packages/sdk-python/tests/test_bootstrap_checksum.py
@@ -247,6 +247,66 @@ class GithubReleaseChecksumTests(unittest.TestCase):
             f"partials must be cleaned up on network error, found {leftover_partials}",
         )
 
+    # ------------------------------------------------------------------
+    # F4 — chmod failure must not leave a stale unverified target.
+    # ------------------------------------------------------------------
+
+    def test_chmod_failure_leaves_no_target_file(self) -> None:
+        """If chmod raises, `target` must not exist.
+
+        Pre-fix the order was os.replace(partial, target) then
+        os.chmod(target). A chmod failure after the rename left
+        `target` on disk with non-executable perms but already past
+        SHA-256 verification — the next ensure_cli()'s _try_cache
+        would return it without re-verifying. The fix chmods the
+        partial first, so a chmod failure aborts before the rename
+        and the unique partial is unlinked.
+        """
+        import os as _os
+
+        real_chmod = _os.chmod
+
+        def _boom_chmod(path, mode):  # noqa: ARG001
+            raise PermissionError("simulated chmod failure")
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_ok,
+        ), patch(
+            "treeship_sdk.bootstrap.os.chmod",
+            side_effect=_boom_chmod,
+        ):
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+        # Best-signal: the final target path must not exist. If it
+        # did, the caller's next _try_cache would skip re-verification
+        # and exec stale bytes.
+        target = self.cache_dir / "treeship"
+        self.assertFalse(
+            target.exists(),
+            "target must not exist when chmod fails — _try_cache would skip re-verify",
+        )
+
+        # No partial file should be stranded either.
+        leftover_partials = list(self.cache_dir.glob("*.partial"))
+        self.assertEqual(
+            leftover_partials, [],
+            f"partial must be cleaned up on chmod failure, found {leftover_partials}",
+        )
+
+        # And the bootstrap should report this as a download-failed
+        # branch the agent can recover from.
+        self.assertEqual(ctx.exception.reason, "binary-download-failed")
+        # Restore (defensive; patch context already restores).
+        del real_chmod
+
 
 class ReadExpectedChecksumTests(unittest.TestCase):
     """Direct tests of the checksum-loading helper."""

--- a/packages/sdk-python/tests/test_bootstrap_checksum.py
+++ b/packages/sdk-python/tests/test_bootstrap_checksum.py
@@ -288,6 +288,31 @@ class ReadExpectedChecksumTests(unittest.TestCase):
         ):
             self.assertEqual(bootstrap._read_expected_checksum("anything"), good)
 
+    def test_returns_none_on_non_utf8_payload(self) -> None:
+        """A wheel that ships a checksum file with non-UTF-8 bytes must
+        surface as "missing/malformed", not a stack trace.
+
+        ``read_text(encoding="utf-8")`` raises ``UnicodeDecodeError`` on
+        bad bytes; that's a subclass of ``ValueError``. The helper's
+        contract is "missing or malformed → None" so the caller can
+        branch through the structured ``checksum-missing`` error path.
+        """
+        from treeship_sdk import bootstrap
+
+        class _StubResource:
+            def is_file(self): return True
+            def read_text(self, encoding="utf-8"):  # noqa: ARG002
+                raise UnicodeDecodeError("utf-8", b"\xff\xfe\x00malformed", 0, 1, "invalid start byte")
+
+        class _StubRoot:
+            def joinpath(self, _name): return _StubResource()
+
+        with patch(
+            "importlib.resources.files",
+            return_value=_StubRoot(),
+        ):
+            self.assertIsNone(bootstrap._read_expected_checksum("anything"))
+
     def test_normalizes_uppercase_hex_to_lowercase(self) -> None:
         from treeship_sdk import bootstrap
 

--- a/packages/sdk-python/tests/test_bootstrap_checksum.py
+++ b/packages/sdk-python/tests/test_bootstrap_checksum.py
@@ -109,14 +109,17 @@ class GithubReleaseChecksumTests(unittest.TestCase):
         self.assertEqual(result.source, "github-release")
 
         target = self.cache_dir / "treeship"
-        partial = self.cache_dir / "treeship.partial"
 
         # The binary lives at the final path with the expected bytes.
         self.assertTrue(target.is_file(), "expected target binary to exist")
         self.assertEqual(target.read_bytes(), _FAKE_BINARY)
 
-        # No .partial leftover.
-        self.assertFalse(partial.exists(), "partial file should be cleaned up")
+        # No *.partial leftover (unique tempfile names land here).
+        leftover_partials = list(self.cache_dir.glob("*.partial"))
+        self.assertEqual(
+            leftover_partials, [],
+            f"expected no .partial leftovers, found {leftover_partials}",
+        )
 
         # Mode 0755 (or compatible) — we explicitly chmod'd it.
         mode = target.stat().st_mode & 0o777
@@ -151,12 +154,15 @@ class GithubReleaseChecksumTests(unittest.TestCase):
         )
 
         target = self.cache_dir / "treeship"
-        partial = self.cache_dir / "treeship.partial"
 
         # The final binary must NOT exist. If it did, a retry could run it.
         self.assertFalse(target.exists(), "tampered binary must not land at final path")
-        # The partial must also be gone — bad bytes deleted, not stranded.
-        self.assertFalse(partial.exists(), "partial file must be removed on mismatch")
+        # No *.partial must remain — bad bytes deleted, not stranded.
+        leftover_partials = list(self.cache_dir.glob("*.partial"))
+        self.assertEqual(
+            leftover_partials, [],
+            f"partial files must be removed on mismatch, found {leftover_partials}",
+        )
 
     def test_hash_mismatch_does_not_chmod_partial(self) -> None:
         """A stronger version of the above: prove we don't even touch chmod.
@@ -235,7 +241,11 @@ class GithubReleaseChecksumTests(unittest.TestCase):
         self.assertEqual(ctx.exception.reason, "binary-download-failed")
         # No partial or target file stranded.
         self.assertFalse((self.cache_dir / "treeship").exists())
-        self.assertFalse((self.cache_dir / "treeship.partial").exists())
+        leftover_partials = list(self.cache_dir.glob("*.partial"))
+        self.assertEqual(
+            leftover_partials, [],
+            f"partials must be cleaned up on network error, found {leftover_partials}",
+        )
 
 
 class ReadExpectedChecksumTests(unittest.TestCase):
@@ -334,6 +344,231 @@ class ReadExpectedChecksumTests(unittest.TestCase):
                 bootstrap._read_expected_checksum("anything"),
                 "a" * 64,
             )
+
+
+class UniquePartialFilenameTests(unittest.TestCase):
+    """Cover the F2 fix: parallel ensure_cli() calls must not collide.
+
+    The pre-fix code used a hardcoded ``cache_dir / "treeship.partial"``
+    filename. Two concurrent installs (pytest-xdist, two CI jobs sharing
+    a cache mount) would overwrite each other's partial mid-stream and
+    corrupt the SHA-256 verify path. The fix uses
+    ``tempfile.NamedTemporaryFile(dir=cache_dir, ...)`` to give each
+    call a unique partial path.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = Path(self._tmp.name) / "cache"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_uses_unique_named_temp_file_per_call(self) -> None:
+        """Two sequential calls must allocate distinct partial paths.
+
+        We capture the ``name`` of each NamedTemporaryFile that the
+        function creates. If the function regresses to a fixed filename
+        these two names will be equal.
+        """
+        from treeship_sdk import bootstrap
+
+        seen_names: list[str] = []
+        real_ntf = tempfile.NamedTemporaryFile
+
+        def _capturing_ntf(*args, **kwargs):
+            f = real_ntf(*args, **kwargs)
+            seen_names.append(f.name)
+            return f
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_ok,
+        ), patch(
+            "treeship_sdk.bootstrap._probe_binary",
+            return_value="treeship 0.0.0-test",
+        ), patch(
+            "treeship_sdk.bootstrap.tempfile.NamedTemporaryFile",
+            side_effect=_capturing_ntf,
+        ):
+            bootstrap._install_via_github_release(self.cache_dir, version="0.0.0-test")
+            bootstrap._install_via_github_release(self.cache_dir, version="0.0.0-test")
+
+        self.assertEqual(len(seen_names), 2, "expected two partial allocations")
+        self.assertNotEqual(
+            seen_names[0], seen_names[1],
+            "two sequential bootstraps must use distinct partial paths",
+        )
+        # Both must live inside cache_dir (so os.replace is same-FS).
+        for name in seen_names:
+            self.assertEqual(
+                Path(name).parent, self.cache_dir,
+                f"partial {name} must be inside cache_dir for atomic replace",
+            )
+
+    def test_concurrent_threads_dont_corrupt_each_other(self) -> None:
+        """Two threads racing through _install_via_github_release must
+        each succeed independently. The hardcoded-partial bug would
+        manifest as one thread reading the other's bytes via the shared
+        partial path and failing the SHA-256 check.
+        """
+        import threading
+
+        from treeship_sdk import bootstrap
+
+        # Pre-stage: each thread gets its own cache_dir so the *target*
+        # path doesn't race (that's a separate orthogonal concern); the
+        # test specifically isolates the partial-filename race that F2
+        # addresses. Even with the same cache_dir the fix should hold.
+        cache_a = Path(self._tmp.name) / "cache-a"
+        cache_b = Path(self._tmp.name) / "cache-b"
+
+        results: dict[str, object] = {}
+        errors: dict[str, BaseException] = {}
+        barrier = threading.Barrier(2)
+
+        def _slow_urlopen(_url, timeout=30):  # noqa: ARG001
+            # Force the threads to interleave inside the streaming loop
+            # by pausing at the response object before bytes are read.
+            barrier.wait(timeout=5)
+            return _FakeResponse(_FAKE_BINARY)
+
+        def _run(key: str, cache: Path) -> None:
+            try:
+                results[key] = bootstrap._install_via_github_release(
+                    cache, version="0.0.0-test",
+                )
+            except BaseException as e:  # capture all, re-raise in assert
+                errors[key] = e
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_slow_urlopen,
+        ), patch(
+            "treeship_sdk.bootstrap._probe_binary",
+            return_value="treeship 0.0.0-test",
+        ):
+            t1 = threading.Thread(target=_run, args=("a", cache_a))
+            t2 = threading.Thread(target=_run, args=("b", cache_b))
+            t1.start(); t2.start()
+            t1.join(timeout=15); t2.join(timeout=15)
+
+        self.assertEqual(errors, {}, f"unexpected errors: {errors}")
+        self.assertIn("a", results)
+        self.assertIn("b", results)
+        # Both final binaries must exist and contain the right bytes.
+        self.assertEqual((cache_a / "treeship").read_bytes(), _FAKE_BINARY)
+        self.assertEqual((cache_b / "treeship").read_bytes(), _FAKE_BINARY)
+
+
+class CacheDirOwnershipTests(unittest.TestCase):
+    """Cover the F3 fix: refuse to install into a cache_dir owned by
+    another user or one that is group/world-writable.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cache_dir = Path(self._tmp.name) / "cache"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _fake_stat(self, st_uid: int, st_mode: int = 0o40700):
+        """Build a stand-in stat_result-ish object with the fields we check."""
+        class _S:
+            pass
+        s = _S()
+        s.st_uid = st_uid
+        s.st_mode = st_mode
+        return s
+
+    def test_rejects_cache_dir_owned_by_other_user(self) -> None:
+        import os as _os
+
+        if not hasattr(_os, "geteuid"):
+            self.skipTest("ownership check is POSIX-only")
+
+        wrong_uid = _os.geteuid() + 1
+        fake = self._fake_stat(st_uid=wrong_uid, st_mode=0o40700)
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch.object(Path, "stat", return_value=fake), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+        ) as mock_urlopen:
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+            # The download must not even start.
+            mock_urlopen.assert_not_called()
+
+        self.assertEqual(ctx.exception.reason, "cache-dir-unsafe")
+        self.assertIn(str(wrong_uid), str(ctx.exception))
+
+    def test_rejects_world_writable_cache_dir(self) -> None:
+        import os as _os
+
+        if not hasattr(_os, "geteuid"):
+            self.skipTest("ownership check is POSIX-only")
+
+        # Owned by us, but world-writable (0o777).
+        fake = self._fake_stat(st_uid=_os.geteuid(), st_mode=0o40777)
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch.object(Path, "stat", return_value=fake), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+        ) as mock_urlopen:
+            with self.assertRaises(TreeshipBootstrapError) as ctx:
+                _install_via_github_release(self.cache_dir, version="0.0.0-test")
+            mock_urlopen.assert_not_called()
+
+        self.assertEqual(ctx.exception.reason, "cache-dir-unsafe")
+
+    def test_accepts_private_cache_dir_owned_by_us(self) -> None:
+        import os as _os
+
+        if not hasattr(_os, "geteuid"):
+            self.skipTest("ownership check is POSIX-only")
+
+        # Owned by us, mode 0700 — should pass.
+        fake = self._fake_stat(st_uid=_os.geteuid(), st_mode=0o40700)
+
+        with patch(
+            "treeship_sdk.bootstrap.platform_release_asset",
+            return_value=(_ASSET, None),
+        ), patch(
+            "treeship_sdk.bootstrap._read_expected_checksum",
+            return_value=_FAKE_SHA256,
+        ), patch.object(Path, "stat", return_value=fake), patch(
+            "treeship_sdk.bootstrap.urllib.request.urlopen",
+            side_effect=_fake_urlopen_ok,
+        ), patch(
+            "treeship_sdk.bootstrap._probe_binary",
+            return_value="treeship 0.0.0-test",
+        ):
+            # No exception — happy path.
+            result = _install_via_github_release(self.cache_dir, version="0.0.0-test")
+            self.assertIsNotNone(result)
 
 
 if __name__ == "__main__":

--- a/packages/sdk-python/treeship_sdk/_data/__init__.py
+++ b/packages/sdk-python/treeship_sdk/_data/__init__.py
@@ -1,0 +1,14 @@
+# Binary integrity data shipped with the wheel.
+#
+# The release pipeline writes one ``expected-checksum-<asset>.txt`` per
+# supported platform into this directory at wheel-build time (see
+# .github/workflows/release.yml). The bootstrap loads them via
+# importlib.resources and uses them to verify GitHub Release binaries
+# before they are made executable.
+#
+# These files are intentionally NOT committed to the repo — the
+# .gitignore at the repo root excludes them. They exist only inside
+# the published wheel, so the hash arrives via PyPI (one trust root)
+# while the binary arrives via GitHub Releases (a separate trust
+# root). Compromising one without the other yields a hash mismatch
+# and a hard install failure.

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -46,6 +46,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import urllib.request
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -338,42 +339,106 @@ def _install_via_github_release(
         )
 
     cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # Cache-dir ownership/perms check. A pre-existing cache_dir owned
+    # by another user (multi-user macOS box, shared dev VM, mounted
+    # volume, a sibling agent's home) means whoever owns it can
+    # pre-stage a malicious binary at the target path. The mkdir
+    # above is a no-op when the directory already exists, so we MUST
+    # validate the inode we got. On Windows there's no euid concept
+    # and `platform_release_asset` already refuses to serve Windows,
+    # so we skip the check there.
+    if hasattr(os, "geteuid"):
+        try:
+            st = cache_dir.stat()
+        except OSError as exc:
+            raise TreeshipBootstrapError(
+                "cache-dir-unsafe",
+                (
+                    f"could not stat cache_dir {cache_dir} to verify "
+                    f"ownership: {exc}. Refusing to install into a "
+                    "directory we can't inspect. Recover: set "
+                    "$TREESHIP_CACHE to a path you own, or remove the "
+                    "existing cache directory."
+                ),
+                [f"cache:{cache_dir}"],
+            ) from exc
+        euid = os.geteuid()
+        if st.st_uid != euid:
+            raise TreeshipBootstrapError(
+                "cache-dir-unsafe",
+                (
+                    f"cache_dir {cache_dir} is owned by uid {st.st_uid}, "
+                    f"not the current user (uid {euid}). Refusing to "
+                    "install — another user could pre-stage a malicious "
+                    "binary here. Recover: set $TREESHIP_CACHE to a path "
+                    "you own (e.g. under your home directory), or remove "
+                    "the existing cache directory and let treeship "
+                    "recreate it."
+                ),
+                [f"cache:{cache_dir}"],
+            )
+        if st.st_mode & 0o022 != 0:
+            raise TreeshipBootstrapError(
+                "cache-dir-unsafe",
+                (
+                    f"cache_dir {cache_dir} is group- or world-writable "
+                    f"(mode {oct(st.st_mode & 0o777)}). Refusing to "
+                    "install — another user could overwrite the binary "
+                    "between download and exec. Recover: `chmod 700 "
+                    f"{cache_dir}` or move the cache to a private path "
+                    "via $TREESHIP_CACHE."
+                ),
+                [f"cache:{cache_dir}"],
+            )
+
     target = cache_dir / "treeship"
-    partial = cache_dir / "treeship.partial"
     url = (
         f"https://github.com/zerkerlabs/treeship/releases/download/v{version}/{asset}"
         if version
         else f"https://github.com/zerkerlabs/treeship/releases/latest/download/{asset}"
     )
 
-    # If a stale partial exists from a prior aborted download, clear it
-    # before we start — otherwise a hash mismatch later would refer to
-    # bytes we didn't just download.
-    try:
-        partial.unlink()
-    except FileNotFoundError:
-        pass
-    except OSError:
-        pass
+    # Use a unique partial filename so two parallel ensure_cli() calls
+    # (pytest-xdist, two CI jobs sharing a cache mount, two Treeship
+    # SDK instances in the same process) can't overwrite each other's
+    # mid-stream bytes. The earlier fixed-name "treeship.partial"
+    # silently raced. tempfile.NamedTemporaryFile guarantees uniqueness
+    # within cache_dir.
+    partial = tempfile.NamedTemporaryFile(
+        dir=str(cache_dir),
+        prefix="treeship-",
+        suffix=".partial",
+        delete=False,
+    )
+    partial_path = partial.name
 
-    # Stream the download into <target>.partial, computing SHA-256
+    def _cleanup_partial() -> None:
+        """Best-effort removal of the in-progress partial file."""
+        try:
+            os.unlink(partial_path)
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+    # Stream the download into the unique partial, computing SHA-256
     # incrementally so we never hold the full binary in memory.
     hasher = hashlib.sha256()
     try:
         with urllib.request.urlopen(url, timeout=30) as resp:  # nosec B310 (vetted https GitHub URL)
-            with open(partial, "wb") as fp:
+            try:
                 while True:
                     chunk = resp.read(64 * 1024)
                     if not chunk:
                         break
                     hasher.update(chunk)
-                    fp.write(chunk)
+                    partial.write(chunk)
+            finally:
+                partial.close()
     except Exception as exc:
         # Clean up the partial so a retry can't pick up bad bytes.
-        try:
-            partial.unlink()
-        except OSError:
-            pass
+        _cleanup_partial()
         raise TreeshipBootstrapError(
             "binary-download-failed",
             (
@@ -390,10 +455,7 @@ def _install_via_github_release(
     if got != expected:
         # Delete the partial BEFORE we abort. A retry must not be able
         # to chmod the bad bytes that are sitting on disk.
-        try:
-            partial.unlink()
-        except OSError:
-            pass
+        _cleanup_partial()
         raise TreeshipBootstrapError(
             "binary-checksum-mismatch",
             (
@@ -412,15 +474,12 @@ def _install_via_github_release(
     # Hash matched: promote the partial to the final path atomically,
     # then chmod. Order matters — never chmod the .partial path.
     try:
-        os.replace(partial, target)
+        os.replace(partial_path, target)
         os.chmod(target, 0o755)
     except OSError as exc:
         # Replace/chmod failed even though bytes were correct. Treat as
         # a download-side failure so the agent can branch on it.
-        try:
-            partial.unlink()
-        except OSError:
-            pass
+        _cleanup_partial()
         raise TreeshipBootstrapError(
             "binary-download-failed",
             f"could not finalize {asset}: {exc}",

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -106,7 +106,11 @@ def _read_expected_checksum(asset: str) -> Optional[str]:
         if not resource.is_file():
             return None
         raw = resource.read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError, OSError):
+    except (FileNotFoundError, ModuleNotFoundError, OSError, ValueError):
+        # ValueError catches UnicodeDecodeError (a subclass) — a wheel
+        # that ships a checksum file with non-UTF-8 bytes must surface
+        # as "missing/malformed" (None) so the caller routes through the
+        # structured ``checksum-missing`` error path, not a stack trace.
         return None
     hex_str = raw.strip().lower()
     if not _HEX_SHA256_RE.match(hex_str):

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -471,14 +471,34 @@ def _install_via_github_release(
             [f"download:{url}", f"expected:{expected}", f"got:{got}"],
         )
 
-    # Hash matched: promote the partial to the final path atomically,
-    # then chmod. Order matters — never chmod the .partial path.
+    # Hash matched. Chmod the partial BEFORE the atomic rename so that
+    # `target` only ever appears on disk in its final, executable
+    # state. If we chmodded AFTER os.replace, a chmod failure (read-
+    # only FS, exotic perms, NFS race) would leave the bytes at
+    # `target` without the executable bit but already past
+    # verification — the next ensure_cli()'s _try_cache would happily
+    # return that path because it doesn't re-verify the SHA. By
+    # ordering chmod first, any chmod failure causes us to abort with
+    # the bytes still under the unique partial name, which we then
+    # unlink — so `target` never exists in an unverified state.
+    try:
+        os.chmod(partial_path, 0o755)
+    except OSError as exc:
+        _cleanup_partial()
+        raise TreeshipBootstrapError(
+            "binary-download-failed",
+            f"could not set executable bit on {asset}: {exc}",
+            [f"download:{url}", f"finalize:{partial_path}"],
+        ) from exc
+
     try:
         os.replace(partial_path, target)
-        os.chmod(target, 0o755)
     except OSError as exc:
-        # Replace/chmod failed even though bytes were correct. Treat as
-        # a download-side failure so the agent can branch on it.
+        # The bytes were correct and chmodded; rename failed (rare:
+        # cross-device, permission, target locked). Clean up the
+        # partial so we don't leave verified-but-orphaned bytes that
+        # a future _try_cache might pick up if a symlink shuffle
+        # happened.
         _cleanup_partial()
         raise TreeshipBootstrapError(
             "binary-download-failed",

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -39,13 +39,13 @@ agents that want to bootstrap without instantiating the SDK first.
 
 from __future__ import annotations
 
-import json
+import hashlib
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
-import tempfile
 import urllib.request
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -59,6 +59,59 @@ __all__ = [
     "default_cache_dir",
     "platform_release_asset",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Binary integrity (SHA-256) — supply-chain hardening
+# ---------------------------------------------------------------------------
+#
+# When we fall back to downloading the CLI binary from a GitHub Release,
+# we must verify the bytes before we ever chmod +x and exec them.
+#
+# Trust roots:
+#   1. The expected SHA-256 ships with the wheel via PyPI. The release
+#      pipeline writes it into ``treeship_sdk/_data/expected-checksum-<asset>.txt``
+#      at build time (see .github/workflows/release.yml). It is never
+#      committed to the repo and never fetched at runtime.
+#   2. The binary arrives via GitHub Releases.
+#
+# Because the hash arrives via PyPI and the binary via GitHub, an
+# attacker would have to compromise both registries to slip a tampered
+# binary past install. If either is tampered, the hashes disagree and
+# we abort — loudly. No silent fallback.
+#
+# Earlier versions (<= 0.10.2) downloaded the binary, chmod +x'd it,
+# and executed it with zero integrity check. This module is the
+# Python-side mirror of the npm postinstall hardening from PR #72.
+
+_CHECKSUM_DATA_PACKAGE = "treeship_sdk._data"
+_HEX_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _read_expected_checksum(asset: str) -> Optional[str]:
+    """Return the expected SHA-256 hex for ``asset``, or None if missing/malformed.
+
+    Reads from the data file that the release pipeline embedded in the
+    wheel. Format: a single line, lowercase hex, 64 characters. An
+    absent or malformed file means the install is unverifiable; the
+    caller must refuse to proceed.
+    """
+    filename = f"expected-checksum-{asset}.txt"
+    try:
+        # importlib.resources.files() is available on Python >= 3.9.
+        from importlib.resources import files
+
+        data_root = files(_CHECKSUM_DATA_PACKAGE)
+        resource = data_root.joinpath(filename)
+        if not resource.is_file():
+            return None
+        raw = resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    hex_str = raw.strip().lower()
+    if not _HEX_SHA256_RE.match(hex_str):
+        return None
+    return hex_str
 
 
 # ---------------------------------------------------------------------------
@@ -237,40 +290,138 @@ def _install_via_github_release(
 ) -> Optional[BootstrapResult]:
     """Download the matching platform binary from the GitHub Release.
 
-    No `sudo`; writes only into ``cache_dir``. Returns None if the
-    download fails or the platform isn't supported. Uses the "latest"
+    No `sudo`; writes only into ``cache_dir``. Uses the "latest"
     release by default; pass ``version`` (e.g. ``"0.9.11"``) to pin.
+
+    Integrity:
+        Before the downloaded bytes are ever made executable, this
+        function verifies their SHA-256 against the expected hash that
+        the release pipeline embedded in the wheel (see
+        :func:`_read_expected_checksum`). On mismatch — or if the
+        expected hash is missing from the install — it raises
+        :class:`TreeshipBootstrapError`. Never falls back silently.
+
+    Returns:
+        ``BootstrapResult`` on success, ``None`` if the current
+        platform has no published release asset.
+
+    Raises:
+        :class:`TreeshipBootstrapError`: when the expected checksum is
+            missing, the download fails, or the hash disagrees. The
+            ``reason`` is one of ``checksum-missing``,
+            ``binary-download-failed``, ``binary-checksum-mismatch``.
     """
     asset, err = platform_release_asset()
     if err:
         return None
+
+    expected = _read_expected_checksum(asset)
+    if expected is None:
+        raise TreeshipBootstrapError(
+            "checksum-missing",
+            (
+                "treeship-sdk install is missing the expected SHA-256 for "
+                f"'{asset}'. The wheel was published without a binary "
+                "integrity hash and cannot install the CLI safely. "
+                "Recover: reinstall the SDK (`pip install --force-reinstall "
+                "treeship-sdk`); if that doesn't help, file an issue at "
+                "https://github.com/zerkerlabs/treeship/issues so we can "
+                "re-publish it. Alternatively, install the CLI directly: "
+                "`npm install -g treeship` or download from "
+                "https://github.com/zerkerlabs/treeship/releases."
+            ),
+            [f"checksum:{asset}"],
+        )
+
     cache_dir.mkdir(parents=True, exist_ok=True)
     target = cache_dir / "treeship"
-    base = (
+    partial = cache_dir / "treeship.partial"
+    url = (
         f"https://github.com/zerkerlabs/treeship/releases/download/v{version}/{asset}"
         if version
         else f"https://github.com/zerkerlabs/treeship/releases/latest/download/{asset}"
     )
-    # Stream into a temp file in the same dir so the final move is atomic.
-    tmp = tempfile.NamedTemporaryFile(dir=str(cache_dir), prefix=".treeship-", suffix=".part", delete=False)
-    tmp_path = Path(tmp.name)
+
+    # If a stale partial exists from a prior aborted download, clear it
+    # before we start — otherwise a hash mismatch later would refer to
+    # bytes we didn't just download.
     try:
-        with urllib.request.urlopen(base, timeout=30) as resp:  # nosec B310 (vetted https GitHub URL)
-            shutil.copyfileobj(resp, tmp)
-        tmp.close()
-        # Mark executable.
-        tmp_path.chmod(0o755)
-        tmp_path.replace(target)
-    except Exception:
+        partial.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+    # Stream the download into <target>.partial, computing SHA-256
+    # incrementally so we never hold the full binary in memory.
+    hasher = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:  # nosec B310 (vetted https GitHub URL)
+            with open(partial, "wb") as fp:
+                while True:
+                    chunk = resp.read(64 * 1024)
+                    if not chunk:
+                        break
+                    hasher.update(chunk)
+                    fp.write(chunk)
+    except Exception as exc:
+        # Clean up the partial so a retry can't pick up bad bytes.
         try:
-            tmp.close()
-        except Exception:
+            partial.unlink()
+        except OSError:
             pass
+        raise TreeshipBootstrapError(
+            "binary-download-failed",
+            (
+                f"could not download {asset} from {url}: {exc}. "
+                "Recover: re-run the install (transient network/CDN "
+                "issues clear up), or download the binary directly from "
+                "https://github.com/zerkerlabs/treeship/releases and "
+                "place it on PATH."
+            ),
+            [f"download:{url}"],
+        ) from exc
+
+    got = hasher.hexdigest()
+    if got != expected:
+        # Delete the partial BEFORE we abort. A retry must not be able
+        # to chmod the bad bytes that are sitting on disk.
         try:
-            tmp_path.unlink()
-        except Exception:
+            partial.unlink()
+        except OSError:
             pass
-        return None
+        raise TreeshipBootstrapError(
+            "binary-checksum-mismatch",
+            (
+                "SHA-256 mismatch on downloaded binary. Do not run it. "
+                f"url={url} expected={expected} got={got}. "
+                "This means either the GitHub Release was tampered with, "
+                "a CDN cached a stale or malicious binary, or the PyPI "
+                "wheel and the release are out of sync. Recover: "
+                "re-run the install in case it's a CDN race; if the "
+                "mismatch persists, file an issue at "
+                "https://github.com/zerkerlabs/treeship/issues."
+            ),
+            [f"download:{url}", f"expected:{expected}", f"got:{got}"],
+        )
+
+    # Hash matched: promote the partial to the final path atomically,
+    # then chmod. Order matters — never chmod the .partial path.
+    try:
+        os.replace(partial, target)
+        os.chmod(target, 0o755)
+    except OSError as exc:
+        # Replace/chmod failed even though bytes were correct. Treat as
+        # a download-side failure so the agent can branch on it.
+        try:
+            partial.unlink()
+        except OSError:
+            pass
+        raise TreeshipBootstrapError(
+            "binary-download-failed",
+            f"could not finalize {asset}: {exc}",
+            [f"download:{url}", f"finalize:{target}"],
+        ) from exc
 
     v = _probe_binary(str(target))
     if v is None:


### PR DESCRIPTION
## Summary

- Verify the downloaded `treeship` binary's SHA-256 before exec, closing a supply-chain gap where a tampered or partial download could be executed.
- Use a unique temp partial path and assert cache-dir ownership so we never trust someone else's leftover file.
- chmod the binary *before* the atomic rename, so we never leave a stale unverified target executable.
- Catch `ValueError` when parsing the checksum file (malformed checksum no longer panics the launcher).
- Pre-create `cache_dir` at `0o700` so umask differences across distros don't widen permissions.

## Audit context

This PR is part of a pre-launch audit covering 11 P0 findings + supporting hardening. The full audit branched into 8 independent lanes (A-H) that compose without conflicts.

**Lane B:** Python SDK launcher checksum + cache-dir hardening.

**Pre-merge verification:** all 8 lanes were merged into `audit/integration-verify` and the full test suite passed:

- Rust workspace: 297 lib + 412 integration tests
- TypeScript SDK: 11 vitest cases (incl. real CLI round-trip + tamper test)
- Python SDK: 44 unittest cases
- YAML workflow parse: OK
- Version preflight script: 23/23 sites consistent

**Commits in this PR:** 5 on top of `main` (`c6802d3`).

## Test plan

- [ ] CI green
- [ ] `cd packages/sdk-python && python3 -m unittest discover -s tests -v` reports 44/44 passing