### PR TITLE
feat(trust): pinned trust roots for checkpoint, hub-checkpoint, agent-cert verification (audit lane J, P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 - **Local AEAD key buffer wrapped in `zeroize::Zeroizing`** so the stack copy is wiped on drop. The aes-gcm cipher's internal expanded key schedule is outside our control, but the raw 32-byte machine-derived key copy at the encrypt/decrypt scope is cleared.
 - **v2 AAD now binds entry id + public_key (closes intra-keystore swap).** The original v2 AAD covered only the framing prefix; a local attacker with write access to `~/.treeship/keys/` could copy entry A's `enc_priv_key` ciphertext into entry B's JSON envelope and silently un-bind `KeyInfo.public_key` from the actual scalar in use. The v2 AAD now also length-prefixes and binds the entry id and public key, so any envelope-vs-ciphertext swap surfaces as a MAC failure. `write_file_600` also now `fsync`s the parent directory after rename so the H1 atomic-write doc-comment's durability promise matches reality on ext4/xfs.
 
+### Added
+
+- `treeship trust` subcommand for managing pinned trust roots (`list`, `add`, `remove`).
+- `~/.treeship/trust_roots.json` config file (mode `0o600`, JSON schema version 1) listing trusted issuers for checkpoint, ship (hub-org), and agent-certificate verification. Path override via `TREESHIP_TRUST_ROOTS`.
+- `treeship_core::trust` module with `TrustRootStore`, `TrustRoot`, `TrustRootKind`, `TrustRootError`.
+
+### Changed (breaking)
+
+- Checkpoint, hub-org checkpoint, and agent-certificate verification now require the embedded public key to match a configured trust root. Previously they trusted the embedded key (self-signed forgeries always passed). Run `treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert>` for each known issuer before verifying.
+- `Checkpoint::verify(&self)` → `Checkpoint::verify(&self, trust: &TrustRootStore)`.
+- `verify_hub_checkpoint_signature(&cp)` → `verify_hub_checkpoint_signature(&cp, trust: &TrustRootStore)`. New `HubCheckpointVerification::UntrustedIssuer` variant covers the unpinned-issuer case.
+- `verify_certificate(&cert)` → `verify_certificate(&cert, trust: &TrustRootStore)`. New `CertificateVerifyError::UntrustedIssuer { key_id }` and `CertificateVerifyError::NoTrustConfigured` variants.
+- `treeship_core::session::verify_package(path)` now auto-loads `~/.treeship/trust_roots.json`; tests that want an explicit store can call the new `verify_package_with_trust(path, &trust)`.
+- WASM exports `verify_certificate`, `cross_verify`, and `verify_merkle_proof` take an additional `trust_roots_json: &str` argument (empty string = fail closed). `@treeship/verify` exposes this via an optional `trustRoots` parameter on `verifyCertificate` and `crossVerify`.
+
 ## 0.10.2 (2026-05-11)
 
 The **Multi-Agent Attribution and Universal Skills** release. v0.10.0 made receipts agent-readable. v0.10.1 hardened the install path that delivers the binary which produces them. v0.10.2 closes two follow-on gaps the post-launch dogfooding surfaced: model/provider attribution silently disappearing on the signed-artifact path, and agents on every CLI re-learning how to use Treeship from scratch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `treeship trust` subcommand for managing pinned trust roots (`list`, `add`, `remove`).
 - `~/.treeship/trust_roots.json` config file (mode `0o600`, JSON schema version 1) listing trusted issuers for checkpoint, ship (hub-org), and agent-certificate verification. Path override via `TREESHIP_TRUST_ROOTS`.
 - `treeship_core::trust` module with `TrustRootStore`, `TrustRoot`, `TrustRootKind`, `TrustRootError`.
+- `treeship trust add` and `treeship trust remove` now require interactive y/N confirmation or an explicit `--yes` flag. Both print the affected key's 16-hex-character SHA-256 fingerprint before the change. Non-interactive stdin without `--yes` refuses; JSON output mode requires `--yes` (a y/N prompt does not compose with JSON). Replacements of an existing `(key_id, kind)` entry show both the existing and incoming fingerprints so an attempted swap is visible.
+- One-time stderr warning when `TREESHIP_TRUST_ROOTS` is set (path override) or `TREESHIP_ALLOW_INSECURE_KEY_PERMS=1` is honored (perms bypass). Deduplicated per-process via `std::sync::Once`. Both env vars are exactly the lever a supply-chain attacker would pull in a CI runner to redirect trust; the warning ensures the boundary move shows up in CI logs.
 
 ### Changed (breaking)
 
@@ -21,8 +23,13 @@
 - `Checkpoint::verify(&self)` → `Checkpoint::verify(&self, trust: &TrustRootStore)`.
 - `verify_hub_checkpoint_signature(&cp)` → `verify_hub_checkpoint_signature(&cp, trust: &TrustRootStore)`. New `HubCheckpointVerification::UntrustedIssuer` variant covers the unpinned-issuer case.
 - `verify_certificate(&cert)` → `verify_certificate(&cert, trust: &TrustRootStore)`. New `CertificateVerifyError::UntrustedIssuer { key_id }` and `CertificateVerifyError::NoTrustConfigured` variants.
-- `treeship_core::session::verify_package(path)` now auto-loads `~/.treeship/trust_roots.json`; tests that want an explicit store can call the new `verify_package_with_trust(path, &trust)`.
+- `treeship_core::session::verify_package(path)` now auto-loads `~/.treeship/trust_roots.json`; tests that want an explicit store can call the new `verify_package_with_trust(path, &trust)`. If the trust file is malformed or has overly-open permissions the function emits a `trust-root` Fail check row instead of silently falling back to an empty store.
+- The `replay-hub-org` check row now emits `Fail` by default (not `Warn`) when the hub signature is untrusted, tampered, or has the wrong kind. Previously these were `Warn` and `--strict` promoted them to `Fail`, which meant a self-signed forgery exited 0 in default mode with only a yellow warning. Non-security shortcomings (missing field, coverage gap) still warn by default and `--strict` still promotes them.
 - WASM exports `verify_certificate`, `cross_verify`, and `verify_merkle_proof` take an additional `trust_roots_json: &str` argument (empty string = fail closed). `@treeship/verify` exposes this via an optional `trustRoots` parameter on `verifyCertificate` and `crossVerify`.
+
+### Migration notes
+
+- **v0.10.2 hub artifacts in the wild**: any receipt or hub-signed checkpoint produced before this version embedded a hub public key that the verifier accepted on the basis of the embedded key alone. After this release the verifier requires that key to appear in `~/.treeship/trust_roots.json` for the matching `kind`. Operators with existing hub artifacts must extract the embedded `signer`/`hub_public_key` value from one of their own trusted artifacts and add it via `treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert>` before this version's verifier will accept their existing receipts. A `treeship trust extract <artifact>` convenience helper that pulls the embedded pubkey out of any signed artifact is tracked separately and not in this release; until then, extract by inspecting the `hub_public_key` (for hub-org checkpoints), `public_key` (for Merkle checkpoints), or `signature.public_key` (for agent certificates) field of the artifact JSON.
 
 ## 0.10.2 (2026-05-11)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,10 @@ Key properties:
 
 The trust boundary is the machine. Root access breaks all guarantees. **Hub "device" identity is key-based (dock + DPoP),** not bound to a specific physical machine unless we add platform attestation later. Hardware key support (YubiKey, Secure Enclave) is a possible future hardening. Copying `~/.treeship` with hub keys copies that identity.
 
+## Trust roots (issuer pinning)
+
+Three verification paths used to trust whichever public key was embedded inside the artifact they verified -- Merkle checkpoints, hub-org `JournalCheckpoint`s, and Agent Certificates. An attacker who minted their own keypair could self-sign any of these and verification returned success. Starting in v0.10.3, each of these surfaces requires the embedded pubkey to be present in the operator's local trust root store at `~/.treeship/trust_roots.json` (mode `0o600`, JSON schema v1). Configure via `treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert>`. Fresh installs have no roots configured; verification fails closed until roots are pinned out-of-band.
+
 ## Known limitations
 
 - Hub connections are as strong as **key storage and revocation hygiene**; treat stolen config like stolen SSH keys.

--- a/packages/cli/src/commands/merkle.rs
+++ b/packages/cli/src/commands/merkle.rs
@@ -251,13 +251,25 @@ pub fn verify(
     let proof_file: ProofFile = serde_json::from_slice(&bytes)
         .map_err(|e| format!("invalid proof JSON: {}", e))?;
 
-    // 1. Verify checkpoint signature. Load the operator's trust roots
-    //    (missing file = empty store, which makes verification fail
-    //    closed -- matches the audit fix: a checkpoint signed by an
+    // 1. Verify checkpoint signature. Load the operator's trust roots.
+    //    Missing file = empty store, which makes verification fail
+    //    closed (matches the audit fix: a checkpoint signed by an
     //    unpinned issuer is no longer accepted just because the
     //    signature math is internally consistent).
+    //
+    //    Audit lane J fix-up: propagate Malformed / PermissionsTooOpen
+    //    instead of silently degrading to an empty store. An operator
+    //    with a broken trust file deserves a clear "your trust file
+    //    is unreadable" error, not a misleading "untrusted issuer"
+    //    further down the pipeline.
     let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
-        .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
+        .map_err(|e| -> Box<dyn std::error::Error> {
+            printer.failure("trust store unreadable", &[
+                ("path",   &treeship_core::trust::TrustRootStore::default_path().display().to_string()),
+                ("reason", &e.to_string()),
+            ]);
+            format!("trust-root: {e}").into()
+        })?;
     let sig_valid = proof_file.checkpoint.verify(&trust);
 
     // 2. Verify inclusion proof

--- a/packages/cli/src/commands/merkle.rs
+++ b/packages/cli/src/commands/merkle.rs
@@ -251,8 +251,14 @@ pub fn verify(
     let proof_file: ProofFile = serde_json::from_slice(&bytes)
         .map_err(|e| format!("invalid proof JSON: {}", e))?;
 
-    // 1. Verify checkpoint signature
-    let sig_valid = proof_file.checkpoint.verify();
+    // 1. Verify checkpoint signature. Load the operator's trust roots
+    //    (missing file = empty store, which makes verification fail
+    //    closed -- matches the audit fix: a checkpoint signed by an
+    //    unpinned issuer is no longer accepted just because the
+    //    signature math is internally consistent).
+    let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
+        .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
+    let sig_valid = proof_file.checkpoint.verify(&trust);
 
     // 2. Verify inclusion proof
     let root_hex = proof_file.checkpoint.root

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -30,4 +30,5 @@ pub mod declare;
 pub mod package;
 pub mod prove;
 pub mod quickstart;
+pub mod trust;
 pub mod zk;

--- a/packages/cli/src/commands/package.rs
+++ b/packages/cli/src/commands/package.rs
@@ -174,12 +174,19 @@ pub fn inspect(
     let approvals_bundle = treeship_core::session::read_approvals_bundle(&path)
         .unwrap_or_default();
     let workspace_config_path = ctx::open(config).ok().map(|c| c.config_path);
+    // Load the operator's trust roots once; the approval-authority and
+    // replay-warning panels both pin embedded hub-org checkpoints
+    // against it. Missing file is fine -- the panels render "not
+    // trusted" rather than hiding the checkpoint.
+    let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
+        .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
     print_approval_authority_panel(
         &approvals_bundle,
         workspace_config_path.as_deref(),
+        &trust,
         printer,
     );
-    print_decision_cards(&receipt, &approvals_bundle, printer);
+    print_decision_cards(&receipt, &approvals_bundle, &trust, printer);
 
     printer.blank();
     printer.section("timeline");
@@ -449,6 +456,7 @@ fn tri(v: Option<bool>) -> &'static str {
 fn print_approval_authority_panel(
     bundle: &ApprovalsBundle,
     workspace_config_path: Option<&Path>,
+    trust: &treeship_core::trust::TrustRootStore,
     printer: &Printer,
 ) {
     if bundle.uses.is_empty() && bundle.grants.is_empty() {
@@ -678,7 +686,7 @@ fn print_approval_authority_panel(
                 let mut this_use_ok = false;
                 let mut this_use_detail: Option<String> = None;
                 for cp in &hub_cps {
-                    match treeship_core::statements::verify_hub_checkpoint_signature(cp) {
+                    match treeship_core::statements::verify_hub_checkpoint_signature(cp, trust) {
                         treeship_core::statements::HubCheckpointVerification::Valid => {
                             if cp.covered_use_ids.iter().any(|id| id == &u.use_id) {
                                 this_use_ok = true;
@@ -702,6 +710,12 @@ fn print_approval_authority_panel(
                         treeship_core::statements::HubCheckpointVerification::Tampered => {
                             this_use_detail = Some(format!(
                                 "{} hub signature failed", cp.checkpoint_id,
+                            ));
+                        }
+                        treeship_core::statements::HubCheckpointVerification::UntrustedIssuer => {
+                            this_use_detail = Some(format!(
+                                "{} hub_public_key not in trust roots (run `treeship trust add`)",
+                                cp.checkpoint_id,
                             ));
                         }
                         treeship_core::statements::HubCheckpointVerification::NotHubKind => {}
@@ -844,6 +858,7 @@ fn print_approval_authority_panel(
 fn print_decision_cards(
     receipt: &SessionReceipt,
     bundle: &ApprovalsBundle,
+    trust: &treeship_core::trust::TrustRootStore,
     printer: &Printer,
 ) {
     use std::collections::HashSet;
@@ -909,7 +924,7 @@ fn print_decision_cards(
         .any(|cp| {
             // Must verify AND cover every use.
             matches!(
-                treeship_core::statements::verify_hub_checkpoint_signature(cp),
+                treeship_core::statements::verify_hub_checkpoint_signature(cp, trust),
                 treeship_core::statements::HubCheckpointVerification::Valid,
             ) && bundle.uses.iter().all(|u| cp.covered_use_ids.iter().any(|id| id == &u.use_id))
         });

--- a/packages/cli/src/commands/trust.rs
+++ b/packages/cli/src/commands/trust.rs
@@ -10,9 +10,18 @@
 //! <key_id> <pubkey> --kind <kind>`. There is no remote sync in this
 //! release; the planned `treeship hub sync-trust` is referenced in
 //! error messages but unimplemented.
+//!
+//! Audit lane J fix-up: `add` and `remove` print the affected key's
+//! fingerprint and require either `--yes` or an interactive y/N
+//! confirmation. Both subcommands previously overwrote silently.
+
+use std::io::{self, BufRead, IsTerminal, Write};
+
+use sha2::{Digest, Sha256};
 
 use treeship_core::trust::{
-    encode_ed25519_pubkey, TrustRoot, TrustRootError, TrustRootKind, TrustRootStore,
+    decode_ed25519_pubkey, encode_ed25519_pubkey, TrustRoot, TrustRootError, TrustRootKind,
+    TrustRootStore,
 };
 
 use crate::printer::{Format, Printer};
@@ -70,13 +79,19 @@ pub fn list(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// `treeship trust add <key_id> <pubkey> --kind <kind>`. Replaces any
-/// previous `(key_id, kind)` entry.
+/// `treeship trust add <key_id> <pubkey> --kind <kind> [--yes]`. Replaces
+/// any previous `(key_id, kind)` entry.
+///
+/// Audit lane J fix-up: previously overwrote silently. Now prints the
+/// pubkey fingerprint and asks for confirmation; `--yes` skips the
+/// prompt; non-interactive stdin without `--yes` is refused so a
+/// supply-chain script can't slip a new root in via curl|sh.
 pub fn add(
     key_id: &str,
     public_key: &str,
     kind: &str,
     label: Option<&str>,
+    yes: bool,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let kind = TrustRootKind::parse(kind)
@@ -86,9 +101,10 @@ pub fn add(
 
     // Accept both `ed25519:<b64>` and bare base64url for ergonomics.
     // Normalize on write so the on-disk file is always prefixed.
-    let parsed = treeship_core::trust::decode_ed25519_pubkey(public_key)
+    let parsed = decode_ed25519_pubkey(public_key)
         .map_err(|m| format!("invalid public key: {m}"))?;
     let canonical_pk = encode_ed25519_pubkey(&parsed);
+    let fingerprint  = pubkey_fingerprint(&canonical_pk);
 
     if key_id.trim().is_empty() {
         return Err("key_id must not be empty".into());
@@ -103,6 +119,50 @@ pub fn add(
         Err(e) => return Err(e.into()),
     };
 
+    // Is this replacing an existing (key_id, kind) entry?
+    let replacing = store.roots().iter().find(|r| r.key_id == key_id && r.kind == kind).cloned();
+
+    // Confirmation gate. JSON callers MUST pass --yes; an interactive
+    // y/N prompt on stdout/stdin doesn't compose with --output json
+    // anyway.
+    if !yes {
+        if printer.format == Format::Json {
+            return Err(
+                "trust add requires --yes when --output json (no interactive confirmation possible)".into(),
+            );
+        }
+        if !io::stdin().is_terminal() {
+            return Err(
+                "trust add refuses to run non-interactively without --yes \
+                 (pass --yes to skip the confirmation prompt)".into(),
+            );
+        }
+        if let Some(ref prev) = replacing {
+            let prev_fp = pubkey_fingerprint(&prev.public_key);
+            printer.warn(
+                &format!(
+                    "WARNING: replacing existing root {} for kind={}",
+                    prev_fp,
+                    kind.as_str(),
+                ),
+                &[
+                    ("existing_key_id", &prev.key_id),
+                    ("existing_label",  if prev.label.is_empty() { "<none>" } else { &prev.label }),
+                    ("new_fingerprint", &fingerprint),
+                ],
+            );
+        } else {
+            printer.info(&format!(
+                "About to add trust root:\n  kind:        {}\n  key_id:      {}\n  fingerprint: {}\n  public_key:  {}",
+                kind.as_str(), key_id, fingerprint, canonical_pk,
+            ));
+        }
+        if !confirm("Add this trust root? [y/N] ") {
+            printer.info("aborted; no changes made");
+            return Ok(());
+        }
+    }
+
     let root = TrustRoot {
         key_id:     key_id.into(),
         public_key: canonical_pk.clone(),
@@ -115,28 +175,36 @@ pub fn add(
 
     if printer.format == Format::Json {
         printer.json(&serde_json::json!({
-            "status":     "ok",
-            "message":    "trust root added",
-            "key_id":     key_id,
-            "kind":       kind.as_str(),
-            "public_key": canonical_pk,
-            "path":       path.display().to_string(),
+            "status":      "ok",
+            "message":     "trust root added",
+            "key_id":      key_id,
+            "kind":        kind.as_str(),
+            "public_key":  canonical_pk,
+            "fingerprint": fingerprint,
+            "replaced":    replacing.is_some(),
+            "path":        path.display().to_string(),
         }));
         return Ok(());
     }
     printer.success("trust root added", &[
-        ("key_id",     key_id),
-        ("kind",       kind.as_str()),
-        ("public_key", &canonical_pk),
-        ("path",       &path.display().to_string()),
+        ("key_id",      key_id),
+        ("kind",        kind.as_str()),
+        ("fingerprint", &fingerprint),
+        ("public_key",  &canonical_pk),
+        ("path",        &path.display().to_string()),
     ]);
     Ok(())
 }
 
-/// `treeship trust remove <key_id>`. Removes every entry matching `key_id`
-/// across all kinds.
+/// `treeship trust remove <key_id> [--yes]`. Removes every entry matching
+/// `key_id` across all kinds.
+///
+/// Audit lane J fix-up: previously removed silently. Now prints which
+/// entries would disappear (with their fingerprints) and asks for
+/// confirmation. Same `--yes` / non-interactive contract as `add`.
 pub fn remove(
     key_id: &str,
+    yes: bool,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let path = TrustRootStore::default_path();
@@ -157,6 +225,60 @@ pub fn remove(
         }
         Err(e) => return Err(e.into()),
     };
+
+    // Collect what would be removed, for the confirmation message.
+    let matches: Vec<TrustRoot> = store
+        .roots()
+        .iter()
+        .filter(|r| r.key_id == key_id)
+        .cloned()
+        .collect();
+
+    if matches.is_empty() {
+        if printer.format == Format::Json {
+            printer.json(&serde_json::json!({
+                "status":  "ok",
+                "key_id":  key_id,
+                "removed": false,
+                "path":    path.display().to_string(),
+            }));
+            return Ok(());
+        }
+        printer.info(&format!("no trust root with key_id={key_id}"));
+        return Ok(());
+    }
+
+    if !yes {
+        if printer.format == Format::Json {
+            return Err(
+                "trust remove requires --yes when --output json (no interactive confirmation possible)".into(),
+            );
+        }
+        if !io::stdin().is_terminal() {
+            return Err(
+                "trust remove refuses to run non-interactively without --yes \
+                 (pass --yes to skip the confirmation prompt)".into(),
+            );
+        }
+        printer.info(&format!(
+            "About to remove {} trust root(s) for key_id={}:",
+            matches.len(),
+            key_id,
+        ));
+        for r in &matches {
+            printer.info(&format!(
+                "  - kind={}  fingerprint={}  label={}",
+                r.kind.as_str(),
+                pubkey_fingerprint(&r.public_key),
+                if r.label.is_empty() { "<none>" } else { &r.label },
+            ));
+        }
+        if !confirm("Remove? [y/N] ") {
+            printer.info("aborted; no changes made");
+            return Ok(());
+        }
+    }
+
     let removed = store.remove(key_id);
     store.save(&path)?;
 
@@ -165,16 +287,41 @@ pub fn remove(
             "status":  "ok",
             "key_id":  key_id,
             "removed": removed,
+            "count":   matches.len(),
             "path":    path.display().to_string(),
         }));
         return Ok(());
     }
     if removed {
-        printer.success("trust root removed", &[("key_id", key_id)]);
+        printer.success("trust root removed", &[
+            ("key_id", key_id),
+            ("count",  &matches.len().to_string()),
+        ]);
     } else {
         printer.info(&format!("no trust root with key_id={key_id}"));
     }
     Ok(())
+}
+
+/// Short fingerprint for a canonical `ed25519:<b64>` pubkey: first 16 hex
+/// chars of SHA-256 over the encoded form. Long enough to be unique in
+/// practice, short enough to read out loud.
+fn pubkey_fingerprint(canonical_pk: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_pk.as_bytes());
+    let bytes = hasher.finalize();
+    let hex_full = hex::encode(bytes);
+    hex_full[..16].to_string()
+}
+
+/// Interactive y/N confirmation. Reads one line from stdin; anything
+/// other than "y" / "Y" / "yes" returns false.
+fn confirm(msg: &str) -> bool {
+    print!("{msg}");
+    let _ = io::stdout().flush();
+    let mut line = String::new();
+    let _ = io::stdin().lock().read_line(&mut line);
+    matches!(line.trim().to_lowercase().as_str(), "y" | "yes")
 }
 
 fn now_rfc3339() -> String {

--- a/packages/cli/src/commands/trust.rs
+++ b/packages/cli/src/commands/trust.rs
@@ -11,8 +11,6 @@
 //! release; the planned `treeship hub sync-trust` is referenced in
 //! error messages but unimplemented.
 
-use std::path::Path;
-
 use treeship_core::trust::{
     encode_ed25519_pubkey, TrustRoot, TrustRootError, TrustRootKind, TrustRootStore,
 };
@@ -186,8 +184,3 @@ fn now_rfc3339() -> String {
         .as_secs();
     treeship_core::statements::unix_to_rfc3339(secs)
 }
-
-// Re-export so main.rs sees the same path even though we don't use
-// `Path` here at the moment. Keeps the import alive for future helpers.
-#[allow(dead_code)]
-fn _path_anchor(_p: &Path) {}

--- a/packages/cli/src/commands/trust.rs
+++ b/packages/cli/src/commands/trust.rs
@@ -1,0 +1,193 @@
+//! `treeship trust` subcommand family.
+//!
+//! Manages pinned trust roots for the three self-signed verification
+//! boundaries (Merkle checkpoint, hub-org JournalCheckpoint, agent
+//! certificate). Roots live at `~/.treeship/trust_roots.json` (override
+//! with the `TREESHIP_TRUST_ROOTS` env var) with mode `0o600`.
+//!
+//! Operators configure trust out-of-band: verify the issuer's public key
+//! fingerprint via a channel they trust, then run `treeship trust add
+//! <key_id> <pubkey> --kind <kind>`. There is no remote sync in this
+//! release; the planned `treeship hub sync-trust` is referenced in
+//! error messages but unimplemented.
+
+use std::path::Path;
+
+use treeship_core::trust::{
+    encode_ed25519_pubkey, TrustRoot, TrustRootError, TrustRootKind, TrustRootStore,
+};
+
+use crate::printer::{Format, Printer};
+
+/// `treeship trust list`. Renders every pinned root, grouped by kind.
+pub fn list(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    let path = TrustRootStore::default_path();
+    let store = match TrustRootStore::open(&path) {
+        Ok(s)  => s,
+        Err(TrustRootError::NotConfigured { .. }) | Err(TrustRootError::Empty { .. }) => {
+            if printer.format == Format::Json {
+                printer.json(&serde_json::json!({
+                    "status": "ok",
+                    "path":   path.display().to_string(),
+                    "roots":  [],
+                }));
+                return Ok(());
+            }
+            printer.info(&format!(
+                "no trust roots configured (would be at {})",
+                path.display(),
+            ));
+            printer.hint("treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert>");
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if printer.format == Format::Json {
+        let roots: Vec<_> = store.roots().iter().map(|r| serde_json::json!({
+            "key_id":     r.key_id,
+            "public_key": r.public_key,
+            "kind":       r.kind.as_str(),
+            "label":      r.label,
+            "added_at":   r.added_at,
+        })).collect();
+        printer.json(&serde_json::json!({
+            "status": "ok",
+            "path":   path.display().to_string(),
+            "roots":  roots,
+        }));
+        return Ok(());
+    }
+
+    printer.info(&format!("trust roots ({}):", path.display()));
+    for r in store.roots() {
+        printer.info(&format!(
+            "  {kind:<16} {key_id:<24} {pk:<58} {label}",
+            kind   = r.kind.as_str(),
+            key_id = r.key_id,
+            pk     = r.public_key,
+            label  = if r.label.is_empty() { "" } else { &r.label },
+        ));
+    }
+    Ok(())
+}
+
+/// `treeship trust add <key_id> <pubkey> --kind <kind>`. Replaces any
+/// previous `(key_id, kind)` entry.
+pub fn add(
+    key_id: &str,
+    public_key: &str,
+    kind: &str,
+    label: Option<&str>,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let kind = TrustRootKind::parse(kind)
+        .ok_or_else(|| format!(
+            "unknown trust root kind '{kind}'. Expected one of: hub_checkpoint, ship, agent_cert",
+        ))?;
+
+    // Accept both `ed25519:<b64>` and bare base64url for ergonomics.
+    // Normalize on write so the on-disk file is always prefixed.
+    let parsed = treeship_core::trust::decode_ed25519_pubkey(public_key)
+        .map_err(|m| format!("invalid public key: {m}"))?;
+    let canonical_pk = encode_ed25519_pubkey(&parsed);
+
+    if key_id.trim().is_empty() {
+        return Err("key_id must not be empty".into());
+    }
+
+    let path = TrustRootStore::default_path();
+    let mut store = match TrustRootStore::open(&path) {
+        Ok(s) => s,
+        Err(TrustRootError::NotConfigured { .. }) | Err(TrustRootError::Empty { .. }) => {
+            TrustRootStore::empty()
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let root = TrustRoot {
+        key_id:     key_id.into(),
+        public_key: canonical_pk.clone(),
+        kind,
+        label:      label.unwrap_or("").into(),
+        added_at:   now_rfc3339(),
+    };
+    store.add(root);
+    store.save(&path)?;
+
+    if printer.format == Format::Json {
+        printer.json(&serde_json::json!({
+            "status":     "ok",
+            "message":    "trust root added",
+            "key_id":     key_id,
+            "kind":       kind.as_str(),
+            "public_key": canonical_pk,
+            "path":       path.display().to_string(),
+        }));
+        return Ok(());
+    }
+    printer.success("trust root added", &[
+        ("key_id",     key_id),
+        ("kind",       kind.as_str()),
+        ("public_key", &canonical_pk),
+        ("path",       &path.display().to_string()),
+    ]);
+    Ok(())
+}
+
+/// `treeship trust remove <key_id>`. Removes every entry matching `key_id`
+/// across all kinds.
+pub fn remove(
+    key_id: &str,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = TrustRootStore::default_path();
+    let mut store = match TrustRootStore::open(&path) {
+        Ok(s) => s,
+        Err(TrustRootError::NotConfigured { .. }) | Err(TrustRootError::Empty { .. }) => {
+            if printer.format == Format::Json {
+                printer.json(&serde_json::json!({
+                    "status":  "ok",
+                    "message": "no trust roots configured; nothing to remove",
+                    "key_id":  key_id,
+                    "removed": false,
+                }));
+                return Ok(());
+            }
+            printer.info("no trust roots configured; nothing to remove");
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let removed = store.remove(key_id);
+    store.save(&path)?;
+
+    if printer.format == Format::Json {
+        printer.json(&serde_json::json!({
+            "status":  "ok",
+            "key_id":  key_id,
+            "removed": removed,
+            "path":    path.display().to_string(),
+        }));
+        return Ok(());
+    }
+    if removed {
+        printer.success("trust root removed", &[("key_id", key_id)]);
+    } else {
+        printer.info(&format!("no trust root with key_id={key_id}"));
+    }
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    treeship_core::statements::unix_to_rfc3339(secs)
+}
+
+// Re-export so main.rs sees the same path even though we don't use
+// `Path` here at the moment. Keeps the import alive for future helpers.
+#[allow(dead_code)]
+fn _path_anchor(_p: &Path) {}

--- a/packages/cli/src/commands/verify_external.rs
+++ b/packages/cli/src/commands/verify_external.rs
@@ -175,8 +175,22 @@ pub fn run(
             }
         };
 
-        let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
-            .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
+        // Audit lane J fix-up: propagate Malformed / PermissionsTooOpen
+        // rather than silently degrading to an empty trust store. A
+        // broken trust file deserves a clear "your trust file is
+        // unreadable" diagnostic, not a misleading downstream failure.
+        let trust = match treeship_core::trust::TrustRootStore::open_default_or_empty() {
+            Ok(t) => t,
+            Err(e) => {
+                emit_step(
+                    printer,
+                    false,
+                    "Trust store readable",
+                    Some(&format!("trust store unreadable: {e}")),
+                );
+                return ExternalExit::CrossVerifyFailed;
+            }
+        };
         match verify_certificate(&cert, &trust) {
             Ok(()) => emit_step(printer, true, "Certificate verified", None),
             Err(e) => {

--- a/packages/cli/src/commands/verify_external.rs
+++ b/packages/cli/src/commands/verify_external.rs
@@ -175,7 +175,9 @@ pub fn run(
             }
         };
 
-        match verify_certificate(&cert) {
+        let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
+            .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
+        match verify_certificate(&cert, &trust) {
             Ok(()) => emit_step(printer, true, "Certificate verified", None),
             Err(e) => {
                 emit_step(printer, false, "Certificate verified", Some(&e.to_string()));
@@ -451,9 +453,11 @@ fn emit_json(
 ) -> ExternalExit {
     let receipt_failed = checks.iter().any(|c| c.status == VerifyStatus::Fail);
 
+    let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
+        .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
     let cross = certificate.and_then(|cert_target| match load_certificate(cert_target) {
         Ok(cert) => {
-            let cert_sig_ok = verify_certificate(&cert).is_ok();
+            let cert_sig_ok = verify_certificate(&cert, &trust).is_ok();
             let now = now_rfc3339_utc();
             let result = cross_verify_receipt_and_certificate(receipt, &cert, &now);
             Some((cert_sig_ok, result))
@@ -533,8 +537,10 @@ fn verify_agent_package_only(path: &Path, printer: &Printer) -> ExternalExit {
         }
     };
 
+    let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
+        .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
     if printer.format == Format::Json {
-        let sig_ok = verify_certificate(&cert).is_ok();
+        let sig_ok = verify_certificate(&cert, &trust).is_ok();
         printer.json(&serde_json::json!({
             "target": path.display().to_string(),
             "outcome": if sig_ok { "pass" } else { "fail" },
@@ -551,7 +557,7 @@ fn verify_agent_package_only(path: &Path, printer: &Printer) -> ExternalExit {
     }
 
     emit_step(printer, true, &format!("Loaded certificate from {}", path.display()), None);
-    match verify_certificate(&cert) {
+    match verify_certificate(&cert, &trust) {
         Ok(()) => emit_step(printer, true, "Certificate signature valid (Ed25519)", None),
         Err(e) => {
             emit_step(printer, false, "Certificate signature valid (Ed25519)", Some(&e.to_string()));

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -140,6 +140,22 @@ enum Command {
     #[command(subcommand)]
     Keys(KeysCommand),
 
+    /// Manage pinned trust roots (issuer keys)
+    ///
+    /// Trust roots gate the three self-signed verification surfaces:
+    /// Merkle checkpoints, hub-org JournalCheckpoints, and Agent
+    /// Certificates. Before v0.10.3 these trusted whatever public key
+    /// they happened to carry -- self-signed forgeries verified. Now
+    /// every embedded pubkey must match a root configured here.
+    ///
+    /// Examples:
+    ///   treeship trust list
+    ///   treeship trust add hub_zerker ed25519:<pubkey> --kind hub_checkpoint
+    ///   treeship trust add ship_acme  ed25519:<pubkey> --kind ship --label "ACME hub"
+    ///   treeship trust remove hub_zerker
+    #[command(subcommand)]
+    Trust(TrustCommand),
+
     /// Connect to treeship.dev Hub -- push, pull, and share artifacts
     ///
     /// Examples:
@@ -1471,6 +1487,49 @@ struct KeysRotateArgs {
     no_default: bool,
 }
 
+// --- trust ------------------------------------------------------------------
+
+#[derive(Subcommand)]
+enum TrustCommand {
+    /// List every pinned trust root.
+    List,
+
+    /// Add or replace a trust root.
+    ///
+    /// Examples:
+    ///   treeship trust add hub_zerker ed25519:<b64> --kind hub_checkpoint
+    ///   treeship trust add ship_acme  ed25519:<b64> --kind ship --label "ACME hub"
+    Add(TrustAddArgs),
+
+    /// Remove a trust root by `key_id` (across all kinds).
+    Remove(TrustRemoveArgs),
+}
+
+#[derive(clap::Args)]
+struct TrustAddArgs {
+    /// Identifier for this root. Matches the existing key_id format but
+    /// human-readable labels are accepted.
+    key_id: String,
+
+    /// Ed25519 public key. Either `ed25519:<base64url>` or bare base64url.
+    public_key: String,
+
+    /// What this root is allowed to verify.
+    #[arg(long, value_parser = ["hub_checkpoint", "ship", "agent_cert"])]
+    kind: String,
+
+    /// Optional human-readable label. Shown by `treeship trust list`.
+    #[arg(long)]
+    label: Option<String>,
+}
+
+#[derive(clap::Args)]
+struct TrustRemoveArgs {
+    /// Identifier to remove. Removes every entry with this `key_id`
+    /// regardless of kind.
+    key_id: String,
+}
+
 // --- hub --------------------------------------------------------------------
 
 #[derive(Subcommand)]
@@ -2126,6 +2185,18 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 cli.config.as_deref(),
                 printer,
             ),
+        },
+
+        Command::Trust(sub) => match sub {
+            TrustCommand::List => commands::trust::list(printer),
+            TrustCommand::Add(a) => commands::trust::add(
+                &a.key_id,
+                &a.public_key,
+                &a.kind,
+                a.label.as_deref(),
+                printer,
+            ),
+            TrustCommand::Remove(a) => commands::trust::remove(&a.key_id, printer),
         },
 
         Command::Hub(sub) => match sub {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1521,6 +1521,11 @@ struct TrustAddArgs {
     /// Optional human-readable label. Shown by `treeship trust list`.
     #[arg(long)]
     label: Option<String>,
+
+    /// Skip the interactive confirmation prompt. Required for
+    /// non-interactive use (CI, scripts, JSON output mode).
+    #[arg(long)]
+    yes: bool,
 }
 
 #[derive(clap::Args)]
@@ -1528,6 +1533,11 @@ struct TrustRemoveArgs {
     /// Identifier to remove. Removes every entry with this `key_id`
     /// regardless of kind.
     key_id: String,
+
+    /// Skip the interactive confirmation prompt. Required for
+    /// non-interactive use (CI, scripts, JSON output mode).
+    #[arg(long)]
+    yes: bool,
 }
 
 // --- hub --------------------------------------------------------------------
@@ -2194,9 +2204,10 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 &a.public_key,
                 &a.kind,
                 a.label.as_deref(),
+                a.yes,
                 printer,
             ),
-            TrustCommand::Remove(a) => commands::trust::remove(&a.key_id, printer),
+            TrustCommand::Remove(a) => commands::trust::remove(&a.key_id, a.yes, printer),
         },
 
         Command::Hub(sub) => match sub {

--- a/packages/core-wasm/src/lib.rs
+++ b/packages/core-wasm/src/lib.rs
@@ -129,13 +129,18 @@ fn decode_inner(envelope_json: &str) -> Result<String, String> {
         .map_err(|e| format!("payload is not UTF-8: {}", e))
 }
 
-/// Verify a Merkle inclusion proof JSON.
+/// Verify a Merkle inclusion proof JSON. The `trust_roots_json` argument
+/// pins the checkpoint issuer; pass an empty string for "no trust
+/// configured" (which causes verification to fail-closed -- post-audit
+/// behavior, the checkpoint's embedded pubkey is no longer trusted on
+/// its own).
+///
 /// Returns JSON: { "valid": true/false, "message": "...", "artifact_id": "...",
 ///   "leaf_index": N, "checkpoint_index": N, "checkpoint_root": "...",
 ///   "signed_at": "...", "signer": "..." }
 #[wasm_bindgen]
-pub fn verify_merkle_proof(proof_json: &str) -> String {
-    match verify_merkle_inner(proof_json) {
+pub fn verify_merkle_proof(proof_json: &str, trust_roots_json: &str) -> String {
+    match verify_merkle_inner(proof_json, trust_roots_json) {
         Ok(result) => result,
         Err(e) => serde_json::json!({
             "valid": false,
@@ -144,12 +149,14 @@ pub fn verify_merkle_proof(proof_json: &str) -> String {
     }
 }
 
-fn verify_merkle_inner(proof_json: &str) -> Result<String, String> {
+fn verify_merkle_inner(proof_json: &str, trust_roots_json: &str) -> Result<String, String> {
     let proof_file: treeship_core::merkle::ProofFile = serde_json::from_str(proof_json)
         .map_err(|e| format!("invalid proof JSON: {}", e))?;
 
-    // 1. Verify checkpoint signature
-    if !proof_file.checkpoint.verify() {
+    let trust = parse_wasm_trust_roots(trust_roots_json)?;
+
+    // 1. Verify checkpoint signature against the pinned trust root.
+    if !proof_file.checkpoint.verify(&trust) {
         return Ok(serde_json::json!({
             "valid": false,
             "message": "checkpoint signature invalid",
@@ -401,7 +408,7 @@ pub fn verify_receipt(receipt_json: &str) -> String {
 /// }
 /// ```
 #[wasm_bindgen]
-pub fn verify_certificate(cert_json: &str, now_rfc3339: &str) -> String {
+pub fn verify_certificate(cert_json: &str, now_rfc3339: &str, trust_roots_json: &str) -> String {
     use treeship_core::agent::{verify_certificate as verify_cert, AgentCertificate};
 
     let cert: AgentCertificate = match serde_json::from_str(cert_json) {
@@ -409,7 +416,15 @@ pub fn verify_certificate(cert_json: &str, now_rfc3339: &str) -> String {
         Err(e) => return error_result("invalid_json", &format!("invalid certificate JSON: {e}")),
     };
 
-    let sig_ok = verify_cert(&cert).is_ok();
+    // Caller-supplied trust roots. Empty string = no trust configured,
+    // which makes verification fail closed -- matches the audit fix:
+    // the browser-side verifier no longer trusts whatever pubkey the
+    // certificate happens to carry.
+    let trust = match parse_wasm_trust_roots(trust_roots_json) {
+        Ok(t)  => t,
+        Err(e) => return error_result("invalid_trust_roots", &e),
+    };
+    let sig_ok = verify_cert(&cert, &trust).is_ok();
 
     let validity = if now_rfc3339.is_empty() {
         "not_checked".to_string()
@@ -464,7 +479,12 @@ pub fn verify_certificate(cert_json: &str, now_rfc3339: &str) -> String {
 /// }
 /// ```
 #[wasm_bindgen]
-pub fn cross_verify(receipt_json: &str, cert_json: &str, now_rfc3339: &str) -> String {
+pub fn cross_verify(
+    receipt_json: &str,
+    cert_json: &str,
+    now_rfc3339: &str,
+    trust_roots_json: &str,
+) -> String {
     use treeship_core::agent::{verify_certificate as verify_cert, AgentCertificate};
     use treeship_core::session::SessionReceipt;
     use treeship_core::verify::{
@@ -479,8 +499,12 @@ pub fn cross_verify(receipt_json: &str, cert_json: &str, now_rfc3339: &str) -> S
         Ok(c) => c,
         Err(e) => return error_result("invalid_json", &format!("invalid certificate JSON: {e}")),
     };
+    let trust = match parse_wasm_trust_roots(trust_roots_json) {
+        Ok(t)  => t,
+        Err(e) => return error_result("invalid_trust_roots", &e),
+    };
 
-    let cert_sig_ok = verify_cert(&cert).is_ok();
+    let cert_sig_ok = verify_cert(&cert, &trust).is_ok();
     let result = cross_verify_receipt_and_certificate(&receipt, &cert, now_rfc3339);
 
     let ship_label = match &result.ship_id_status {
@@ -516,6 +540,37 @@ fn error_result(error_code: &str, message: &str) -> String {
         "message": message,
     })
     .to_string()
+}
+
+/// Parse the `trust_roots_json` argument the WASM verify_* surfaces
+/// accept. The JSON shape mirrors the on-disk
+/// `~/.treeship/trust_roots.json`:
+///
+/// ```json
+/// { "version": 1, "roots": [ { "key_id": "...", "public_key": "ed25519:...", "kind": "agent_cert", ... } ] }
+/// ```
+///
+/// An empty string means "no trust roots configured" -- verifiers
+/// fail-closed in that state, which matches the audit fix.
+fn parse_wasm_trust_roots(s: &str) -> Result<treeship_core::trust::TrustRootStore, String> {
+    use treeship_core::trust::{TrustRoot, TrustRootStore};
+    if s.trim().is_empty() {
+        return Ok(TrustRootStore::empty());
+    }
+    #[derive(serde::Deserialize)]
+    struct File { version: u8, roots: Vec<TrustRoot> }
+    let file: File = serde_json::from_str(s)
+        .map_err(|e| format!("invalid trust_roots_json: {e}"))?;
+    if file.version != 1 {
+        return Err(format!("unsupported trust_roots schema version: {}", file.version));
+    }
+    // Validate every embedded pubkey parses now -- otherwise the
+    // verifier would silently ignore a malformed root.
+    for r in &file.roots {
+        treeship_core::trust::decode_ed25519_pubkey(&r.public_key)
+            .map_err(|m| format!("trust root {}: {m}", r.key_id))?;
+    }
+    Ok(TrustRootStore::with_roots(file.roots))
 }
 
 fn status_label(s: &treeship_core::session::VerifyStatus) -> &'static str {
@@ -597,7 +652,23 @@ mod tests {
         serde_json::to_string(&r).unwrap()
     }
 
-    fn sample_cert_json(valid_until: &str) -> String {
+    /// Build a trust_roots_json that pins `pk_b64` for kind `agent_cert`.
+    /// Every certificate-verifying WASM test below uses this so the trust
+    /// pin doesn't short-circuit before the signature math runs.
+    fn trust_roots_for(pk_b64: &str) -> String {
+        serde_json::json!({
+            "version": 1,
+            "roots": [{
+                "key_id":     "key_demo",
+                "public_key": format!("ed25519:{pk_b64}"),
+                "kind":       "agent_cert",
+                "label":      "test issuer",
+                "added_at":   "2026-05-15T00:00:00Z",
+            }]
+        }).to_string()
+    }
+
+    fn sample_cert_with_key(valid_until: &str) -> (String, String) {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
         use treeship_core::agent::{
             AgentCapabilities, AgentCertificate, AgentDeclaration, AgentIdentity,
@@ -642,12 +713,16 @@ mod tests {
             signature: CertificateSignature {
                 algorithm: "ed25519".into(),
                 key_id: "key_demo".into(),
-                public_key: pk_b64,
+                public_key: pk_b64.clone(),
                 signature: URL_SAFE_NO_PAD.encode(sig),
                 signed_fields: "identity+capabilities+declaration".into(),
             },
         };
-        serde_json::to_string(&cert).unwrap()
+        (serde_json::to_string(&cert).unwrap(), pk_b64)
+    }
+
+    fn sample_cert_json(valid_until: &str) -> String {
+        sample_cert_with_key(valid_until).0
     }
 
     #[test]
@@ -685,9 +760,11 @@ mod tests {
 
     #[test]
     fn verify_certificate_passes_freshly_signed_cert() {
-        let cert = sample_cert_json("2027-01-01T00:00:00Z");
-        let out: serde_json::Value =
-            serde_json::from_str(&verify_certificate(&cert, "2026-06-01T00:00:00Z")).unwrap();
+        let (cert, pk) = sample_cert_with_key("2027-01-01T00:00:00Z");
+        let trust = trust_roots_for(&pk);
+        let out: serde_json::Value = serde_json::from_str(
+            &verify_certificate(&cert, "2026-06-01T00:00:00Z", &trust),
+        ).unwrap();
         assert_eq!(out["outcome"], "pass", "got: {out}");
         assert_eq!(out["signature_valid"], true);
         assert_eq!(out["validity"], "valid");
@@ -696,28 +773,65 @@ mod tests {
 
     #[test]
     fn verify_certificate_flags_expiry() {
-        let cert = sample_cert_json("2026-04-10T00:00:00Z");
-        let out: serde_json::Value =
-            serde_json::from_str(&verify_certificate(&cert, "2026-06-01T00:00:00Z")).unwrap();
+        let (cert, pk) = sample_cert_with_key("2026-04-10T00:00:00Z");
+        let trust = trust_roots_for(&pk);
+        let out: serde_json::Value = serde_json::from_str(
+            &verify_certificate(&cert, "2026-06-01T00:00:00Z", &trust),
+        ).unwrap();
         assert_eq!(out["outcome"], "fail");
         assert_eq!(out["validity"], "expired");
     }
 
     #[test]
     fn verify_certificate_empty_now_defers_validity() {
-        let cert = sample_cert_json("2027-01-01T00:00:00Z");
-        let out: serde_json::Value =
-            serde_json::from_str(&verify_certificate(&cert, "")).unwrap();
+        let (cert, pk) = sample_cert_with_key("2027-01-01T00:00:00Z");
+        let trust = trust_roots_for(&pk);
+        let out: serde_json::Value = serde_json::from_str(
+            &verify_certificate(&cert, "", &trust),
+        ).unwrap();
         assert_eq!(out["outcome"], "pass");
         assert_eq!(out["validity"], "not_checked");
+    }
+
+    /// Trust pin: with no trust_roots_json supplied, the WASM verifier
+    /// must reject a freshly-signed cert. This is the headline audit
+    /// fix on the browser-side path.
+    #[test]
+    fn verify_certificate_rejects_with_no_trust_roots() {
+        let cert = sample_cert_json("2027-01-01T00:00:00Z");
+        let out: serde_json::Value = serde_json::from_str(
+            &verify_certificate(&cert, "2026-06-01T00:00:00Z", ""),
+        ).unwrap();
+        assert_eq!(out["outcome"], "fail",
+                   "no trust roots must fail: {out}");
+        assert_eq!(out["signature_valid"], false);
+    }
+
+    /// Trust pin: cert whose issuer is not in the supplied trust set
+    /// must be rejected even though the signature math is good.
+    #[test]
+    fn verify_certificate_rejects_unknown_issuer() {
+        let cert = sample_cert_json("2027-01-01T00:00:00Z");
+        // Trust a totally unrelated public key.
+        let bogus_trust = trust_roots_for(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // 32 zero bytes
+        );
+        let out: serde_json::Value = serde_json::from_str(
+            &verify_certificate(&cert, "2026-06-01T00:00:00Z", &bogus_trust),
+        ).unwrap();
+        assert_eq!(out["outcome"], "fail",
+                   "unknown issuer must fail: {out}");
+        assert_eq!(out["signature_valid"], false);
     }
 
     #[test]
     fn cross_verify_rolls_up_pass() {
         let receipt = sample_receipt_json();
-        let cert = sample_cert_json("2027-01-01T00:00:00Z");
-        let out: serde_json::Value =
-            serde_json::from_str(&cross_verify(&receipt, &cert, "2026-06-01T00:00:00Z")).unwrap();
+        let (cert, pk) = sample_cert_with_key("2027-01-01T00:00:00Z");
+        let trust = trust_roots_for(&pk);
+        let out: serde_json::Value = serde_json::from_str(
+            &cross_verify(&receipt, &cert, "2026-06-01T00:00:00Z", &trust),
+        ).unwrap();
         assert_eq!(out["outcome"], "pass", "got: {out}");
         assert_eq!(out["ok"], true);
         assert_eq!(out["ship_id_status"], "match");
@@ -729,17 +843,20 @@ mod tests {
     #[test]
     fn cross_verify_fails_when_cert_expired() {
         let receipt = sample_receipt_json();
-        let cert = sample_cert_json("2026-04-10T00:00:00Z");
-        let out: serde_json::Value =
-            serde_json::from_str(&cross_verify(&receipt, &cert, "2026-06-01T00:00:00Z")).unwrap();
+        let (cert, pk) = sample_cert_with_key("2026-04-10T00:00:00Z");
+        let trust = trust_roots_for(&pk);
+        let out: serde_json::Value = serde_json::from_str(
+            &cross_verify(&receipt, &cert, "2026-06-01T00:00:00Z", &trust),
+        ).unwrap();
         assert_eq!(out["ok"], false);
         assert_eq!(out["certificate_status"], "expired");
     }
 
     #[test]
     fn cross_verify_returns_error_on_malformed_input() {
-        let out: serde_json::Value =
-            serde_json::from_str(&cross_verify("bad", "also bad", "2026-06-01T00:00:00Z")).unwrap();
+        let out: serde_json::Value = serde_json::from_str(
+            &cross_verify("bad", "also bad", "2026-06-01T00:00:00Z", ""),
+        ).unwrap();
         assert_eq!(out["outcome"], "error");
         assert_eq!(out["error_code"], "invalid_json");
     }

--- a/packages/core/src/agent.rs
+++ b/packages/core/src/agent.rs
@@ -111,6 +111,16 @@ pub enum CertificateVerifyError {
     UnsupportedAlgorithm(String),
     /// `signed_fields` does not name the expected payload composition.
     UnsupportedSignedFields(String),
+    /// The embedded `signature.public_key` is not pinned in the
+    /// operator's trust root store under kind `AgentCert`. The signature
+    /// math may be internally consistent, but the issuer is unknown.
+    /// Self-signed certificates an attacker mints to authorize their own
+    /// agent's tool calls land here.
+    UntrustedIssuer { key_id: String },
+    /// No trust roots configured at all (or none for kind `AgentCert`).
+    /// Distinct from `UntrustedIssuer` so the CLI can render the
+    /// "configure trust" remediation rather than "key not in store".
+    NoTrustConfigured,
 }
 
 impl std::fmt::Display for CertificateVerifyError {
@@ -124,6 +134,17 @@ impl std::fmt::Display for CertificateVerifyError {
             Self::UnsupportedSignedFields(s) => {
                 write!(f, "certificate signed_fields '{s}' not recognized")
             }
+            Self::UntrustedIssuer { key_id } => write!(
+                f,
+                "certificate issuer (key_id={key_id}) is not in the trust root store. \
+                 Run `treeship trust add <key_id> <pubkey> --kind agent_cert` if you trust this issuer.",
+            ),
+            Self::NoTrustConfigured => write!(
+                f,
+                "no trust roots configured for agent certificates. \
+                 Run `treeship trust add <key_id> <pubkey> --kind agent_cert` \
+                 or sync from your hub via `treeship hub sync-trust`.",
+            ),
         }
     }
 }
@@ -133,14 +154,26 @@ impl std::error::Error for CertificateVerifyError {}
 /// The signed payload composition used by v0.x agent certificates.
 const SIGNED_FIELDS_V1: &str = "identity+capabilities+declaration";
 
-/// Verify the Ed25519 signature on an `AgentCertificate` against the public
-/// key embedded in `signature.public_key`. Reconstructs the same canonical
-/// JSON the issuer signed and checks the bytes match.
+/// Verify the Ed25519 signature on an `AgentCertificate`. Requires the
+/// embedded `signature.public_key` to be present in `trust` under kind
+/// `AgentCert`, then reconstructs the canonical JSON the issuer signed
+/// and verifies the signature bytes match.
 ///
-/// This does NOT check certificate validity (issued_at / valid_until) or
-/// chain to a trusted issuer. Validity is the cross-verifier's job; trust
-/// chaining is out of scope for v0.9.0.
-pub fn verify_certificate(cert: &AgentCertificate) -> Result<(), CertificateVerifyError> {
+/// Trust pinning is mandatory. Before this, the function trusted whichever
+/// public key the certificate happened to carry -- making the certificate
+/// self-signed. With it, an operator pins which issuer keys are allowed to
+/// vouch for agents, and any other issuer's certificate is rejected with
+/// `UntrustedIssuer` (or `NoTrustConfigured` when the store has nothing
+/// for kind `AgentCert`).
+///
+/// This does NOT check certificate validity windows (issued_at /
+/// valid_until). That's the cross-verifier's job.
+pub fn verify_certificate(
+    cert: &AgentCertificate,
+    trust: &crate::trust::TrustRootStore,
+) -> Result<(), CertificateVerifyError> {
+    use crate::trust::TrustRootKind;
+
     if cert.signature.algorithm != "ed25519" {
         return Err(CertificateVerifyError::UnsupportedAlgorithm(
             cert.signature.algorithm.clone(),
@@ -161,6 +194,19 @@ pub fn verify_certificate(cert: &AgentCertificate) -> Result<(), CertificateVeri
         .map_err(|_| CertificateVerifyError::BadPublicKey(format!("expected 32 bytes, got {}", pk_bytes.len())))?;
     let verifying_key = VerifyingKey::from_bytes(&pk_arr)
         .map_err(|e| CertificateVerifyError::BadPublicKey(e.to_string()))?;
+
+    // Trust pin -- fail-closed before signature math runs. We
+    // distinguish "no trust configured at all (for this kind)" from
+    // "trust configured but this issuer isn't in it" so the CLI can
+    // render a more useful remediation.
+    if !trust.contains(&verifying_key, TrustRootKind::AgentCert) {
+        if trust.is_empty_for_kind(TrustRootKind::AgentCert) {
+            return Err(CertificateVerifyError::NoTrustConfigured);
+        }
+        return Err(CertificateVerifyError::UntrustedIssuer {
+            key_id: cert.signature.key_id.clone(),
+        });
+    }
 
     let sig_bytes = URL_SAFE_NO_PAD
         .decode(&cert.signature.signature)
@@ -244,6 +290,20 @@ mod tests {
         assert_eq!(effective_schema_version(parsed.schema_version.as_deref()), "0");
     }
 
+    /// Build a single-entry trust store pinning `pk_b64` for kind
+    /// `AgentCert`. Tests that exercise valid signatures use this so the
+    /// trust pin doesn't short-circuit before signature verification.
+    fn trust_with(pk_b64: &str) -> crate::trust::TrustRootStore {
+        use crate::trust::{TrustRoot, TrustRootKind, TrustRootStore};
+        TrustRootStore::with_roots(vec![TrustRoot {
+            key_id:     "key_demo".into(),
+            public_key: format!("ed25519:{pk_b64}"),
+            kind:       TrustRootKind::AgentCert,
+            label:      "test issuer".into(),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        }])
+    }
+
     #[test]
     fn verify_certificate_round_trip() {
         // Mint a cert, sign it the way the CLI does, then call verify.
@@ -286,13 +346,14 @@ mod tests {
             signature: CertificateSignature {
                 algorithm: "ed25519".into(),
                 key_id: "key_demo".into(),
-                public_key: pk_b64,
+                public_key: pk_b64.clone(),
                 signature: URL_SAFE_NO_PAD.encode(sig),
                 signed_fields: "identity+capabilities+declaration".into(),
             },
         };
 
-        verify_certificate(&cert).expect("freshly-signed cert must verify");
+        let trust = trust_with(&pk_b64);
+        verify_certificate(&cert, &trust).expect("freshly-signed cert must verify");
     }
 
     #[test]
@@ -347,13 +408,14 @@ mod tests {
             signature: CertificateSignature {
                 algorithm: "ed25519".into(),
                 key_id: "key_demo".into(),
-                public_key: pk_b64,
+                public_key: pk_b64.clone(),
                 signature: URL_SAFE_NO_PAD.encode(sig),
                 signed_fields: "identity+capabilities+declaration".into(),
             },
         };
 
-        let err = verify_certificate(&cert).unwrap_err();
+        let trust = trust_with(&pk_b64);
+        let err = verify_certificate(&cert, &trust).unwrap_err();
         assert!(matches!(err, CertificateVerifyError::InvalidSignature),
             "expected InvalidSignature, got: {err}");
     }
@@ -362,8 +424,123 @@ mod tests {
     fn verify_certificate_rejects_unsupported_algorithm() {
         let mut cert = sample_certificate(Some(CERTIFICATE_SCHEMA_VERSION));
         cert.signature.algorithm = "rsa-pss-sha256".into();
-        let err = verify_certificate(&cert).unwrap_err();
+        let err = verify_certificate(&cert, &crate::trust::TrustRootStore::empty()).unwrap_err();
         assert!(matches!(err, CertificateVerifyError::UnsupportedAlgorithm(_)));
+    }
+
+    /// Trust pin headline: a freshly-signed cert whose issuer key is
+    /// NOT in the operator's trust store must be rejected with
+    /// `UntrustedIssuer` -- even though the signature math is fine.
+    #[test]
+    fn verify_certificate_rejects_unknown_issuer() {
+        use crate::attestation::{Ed25519Signer, Signer};
+        let signer = Ed25519Signer::generate("key_attacker").unwrap();
+        let pk_b64 = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+
+        let identity = AgentIdentity {
+            agent_name: "agent-007".into(),
+            ship_id: "ship_x".into(),
+            public_key: pk_b64.clone(),
+            issuer: "ship://attacker-claims-zerker".into(),
+            issued_at: "2026-04-15T00:00:00Z".into(),
+            valid_until: "2027-04-15T00:00:00Z".into(),
+            model: None,
+            description: None,
+        };
+        let capabilities = AgentCapabilities {
+            tools: vec![ToolCapability { name: "Bash".into(), description: None }],
+            api_endpoints: vec![],
+            mcp_servers: vec![],
+        };
+        let declaration = AgentDeclaration {
+            bounded_actions: vec!["Bash".into()],
+            forbidden: vec![],
+            escalation_required: vec![],
+        };
+        let payload = serde_json::json!({
+            "identity": identity, "capabilities": capabilities, "declaration": declaration,
+        });
+        let sig = signer.sign(&serde_json::to_vec(&payload).unwrap()).unwrap();
+        let cert = AgentCertificate {
+            r#type: CERTIFICATE_TYPE.into(),
+            schema_version: Some(CERTIFICATE_SCHEMA_VERSION.into()),
+            identity,
+            capabilities,
+            declaration,
+            signature: CertificateSignature {
+                algorithm: "ed25519".into(),
+                key_id: "key_attacker".into(),
+                public_key: pk_b64,
+                signature: URL_SAFE_NO_PAD.encode(sig),
+                signed_fields: "identity+capabilities+declaration".into(),
+            },
+        };
+
+        // Trust an unrelated issuer.
+        let honest = Ed25519Signer::generate("honest_issuer").unwrap();
+        let honest_pk = URL_SAFE_NO_PAD.encode(honest.public_key_bytes());
+        let trust = trust_with(&honest_pk);
+
+        let err = verify_certificate(&cert, &trust).unwrap_err();
+        assert!(matches!(err, CertificateVerifyError::UntrustedIssuer { .. }),
+            "expected UntrustedIssuer, got: {err}");
+    }
+
+    /// Empty trust store yields `NoTrustConfigured` so the CLI can
+    /// render the install-time remediation distinct from "this
+    /// particular key is wrong".
+    #[test]
+    fn verify_certificate_rejects_with_no_trust_configured() {
+        use crate::attestation::{Ed25519Signer, Signer};
+        let signer = Ed25519Signer::generate("key_demo").unwrap();
+        let pk_b64 = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+
+        let identity = AgentIdentity {
+            agent_name: "agent-007".into(),
+            ship_id: "ship_x".into(),
+            public_key: pk_b64.clone(),
+            issuer: "ship://ship_x".into(),
+            issued_at: "2026-04-15T00:00:00Z".into(),
+            valid_until: "2027-04-15T00:00:00Z".into(),
+            model: None,
+            description: None,
+        };
+        let capabilities = AgentCapabilities {
+            tools: vec![ToolCapability { name: "Bash".into(), description: None }],
+            api_endpoints: vec![],
+            mcp_servers: vec![],
+        };
+        let declaration = AgentDeclaration {
+            bounded_actions: vec!["Bash".into()],
+            forbidden: vec![],
+            escalation_required: vec![],
+        };
+        let payload = serde_json::json!({
+            "identity": identity, "capabilities": capabilities, "declaration": declaration,
+        });
+        let sig = signer.sign(&serde_json::to_vec(&payload).unwrap()).unwrap();
+        let cert = AgentCertificate {
+            r#type: CERTIFICATE_TYPE.into(),
+            schema_version: Some(CERTIFICATE_SCHEMA_VERSION.into()),
+            identity,
+            capabilities,
+            declaration,
+            signature: CertificateSignature {
+                algorithm: "ed25519".into(),
+                key_id: "key_demo".into(),
+                public_key: pk_b64,
+                signature: URL_SAFE_NO_PAD.encode(sig),
+                signed_fields: "identity+capabilities+declaration".into(),
+            },
+        };
+
+        let err = verify_certificate(&cert, &crate::trust::TrustRootStore::empty()).unwrap_err();
+        assert!(matches!(err, CertificateVerifyError::NoTrustConfigured),
+            "expected NoTrustConfigured, got: {err}");
+        // And the error must reference the CLI remediation.
+        let msg = format!("{err}");
+        assert!(msg.contains("treeship trust add"),
+                "remediation must mention treeship trust add: {msg}");
     }
 
     #[test]

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -9,4 +9,5 @@ pub mod agent;
 pub mod artifacts;
 pub mod journal;
 pub mod session;
+pub mod trust;
 pub mod verify;

--- a/packages/core/src/merkle/checkpoint.rs
+++ b/packages/core/src/merkle/checkpoint.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::attestation::{Signer, SignerError};
 use crate::statements::unix_to_rfc3339;
+use crate::trust::{TrustRootKind, TrustRootStore};
 
 use super::tree::MerkleTree;
 
@@ -103,9 +104,16 @@ impl Checkpoint {
         })
     }
 
-    /// Verify the checkpoint signature. Returns `false` on any failure
-    /// (bad encoding, wrong key size, invalid signature). Never panics.
-    pub fn verify(&self) -> bool {
+    /// Verify the checkpoint signature AND require the embedded public key
+    /// to be present in `trust` under kind `HubCheckpoint`. Returns `false`
+    /// on any failure (bad encoding, wrong key size, invalid signature,
+    /// untrusted issuer, no trust configured). Never panics.
+    ///
+    /// Trust pinning is mandatory. A self-signed checkpoint (an attacker
+    /// minting their own keypair, embedding the pubkey, and signing the
+    /// canonical bytes) used to satisfy this function -- it now does not,
+    /// because `trust.contains` rejects unknown issuers.
+    pub fn verify(&self, trust: &TrustRootStore) -> bool {
         let pub_bytes = match URL_SAFE_NO_PAD.decode(&self.public_key) {
             Ok(b) => b,
             Err(_) => return false,
@@ -118,6 +126,13 @@ impl Checkpoint {
             Ok(k) => k,
             Err(_) => return false,
         };
+
+        // Trust pin: the embedded pubkey must be a configured root.
+        // An empty store or no matching root rejects -- closes the
+        // self-signed loophole.
+        if !trust.contains(&vk, TrustRootKind::HubCheckpoint) {
+            return false;
+        }
 
         let canonical = format!("{}|{}|{}|{}|{}|{}", self.index, self.root, self.tree_size, self.height, self.signer, self.signed_at);
 
@@ -132,5 +147,117 @@ impl Checkpoint {
         let sig = Signature::from_bytes(&sig_array);
 
         vk.verify(canonical.as_bytes(), &sig).is_ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Trust-pin tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod trust_pin_tests {
+    use super::*;
+    use crate::attestation::{Ed25519Signer, Signer};
+    use crate::merkle::MerkleTree;
+    use crate::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
+
+    fn signer_and_tree() -> (Ed25519Signer, MerkleTree) {
+        let mut tree = MerkleTree::new();
+        tree.append("art_alpha");
+        tree.append("art_beta");
+        let signer = Ed25519Signer::generate("key_test").unwrap();
+        (signer, tree)
+    }
+
+    fn trust_with(signer: &Ed25519Signer) -> TrustRootStore {
+        use ed25519_dalek::VerifyingKey;
+        let pk_bytes: [u8; 32] = signer.public_key_bytes().try_into().unwrap();
+        let vk = VerifyingKey::from_bytes(&pk_bytes).unwrap();
+        TrustRootStore::with_roots(vec![TrustRoot {
+            key_id:     signer.key_id().to_string(),
+            public_key: encode_ed25519_pubkey(&vk),
+            kind:       TrustRootKind::HubCheckpoint,
+            label:      "trusted hub".into(),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        }])
+    }
+
+    /// The headline case from the audit: a checkpoint signed by a key
+    /// the operator never trusted MUST NOT verify, even though the
+    /// signature math is internally consistent.
+    #[test]
+    fn verify_rejects_unknown_pubkey() {
+        let (signer, tree) = signer_and_tree();
+        let cp = Checkpoint::create(1, &tree, &signer).unwrap();
+
+        // Different signer's key is the only one in the store.
+        let other = Ed25519Signer::generate("other").unwrap();
+        let trust = trust_with(&other);
+
+        assert!(!cp.verify(&trust),
+                "unknown issuer must be rejected even with valid signature");
+    }
+
+    /// Happy path: the issuer is pinned, the signature math is good,
+    /// verify returns true.
+    #[test]
+    fn verify_accepts_trusted_pubkey() {
+        let (signer, tree) = signer_and_tree();
+        let cp = Checkpoint::create(1, &tree, &signer).unwrap();
+        let trust = trust_with(&signer);
+        assert!(cp.verify(&trust), "trusted issuer + good signature must verify");
+    }
+
+    /// No trust configured at all (empty store) is the operator's
+    /// fresh-install state. Verification must fail closed: a verifier
+    /// without a trust set cannot vouch for anyone.
+    #[test]
+    fn verify_rejects_with_no_trust_configured() {
+        let (signer, tree) = signer_and_tree();
+        let cp = Checkpoint::create(1, &tree, &signer).unwrap();
+        let trust = TrustRootStore::empty();
+        assert!(!cp.verify(&trust),
+                "empty trust store must reject all checkpoints");
+    }
+
+    /// Trust pinning is kind-scoped: a key trusted for AgentCert is
+    /// NOT trusted for a Merkle checkpoint. This is the firewall
+    /// between certificate issuance and journal anchoring.
+    #[test]
+    fn verify_rejects_pubkey_pinned_for_wrong_kind() {
+        let (signer, tree) = signer_and_tree();
+        let cp = Checkpoint::create(1, &tree, &signer).unwrap();
+
+        use ed25519_dalek::VerifyingKey;
+        let pk_bytes: [u8; 32] = signer.public_key_bytes().try_into().unwrap();
+        let vk = VerifyingKey::from_bytes(&pk_bytes).unwrap();
+        let mismatched = TrustRootStore::with_roots(vec![TrustRoot {
+            key_id:     signer.key_id().to_string(),
+            public_key: encode_ed25519_pubkey(&vk),
+            kind:       TrustRootKind::AgentCert, // wrong kind!
+            label:      "trusted for agent certs only".into(),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        }]);
+        assert!(!cp.verify(&mismatched),
+                "kind discrimination must keep AgentCert roots out of checkpoint trust");
+    }
+
+    /// Forge attempt -- attacker re-signs with a non-trusted key.
+    /// The signature is internally valid (sig was made over canonical
+    /// bytes by the embedded pubkey) but the pubkey is unknown to the
+    /// operator. Pre-pin this passed; post-pin it must not.
+    #[test]
+    fn verify_rejects_attacker_self_signed_forgery() {
+        // Attacker mints their own keypair, builds a checkpoint over
+        // their own canonical bytes, embeds their own pubkey, signs.
+        let (attacker_signer, tree) = signer_and_tree();
+        let forgery = Checkpoint::create(99, &tree, &attacker_signer).unwrap();
+
+        // Honest operator has trusted a DIFFERENT issuer.
+        let honest = Ed25519Signer::generate("honest_hub").unwrap();
+        let trust = trust_with(&honest);
+
+        assert!(!forgery.verify(&trust),
+                "self-signed forgery must not verify against operator's trust set");
     }
 }

--- a/packages/core/src/merkle/mod.rs
+++ b/packages/core/src/merkle/mod.rs
@@ -12,7 +12,21 @@ pub use proof::{ProofFile, ArtifactSummary};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::attestation::Ed25519Signer;
+    use crate::attestation::{Ed25519Signer, Signer};
+    use crate::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
+
+    fn trust_for(signer: &Ed25519Signer) -> TrustRootStore {
+        use ed25519_dalek::VerifyingKey;
+        let pk_bytes: [u8; 32] = signer.public_key_bytes().try_into().unwrap();
+        let vk = VerifyingKey::from_bytes(&pk_bytes).unwrap();
+        TrustRootStore::with_roots(vec![TrustRoot {
+            key_id:     signer.key_id().to_string(),
+            public_key: encode_ed25519_pubkey(&vk),
+            kind:       TrustRootKind::HubCheckpoint,
+            label:      "test".into(),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        }])
+    }
 
     #[test]
     fn checkpoint_signs_and_verifies() {
@@ -21,9 +35,10 @@ mod tests {
         tree.append("art_b");
 
         let signer = Ed25519Signer::generate("key_test").unwrap();
+        let trust = trust_for(&signer);
         let checkpoint = Checkpoint::create(1, &tree, &signer).unwrap();
 
-        assert!(checkpoint.verify());
+        assert!(checkpoint.verify(&trust));
     }
 
     #[test]
@@ -32,11 +47,12 @@ mod tests {
         tree.append("art_a");
 
         let signer = Ed25519Signer::generate("key_test").unwrap();
+        let trust = trust_for(&signer);
         let mut checkpoint = Checkpoint::create(1, &tree, &signer).unwrap();
 
         checkpoint.tree_size = 999; // tamper
 
-        assert!(!checkpoint.verify());
+        assert!(!checkpoint.verify(&trust));
     }
 
     #[test]

--- a/packages/core/src/session/mod.rs
+++ b/packages/core/src/session/mod.rs
@@ -25,6 +25,7 @@ pub use receipt::{ArtifactEntry, ReceiptComposer, SessionReceipt};
 pub use render::RenderConfig;
 pub use package::{
     build_package, build_package_with_approvals, read_approvals_bundle, read_package,
-    verify_package, ApprovalsBundle, ApprovalsIndex, VerifyCheck, VerifyStatus,
+    verify_package, verify_package_with_trust,
+    ApprovalsBundle, ApprovalsIndex, VerifyCheck, VerifyStatus,
 };
 pub use git::{reconcile_changes, current_head_sha, GitChange};

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -419,9 +419,28 @@ pub fn read_package(pkg_dir: &Path) -> Result<SessionReceipt, PackageError> {
 /// `TrustRootStore::default_path()`. Use
 /// [`verify_package_with_trust`] when the trust store is already in
 /// hand (CLI paths that take a `Ctx`, or tests).
+///
+/// Audit lane J fix-up: `open_default_or_empty` propagates `Malformed`
+/// and `PermissionsTooOpen` errors -- those are operator
+/// misconfiguration that must NOT be silently downgraded to an empty
+/// trust store (an empty store fails verification of any hub-org
+/// checkpoint, which is the right end-state, but the operator needs a
+/// clear "your trust file is broken" diagnostic instead of a misleading
+/// "untrusted issuer" message). Surface the error as a `trust-root`
+/// fail row and stop before doing real work that depends on trust.
 pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> {
-    let trust = crate::trust::TrustRootStore::open_default_or_empty()
-        .unwrap_or_else(|_| crate::trust::TrustRootStore::empty());
+    let trust = match crate::trust::TrustRootStore::open_default_or_empty() {
+        Ok(t) => t,
+        Err(e) => {
+            // Build a minimal check list so the caller's printer still
+            // renders a coherent failure rather than silently routing
+            // through a fake empty store.
+            return Ok(vec![VerifyCheck::fail(
+                "trust-root",
+                &format!("trust store unreadable: {e}"),
+            )]);
+        }
+    };
     verify_package_with_trust(pkg_dir, &trust)
 }
 

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -1076,6 +1076,15 @@ pub(crate) fn add_approval_evidence_checks(
         let mut all_ok = true;
         let mut details: Vec<String> = Vec::new();
         let mut have_valid_signature = false;
+        // Security-critical failures (untrusted-issuer / tampered /
+        // not-hub-kind) must FAIL unconditionally, not warn. Audit
+        // lane J fix-up: previously these emitted WARN and the CLI
+        // wrapper's --strict promoted to FAIL, which meant the
+        // headline audit case (self-signed hub-org forgery) passed
+        // green-but-yellow in default mode. The release rule is
+        // "trust pinning is on by default"; expressed in this row
+        // as "any signature/issuer failure is a hard fail."
+        let mut security_fatal = false;
 
         for cp in &hub_checkpoints {
             match crate::statements::verify_hub_checkpoint_signature(cp, trust) {
@@ -1119,6 +1128,7 @@ pub(crate) fn add_approval_evidence_checks(
                 }
                 crate::statements::HubCheckpointVerification::Tampered => {
                     all_ok = false;
+                    security_fatal = true;
                     details.push(format!(
                         "{} hub signature failed verification (tampered or wrong key)",
                         cp.checkpoint_id,
@@ -1129,6 +1139,7 @@ pub(crate) fn add_approval_evidence_checks(
                     // arm so a future filter relaxation doesn't go
                     // silent.
                     all_ok = false;
+                    security_fatal = true;
                     details.push(format!(
                         "{} kind toggled out of hub-org during verify",
                         cp.checkpoint_id,
@@ -1136,6 +1147,7 @@ pub(crate) fn add_approval_evidence_checks(
                 }
                 crate::statements::HubCheckpointVerification::UntrustedIssuer => {
                     all_ok = false;
+                    security_fatal = true;
                     details.push(format!(
                         "{} hub_public_key is not a trusted root (configure via `treeship trust add`)",
                         cp.checkpoint_id,
@@ -1148,10 +1160,19 @@ pub(crate) fn add_approval_evidence_checks(
                 "replay-hub-org",
                 &details.join("; "),
             ));
+        } else if security_fatal {
+            // Untrusted issuer or tampered signature: fail-by-default
+            // regardless of --strict. Self-signed forgeries must not
+            // pass yellow.
+            checks.push(VerifyCheck::fail(
+                "replay-hub-org",
+                &details.join("; "),
+            ));
         } else {
             // Hub checkpoint is present but does not satisfy every
-            // gate. Default mode warns; the CLI verify wrapper's
-            // --strict promotes to fail.
+            // non-security gate (missing-field, coverage gap).
+            // Default mode warns; the CLI verify wrapper's --strict
+            // promotes to fail.
             checks.push(VerifyCheck::warn(
                 "replay-hub-org",
                 &details.join("; "),

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -414,7 +414,24 @@ pub fn read_package(pkg_dir: &Path) -> Result<SessionReceipt, PackageError> {
 /// Verify a `.treeship` package locally.
 ///
 /// Returns a list of check results. All must pass for the package to be valid.
+///
+/// Auto-loads the operator's trust roots from
+/// `TrustRootStore::default_path()`. Use
+/// [`verify_package_with_trust`] when the trust store is already in
+/// hand (CLI paths that take a `Ctx`, or tests).
 pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> {
+    let trust = crate::trust::TrustRootStore::open_default_or_empty()
+        .unwrap_or_else(|_| crate::trust::TrustRootStore::empty());
+    verify_package_with_trust(pkg_dir, &trust)
+}
+
+/// Like `verify_package` but takes an explicit `TrustRootStore` so the
+/// caller can verify with a constructed-in-memory trust set (tests) or
+/// a non-default location (CLI `--trust-roots`).
+pub fn verify_package_with_trust(
+    pkg_dir: &Path,
+    trust: &crate::trust::TrustRootStore,
+) -> Result<Vec<VerifyCheck>, PackageError> {
     let mut checks = Vec::new();
 
     // 1. receipt.json exists and parses
@@ -547,7 +564,7 @@ pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> 
     // verify_package wrapper that has Ctx access. The hub-org level is
     // reserved for PR 6 -- not claimed without a real Hub checkpoint.
     let bundle = read_approvals_bundle(pkg_dir).unwrap_or_default();
-    add_approval_evidence_checks(&mut checks, &bundle);
+    add_approval_evidence_checks(&mut checks, &bundle, trust);
 
     Ok(checks)
 }
@@ -565,6 +582,7 @@ pub fn verify_package(pkg_dir: &Path) -> Result<Vec<VerifyCheck>, PackageError> 
 pub(crate) fn add_approval_evidence_checks(
     checks: &mut Vec<VerifyCheck>,
     bundle: &ApprovalsBundle,
+    trust: &crate::trust::TrustRootStore,
 ) {
     if bundle.uses.is_empty() && bundle.checkpoints.is_empty() {
         // Nothing to assert. Stay quiet rather than emit a "skipped"
@@ -1060,7 +1078,7 @@ pub(crate) fn add_approval_evidence_checks(
         let mut have_valid_signature = false;
 
         for cp in &hub_checkpoints {
-            match crate::statements::verify_hub_checkpoint_signature(cp) {
+            match crate::statements::verify_hub_checkpoint_signature(cp, trust) {
                 crate::statements::HubCheckpointVerification::Valid => {
                     have_valid_signature = true;
                     // Coverage: every embedded use_id MUST appear in
@@ -1113,6 +1131,13 @@ pub(crate) fn add_approval_evidence_checks(
                     all_ok = false;
                     details.push(format!(
                         "{} kind toggled out of hub-org during verify",
+                        cp.checkpoint_id,
+                    ));
+                }
+                crate::statements::HubCheckpointVerification::UntrustedIssuer => {
+                    all_ok = false;
+                    details.push(format!(
+                        "{} hub_public_key is not a trusted root (configure via `treeship trust add`)",
                         cp.checkpoint_id,
                     ));
                 }

--- a/packages/core/src/statements/approval_use.rs
+++ b/packages/core/src/statements/approval_use.rs
@@ -528,6 +528,12 @@ pub enum HubCheckpointVerification {
     /// Caller should not have called this; surface as a programming
     /// error.
     NotHubKind,
+    /// The embedded `hub_public_key` is not in the operator's trust root
+    /// store under kind `Ship`. The signature math may be internally
+    /// consistent, but the issuer is unknown -- self-signed forgeries
+    /// land here. Distinct from `Tampered` so callers can render the
+    /// actionable "configure trust" remediation.
+    UntrustedIssuer,
 }
 
 /// Verify the embedded Hub signature on a `JournalCheckpoint`. Does NOT
@@ -543,9 +549,11 @@ pub enum HubCheckpointVerification {
 /// checkpoint" is enforced here.
 pub fn verify_hub_checkpoint_signature(
     cp: &JournalCheckpoint,
+    trust: &crate::trust::TrustRootStore,
 ) -> HubCheckpointVerification {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    use crate::trust::TrustRootKind;
 
     if cp.checkpoint_kind != CheckpointKind::HubOrg {
         return HubCheckpointVerification::NotHubKind;
@@ -572,6 +580,17 @@ pub fn verify_hub_checkpoint_signature(
         Ok(k)  => k,
         Err(_) => return HubCheckpointVerification::Tampered,
     };
+
+    // Trust pin: the embedded hub_public_key MUST be in the operator's
+    // trust root store under kind `Ship` before we honor the signature.
+    // Without this an attacker-minted keypair can self-sign a hub-org
+    // checkpoint and promote `replay-local-journal` to
+    // `replay-hub-org`. With it, the operator decides which hubs they
+    // trust to vouch for global single-use claims.
+    if !trust.contains(&vk, TrustRootKind::Ship) {
+        return HubCheckpointVerification::UntrustedIssuer;
+    }
+
     let sig = Signature::from_bytes(&sig_arr);
     let payload = cp.canonical_hub_signing_bytes();
     match vk.verify(&payload, &sig) {
@@ -785,12 +804,26 @@ mod tests {
         assert_eq!(v["checkpoint_kind"], "hub-org");
     }
 
+    /// Build a one-entry trust store that pins `pk` for kind `Ship`.
+    /// Used by every test below now that hub-checkpoint verification
+    /// requires a pin.
+    fn trust_with(pk: &ed25519_dalek::VerifyingKey) -> crate::trust::TrustRootStore {
+        use crate::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
+        TrustRootStore::with_roots(vec![TrustRoot {
+            key_id:     "test_hub".into(),
+            public_key: encode_ed25519_pubkey(pk),
+            kind:       TrustRootKind::Ship,
+            label:      "test pin".into(),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        }])
+    }
+
     #[test]
     fn local_journal_checkpoint_is_not_hub_signed() {
         let cp = sample_checkpoint(CheckpointKind::LocalJournal);
         assert!(!cp.is_hub_signed());
         assert_eq!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &crate::trust::TrustRootStore::empty()),
             HubCheckpointVerification::NotHubKind,
         );
     }
@@ -800,7 +833,7 @@ mod tests {
         let cp = sample_checkpoint(CheckpointKind::HubOrg);
         assert!(!cp.is_hub_signed());
         assert!(matches!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &crate::trust::TrustRootStore::empty()),
             HubCheckpointVerification::MissingFields(_),
         ));
     }
@@ -808,7 +841,7 @@ mod tests {
     /// End-to-end: sign a Hub checkpoint with a real Ed25519 key,
     /// embed the signature, verify it round-trips. The release rule
     /// pins on this path: replay-hub-org cannot pass without a real
-    /// signature here.
+    /// signature here AND a configured trust root.
     #[test]
     fn hub_checkpoint_signature_round_trip() {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -833,8 +866,9 @@ mod tests {
         cp.hub_signature = URL_SAFE_NO_PAD.encode(sig.to_bytes());
 
         assert!(cp.is_hub_signed());
+        let trust = trust_with(&pk);
         assert_eq!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &trust),
             HubCheckpointVerification::Valid,
         );
     }
@@ -855,14 +889,15 @@ mod tests {
 
         let sig = sk.sign(&cp.canonical_hub_signing_bytes());
         cp.hub_signature = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        let trust = trust_with(&pk);
         // Sanity: signature is good before tamper.
-        assert_eq!(verify_hub_checkpoint_signature(&cp), HubCheckpointVerification::Valid);
+        assert_eq!(verify_hub_checkpoint_signature(&cp, &trust), HubCheckpointVerification::Valid);
 
         // Tamper with covered_use_ids -- now the canonical bytes
         // change, signature no longer applies.
         cp.covered_use_ids.push("use_smuggled".into());
         assert_eq!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &trust),
             HubCheckpointVerification::Tampered,
         );
     }
@@ -883,8 +918,12 @@ mod tests {
         cp.signed_at       = "2026-04-30T07:00:00Z".into();
         let sig = sk_real.sign(&cp.canonical_hub_signing_bytes());
         cp.hub_signature   = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        // Pin the impersonator's key so the trust pin doesn't short-circuit
+        // before we hit the signature mismatch -- this test exercises the
+        // signature-failure path, not the trust-pin path.
+        let trust = trust_with(&pk_imp);
         assert_eq!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &trust),
             HubCheckpointVerification::Tampered,
         );
     }
@@ -897,8 +936,61 @@ mod tests {
         cp.hub_signature   = "also-not-base64".into();
         cp.signed_at       = "2026-04-30T07:00:00Z".into();
         assert_eq!(
-            verify_hub_checkpoint_signature(&cp),
+            verify_hub_checkpoint_signature(&cp, &crate::trust::TrustRootStore::empty()),
             HubCheckpointVerification::Tampered,
+        );
+    }
+
+    /// Trust pin: a checkpoint signed by a key the operator never
+    /// trusted MUST return `UntrustedIssuer`, even though the
+    /// signature math is internally consistent. This is the headline
+    /// case from the v0.10.2 audit -- self-signed forgery was the
+    /// pre-fix behavior, post-fix it's quarantined.
+    #[test]
+    fn hub_checkpoint_rejects_untrusted_issuer() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let attacker = SigningKey::from_bytes(&[42u8; 32]);
+        let pk = attacker.verifying_key();
+
+        let mut cp = sample_checkpoint(CheckpointKind::HubOrg);
+        cp.hub_id          = "hub://attacker-claims-zerker".into();
+        cp.hub_public_key  = URL_SAFE_NO_PAD.encode(pk.to_bytes());
+        cp.signed_at       = "2026-04-30T07:00:00Z".into();
+        cp.covered_use_ids = vec!["use_alpha".into()];
+        let sig = attacker.sign(&cp.canonical_hub_signing_bytes());
+        cp.hub_signature = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+
+        // Operator trusts a different hub.
+        let honest = SigningKey::from_bytes(&[7u8; 32]);
+        let trust = trust_with(&honest.verifying_key());
+
+        assert_eq!(
+            verify_hub_checkpoint_signature(&cp, &trust),
+            HubCheckpointVerification::UntrustedIssuer,
+        );
+    }
+
+    /// With no trust configured at all, any hub-org checkpoint is
+    /// untrusted -- the fail-closed contract.
+    #[test]
+    fn hub_checkpoint_rejects_with_no_trust_configured() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        let pk = sk.verifying_key();
+        let mut cp = sample_checkpoint(CheckpointKind::HubOrg);
+        cp.hub_id          = "hub://anything".into();
+        cp.hub_public_key  = URL_SAFE_NO_PAD.encode(pk.to_bytes());
+        cp.signed_at       = "2026-04-30T07:00:00Z".into();
+        let sig = sk.sign(&cp.canonical_hub_signing_bytes());
+        cp.hub_signature = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+
+        assert_eq!(
+            verify_hub_checkpoint_signature(&cp, &crate::trust::TrustRootStore::empty()),
+            HubCheckpointVerification::UntrustedIssuer,
         );
     }
 }

--- a/packages/core/src/trust/mod.rs
+++ b/packages/core/src/trust/mod.rs
@@ -198,6 +198,27 @@ impl TrustRootStore {
         Self { roots }
     }
 
+    /// Convenience wrapper for code paths that want to "load if
+    /// present, otherwise treat as no-trust-configured". Returns an
+    /// empty store on `NotConfigured`/`Empty`, propagates `Malformed`
+    /// and `PermissionsTooOpen` (operator misconfiguration that
+    /// shouldn't silently downgrade to empty).
+    pub fn open_or_empty(path: &Path) -> Result<Self, TrustRootError> {
+        match Self::open(path) {
+            Ok(s)                                          => Ok(s),
+            Err(TrustRootError::NotConfigured { .. })      => Ok(Self::empty()),
+            Err(TrustRootError::Empty { .. })              => Ok(Self::empty()),
+            Err(e)                                         => Err(e),
+        }
+    }
+
+    /// Convenience: open the default-path file or return empty if it's
+    /// missing. Loud on malformed/perms errors. Suitable for the
+    /// "thread trust through internal verify pipelines" use case.
+    pub fn open_default_or_empty() -> Result<Self, TrustRootError> {
+        Self::open_or_empty(&Self::default_path())
+    }
+
     /// Open the trust root file at `path`. Returns `NotConfigured` if it
     /// does not exist, `Empty` if it exists but has zero roots.
     pub fn open(path: &Path) -> Result<Self, TrustRootError> {

--- a/packages/core/src/trust/mod.rs
+++ b/packages/core/src/trust/mod.rs
@@ -30,11 +30,45 @@ use std::{
     fs,
     io,
     path::{Path, PathBuf},
+    sync::Once,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use ed25519_dalek::VerifyingKey;
 use serde::{Deserialize, Serialize};
+
+// Audit lane J fix-up: warn once per process when an env var override
+// is in effect. Silently honoring TREESHIP_TRUST_ROOTS or
+// TREESHIP_ALLOW_INSECURE_KEY_PERMS is exactly the kind of thing a
+// supply-chain attacker would set in a CI runner to redirect trust to
+// a key they control. The warning shows up in stderr at every load
+// (once, deduplicated) so it lands in CI logs.
+static WARN_TRUST_PATH_OVERRIDE_ONCE: Once = Once::new();
+static WARN_INSECURE_PERMS_ONCE: Once = Once::new();
+
+fn warn_trust_path_override_if_set() {
+    if let Some(p) = std::env::var_os("TREESHIP_TRUST_ROOTS") {
+        WARN_TRUST_PATH_OVERRIDE_ONCE.call_once(|| {
+            eprintln!(
+                "treeship: WARNING: trust store path overridden by TREESHIP_TRUST_ROOTS={} (not the default ~/.treeship/trust_roots.json)",
+                std::path::Path::new(&p).display(),
+            );
+        });
+    }
+}
+
+fn warn_insecure_perms_if_bypassed() {
+    if std::env::var_os("TREESHIP_ALLOW_INSECURE_KEY_PERMS")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        WARN_INSECURE_PERMS_ONCE.call_once(|| {
+            eprintln!(
+                "treeship: WARNING: trust file permission check bypassed by TREESHIP_ALLOW_INSECURE_KEY_PERMS=1 -- this opens a supply-chain hole if not a deliberate CI sandbox override"
+            );
+        });
+    }
+}
 
 /// What this trust root is allowed to verify. Encoded kebab-case in JSON
 /// because the rest of the codebase (CheckpointKind, etc.) does the same.
@@ -175,7 +209,13 @@ impl From<io::Error> for TrustRootError {
 
 impl TrustRootStore {
     /// Default file location: `~/.treeship/trust_roots.json`.
+    ///
+    /// The `TREESHIP_TRUST_ROOTS` env var overrides the path. When set,
+    /// a one-time warning is emitted on stderr (deduplicated per
+    /// process via `std::sync::Once`) so CI logs show that the trust
+    /// boundary moved.
     pub fn default_path() -> PathBuf {
+        warn_trust_path_override_if_set();
         std::env::var_os("TREESHIP_TRUST_ROOTS")
             .map(PathBuf::from)
             .unwrap_or_else(|| {
@@ -377,10 +417,14 @@ fn check_trust_file_perms(path: &Path) -> Result<(), TrustRootError> {
         use std::os::unix::fs::PermissionsExt;
         // Honour the same bypass the keystore honors -- CI sandboxes and
         // recovery flows occasionally need to load on a loose-perm file.
+        // Audit lane J fix-up: this bypass is a supply-chain hole if
+        // set by a malicious build script. Emit a one-time stderr
+        // warning every time it's honoured so CI logs surface it.
         if std::env::var_os("TREESHIP_ALLOW_INSECURE_KEY_PERMS")
             .map(|v| v == "1")
             .unwrap_or(false)
         {
+            warn_insecure_perms_if_bypassed();
             return Ok(());
         }
         let meta = fs::metadata(path)?;

--- a/packages/core/src/trust/mod.rs
+++ b/packages/core/src/trust/mod.rs
@@ -1,0 +1,564 @@
+//! Trust root pinning for self-signed verification surfaces.
+//!
+//! Three verification paths in Treeship trust a public key that travels
+//! inside the artifact they're verifying:
+//!
+//! 1. `Checkpoint::verify` — the Merkle checkpoint's `public_key` field.
+//! 2. `verify_hub_checkpoint_signature` — the `hub_public_key` field of a
+//!    `JournalCheckpoint` of kind `hub-org`.
+//! 3. `verify_certificate` — the Agent Certificate's
+//!    `signature.public_key` field.
+//!
+//! Without an external pin every one of these is self-signed: an attacker
+//! who mints a new keypair, embeds the public key in the artifact, signs
+//! over the canonical bytes, and presents the result will verify.
+//!
+//! `TrustRootStore` is the pin: a small JSON file at
+//! `~/.treeship/trust_roots.json` listing every public key the operator
+//! has decided to trust as an issuer, keyed by `kind`. The three
+//! verification functions reject any embedded public key that is not in
+//! the store for the matching kind.
+//!
+//! The store deliberately mirrors the keystore: same `~/.treeship`
+//! directory, same `0o600` permission expectation, same JSON-on-disk
+//! shape. There is no remote sync in this release — operators add roots
+//! by hand via `treeship trust add` after verifying the key fingerprint
+//! out-of-band (`treeship hub sync-trust` is referenced in error
+//! messages as the forward-looking automation hook).
+
+use std::{
+    fs,
+    io,
+    path::{Path, PathBuf},
+};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use ed25519_dalek::VerifyingKey;
+use serde::{Deserialize, Serialize};
+
+/// What this trust root is allowed to verify. Encoded kebab-case in JSON
+/// because the rest of the codebase (CheckpointKind, etc.) does the same.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustRootKind {
+    /// Merkle `Checkpoint` produced by `treeship merkle checkpoint`. This is
+    /// the ship-local journal checkpoint, distinct from the hub-org
+    /// JournalCheckpoint kind below.
+    HubCheckpoint,
+    /// `JournalCheckpoint` of kind `hub-org` -- signed by a remote Hub to
+    /// promote a local journal claim to a global single-use claim.
+    Ship,
+    /// `AgentCertificate` issued by a ship to one of its agents.
+    AgentCert,
+}
+
+impl TrustRootKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HubCheckpoint => "hub_checkpoint",
+            Self::Ship          => "ship",
+            Self::AgentCert     => "agent_cert",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "hub_checkpoint" => Some(Self::HubCheckpoint),
+            "ship"           => Some(Self::Ship),
+            "agent_cert"     => Some(Self::AgentCert),
+            _                => None,
+        }
+    }
+}
+
+/// One pinned trust root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrustRoot {
+    /// Opaque identifier. Matches the existing `KeyId` format used elsewhere,
+    /// but the trust store does not require any particular shape -- any
+    /// non-empty string is accepted so operators can use human labels like
+    /// `hub_zerker_labs`.
+    pub key_id: String,
+
+    /// Public key encoded as `ed25519:<base64url-no-pad>`. The prefix is
+    /// required so the format stays algorithm-agnostic when we add more
+    /// signature schemes; today only `ed25519` is recognized.
+    pub public_key: String,
+
+    /// What this root is allowed to verify.
+    pub kind: TrustRootKind,
+
+    /// Human-readable label. Shown by `treeship trust list`. Optional in
+    /// the file format; defaults to the empty string.
+    #[serde(default)]
+    pub label: String,
+
+    /// RFC 3339 timestamp the root was added. Useful for auditing.
+    #[serde(default)]
+    pub added_at: String,
+}
+
+/// On-disk wire format. A separate type so we can evolve the file without
+/// breaking the public `TrustRoot` API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TrustRootFile {
+    /// Schema version. Currently `1`.
+    pub version: u8,
+    pub roots:   Vec<TrustRoot>,
+}
+
+const SCHEMA_VERSION: u8 = 1;
+
+/// In-memory view of the trust root file.
+#[derive(Debug, Clone, Default)]
+pub struct TrustRootStore {
+    roots: Vec<TrustRoot>,
+}
+
+/// Errors loading or operating on a trust root file.
+#[derive(Debug)]
+pub enum TrustRootError {
+    /// The file does not exist. The caller should surface the actionable
+    /// remediation: run `treeship trust add` (or sync from a hub).
+    NotConfigured { path: PathBuf },
+    /// JSON parse or schema validation failed.
+    Malformed { path: PathBuf, msg: String },
+    /// The file exists and is well-formed but contains zero roots. Treated
+    /// the same as `NotConfigured` by verifiers but kept distinct so the
+    /// CLI can show a more targeted error.
+    Empty { path: PathBuf },
+    /// File mode allows group or world access. Refuse to load.
+    PermissionsTooOpen { path: PathBuf, mode: u32 },
+    /// Underlying I/O failure (read, write, mkdir).
+    Io(io::Error),
+}
+
+impl std::fmt::Display for TrustRootError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotConfigured { path } => write!(
+                f,
+                "no trust roots configured (looked for {}). \
+                 Run `treeship trust add <key_id> <pubkey> --kind <kind>` \
+                 or sync from your hub via `treeship hub sync-trust`.",
+                path.display(),
+            ),
+            Self::Malformed { path, msg } => write!(
+                f,
+                "trust root file {} is malformed: {msg}",
+                path.display(),
+            ),
+            Self::Empty { path } => write!(
+                f,
+                "trust root file {} has no roots configured. \
+                 Run `treeship trust add <key_id> <pubkey> --kind <kind>` \
+                 to add an issuer.",
+                path.display(),
+            ),
+            Self::PermissionsTooOpen { path, mode } => write!(
+                f,
+                "trust root file {} has insecure permissions (mode {:o}); \
+                 chmod 600 the file and try again.",
+                path.display(),
+                mode & 0o777,
+            ),
+            Self::Io(e) => write!(f, "trust root io: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TrustRootError {}
+
+impl From<io::Error> for TrustRootError {
+    fn from(e: io::Error) -> Self { Self::Io(e) }
+}
+
+impl TrustRootStore {
+    /// Default file location: `~/.treeship/trust_roots.json`.
+    pub fn default_path() -> PathBuf {
+        std::env::var_os("TREESHIP_TRUST_ROOTS")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                let home = std::env::var("HOME").unwrap_or_default();
+                PathBuf::from(home).join(".treeship").join("trust_roots.json")
+            })
+    }
+
+    /// Construct an empty in-memory store. Useful for tests; the
+    /// verification path treats an empty store the same as a missing
+    /// file (no trust configured).
+    pub fn empty() -> Self {
+        Self { roots: Vec::new() }
+    }
+
+    /// Construct a store from an explicit list of roots. Tests use this
+    /// to thread a known trust set into the verifier; production callers
+    /// should `open` the on-disk file.
+    pub fn with_roots(roots: Vec<TrustRoot>) -> Self {
+        Self { roots }
+    }
+
+    /// Open the trust root file at `path`. Returns `NotConfigured` if it
+    /// does not exist, `Empty` if it exists but has zero roots.
+    pub fn open(path: &Path) -> Result<Self, TrustRootError> {
+        if !path.exists() {
+            return Err(TrustRootError::NotConfigured { path: path.to_path_buf() });
+        }
+        check_trust_file_perms(path)?;
+        let bytes = fs::read(path)?;
+        let file: TrustRootFile = serde_json::from_slice(&bytes)
+            .map_err(|e| TrustRootError::Malformed {
+                path: path.to_path_buf(),
+                msg:  e.to_string(),
+            })?;
+        if file.version != SCHEMA_VERSION {
+            return Err(TrustRootError::Malformed {
+                path: path.to_path_buf(),
+                msg:  format!(
+                    "schema version mismatch: file has v{}, this binary supports v{}",
+                    file.version, SCHEMA_VERSION,
+                ),
+            });
+        }
+        // Validate every embedded public key parses now -- catch a
+        // malformed key at load time rather than at verify time.
+        for root in &file.roots {
+            decode_ed25519_pubkey(&root.public_key)
+                .map_err(|msg| TrustRootError::Malformed {
+                    path: path.to_path_buf(),
+                    msg:  format!("root {}: {msg}", root.key_id),
+                })?;
+        }
+        if file.roots.is_empty() {
+            return Err(TrustRootError::Empty { path: path.to_path_buf() });
+        }
+        Ok(Self { roots: file.roots })
+    }
+
+    /// Save the store to `path`. Creates parent directories with mode
+    /// 0o700 and writes the file with mode 0o600.
+    pub fn save(&self, path: &Path) -> Result<(), TrustRootError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o700));
+            }
+        }
+        let file = TrustRootFile {
+            version: SCHEMA_VERSION,
+            roots:   self.roots.clone(),
+        };
+        let json = serde_json::to_vec_pretty(&file)
+            .map_err(|e| TrustRootError::Malformed {
+                path: path.to_path_buf(),
+                msg:  e.to_string(),
+            })?;
+        fs::write(path, &json)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
+    }
+
+    /// Returns true if `key` is pinned for `kind`. The CLI helper does
+    /// not pre-decode; callers that already hold a `VerifyingKey` should
+    /// use this directly.
+    pub fn contains(&self, key: &VerifyingKey, kind: TrustRootKind) -> bool {
+        let key_bytes = key.to_bytes();
+        self.roots.iter().any(|r| {
+            r.kind == kind
+                && decode_ed25519_pubkey(&r.public_key)
+                    .map(|k| k.to_bytes() == key_bytes)
+                    .unwrap_or(false)
+        })
+    }
+
+    /// Convenience: lookup against a raw 32-byte Ed25519 key without first
+    /// constructing a `VerifyingKey`. Returns false if the bytes are not
+    /// a valid public key (mirrors the verifier's reject-on-decode-failure
+    /// behavior).
+    pub fn contains_bytes(&self, key_bytes: &[u8; 32], kind: TrustRootKind) -> bool {
+        match VerifyingKey::from_bytes(key_bytes) {
+            Ok(vk) => self.contains(&vk, kind),
+            Err(_) => false,
+        }
+    }
+
+    /// True when the store carries zero pinned roots. Verifiers reject
+    /// any artifact when this returns true with a clear "configure trust"
+    /// error.
+    pub fn is_empty(&self) -> bool {
+        self.roots.is_empty()
+    }
+
+    /// True when the store has no pinned root of `kind`. Used by
+    /// verifiers to surface a kind-specific error message when an
+    /// operator has set up `agent_cert` trust but is verifying a
+    /// `hub_checkpoint` (or vice versa).
+    pub fn is_empty_for_kind(&self, kind: TrustRootKind) -> bool {
+        !self.roots.iter().any(|r| r.kind == kind)
+    }
+
+    /// Append a root. Idempotent: re-adding the same `(key_id, kind)`
+    /// pair replaces the previous entry. The CLI `treeship trust add`
+    /// goes through here.
+    pub fn add(&mut self, root: TrustRoot) {
+        self.roots.retain(|r| !(r.key_id == root.key_id && r.kind == root.kind));
+        self.roots.push(root);
+    }
+
+    /// Remove a root by `key_id`. Returns true if a root was removed.
+    /// Removes every entry matching the id across all kinds.
+    pub fn remove(&mut self, key_id: &str) -> bool {
+        let before = self.roots.len();
+        self.roots.retain(|r| r.key_id != key_id);
+        self.roots.len() != before
+    }
+
+    /// Iterate over every root.
+    pub fn roots(&self) -> &[TrustRoot] {
+        &self.roots
+    }
+
+    /// Number of roots configured.
+    pub fn len(&self) -> usize {
+        self.roots.len()
+    }
+}
+
+/// Decode an `ed25519:<base64url>` or bare base64url public key into a
+/// `VerifyingKey`. The `ed25519:` prefix is the canonical form; the bare
+/// form is accepted for forward-compatibility with operator-typed input.
+pub fn decode_ed25519_pubkey(s: &str) -> Result<VerifyingKey, String> {
+    let b64 = s.strip_prefix("ed25519:").unwrap_or(s);
+    let bytes = URL_SAFE_NO_PAD
+        .decode(b64)
+        .map_err(|e| format!("base64url decode failed: {e}"))?;
+    let arr: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| format!("expected 32-byte public key, got {} bytes", bytes.len()))?;
+    VerifyingKey::from_bytes(&arr).map_err(|e| format!("not a valid Ed25519 public key: {e}"))
+}
+
+/// Encode a `VerifyingKey` into the canonical `ed25519:<base64url>` form.
+pub fn encode_ed25519_pubkey(key: &VerifyingKey) -> String {
+    format!("ed25519:{}", URL_SAFE_NO_PAD.encode(key.to_bytes()))
+}
+
+fn check_trust_file_perms(path: &Path) -> Result<(), TrustRootError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // Honour the same bypass the keystore honors -- CI sandboxes and
+        // recovery flows occasionally need to load on a loose-perm file.
+        if std::env::var_os("TREESHIP_ALLOW_INSECURE_KEY_PERMS")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+        let meta = fs::metadata(path)?;
+        let mode = meta.permissions().mode();
+        if mode & 0o077 != 0 {
+            return Err(TrustRootError::PermissionsTooOpen {
+                path: path.to_path_buf(),
+                mode,
+            });
+        }
+    }
+    let _ = path;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        let mut b = [0u8; 4];
+        use rand::RngCore;
+        rand::thread_rng().fill_bytes(&mut b);
+        p.push(format!("treeship-trust-test-{tag}-{}", hex::encode(b)));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn cleanup(p: &Path) {
+        let _ = fs::remove_dir_all(p);
+    }
+
+    fn fresh_root(key_id: &str, kind: TrustRootKind) -> (SigningKey, TrustRoot) {
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let pk = sk.verifying_key();
+        let root = TrustRoot {
+            key_id:     key_id.into(),
+            public_key: encode_ed25519_pubkey(&pk),
+            kind,
+            label:      format!("test root {key_id}"),
+            added_at:   "2026-05-15T00:00:00Z".into(),
+        };
+        (sk, root)
+    }
+
+    #[test]
+    fn roundtrip_save_load() {
+        let dir = tmp_dir("roundtrip");
+        let path = dir.join("trust_roots.json");
+        let (_, r1) = fresh_root("hub_a", TrustRootKind::HubCheckpoint);
+        let (_, r2) = fresh_root("ship_b", TrustRootKind::Ship);
+        let store = TrustRootStore::with_roots(vec![r1.clone(), r2.clone()]);
+        store.save(&path).unwrap();
+        let loaded = TrustRootStore::open(&path).unwrap();
+        assert_eq!(loaded.roots().len(), 2);
+        assert_eq!(loaded.roots()[0], r1);
+        assert_eq!(loaded.roots()[1], r2);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn rejects_missing_file() {
+        let dir = tmp_dir("missing");
+        let path = dir.join("nope.json");
+        match TrustRootStore::open(&path).unwrap_err() {
+            TrustRootError::NotConfigured { path: p } => assert_eq!(p, path),
+            other => panic!("expected NotConfigured, got {other:?}"),
+        }
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let dir = tmp_dir("malformed");
+        let path = dir.join("trust_roots.json");
+        fs::write(&path, b"{ this is not json").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        match TrustRootStore::open(&path).unwrap_err() {
+            TrustRootError::Malformed { path: p, .. } => assert_eq!(p, path),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn rejects_empty_roots() {
+        let dir = tmp_dir("empty");
+        let path = dir.join("trust_roots.json");
+        let file = serde_json::json!({"version": 1, "roots": []});
+        fs::write(&path, serde_json::to_vec_pretty(&file).unwrap()).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        match TrustRootStore::open(&path).unwrap_err() {
+            TrustRootError::Empty { path: p } => assert_eq!(p, path),
+            other => panic!("expected Empty, got {other:?}"),
+        }
+        cleanup(&dir);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn permission_too_open_warns() {
+        use std::os::unix::fs::PermissionsExt;
+        // Ensure the bypass env var isn't leaking in from the host.
+        std::env::remove_var("TREESHIP_ALLOW_INSECURE_KEY_PERMS");
+
+        let dir = tmp_dir("perms");
+        let path = dir.join("trust_roots.json");
+        let (_, r) = fresh_root("hub_a", TrustRootKind::HubCheckpoint);
+        let file = TrustRootFile { version: SCHEMA_VERSION, roots: vec![r] };
+        fs::write(&path, serde_json::to_vec_pretty(&file).unwrap()).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        match TrustRootStore::open(&path).unwrap_err() {
+            TrustRootError::PermissionsTooOpen { path: p, mode } => {
+                assert_eq!(p, path);
+                assert_eq!(mode & 0o777, 0o644);
+            }
+            other => panic!("expected PermissionsTooOpen, got {other:?}"),
+        }
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn contains_matches_kind_correctly() {
+        let (sk, r) = fresh_root("hub_a", TrustRootKind::HubCheckpoint);
+        let store = TrustRootStore::with_roots(vec![r]);
+        let vk = sk.verifying_key();
+
+        assert!(store.contains(&vk, TrustRootKind::HubCheckpoint),
+                "must accept matching kind");
+        assert!(!store.contains(&vk, TrustRootKind::Ship),
+                "must reject mismatching kind");
+        assert!(!store.contains(&vk, TrustRootKind::AgentCert),
+                "must reject mismatching kind");
+    }
+
+    #[test]
+    fn add_replaces_same_key_id_and_kind() {
+        let mut store = TrustRootStore::empty();
+        let (_, r1) = fresh_root("hub_a", TrustRootKind::HubCheckpoint);
+        let (_, r1b) = fresh_root("hub_a", TrustRootKind::HubCheckpoint);
+        store.add(r1);
+        store.add(r1b.clone());
+        assert_eq!(store.len(), 1, "same (id, kind) replaces previous");
+        assert_eq!(&store.roots()[0], &r1b);
+    }
+
+    #[test]
+    fn add_keeps_same_key_id_across_kinds() {
+        let mut store = TrustRootStore::empty();
+        let (_, r_hub) = fresh_root("issuer_x", TrustRootKind::HubCheckpoint);
+        let (_, r_ship) = fresh_root("issuer_x", TrustRootKind::Ship);
+        store.add(r_hub);
+        store.add(r_ship);
+        assert_eq!(store.len(), 2, "same id is allowed across different kinds");
+    }
+
+    #[test]
+    fn remove_strips_all_kinds_for_id() {
+        let mut store = TrustRootStore::empty();
+        let (_, r_hub) = fresh_root("issuer_x", TrustRootKind::HubCheckpoint);
+        let (_, r_ship) = fresh_root("issuer_x", TrustRootKind::Ship);
+        store.add(r_hub);
+        store.add(r_ship);
+        assert!(store.remove("issuer_x"));
+        assert!(store.is_empty());
+        assert!(!store.remove("issuer_x"), "second remove is a no-op");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let pk = sk.verifying_key();
+        let encoded = encode_ed25519_pubkey(&pk);
+        assert!(encoded.starts_with("ed25519:"));
+        let decoded = decode_ed25519_pubkey(&encoded).unwrap();
+        assert_eq!(decoded.to_bytes(), pk.to_bytes());
+    }
+
+    #[test]
+    fn decode_accepts_bare_base64() {
+        let sk = SigningKey::generate(&mut rand::thread_rng());
+        let pk = sk.verifying_key();
+        let bare = URL_SAFE_NO_PAD.encode(pk.to_bytes());
+        let decoded = decode_ed25519_pubkey(&bare).unwrap();
+        assert_eq!(decoded.to_bytes(), pk.to_bytes());
+    }
+}

--- a/packages/core/tests/hub_checkpoint_verify.rs
+++ b/packages/core/tests/hub_checkpoint_verify.rs
@@ -19,13 +19,28 @@ use serde_json::Value;
 
 use treeship_core::session::{
     build_package_with_approvals, read_approvals_bundle, verify_package,
-    ApprovalsBundle, VerifyStatus,
+    verify_package_with_trust, ApprovalsBundle, VerifyStatus,
 };
 use treeship_core::statements::{
     CheckpointKind, JournalCheckpoint, ApprovalUse, ReplayCheckLevel,
     TYPE_APPROVAL_USE, TYPE_JOURNAL_CHECKPOINT,
     approval_use_record_digest, journal_checkpoint_record_digest,
 };
+use treeship_core::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
+
+/// Build a trust store that pins `pk` for hub-org-checkpoint verification.
+/// Every hub-org test below uses this -- post-pin, `verify_package` reads
+/// the operator's default trust roots from disk, but in-process tests need
+/// to thread an explicit store via `verify_package_with_trust`.
+fn trust_for_hub(pk: &ed25519_dalek::VerifyingKey) -> TrustRootStore {
+    TrustRootStore::with_roots(vec![TrustRoot {
+        key_id:     "hub_test".into(),
+        public_key: encode_ed25519_pubkey(pk),
+        kind:       TrustRootKind::Ship,
+        label:      "test hub".into(),
+        added_at:   "2026-05-15T00:00:00Z".into(),
+    }])
+}
 
 // ---------------------------------------------------------------------------
 // Fixture builders
@@ -167,6 +182,7 @@ fn no_hub_checkpoint_no_row() {
 #[test]
 fn valid_hub_checkpoint_passes() {
     let sk = SigningKey::from_bytes(&[7u8; 32]);
+    let trust = trust_for_hub(&sk.verifying_key());
 
     let mut bundle = ApprovalsBundle::default();
     let u = make_use("use_a", "art_g", 1);
@@ -175,7 +191,7 @@ fn valid_hub_checkpoint_passes() {
     bundle.checkpoints.push(cp);
 
     let pkg = build_package_with_bundle(bundle);
-    let checks = verify_package(&pkg).unwrap();
+    let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
     assert_eq!(hub.status, VerifyStatus::Pass, "expected PASS, got: {hub:?}");
@@ -187,6 +203,7 @@ fn valid_hub_checkpoint_passes() {
 #[test]
 fn tampered_hub_signature_warns_default() {
     let sk = SigningKey::from_bytes(&[8u8; 32]);
+    let trust = trust_for_hub(&sk.verifying_key());
 
     let u = make_use("use_a", "art_g", 1);
     let mut cp = sign_hub_checkpoint(&sk, vec!["use_a".into()]);
@@ -199,7 +216,7 @@ fn tampered_hub_signature_warns_default() {
     bundle.checkpoints.push(cp);
 
     let pkg = build_package_with_bundle(bundle);
-    let checks = verify_package(&pkg).unwrap();
+    let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
     assert_eq!(hub.status, VerifyStatus::Warn, "expected WARN on tamper, got: {hub:?}");
@@ -215,6 +232,7 @@ fn tampered_hub_signature_warns_default() {
 #[test]
 fn hub_checkpoint_missing_use_coverage_warns() {
     let sk = SigningKey::from_bytes(&[9u8; 32]);
+    let trust = trust_for_hub(&sk.verifying_key());
 
     let u_a = make_use("use_a", "art_g", 1);
     let u_b = make_use("use_b", "art_g", 1);
@@ -227,7 +245,7 @@ fn hub_checkpoint_missing_use_coverage_warns() {
     bundle.checkpoints.push(cp);
 
     let pkg = build_package_with_bundle(bundle);
-    let checks = verify_package(&pkg).unwrap();
+    let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
     assert_eq!(hub.status, VerifyStatus::Warn, "expected WARN on missing coverage, got: {hub:?}");
@@ -240,6 +258,7 @@ fn hub_checkpoint_missing_use_coverage_warns() {
 #[test]
 fn hub_checkpoint_missing_field_warns() {
     let sk = SigningKey::from_bytes(&[10u8; 32]);
+    let trust = trust_for_hub(&sk.verifying_key());
 
     let u = make_use("use_a", "art_g", 1);
     let mut cp = sign_hub_checkpoint(&sk, vec!["use_a".into()]);
@@ -250,11 +269,36 @@ fn hub_checkpoint_missing_field_warns() {
     bundle.checkpoints.push(cp);
 
     let pkg = build_package_with_bundle(bundle);
-    let checks = verify_package(&pkg).unwrap();
+    let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
     assert_eq!(hub.status, VerifyStatus::Warn);
     assert!(hub.detail.contains("hub_id"), "detail should name missing field: {}", hub.detail);
+}
+
+/// Trust pin: a checkpoint signed by a key not in the operator's
+/// trust store must surface as UntrustedIssuer (rendered as WARN, with
+/// detail referencing `treeship trust add`). This is the headline
+/// audit fix -- previously a self-signed checkpoint passed silently.
+#[test]
+fn hub_checkpoint_with_untrusted_issuer_warns() {
+    let attacker_sk = SigningKey::from_bytes(&[42u8; 32]);
+    // Operator trusts a DIFFERENT issuer.
+    let honest_sk = SigningKey::from_bytes(&[7u8; 32]);
+    let trust = trust_for_hub(&honest_sk.verifying_key());
+
+    let mut bundle = ApprovalsBundle::default();
+    bundle.uses.push(make_use("use_a", "art_g", 1));
+    bundle.checkpoints.push(sign_hub_checkpoint(&attacker_sk, vec!["use_a".into()]));
+
+    let pkg = build_package_with_bundle(bundle);
+    let checks = verify_package_with_trust(&pkg, &trust).unwrap();
+    let hub = checks.iter().find(|c| c.name == "replay-hub-org")
+        .expect("replay-hub-org row expected");
+    assert_eq!(hub.status, VerifyStatus::Warn,
+               "untrusted-issuer must not promote to Pass: {hub:?}");
+    assert!(hub.detail.contains("not a trusted root") || hub.detail.contains("treeship trust add"),
+            "detail must reference the trust remediation: {}", hub.detail);
 }
 
 /// Acceptance: a LocalJournal-kind checkpoint must NOT promote

--- a/packages/core/tests/hub_checkpoint_verify.rs
+++ b/packages/core/tests/hub_checkpoint_verify.rs
@@ -198,10 +198,11 @@ fn valid_hub_checkpoint_passes() {
     assert!(hub.detail.contains("verifies"), "detail should mention verification: {}", hub.detail);
 }
 
-/// Acceptance: tampered signature -> default WARN (CLI --strict promotes
-/// to FAIL; tested in the CLI integration tests).
+/// Acceptance: tampered signature -> FAIL by default (audit lane J
+/// fix-up). Previously this was WARN and --strict promoted to FAIL,
+/// which let forged signatures exit 0 in default mode.
 #[test]
-fn tampered_hub_signature_warns_default() {
+fn tampered_hub_signature_fails_default() {
     let sk = SigningKey::from_bytes(&[8u8; 32]);
     let trust = trust_for_hub(&sk.verifying_key());
 
@@ -219,7 +220,8 @@ fn tampered_hub_signature_warns_default() {
     let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
-    assert_eq!(hub.status, VerifyStatus::Warn, "expected WARN on tamper, got: {hub:?}");
+    assert_eq!(hub.status, VerifyStatus::Fail,
+               "tampered signature must FAIL by default (not warn): {hub:?}");
     assert!(
         hub.detail.contains("hub signature failed") || hub.detail.contains("tampered"),
         "detail should mention signature failure: {}",
@@ -277,11 +279,14 @@ fn hub_checkpoint_missing_field_warns() {
 }
 
 /// Trust pin: a checkpoint signed by a key not in the operator's
-/// trust store must surface as UntrustedIssuer (rendered as WARN, with
-/// detail referencing `treeship trust add`). This is the headline
-/// audit fix -- previously a self-signed checkpoint passed silently.
+/// trust store must surface as UntrustedIssuer and FAIL by default
+/// (not warn). This is the headline audit fix -- previously a
+/// self-signed checkpoint passed silently, then was downgraded to a
+/// WARN that exited 0 unless the user remembered `--strict`. Now any
+/// untrusted-issuer or tampered hub signature is a hard failure
+/// regardless of strict mode.
 #[test]
-fn hub_checkpoint_with_untrusted_issuer_warns() {
+fn hub_checkpoint_with_untrusted_issuer_fails() {
     let attacker_sk = SigningKey::from_bytes(&[42u8; 32]);
     // Operator trusts a DIFFERENT issuer.
     let honest_sk = SigningKey::from_bytes(&[7u8; 32]);
@@ -295,8 +300,8 @@ fn hub_checkpoint_with_untrusted_issuer_warns() {
     let checks = verify_package_with_trust(&pkg, &trust).unwrap();
     let hub = checks.iter().find(|c| c.name == "replay-hub-org")
         .expect("replay-hub-org row expected");
-    assert_eq!(hub.status, VerifyStatus::Warn,
-               "untrusted-issuer must not promote to Pass: {hub:?}");
+    assert_eq!(hub.status, VerifyStatus::Fail,
+               "untrusted-issuer must FAIL by default (not warn): {hub:?}");
     assert!(hub.detail.contains("not a trusted root") || hub.detail.contains("treeship trust add"),
             "detail must reference the trust remediation: {}", hub.detail);
 }

--- a/packages/verify-js/src/index.ts
+++ b/packages/verify-js/src/index.ts
@@ -16,9 +16,44 @@
 // load cost; subsequent calls reuse cached bindings.
 type WasmBindings = {
   verify_receipt: (json: string) => string;
-  verify_certificate: (json: string, now: string) => string;
-  cross_verify: (receipt: string, cert: string, now: string) => string;
+  verify_certificate: (json: string, now: string, trustRoots: string) => string;
+  cross_verify: (
+    receipt: string,
+    cert: string,
+    now: string,
+    trustRoots: string,
+  ) => string;
 };
+
+/**
+ * Trust roots input shape. Mirrors the on-disk
+ * `~/.treeship/trust_roots.json` so the browser-side verifier sees the
+ * same data the CLI does.
+ */
+export interface TrustRootInput {
+  key_id: string;
+  /** `ed25519:<base64url-no-pad>` */
+  public_key: string;
+  kind: 'hub_checkpoint' | 'ship' | 'agent_cert';
+  label?: string;
+  added_at?: string;
+}
+
+export interface TrustRootsBundle {
+  version: 1;
+  roots: TrustRootInput[];
+}
+
+/** Empty bundle is valid input -- the verifier will fail-closed. */
+function serializeTrustRoots(
+  roots: TrustRootsBundle | TrustRootInput[] | undefined,
+): string {
+  if (!roots) return '';
+  if (Array.isArray(roots)) {
+    return JSON.stringify({ version: 1, roots });
+  }
+  return JSON.stringify(roots);
+}
 
 let wasmBindings: WasmBindings | null = null;
 
@@ -119,8 +154,14 @@ export async function verifyReceipt(
 
 /**
  * Verify an Agent Certificate. Checks the embedded Ed25519 signature
- * against the certificate's embedded public key, then optionally
+ * against a trust root the caller pins via `trustRoots`, then optionally
  * classifies the validity window relative to `now`.
+ *
+ * `trustRoots` is REQUIRED for the signature to be accepted: as of the
+ * v0.10.3 trust-root audit fix, the previous self-signed behavior (trust
+ * the embedded pubkey) is gone. Pass the same JSON shape your CLI uses
+ * (`~/.treeship/trust_roots.json`) or an array of `TrustRootInput`.
+ * Omit it to get a deliberate fail-closed result for diagnostic UIs.
  *
  * Omit `now` (or pass `undefined`) to defer validity classification
  * (signature-only). Pass a `Date` or RFC 3339 string to check expiry.
@@ -128,12 +169,15 @@ export async function verifyReceipt(
 export async function verifyCertificate(
   target: VerifyTarget,
   now?: Date | string,
+  trustRoots?: TrustRootsBundle | TrustRootInput[],
 ): Promise<VerifyCertificateResult> {
   const json = await normalizeToJson(target);
   const nowStr =
     now === undefined ? '' : now instanceof Date ? now.toISOString() : now;
   const wasm = await loadWasm();
-  return JSON.parse(wasm.verify_certificate(json, nowStr));
+  return JSON.parse(
+    wasm.verify_certificate(json, nowStr, serializeTrustRoots(trustRoots)),
+  );
 }
 
 /**
@@ -143,12 +187,15 @@ export async function verifyCertificate(
  * session called authorized by the certificate?
  *
  * The `ok` field is the roll-up: true iff all three checks pass. Defaults
- * `now` to `Date.now()` if omitted.
+ * `now` to `Date.now()` if omitted. As with `verifyCertificate`,
+ * `trustRoots` is required for the certificate's embedded signature to
+ * be accepted.
  */
 export async function crossVerify(
   receipt: VerifyTarget,
   certificate: VerifyTarget,
   now?: Date | string,
+  trustRoots?: TrustRootsBundle | TrustRootInput[],
 ): Promise<CrossVerifyResult> {
   const [receiptJson, certJson] = await Promise.all([
     normalizeToJson(receipt),
@@ -161,5 +208,7 @@ export async function crossVerify(
         ? now.toISOString()
         : now;
   const wasm = await loadWasm();
-  return JSON.parse(wasm.cross_verify(receiptJson, certJson, nowStr));
+  return JSON.parse(
+    wasm.cross_verify(receiptJson, certJson, nowStr, serializeTrustRoots(trustRoots)),
+  );
 }


### PR DESCRIPTION
## Summary

- Add \`TrustRootStore\` module + \`~/.treeship/trust_roots.json\` (mode 0o600) listing pinned issuers (audit P0 #3).
- Wire all 3 previously-self-signed verifiers to require the embedded pubkey match a configured trust root:
  - \`Checkpoint::verify(&self, trust: &TrustRootStore)\`
  - \`verify_hub_checkpoint_signature(&cp, &TrustRootStore)\`
  - \`agent::verify_certificate(&cert, &TrustRootStore)\`
- New \`treeship trust {list, add, remove}\` CLI subcommands (with \`--format json\` envelopes following Lane G's pattern).
- WASM bindings (\`verify_certificate\`, \`cross_verify\`, \`verify_merkle_proof\`) now accept \`trust_roots_json\` for browser/Node verifier callers.
- 23 new tests across 6 surfaces; integration test \`hub_checkpoint_with_untrusted_issuer_warns\` proves the verifier-side gate fires.

## Audit context

Part of the pre-launch audit. Lane J addresses original P0 #3 (verifiers trust the embedded pubkey — self-signed always passes).

**Trust root JSON format:**
\`\`\`json
{
  "version": 1,
  "roots": [
    {
      "key_id": "hub_zerker_labs",
      "public_key": "ed25519:<base64>",
      "kind": "hub_checkpoint",
      "label": "...",
      "added_at": "2026-05-15T00:00:00Z"
    }
  ]
}
\`\`\`

Kinds: \`hub_checkpoint\` | \`ship\` | \`agent_cert\`. Permissions enforced at load (0o600). \`TREESHIP_TRUST_ROOTS\` env var overrides the default path.

**Cross-lane coordination:**
- Lane H (PR #86): same shape — "pass a verifier with trusted keys to anything that verifies." This PR applies it to the 3 self-signed boundaries Lane H didn't cover.
- Lane I (PR #88): both touch \`checkpoint.rs\` but with no textual overlap — Lane I adds a struct field, this PR modifies the \`verify\` method signature.

## Breaking change

Self-signed checkpoint/cert verification no longer passes. To unblock existing deployments:
\`\`\`bash
treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert> [--label "..."]
\`\`\`

If no trust roots configured, verifier returns a clear error message referencing the CLI command. Future \`treeship hub sync-trust\` (separate lane) will sync roots from a configured hub.

## Test plan

- [ ] CI green
- [ ] \`cargo test -p treeship-core --lib trust\` — 11 module tests pass
- [ ] \`cargo test -p treeship-core --tests hub_checkpoint_verify\` — 8 integration tests (incl. new untrusted-issuer case)
- [ ] \`treeship trust list\` returns empty store on fresh install with clear "configure" message
- [ ] \`treeship trust add ... --format json\` emits structured envelope