### PR TITLE
fix(verify,bundle): reject empty-signature + unverified envelopes; drop fake chain_linkage (audit lane H, P0)

### DIFF
--- a/packages/cli/src/commands/bundle.rs
+++ b/packages/cli/src/commands/bundle.rs
@@ -1,6 +1,9 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+use treeship_core::attestation::Verifier;
 use treeship_core::bundle;
+use ed25519_dalek::VerifyingKey;
 
 use crate::{ctx, printer::Printer};
 
@@ -72,7 +75,15 @@ pub fn import(args: ImportArgs, printer: &Printer) -> Result<(), Box<dyn std::er
     let ctx = ctx::open(args.config.as_deref())?;
     let path = PathBuf::from(&args.file);
 
-    let bundle_id = bundle::import(&path, &ctx.storage)
+    // Build the trust root from the local keystore. Every public key the
+    // user has generated or added becomes a trusted signer for imports.
+    // To accept a bundle from a third party, the user must add that
+    // party's public key via `treeship keys add` first — which is the
+    // intended explicit-trust step, not a silent surprise.
+    let verifier = build_local_verifier(&ctx.keys)
+        .map_err(|e| format!("build verifier: {e}"))?;
+
+    let bundle_id = bundle::import(&path, &ctx.storage, &verifier)
         .map_err(|e| format!("{e}"))?;
 
     printer.success("bundle imported", &[
@@ -82,4 +93,31 @@ pub fn import(args: ImportArgs, printer: &Printer) -> Result<(), Box<dyn std::er
     printer.hint(&format!("treeship verify {}", bundle_id));
     printer.blank();
     Ok(())
+}
+
+/// Construct a `Verifier` from every key in the local keystore. Returns
+/// `bundle::BundleError::NoTrustRoot` if the keystore is empty so the caller
+/// can surface a useful "run `treeship init` first" message instead of a
+/// silent accept-everything.
+fn build_local_verifier(
+    keys: &treeship_core::keys::Store,
+) -> Result<Verifier, Box<dyn std::error::Error>> {
+    let infos = keys.list()?;
+    if infos.is_empty() {
+        return Err(Box::new(bundle::BundleError::NoTrustRoot));
+    }
+
+    let mut map: HashMap<String, VerifyingKey> = HashMap::new();
+    for info in infos {
+        let pk_arr: [u8; 32] = info.public_key.as_slice().try_into()
+            .map_err(|_| format!(
+                "key {} has malformed public key (expected 32 bytes, got {})",
+                info.id,
+                info.public_key.len(),
+            ))?;
+        let vk = VerifyingKey::from_bytes(&pk_arr)
+            .map_err(|e| format!("key {}: {e}", info.id))?;
+        map.insert(info.id, vk);
+    }
+    Ok(Verifier::new(map))
 }

--- a/packages/cli/src/commands/bundle.rs
+++ b/packages/cli/src/commands/bundle.rs
@@ -95,10 +95,18 @@ pub fn import(args: ImportArgs, printer: &Printer) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-/// Construct a `Verifier` from every key in the local keystore. Returns
-/// `bundle::BundleError::NoTrustRoot` if the keystore is empty so the caller
-/// can surface a useful "run `treeship init` first" message instead of a
-/// silent accept-everything.
+/// Construct a `Verifier` from every Ed25519 key in the local keystore.
+///
+/// Returns `bundle::BundleError::NoTrustRoot` if the keystore is empty so the
+/// caller can surface a useful "run `treeship init` first" message instead of
+/// a silent accept-everything.
+///
+/// Forward-compat: future keystore entries may carry non-Ed25519 algorithms
+/// (e.g. hybrid ML-DSA). We filter by `algorithm == "ed25519"` and skip
+/// malformed entries rather than hard-failing the entire import, mirroring the
+/// pattern in `verify::build_verifier`. A single bad or unsupported entry
+/// must not lock the user out of importing bundles signed by their working
+/// keys.
 fn build_local_verifier(
     keys: &treeship_core::keys::Store,
 ) -> Result<Verifier, Box<dyn std::error::Error>> {
@@ -109,15 +117,121 @@ fn build_local_verifier(
 
     let mut map: HashMap<String, VerifyingKey> = HashMap::new();
     for info in infos {
-        let pk_arr: [u8; 32] = info.public_key.as_slice().try_into()
-            .map_err(|_| format!(
-                "key {} has malformed public key (expected 32 bytes, got {})",
-                info.id,
-                info.public_key.len(),
-            ))?;
-        let vk = VerifyingKey::from_bytes(&pk_arr)
-            .map_err(|e| format!("key {}: {e}", info.id))?;
-        map.insert(info.id, vk);
+        if info.algorithm == "ed25519" && info.public_key.len() == 32 {
+            let bytes: [u8; 32] = info.public_key.try_into().unwrap();
+            if let Ok(vk) = VerifyingKey::from_bytes(&bytes) {
+                map.insert(info.id, vk);
+            }
+        }
     }
     Ok(Verifier::new(map))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+    use treeship_core::bundle as core_bundle;
+    use treeship_core::keys::Store as KeyStore;
+    use treeship_core::statements::ActionStatement;
+    use treeship_core::storage::Store as StorageStore;
+
+    /// build_local_verifier must tolerate a non-ed25519 keystore entry without
+    /// failing the entire import. Before the forward-compat fix, an entry
+    /// whose `public_key` was not exactly 32 bytes (e.g. a future ML-DSA-65
+    /// key) caused `try_into::<[u8; 32]>` to fail and the entire keystore was
+    /// rejected — locking the user out of importing bundles signed by their
+    /// working ed25519 key. The Verifier built here must still successfully
+    /// verify a bundle signed by the working ed25519 key.
+    #[test]
+    fn build_local_verifier_skips_non_ed25519_entries() {
+        // Set up a fresh keystore with one real ed25519 key.
+        let keys_dir = tempdir().unwrap();
+        let keys = KeyStore::open(keys_dir.path()).unwrap();
+        let ed_info = keys.generate(true).unwrap();
+
+        // Drop a fake non-ed25519 keystore entry into the directory. We
+        // synthesize a JSON blob matching `EncryptedEntry`'s on-disk schema
+        // (the fields the keystore deserializer requires). The `public_key`
+        // is intentionally longer than 32 bytes to mimic a future hybrid
+        // ML-DSA-65 key — the exact thing that used to break import.
+        let fake_id = "key_mldsa_future";
+        let fake_entry = serde_json::json!({
+            "id":           fake_id,
+            "algorithm":    "ml-dsa-65",
+            "created_at":   "2026-01-01T00:00:00Z",
+            "public_key":   vec![0u8; 1952], // ML-DSA-65 pubkey size, not 32
+            "enc_priv_key": vec![0u8; 64],
+            "nonce":        vec![0u8; 12],
+        });
+        fs::write(
+            keys_dir.path().join(format!("{fake_id}.json")),
+            serde_json::to_vec_pretty(&fake_entry).unwrap(),
+        ).unwrap();
+
+        // Splice the fake entry's id into the keystore manifest so list()
+        // returns it. Read the existing manifest produced by `generate`, push
+        // the new id, write back.
+        let manifest_path = keys_dir.path().join("manifest.json");
+        let mut manifest: serde_json::Value =
+            serde_json::from_slice(&fs::read(&manifest_path).unwrap()).unwrap();
+        manifest["key_ids"].as_array_mut().unwrap()
+            .push(serde_json::Value::String(fake_id.into()));
+        fs::write(&manifest_path, serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+
+        // Sanity: the keystore now lists both keys.
+        let listed = keys.list().unwrap();
+        assert_eq!(listed.len(), 2, "keystore must list both keys");
+        assert!(listed.iter().any(|k| k.algorithm == "ml-dsa-65"));
+        assert!(listed.iter().any(|k| k.algorithm == "ed25519"));
+
+        // build_local_verifier must succeed and yield a Verifier with the
+        // ed25519 key trusted. Before the fix, the non-32-byte ML-DSA pubkey
+        // tripped a hard error here.
+        let verifier = build_local_verifier(&keys)
+            .expect("build_local_verifier must skip non-ed25519 entries");
+
+        // Build a bundle in a separate storage store, signed by the ed25519
+        // key, then export and import it through the constructed verifier.
+        let storage_dir = tempdir().unwrap();
+        let storage = StorageStore::open(storage_dir.path()).unwrap();
+        let signer = keys.signer(&ed_info.id).unwrap();
+
+        // Create a tiny action artifact to bundle.
+        let pt_action = treeship_core::statements::payload_type("action");
+        let action = ActionStatement::new("agent://test", "tool.call");
+        let signed = treeship_core::attestation::sign(&pt_action, &action, signer.as_ref())
+            .unwrap();
+        storage.write(&treeship_core::storage::Record {
+            artifact_id:  signed.artifact_id.clone(),
+            digest:       signed.digest.clone(),
+            payload_type: pt_action.clone(),
+            key_id:       signer.key_id().to_string(),
+            signed_at:    "2026-01-01T00:00:00Z".into(),
+            parent_id:    None,
+            envelope:     signed.envelope,
+            hub_url:      None,
+        }).unwrap();
+
+        let bundle_res = core_bundle::create(
+            &[signed.artifact_id.as_str()],
+            Some("forward-compat-test"),
+            None,
+            &storage,
+            signer.as_ref(),
+        ).unwrap();
+
+        let export_path = storage_dir.path().join("fwd.treeship");
+        core_bundle::export(&bundle_res.artifact_id, &export_path, &storage).unwrap();
+
+        // Import into a fresh storage using our Verifier. This is the
+        // regression assertion: the import must succeed even though the
+        // keystore contained a non-ed25519 entry.
+        let dest_dir = tempdir().unwrap();
+        let dest_storage = StorageStore::open(dest_dir.path()).unwrap();
+        let imported_id = core_bundle::import(&export_path, &dest_storage, &verifier)
+            .expect("import must succeed when only non-ed25519 keys are unsupported");
+        assert_eq!(imported_id, bundle_res.artifact_id);
+    }
 }

--- a/packages/cli/src/commands/verify_external.rs
+++ b/packages/cli/src/commands/verify_external.rs
@@ -402,7 +402,6 @@ fn format_check_label(c: &treeship_core::session::VerifyCheck) -> String {
         "inclusion_proofs" => c.detail.clone(),
         "leaf_count" => "Leaf count matches artifact count".into(),
         "timeline_order" => "Timeline ordering verified".into(),
-        "chain_linkage" => "Chain linkage intact".into(),
         n if n.starts_with("inclusion:") => format!("Inclusion proof {}", &n[10..]),
         other => other.to_string(),
     }

--- a/packages/core-wasm/src/lib.rs
+++ b/packages/core-wasm/src/lib.rs
@@ -330,9 +330,9 @@ fn verify_risc0_proof_inner(proof: &serde_json::Value) -> Result<String, String>
 
 /// Verify a Session Receipt JSON document. Runs the receipt-level checks
 /// derivable from JSON alone (Merkle root recomputation, inclusion proofs,
-/// leaf count, timeline ordering, chain linkage). Signature verification on
-/// individual envelopes requires the original envelope bytes and is NOT
-/// part of this function — use the CLI's local-storage path for that.
+/// leaf count, timeline ordering). Signature verification on individual
+/// envelopes requires the original envelope bytes and is NOT part of this
+/// function — use the CLI's local-storage path for that.
 ///
 /// Returns JSON:
 /// ```json

--- a/packages/core/src/attestation/verify.rs
+++ b/packages/core/src/attestation/verify.rs
@@ -93,6 +93,14 @@ impl Verifier {
     /// Use this for strict verification where all listed signers must be valid
     /// (e.g., hybrid Ed25519 + ML-DSA in v2 where both are required).
     pub fn verify(&self, envelope: &Envelope) -> Result<VerifyResult, VerifyError> {
+        // An envelope with zero signatures has nothing to verify. The for-loop
+        // below would be a no-op and `verified` would stay empty, returning
+        // `Ok` to any caller that only checks `Result::is_ok()`. Reject up
+        // front so an unsigned envelope cannot masquerade as verified.
+        if envelope.signatures.is_empty() {
+            return Err(VerifyError::NoValidSignature);
+        }
+
         let pae_bytes = self.reconstruct_pae(envelope)?;
         let mut verified = Vec::new();
 
@@ -324,6 +332,34 @@ mod tests {
         let signed = sign(PT, &stmt(), &signer).unwrap();
         let result = verifier.verify_any(&signed.envelope).unwrap();
         assert_eq!(result.verified_key_ids.len(), 1);
+    }
+
+    #[test]
+    fn verify_rejects_empty_signature_envelope() {
+        // P0 #4: an envelope with zero signatures must not verify. Without
+        // the explicit check, the for-loop is a no-op and `verify` returns
+        // `Ok(...)` with an empty `verified_key_ids` list — callers that
+        // only check `Result::is_ok()` would accept unsigned envelopes.
+        let signer   = make_signer();
+        let verifier = Verifier::from_signer(&signer);
+        let signed   = sign(PT, &stmt(), &signer).unwrap();
+
+        // Strip the signatures off an otherwise-valid envelope.
+        let mut unsigned = signed.envelope.clone();
+        unsigned.signatures.clear();
+
+        let err = verifier.verify(&unsigned).unwrap_err();
+        assert!(
+            matches!(err, VerifyError::NoValidSignature),
+            "expected NoValidSignature for zero-signature envelope, got: {err}"
+        );
+
+        // verify_any already rejects this via its `verified.is_empty()` guard,
+        // but assert it explicitly to keep both paths covered.
+        assert!(matches!(
+            verifier.verify_any(&unsigned).unwrap_err(),
+            VerifyError::NoValidSignature
+        ));
     }
 
     #[test]

--- a/packages/core/src/bundle/mod.rs
+++ b/packages/core/src/bundle/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::{
-    attestation::{sign, ArtifactId, Envelope, Signer, SignError},
+    attestation::{sign, ArtifactId, Envelope, Signer, SignError, Verifier, VerifyError},
     statements::{payload_type, ArtifactRef, BundleStatement},
     storage::{Record, Store, StorageError},
 };
@@ -15,6 +15,15 @@ pub enum BundleError {
     Json(serde_json::Error),
     ArtifactNotFound(String),
     InvalidBundle(String),
+    /// A signature on an imported envelope did not verify against the
+    /// configured trust root. Carries the offending envelope's index in
+    /// the export (0 = bundle envelope, 1..=N = artifact envelopes) and
+    /// the underlying verification error.
+    UnverifiedEnvelope { index: usize, source: VerifyError },
+    /// `import` was called with an empty trust root. Without trusted keys
+    /// there is nothing to verify signatures against, so import would
+    /// degenerate to "trust whatever the file says" — refused loudly.
+    NoTrustRoot,
 }
 
 impl std::fmt::Display for BundleError {
@@ -26,6 +35,16 @@ impl std::fmt::Display for BundleError {
             Self::Json(e)             => write!(f, "bundle json: {e}"),
             Self::ArtifactNotFound(id)=> write!(f, "artifact not found: {id}"),
             Self::InvalidBundle(msg)  => write!(f, "invalid bundle: {msg}"),
+            Self::UnverifiedEnvelope { index, source } => write!(
+                f,
+                "envelope {index} failed signature verification: {source}",
+            ),
+            Self::NoTrustRoot => write!(
+                f,
+                "bundle import requires a configured trust root: \
+                 generate or import a signer key (treeship init / treeship keys add) \
+                 before importing a .treeship bundle",
+            ),
         }
     }
 }
@@ -170,11 +189,20 @@ pub fn export(
 
 /// Import a .treeship file into local storage.
 ///
-/// Reads the export file, re-derives content-addressed IDs for each envelope,
-/// and stores everything locally. Returns the bundle's artifact ID.
+/// Reads the export file, verifies every envelope's signatures against the
+/// provided `verifier`, re-derives content-addressed IDs, and stores everything
+/// locally. Returns the bundle's artifact ID.
+///
+/// P0 #5 (audit): import previously called `record_from_envelope` with no
+/// signature check, which made imported bundles forged-record vectors. The
+/// `verifier` argument carries the caller's trust root — typically built from
+/// the local keystore's public keys. If verification fails for any envelope
+/// the entire import is rejected; partial writes are avoided by verifying all
+/// envelopes before writing any record.
 pub fn import(
-    path:    &Path,
-    storage: &Store,
+    path:     &Path,
+    storage:  &Store,
+    verifier: &Verifier,
 ) -> Result<ArtifactId, BundleError> {
     let bytes = std::fs::read(path)?;
     let export: ExportFile = serde_json::from_slice(&bytes)?;
@@ -186,13 +214,24 @@ pub fn import(
         )));
     }
 
-    // Import each artifact envelope.
+    // Verify every envelope before writing any record. `verify_any` (not
+    // `verify`) is the right primitive here: an envelope may carry multiple
+    // signatures from a rotation/co-sign setup and the local trust root only
+    // needs one to match. Index 0 = bundle envelope, 1..=N = artifact
+    // envelopes (matches the order shown in error messages and CLI output).
+    verifier.verify_any(&export.bundle)
+        .map_err(|source| BundleError::UnverifiedEnvelope { index: 0, source })?;
+    for (i, env) in export.artifacts.iter().enumerate() {
+        verifier.verify_any(env)
+            .map_err(|source| BundleError::UnverifiedEnvelope { index: i + 1, source })?;
+    }
+
+    // All signatures check out: now write.
     for env in &export.artifacts {
         let record = record_from_envelope(env)?;
         storage.write(&record)?;
     }
 
-    // Import the bundle envelope.
     let bundle_record = record_from_envelope(&export.bundle)?;
     let bundle_id = bundle_record.artifact_id.clone();
     storage.write(&bundle_record)?;
@@ -333,6 +372,7 @@ mod tests {
     fn export_and_import_roundtrip() {
         let (store, dir) = tmp_store();
         let signer = Ed25519Signer::generate("key_test").unwrap();
+        let verifier = crate::attestation::Verifier::from_signer(&signer);
 
         let a1 = sign_and_store(&store, &signer, &payload_type("action"),
             &ActionStatement::new("agent://a", "tool.call"));
@@ -354,7 +394,7 @@ mod tests {
 
         // Import into a fresh store
         let (store2, dir2) = tmp_store();
-        let imported_id = import(&export_path, &store2).unwrap();
+        let imported_id = import(&export_path, &store2, &verifier).unwrap();
         assert_eq!(imported_id, bundle.artifact_id);
 
         // All artifacts are now in the new store
@@ -382,6 +422,8 @@ mod tests {
     #[test]
     fn import_bad_version_fails() {
         let (store, dir) = tmp_store();
+        let signer   = Ed25519Signer::generate("key_test").unwrap();
+        let verifier = crate::attestation::Verifier::from_signer(&signer);
         let bad = ExportFile {
             version:   "bad/v99".into(),
             bundle:    Envelope {
@@ -394,8 +436,90 @@ mod tests {
         let path = dir.join("bad.treeship");
         std::fs::write(&path, serde_json::to_vec(&bad).unwrap()).unwrap();
 
-        let err = import(&path, &store).unwrap_err();
+        let err = import(&path, &store, &verifier).unwrap_err();
         assert!(err.to_string().contains("unsupported export version"));
         rm(dir);
+    }
+
+    #[test]
+    fn import_rejects_envelope_with_invalid_signature() {
+        // P0 #5: before this fix, `import` called `record_from_envelope`
+        // straight from the file with no verification — an attacker could
+        // hand-craft a `.treeship` whose envelopes pointed at any payload
+        // and the import would happily land it in storage. Now every
+        // envelope must verify against the caller's trust root.
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+        let (store, dir) = tmp_store();
+        let signer       = Ed25519Signer::generate("key_test").unwrap();
+        let verifier     = crate::attestation::Verifier::from_signer(&signer);
+
+        // Build a normal bundle so we have a valid export to start from.
+        let a1 = sign_and_store(&store, &signer, &payload_type("action"),
+            &ActionStatement::new("agent://a", "tool.call"));
+        let bundle = create(&[&a1], Some("tampered"), None, &store, &signer).unwrap();
+        let export_path = dir.join("tampered.treeship");
+        export(&bundle.artifact_id, &export_path, &store).unwrap();
+
+        // Tamper the *first* artifact envelope's signature bytes. The keyid
+        // remains correct (still our trusted key) but the cipher-bytes no
+        // longer verify against the PAE.
+        let raw = std::fs::read(&export_path).unwrap();
+        let mut ef: ExportFile = serde_json::from_slice(&raw).unwrap();
+        // Replace the 64-byte signature with all zeros — well-formed length,
+        // mathematically invalid.
+        ef.artifacts[0].signatures[0].sig = URL_SAFE_NO_PAD.encode([0u8; 64]);
+        std::fs::write(&export_path, serde_json::to_vec(&ef).unwrap()).unwrap();
+
+        // Import into a fresh store. The tamper must be detected and the
+        // import must fail; the fresh store must remain empty of the
+        // artifact and bundle.
+        let (store2, dir2) = tmp_store();
+        let err = import(&export_path, &store2, &verifier).unwrap_err();
+        assert!(
+            matches!(err, BundleError::UnverifiedEnvelope { index: 1, .. }),
+            "expected UnverifiedEnvelope{{index:1, ..}}, got: {err}"
+        );
+        // Verify nothing was written: signatures are checked before any
+        // record is persisted, so the destination store stays clean.
+        assert!(!store2.exists(&a1));
+        assert!(!store2.exists(&bundle.artifact_id));
+
+        rm(dir);
+        rm(dir2);
+    }
+
+    #[test]
+    fn import_rejects_unsigned_envelope() {
+        // Companion to the P0 #4 fix: a bundle file whose envelopes carry
+        // zero signatures must not import. The `Verifier` returns
+        // `NoValidSignature` and `import` propagates it as
+        // `UnverifiedEnvelope`.
+        let (store, dir) = tmp_store();
+        let signer       = Ed25519Signer::generate("key_test").unwrap();
+        let verifier     = crate::attestation::Verifier::from_signer(&signer);
+
+        let a1 = sign_and_store(&store, &signer, &payload_type("action"),
+            &ActionStatement::new("agent://a", "tool.call"));
+        let bundle = create(&[&a1], Some("unsigned"), None, &store, &signer).unwrap();
+        let export_path = dir.join("unsigned.treeship");
+        export(&bundle.artifact_id, &export_path, &store).unwrap();
+
+        // Strip every signature off every envelope in the export.
+        let raw = std::fs::read(&export_path).unwrap();
+        let mut ef: ExportFile = serde_json::from_slice(&raw).unwrap();
+        ef.bundle.signatures.clear();
+        for env in &mut ef.artifacts { env.signatures.clear(); }
+        std::fs::write(&export_path, serde_json::to_vec(&ef).unwrap()).unwrap();
+
+        let (store2, dir2) = tmp_store();
+        let err = import(&export_path, &store2, &verifier).unwrap_err();
+        assert!(
+            matches!(err, BundleError::UnverifiedEnvelope { index: 0, .. }),
+            "expected UnverifiedEnvelope{{index:0, ..}} (bundle envelope first), got: {err}"
+        );
+
+        rm(dir);
+        rm(dir2);
     }
 }

--- a/packages/core/src/verify.rs
+++ b/packages/core/src/verify.rs
@@ -481,4 +481,73 @@ mod tests {
         assert_eq!(r.authorized_tools_never_called, vec!["Bash"]);
         assert!(r.ok());
     }
+
+    // P0 #7 regression guard: `verify_receipt_json_checks` previously pushed
+    // an unconditional `chain_linkage = pass` row that advertised a check
+    // which never ran. The fix removed the row; this test pins it down so a
+    // future "helpful" refactor cannot silently restore the lie. We exercise
+    // both branches of the function: the empty-artifacts path and the
+    // populated-artifacts path. Neither must emit a check named
+    // `"chain_linkage"`.
+    #[test]
+    fn chain_linkage_check_never_emitted() {
+        use crate::session::receipt::{ArtifactEntry, TimelineEntry};
+
+        // Branch 1: empty artifacts + empty timeline (the warn-only path).
+        let rec_empty = receipt(Some("ship_a"), &[]);
+        let checks_empty = verify_receipt_json_checks(&rec_empty);
+        assert!(
+            !checks_empty.iter().any(|c| c.name == "chain_linkage"),
+            "chain_linkage check must not be emitted (empty receipt). got: {:?}",
+            checks_empty.iter().map(|c| &c.name).collect::<Vec<_>>(),
+        );
+
+        // Branch 2: a receipt with real artifacts and timeline entries so
+        // the merkle/inclusion/leaf-count/timeline branches all run.
+        let mut rec_full = receipt(Some("ship_a"), &[]);
+        rec_full.artifacts = vec![
+            ArtifactEntry {
+                artifact_id:  "art_aaaa".into(),
+                payload_type: "treeship.dev/v0/action".into(),
+                digest:       None,
+                signed_at:    None,
+            },
+            ArtifactEntry {
+                artifact_id:  "art_bbbb".into(),
+                payload_type: "treeship.dev/v0/action".into(),
+                digest:       None,
+                signed_at:    None,
+            },
+        ];
+        rec_full.merkle.leaf_count = 2;
+        rec_full.timeline = vec![
+            TimelineEntry {
+                sequence_no:       1,
+                timestamp:         "2026-04-10T00:00:01Z".into(),
+                event_id:          "evt_1".into(),
+                event_type:        "tool.call".into(),
+                agent_instance_id: "ai_1".into(),
+                agent_name:        "a".into(),
+                host_id:           "h_1".into(),
+                summary:           None,
+            },
+            TimelineEntry {
+                sequence_no:       2,
+                timestamp:         "2026-04-10T00:00:02Z".into(),
+                event_id:          "evt_2".into(),
+                event_type:        "tool.call".into(),
+                agent_instance_id: "ai_1".into(),
+                agent_name:        "a".into(),
+                host_id:           "h_1".into(),
+                summary:           None,
+            },
+        ];
+
+        let checks_full = verify_receipt_json_checks(&rec_full);
+        assert!(
+            !checks_full.iter().any(|c| c.name == "chain_linkage"),
+            "chain_linkage check must not be emitted (populated receipt). got: {:?}",
+            checks_full.iter().map(|c| &c.name).collect::<Vec<_>>(),
+        );
+    }
 }

--- a/packages/core/src/verify.rs
+++ b/packages/core/src/verify.rs
@@ -109,10 +109,18 @@ pub fn verify_receipt_json_checks(receipt: &SessionReceipt) -> Vec<VerifyCheck> 
         ));
     }
 
-    checks.push(VerifyCheck::pass(
-        "chain_linkage",
-        "Receipt-level chain linkage intact",
-    ));
+    // P0 #7 (audit): the previous implementation pushed an unconditional
+    // `chain_linkage = pass` row regardless of receipt contents. That
+    // advertised a check that never ran — a verifier output row that
+    // could not fail is worse than no row at all. Each `TimelineEntry`
+    // currently carries `event_id` + `sequence_no` but no `prev_event_id`
+    // field, so the receipt JSON has no per-event linkage we can
+    // recompute. `timeline_order` above already validates the only
+    // ordering signal the receipt actually contains.
+    //
+    // TODO: real chain-linkage check (post-launch). Would require adding
+    // `prev_event_id` to `TimelineEntry` and a format-version bump —
+    // tracked separately from this audit lane.
 
     checks
 }

--- a/packages/core/src/verify.rs
+++ b/packages/core/src/verify.rs
@@ -19,9 +19,9 @@ use crate::session::package::{VerifyCheck, VerifyStatus};
 
 /// Receipt-level checks derivable from the receipt JSON alone (no on-disk
 /// package). Runs Merkle root recomputation, inclusion proof verification,
-/// leaf-count parity, timeline ordering, and receipt-level chain linkage.
-/// Shared between the CLI's URL-fetch path and the WASM `verify_receipt`
-/// export so both surfaces apply the same rules.
+/// leaf-count parity, and timeline ordering. Shared between the CLI's
+/// URL-fetch path and the WASM `verify_receipt` export so both surfaces
+/// apply the same rules.
 ///
 /// Signature checks on individual envelopes are NOT part of this function:
 /// a raw receipt JSON does not carry envelope bytes. Use the local-storage

--- a/packages/verify-js/README.md
+++ b/packages/verify-js/README.md
@@ -16,7 +16,7 @@ Three functions. Each accepts a parsed object, a JSON string, or a URL.
 
 ### `verifyReceipt(target)`
 
-Runs the JSON-level checks a Treeship Session Receipt carries: Merkle root recomputation, inclusion proof verification, leaf-count parity, timeline ordering, chain linkage.
+Runs the JSON-level checks a Treeship Session Receipt carries: Merkle root recomputation, inclusion proof verification, leaf-count parity, timeline ordering.
 
 ```typescript
 import { verifyReceipt } from '@treeship/verify';

--- a/packages/verify-js/src/index.ts
+++ b/packages/verify-js/src/index.ts
@@ -99,9 +99,9 @@ export interface CrossVerifyResult {
 /**
  * Verify a Treeship Session Receipt. Runs the checks derivable from the
  * receipt JSON alone (Merkle root recomputation, inclusion proofs, leaf
- * count, timeline ordering, chain linkage). Signature verification on
- * individual envelopes requires the original envelope bytes and is out of
- * scope for URL-fetched receipts; use the `treeship verify` CLI for that.
+ * count, timeline ordering). Signature verification on individual envelopes
+ * requires the original envelope bytes and is out of scope for URL-fetched
+ * receipts; use the `treeship verify` CLI for that.
  *
  * Accepts:
  * - a parsed receipt object (best for callers that already have the JSON)


### PR DESCRIPTION
## Summary

- P0: `verify` accepted envelopes with zero signatures — now rejects them outright.
- P0 (breaking): `bundle import` previously accepted unverified envelopes. It now requires a verifier trust root from the local keystore and refuses anything it can't verify. Callers relying on accept-all behavior must now configure trust.
- P0: remove the fake `chain_linkage` row that was being synthesized into the verify report. Verifier output now reflects only real evidence.

> Breaking change flag: any caller previously importing bundles without a configured trust root will now fail. This is intentional and is the audit-mandated behavior. Document if your tooling depends on the old laxer path.

## Audit context

This PR is part of a pre-launch audit covering 11 P0 findings + supporting hardening. The full audit branched into 8 independent lanes (A-H) that compose without conflicts.

**Lane H:** verifier and bundle-import hardening (three P0s); contains the `bundle::import` behavior change.

**Pre-merge verification:** all 8 lanes were merged into `audit/integration-verify` and the full test suite passed:

- Rust workspace: 297 lib + 412 integration tests
- TypeScript SDK: 11 vitest cases (incl. real CLI round-trip + tamper test)
- Python SDK: 44 unittest cases
- YAML workflow parse: OK
- Version preflight script: 23/23 sites consistent

**Commits in this PR:** 3 on top of `main` (`c6802d3`).

## Test plan

- [ ] CI green
- [ ] `treeship bundle import` requires a verifier trust root from the local keystore (breaking change for any caller relying on accept-all behavior)
- [ ] `cargo test -p treeship-core --lib verify::tests::verify_rejects_empty_signature_envelope` passes