### PR TITLE
fix(cli): emit JSON for hub ls, status, session, log (audit lane G)

### DIFF
--- a/packages/cli/src/commands/daemon.rs
+++ b/packages/cli/src/commands/daemon.rs
@@ -729,6 +729,46 @@ pub fn stop(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
 pub fn status(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
     let ts = ts_dir().ok_or("no .treeship directory found")?;
 
+    // JSON mode: emit a structured envelope. Without this branch the
+    // pretty path emits via `printer.info` / `printer.section` /
+    // `printer.hint`, all of which are no-ops in JSON mode (see
+    // printer.rs), so callers parsing stdout get zero bytes and have
+    // no way to tell whether the daemon is running.
+    //
+    // Shape:
+    //   running:  {"status":"running","running":true,"pid":<u32>,
+    //              "uptime_secs":<u64> | null}
+    //   stopped:  {"status":"stopped","running":false}
+    //
+    // `status` matches Lane D's hub::status convention (enum string),
+    // and `running` is a boolean alias so callers can branch on a
+    // single field without parsing the string.
+    if printer.format == crate::printer::Format::Json {
+        let body = if is_running(&ts) {
+            let pid = read_pid(&ts).unwrap_or(0);
+            let uptime_secs = read_start_time(&ts)
+                .map(|start| epoch_secs().saturating_sub(start));
+            serde_json::json!({
+                "status":      "running",
+                "running":     true,
+                "pid":         pid,
+                "uptime_secs": uptime_secs,
+            })
+        } else {
+            // Clean up stale PID file even in JSON mode -- the side
+            // effect is unrelated to the output channel.
+            if pid_path(&ts).exists() {
+                let _ = std::fs::remove_file(pid_path(&ts));
+            }
+            serde_json::json!({
+                "status":  "stopped",
+                "running": false,
+            })
+        };
+        printer.json(&body);
+        return Ok(());
+    }
+
     printer.blank();
     printer.section("daemon");
 

--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -209,6 +209,52 @@ pub fn ls(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = ctx::open(config)?;
 
+    // JSON mode: emit a structured list. The pretty path uses
+    // `printer.info(...)` which is a no-op in JSON mode (see
+    // printer.rs), so without this branch `treeship hub ls --format
+    // json` emits zero bytes -- breaking the SDK and any automation
+    // that wants to enumerate configured hubs.
+    //
+    // Shape:
+    //   {
+    //     "items": [
+    //       {"name": "...", "hub_id": "...", "endpoint": "...",
+    //        "key_id": "...", "active": true|false},
+    //       ...
+    //     ],
+    //     "active": "<name>" | null,
+    //     "count":  <items.len()>
+    //   }
+    //
+    // Each entry includes both `active` (per-row boolean for filtering)
+    // and `key_id` so callers don't need to round-trip through `hub
+    // status` to know which connection is selected or what key it uses.
+    if printer.format == crate::printer::Format::Json {
+        let active = ctx.config.active_hub.as_deref();
+        let mut names: Vec<&String> = ctx.config.hub_connections.keys().collect();
+        names.sort();
+        let items: Vec<serde_json::Value> = names
+            .iter()
+            .map(|name| {
+                let entry = &ctx.config.hub_connections[name.as_str()];
+                serde_json::json!({
+                    "name":     name,
+                    "hub_id":   entry.hub_id,
+                    "key_id":   entry.key_id,
+                    "endpoint": entry.endpoint,
+                    "active":   active == Some(name.as_str()),
+                })
+            })
+            .collect();
+        let body = serde_json::json!({
+            "items":  items,
+            "active": active,
+            "count":  items.len(),
+        });
+        printer.json(&body);
+        return Ok(());
+    }
+
     printer.blank();
 
     if ctx.config.hub_connections.is_empty() {

--- a/packages/cli/src/commands/log.rs
+++ b/packages/cli/src/commands/log.rs
@@ -14,6 +14,51 @@ pub fn run(
 
     let entries = ctx.storage.list();
 
+    // JSON mode: emit a structured list envelope. The pretty path uses
+    // `printer.dim_info` / `printer.info`, both of which are no-ops in
+    // JSON mode, so without this branch `treeship log --format json`
+    // emits zero bytes -- breaking any SDK / automation caller that
+    // parses stdout.
+    //
+    // Shape:
+    //   {
+    //     "items": [
+    //       {
+    //         "id":            "...",
+    //         "payload_type":  "application/vnd.treeship.<kind>.v1+json",
+    //         "signed_at":     "...",
+    //       },
+    //       ...
+    //     ],
+    //     "count": <items.len()>,
+    //     "total": <entries.len()>
+    //   }
+    //
+    // `count` is the number actually returned (capped by --tail) and
+    // `total` is the underlying storage size, so callers can detect
+    // truncation without re-running with a larger tail.
+    if printer.format == crate::printer::Format::Json {
+        let count = entries.len().min(tail);
+        let items: Vec<serde_json::Value> = entries
+            .iter()
+            .take(count)
+            .map(|e| {
+                serde_json::json!({
+                    "id":           e.id,
+                    "payload_type": e.payload_type,
+                    "signed_at":    e.signed_at,
+                })
+            })
+            .collect();
+        let body = serde_json::json!({
+            "items": items,
+            "count": items.len(),
+            "total": entries.len(),
+        });
+        printer.json(&body);
+        return Ok(());
+    }
+
     if entries.is_empty() {
         printer.blank();
         printer.dim_info("  No receipts yet.");

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -355,7 +355,81 @@ pub fn status(
     config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let manifest = match load_session() {
+    let manifest_opt = load_session();
+
+    // JSON mode: emit a structured envelope. Without this branch the
+    // pretty path's `printer.dim_info` / `printer.info` / `printer.section`
+    // all no-op under `--format json` (see printer.rs), so the SDK and
+    // any automation parsing stdout get zero bytes -- silently treating
+    // every workspace as having no active session.
+    //
+    // Shape (no active session):
+    //   { "status": "inactive", "active": false }
+    //
+    // Shape (active session):
+    //   {
+    //     "status":     "active",
+    //     "active":     true,
+    //     "session_id": "...",
+    //     "name":       "..." | null,
+    //     "actor":      "...",
+    //     "started_at": "<RFC3339>",
+    //     "elapsed_ms": <u64>,
+    //     "receipts":   <u64>,        // verified from chain
+    //     "events":     <u64>,
+    //     "root_artifact_id": "..." | null,
+    //     "root_verified": true|false
+    //   }
+    //
+    // `status` matches the hub::status convention (enum string), and the
+    // boolean `active` is also surfaced so SDK callers can branch on a
+    // single field without string-matching.
+    if printer.format == crate::printer::Format::Json {
+        let Some(manifest) = manifest_opt else {
+            let body = serde_json::json!({
+                "status": "inactive",
+                "active": false,
+            });
+            printer.json(&body);
+            return Ok(());
+        };
+
+        let ctx = ctx::open(config)?;
+        let root_verified = if let Some(ref root_id) = manifest.root_artifact_id {
+            ctx.storage.read(root_id).is_ok()
+        } else {
+            false
+        };
+        let artifact_count = match &manifest.root_artifact_id {
+            Some(root_id) => count_chain_artifacts(&ctx, root_id),
+            None => 0,
+        };
+        let elapsed_ms = epoch_ms().saturating_sub(manifest.started_at_ms);
+        let evt_dir = session_dir()
+            .map(|d| d.join("sessions").join(&manifest.session_id));
+        let event_count = evt_dir
+            .and_then(|d| EventLog::open(&d).ok())
+            .map(|log| log.event_count())
+            .unwrap_or(0);
+
+        let body = serde_json::json!({
+            "status":           "active",
+            "active":           true,
+            "session_id":       manifest.session_id,
+            "name":             manifest.name,
+            "actor":            manifest.actor,
+            "started_at":       manifest.started_at,
+            "elapsed_ms":       elapsed_ms,
+            "receipts":         artifact_count,
+            "events":           event_count,
+            "root_artifact_id": manifest.root_artifact_id,
+            "root_verified":    root_verified,
+        });
+        printer.json(&body);
+        return Ok(());
+    }
+
+    let manifest = match manifest_opt {
         Some(m) => m,
         None => {
             printer.blank();

--- a/packages/cli/src/commands/status.rs
+++ b/packages/cli/src/commands/status.rs
@@ -17,6 +17,138 @@ pub fn run(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::e
     let ctx = ctx::open(config)?;
     let cfg = &ctx.config;
 
+    // JSON mode: emit a single structured envelope summarising the full
+    // workspace state. The pretty path below uses `printer.section`,
+    // `printer.info`, `printer.dim_info`, and `printer.hint` -- ALL of
+    // which are no-ops in JSON mode (see printer.rs). So before this
+    // branch, `treeship status --format json` produced zero stdout
+    // bytes and every SDK / automation caller silently treated the
+    // workspace as empty.
+    //
+    // Shape (top-level groups mirror the pretty sections so callers
+    // can map field-for-field):
+    //   {
+    //     "ship":    { "id": "...", "name": "..." | null },
+    //     "session": null | {
+    //       "session_id": "...", "name": "..." | null,
+    //       "started_at_ms": <u64>, "elapsed_ms": <u64>
+    //     },
+    //     "keys":    [{"id":"...","algorithm":"...","fingerprint":"...","is_default":bool}],
+    //     "artifacts": {
+    //       "items": [{"id":"...","payload_type":"...","signed_at":"..."}],
+    //       "count": <u64>,    // returned (capped at 5)
+    //       "total": <u64>     // underlying storage size
+    //     },
+    //     "daemon":  { "status": "running"|"stopped",
+    //                  "pid": <u32> | null, "uptime_secs": <u64> | null },
+    //     "hub":     { "status": "attached"|"detached"|"configured",
+    //                  "active": "<name>" | null, "hub_id": "..." | null,
+    //                  "endpoint": "..." | null, "count": <u64> }
+    //   }
+    //
+    // `daemon.status` and `hub.status` use the same enum-string convention
+    // as Lane D's `hub status` to keep the SDK consistent.
+    if printer.format == crate::printer::Format::Json {
+        let session = super::session::load_session().map(|m| {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            let elapsed_ms = now_ms.saturating_sub(m.started_at_ms);
+            serde_json::json!({
+                "session_id":    m.session_id,
+                "name":          m.name,
+                "started_at_ms": m.started_at_ms,
+                "elapsed_ms":    elapsed_ms,
+            })
+        });
+
+        let keys = ctx.keys.list()?;
+        let keys_json: Vec<serde_json::Value> = keys
+            .iter()
+            .map(|k| {
+                serde_json::json!({
+                    "id":          k.id,
+                    "algorithm":   k.algorithm,
+                    "fingerprint": k.fingerprint,
+                    "is_default":  k.is_default,
+                })
+            })
+            .collect();
+
+        let artifacts = ctx.storage.list();
+        let artifact_items: Vec<serde_json::Value> = artifacts
+            .iter()
+            .take(5)
+            .map(|a| {
+                serde_json::json!({
+                    "id":           a.id,
+                    "payload_type": a.payload_type,
+                    "signed_at":    a.signed_at,
+                })
+            })
+            .collect();
+
+        let (daemon_running, daemon_pid, daemon_uptime) = super::daemon::daemon_info();
+        let daemon = if daemon_running {
+            serde_json::json!({
+                "status":      "running",
+                "pid":         daemon_pid,
+                "uptime_secs": daemon_uptime,
+            })
+        } else {
+            serde_json::json!({
+                "status":      "stopped",
+                "pid":         serde_json::Value::Null,
+                "uptime_secs": serde_json::Value::Null,
+            })
+        };
+
+        let hub = if let Some((name, entry)) = cfg.active_hub_connection() {
+            serde_json::json!({
+                "status":   "attached",
+                "active":   name,
+                "hub_id":   entry.hub_id,
+                "endpoint": entry.endpoint,
+                "count":    cfg.hub_connections.len(),
+            })
+        } else if cfg.hub_connections.is_empty() {
+            serde_json::json!({
+                "status":   "detached",
+                "active":   serde_json::Value::Null,
+                "hub_id":   serde_json::Value::Null,
+                "endpoint": serde_json::Value::Null,
+                "count":    0,
+            })
+        } else {
+            serde_json::json!({
+                "status":   "configured",
+                "active":   serde_json::Value::Null,
+                "hub_id":   serde_json::Value::Null,
+                "endpoint": serde_json::Value::Null,
+                "count":    cfg.hub_connections.len(),
+            })
+        };
+
+        let body = serde_json::json!({
+            "ship": {
+                "id":   cfg.ship_id,
+                "name": cfg.name,
+            },
+            "session": session,
+            "keys":    keys_json,
+            "artifacts": {
+                "items": artifact_items,
+                "count": artifacts.len().min(5),
+                "total": artifacts.len(),
+            },
+            "daemon": daemon,
+            "hub":    hub,
+        });
+        printer.json(&body);
+        return Ok(());
+    }
+
     // Session info (if active)
     if let Some(manifest) = super::session::load_session() {
         let elapsed_ms = {


### PR DESCRIPTION
## Summary

- Several CLI subcommands accepted `--format json` but silently fell back to human output (latent no-op). This PR makes `hub ls`, `status`, `session status`, `log`, and `daemon status` emit real non-empty JSON envelopes when `--format json` is passed.
- Unblocks scripted / SDK callers that were relying on the documented JSON contract.

## Audit context

This PR is part of a pre-launch audit covering 11 P0 findings + supporting hardening. The full audit branched into 8 independent lanes (A-H) that compose without conflicts.

**Lane G:** CLI `--format json` correctness across read-only subcommands.

**Pre-merge verification:** all 8 lanes were merged into `audit/integration-verify` and the full test suite passed:

- Rust workspace: 297 lib + 412 integration tests
- TypeScript SDK: 11 vitest cases (incl. real CLI round-trip + tamper test)
- Python SDK: 44 unittest cases
- YAML workflow parse: OK
- Version preflight script: 23/23 sites consistent

**Commits in this PR:** 1 on top of `main` (`c6802d3`).

## Test plan

- [ ] CI green
- [ ] `treeship hub ls --format json` emits a non-empty JSON envelope
- [ ] `treeship status --format json` emits a non-empty JSON envelope
- [ ] `treeship session status --format json` emits a non-empty JSON envelope
- [ ] `treeship log --format json` emits a non-empty JSON envelope
- [ ] `treeship daemon status --format json` emits a non-empty JSON envelope