### PR TITLE
Release v0.10.4 — Audit P1 Follow-ups

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## 0.10.4 (unreleased)
+## 0.10.4 (2026-05-17)
 
-The **Audit Follow-ups (P1)** release. v0.10.3 closed the P0 findings; v0.10.4 closes the P1 follow-ups that surfaced while landing them.
+The **Audit Follow-ups (P1)** release. v0.10.3 closed the P0 findings; v0.10.4 closes the P1 follow-ups that surfaced while landing them, plus an OpenClaw event-capture fix and the Codex contributor skill.
 
-The connective theme: v0.10.3 fixed the headline downgrade (`merkle_version`), v0.10.4 fixes the long tail. Same bug class, same fix shape — bind every wire-controllable field that participates in dispatch or display.
+The connective theme: v0.10.3 fixed the headline downgrade (`merkle_version`), v0.10.4 fixes the long tail. Same bug class, same fix shape: bind every wire-controllable field that participates in dispatch or display.
+
+Eight PRs from the v0.10.3 audit follow-up wave ship in this release: five P1s (#93, #94, #95, #96, #98) and three P2s (#92, #97, #99). Plus two unrelated improvements that landed alongside: an OpenClaw integration hook-capture fix (commit `41271cd`) and the Codex contributor skill docs.
 
 ### Security
 
@@ -26,6 +28,7 @@ The connective theme: v0.10.3 fixed the headline downgrade (`merkle_version`), v
 ### Fixed
 
 - **CLI no longer panics on unexpected enum variants in `treeship prove` and `treeship verify --external` (`prove.rs:127`, `verify_external.rs:224`).** The two `unreachable!()` calls were reachable via clap-parsed input; replaced with explicit `Err` returns with actionable messages.
+- **OpenClaw plugin now captures tool calls under OpenClaw v0.10.3's hook API.** Three issues fixed in one pass. (1) Hook registration: OpenClaw v0.10.3 switched to camelCase hook names (`beforeToolCall`/`afterToolCall`) with an `api.on()` registration method; the plugin now registers under BOTH the snake_case + camelCase names AND via both `registerHook` + `api.on()`, so events are captured regardless of which hook surface OpenClaw uses at runtime. (2) Event types: `before_tool_call` now emits `agent.called_tool` with `phase=intent` metadata (not the unsupported `agent.requested_tool`); the bash handler emits `agent.called_tool` with `command` metadata (not the unsupported `agent.ran_shell`); the network handler emits `agent.connected_network` with `--destination`. (3) Type safety: dynamic hook registration sites use `as any` casts for TypeScript without runtime impact. End-to-end verified on a real OpenClaw session: paired intent + result events captured correctly for `read`, `exec`, and network calls.
 
 ### Internal
 
@@ -35,6 +38,7 @@ The connective theme: v0.10.3 fixed the headline downgrade (`merkle_version`), v
 
 ### Documentation
 
+- **Codex contributor skill added.** `skills/treeship-dev/SKILL.md` plus `plugins/treeship-dev/.codex-plugin/plugin.json` give Codex (and any other agent that consumes the Codex plugin format) a single declarative skill describing how to work safely in the Treeship source repo: scope, required read order, crypto invariants, CLI UX rules, validation commands. Mirrors the structure of the `skills/treeship` agent skill from v0.10.2 (#67); same shape, different audience (contributor vs. end-user). `docs/content/docs/integrations/codex.mdx` is the docs page; `integrations/codex/README.md` covers local setup. Closes the v0.10.2 follow-on of "every supported agent gets a Treeship skill" by adding Codex to the list.
 - **Documented subcrate version policy (`docs/architecture/subcrate-versions.md`).** `packages/vi`, `packages/zk-circom`, and `packages/zk-risc0` follow independent release cadences from the main Treeship monorepo (each is `publish = false` and not a hard dependency of the CLI release path). The version-consistency preflight (`scripts/check-release-versions.py`) intentionally does not cover them. `CONTRIBUTING.md` now points at the new doc and the project-structure table calls out the sibling-cadence crates. Closes a v0.10.3 audit P2 flagging version skew between `packages/core` (0.10.3) and `packages/vi` (0.6.0) / `packages/zk-*` (0.5.0). No genuine drift found; the stale `packages/zk-circom/package.json` at 1.0.0 (npm scaffolding default, never published, never consumed) is documented as cosmetic cleanup, not skew.
 
 ## 0.10.3 (2026-05-17)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64",
  "clap",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.3"
+    "@treeship/core-wasm": "0.10.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.10.3",
+    "@treeship/core-wasm": "0.10.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/docs/content/docs/integrations/agent-skills.mdx
+++ b/docs/content/docs/integrations/agent-skills.mdx
@@ -27,6 +27,9 @@ npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y
 # Codex
 npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
 
+# Codex contributor skill for this repo
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+
 # Cursor
 npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y
 
@@ -81,6 +84,16 @@ Codex's MCP config lives at `~/.codex/config.toml`; Hermes routes commands throu
 
 The skill's job is to lift any agent from "doesn't know about Treeship" to at least Medium. Adding the MCP bridge — or installing the [Claude Code plugin](/integrations/claude-code) where available — lifts coverage to High. See the [coverage levels guide](/guides/coverage-levels) for the full ladder.
 
+## Contributor Skill for Codex
+
+The public `treeship` skill teaches agents how to use Treeship. The `treeship-dev` skill is narrower: it teaches Codex how to work inside the `zerkerlabs/treeship` source repo without violating protocol invariants.
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+```
+
+Use it when an agent is editing `packages/core`, `packages/cli`, `packages/hub`, SDKs, docs, or integration packages in this repo. It tells Codex to read `AGENTS.md` and `ONBOARDING.md`, preserve DSSE/PAE and artifact ID rules, keep CLI UX stable, and choose focused validation commands. A Codex plugin candidate that bundles this contributor skill lives at [`plugins/treeship-dev`](https://github.com/zerkerlabs/treeship/tree/main/plugins/treeship-dev).
+
 ## How It Works
 
 `SKILL.md` is a [YAML-frontmatter Markdown file](https://github.com/anthropics/skills) the agent loads as durable instructions. The frontmatter has a `name` and a `description`; the description is what the agent matches against the user's intent to decide when the skill applies. The body is regular Markdown — code blocks, tables, headings — that the agent reads as authoritative reference for the API.
@@ -114,7 +127,9 @@ The skill leaves no other state behind — no daemons, no background processes, 
 ## Resources
 
 - [`skills/treeship/SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship/SKILL.md) — the skill content
+- [`skills/treeship-dev/SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship-dev/SKILL.md) — Codex contributor guardrails for this repo
 - [`integrations/agent-skills/README.md`](https://github.com/zerkerlabs/treeship/blob/main/integrations/agent-skills/README.md) — full multi-agent integration guide
+- [Codex integration](/integrations/codex) — Codex skill, MCP, and plugin candidate setup
 - [Claude Code integration](/integrations/claude-code) — higher-coverage path for Claude Code (plugin)
 - [Coverage levels](/guides/coverage-levels) — what High / Medium / Basic mean
 - [Install + registry topology](/guides/install) — what's on each registry and how to install Treeship itself

--- a/docs/content/docs/integrations/codex.mdx
+++ b/docs/content/docs/integrations/codex.mdx
@@ -1,0 +1,117 @@
+---
+title: Codex
+description: Install the Treeship Codex skill, attach the MCP bridge, or test the Codex plugin candidate.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Steps, Step } from 'fumadocs-ui/components/steps';
+
+# Codex
+
+Codex has two Treeship paths today. The skill teaches Codex how to use Treeship and how to work safely in this repo. The MCP bridge captures MCP-routed tool calls into a Treeship session.
+
+<Callout type="info">
+For users building with Treeship, install the public `treeship` skill. For contributors working on this repository, install `treeship-dev`.
+</Callout>
+
+## Method 1: Install the skill
+
+<Steps>
+<Step>
+### Install the public Treeship skill
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
+```
+
+Use this when you want Codex to sign actions, verify chains, manage approvals, push receipts, or explain the Treeship CLI and SDKs.
+</Step>
+<Step>
+### Install the contributor skill
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+```
+
+Use this inside a `zerkerlabs/treeship` checkout. It tells Codex to read `AGENTS.md` and `ONBOARDING.md`, preserve DSSE and artifact ID invariants, keep CLI UX rules intact, and run focused validation.
+</Step>
+<Step>
+### Start a fresh Codex conversation
+
+Codex discovers new skills at conversation start. Open the Treeship repo and say:
+
+```text
+Use treeship-dev. Read AGENTS.md first, then update the Codex integration docs.
+```
+</Step>
+</Steps>
+
+## Method 2: Attach the MCP bridge
+
+From a project with `treeship init` already run:
+
+```bash
+curl -fsSL treeship.dev/install | sh
+treeship init
+treeship add codex
+```
+
+This appends a `[mcp_servers.treeship]` block to `~/.codex/config.toml`, creating the file and parent directories if needed.
+
+Manual config:
+
+```toml
+[mcp_servers.treeship]
+command = "npx"
+args = ["-y", "@treeship/mcp"]
+
+[mcp_servers.treeship.env]
+TREESHIP_ACTOR = "agent://codex"
+TREESHIP_HUB_ENDPOINT = "https://api.treeship.dev"
+```
+
+Restart Codex after changing MCP config.
+
+## Method 3: Codex plugin candidate
+
+The repo includes a candidate Codex plugin package at:
+
+```text
+plugins/treeship-dev/
+```
+
+It bundles the `treeship-dev` skill and a `.codex-plugin/plugin.json` manifest for local testing and future plugin submission. Until the plugin is accepted into an official marketplace, the direct skill install above is the stable path for users.
+
+For maintainers preparing submission:
+
+1. Keep `plugins/treeship-dev/skills/treeship-dev/SKILL.md` in sync with `skills/treeship-dev/SKILL.md`.
+2. Review `plugins/treeship-dev/.codex-plugin/plugin.json` for current version, URLs, policy links, and screenshots/assets if the marketplace requires them.
+3. Test in a fresh Codex session against a clean Treeship checkout.
+4. Submit the plugin package from `plugins/treeship-dev/` using the current Codex plugin submission process.
+
+## What Gets Captured
+
+The skill itself is just instructions. It does not capture anything. The MCP bridge captures MCP `callTool` activity while a Treeship session is active:
+
+- signed intent attestation before the call
+- signed result receipt after the call
+- session timeline event for the Codex actor
+
+Codex built-in shell and file tools do not currently route through this MCP bridge. Use `treeship wrap -- <command>` for commands that need explicit receipts until Codex exposes hook coverage similar to the Claude Code plugin.
+
+## Coverage
+
+| Setup | Coverage |
+|---|---|
+| `treeship` skill only | Medium: Codex knows when and how to use Treeship |
+| `treeship-dev` skill only | Medium: Codex follows repo guardrails and validation |
+| Skill + MCP bridge | High for MCP-routed tool calls |
+| Future Codex plugin | Intended to bundle the contributor skill and any future Codex-native capture points |
+
+## See Also
+
+- [`skills/treeship/SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship/SKILL.md)
+- [`skills/treeship-dev/SKILL.md`](https://github.com/zerkerlabs/treeship/blob/main/skills/treeship-dev/SKILL.md)
+- [`integrations/codex/`](https://github.com/zerkerlabs/treeship/tree/main/integrations/codex)
+- [Agent Skills](/integrations/agent-skills)
+- [MCP bridge](/integrations/mcp)

--- a/docs/content/docs/integrations/meta.json
+++ b/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["agent-skills", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
+  "pages": ["agent-skills", "codex", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "verifiable-intent"]
 }

--- a/integrations/agent-skills/README.md
+++ b/integrations/agent-skills/README.md
@@ -11,6 +11,7 @@ The skill covers the full Treeship surface: CLI commands (`treeship wrap`, `tree
 | Kimi Code CLI | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` | `kimi-cli` | `~/.config/agents/skills/` |
 | Claude Code | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` | `claude-code` | `~/.claude/skills/` |
 | Codex | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` | `codex` | `~/.codex/skills/` |
+| Codex contributor | `npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y` | `codex` | `~/.codex/skills/` |
 | Cursor | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` | `cursor` | `~/.cursor/skills/` |
 | OpenClaw | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` | `openclaw` | `~/.openclaw/skills/` |
 | Hermes | Manual curl (see below) | — | `~/.hermes/skills/` |
@@ -65,6 +66,14 @@ npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
 ```
 
 Skill lands at `~/.codex/skills/treeship/SKILL.md`. Codex picks up new skills on the next conversation; no restart required.
+
+If Codex is contributing to this repository, install the repo-specific guardrail skill too:
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+```
+
+That skill lands at `~/.codex/skills/treeship-dev/SKILL.md` and tells Codex to read `AGENTS.md`, preserve the DSSE and artifact ID invariants, and run focused validation. A Codex plugin candidate that bundles the contributor skill lives at [`plugins/treeship-dev`](../../plugins/treeship-dev/).
 
 **MCP bridge (optional)** — Codex's MCP config lives at `~/.codex/config.toml`:
 

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,8 +1,31 @@
 # Treeship + Codex CLI
 
+Codex has two Treeship paths:
+
+1. **Skills** teach Codex how to use Treeship or how to work safely in this repo.
+2. **MCP** captures MCP-routed tool calls into a Treeship session.
+
 Codex CLI talks to MCP servers via TOML config in `~/.codex/config.toml`. The same [`@treeship/mcp`](../../bridges/mcp/) bridge that powers the Claude Code and Cursor integrations works here too: every MCP `callTool` is attested and appears in the session timeline when a Treeship session is active.
 
-## Method 1: CLI (recommended)
+## Method 1: Install the Codex skills
+
+Use the public Treeship skill when you want Codex to sign actions, verify chains, manage approvals, push receipts, or explain Treeship APIs:
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y
+```
+
+Use the contributor skill when Codex is working inside this source repo:
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+```
+
+The contributor skill tells Codex to read `AGENTS.md` and `ONBOARDING.md`, preserve cryptographic invariants, keep CLI UX rules intact, and run focused validation.
+
+Open a fresh Codex conversation after installing skills.
+
+## Method 2: CLI (recommended for MCP)
 
 From a project with `treeship init` already run:
 
@@ -19,9 +42,21 @@ This appends a `[mcp_servers.treeship]` block to `~/.codex/config.toml` (creatin
 
 `treeship add` also drops `./TREESHIP.md` in the project (once) with the trust and capture details — read that before enabling the server.
 
-## Method 2: Copy the template
+## Method 3: Copy the MCP template
 
 If you prefer to edit config by hand, append the contents of `config.toml` in this directory to your existing `~/.codex/config.toml`.
+
+## Method 4: Codex plugin candidate
+
+The repo includes a candidate Codex plugin package at [`plugins/treeship-dev`](../../plugins/treeship-dev/). It bundles the `treeship-dev` skill and a `.codex-plugin/plugin.json` manifest for local testing and future plugin submission.
+
+Until that plugin is accepted into an official marketplace, the direct skill install is the stable path:
+
+```bash
+npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y
+```
+
+Maintainers preparing submission should keep the plugin-bundled skill in sync with [`skills/treeship-dev/SKILL.md`](../../skills/treeship-dev/SKILL.md), review the manifest metadata, test in a fresh Codex session, and submit `plugins/treeship-dev/` through the current Codex plugin submission process.
 
 ## Prerequisites
 

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.10.3",
-    "@treeship/cli-darwin-arm64": "0.10.3",
-    "@treeship/cli-darwin-x64": "0.10.3"
+    "@treeship/cli-linux-x64": "0.10.4",
+    "@treeship/cli-darwin-arm64": "0.10.4",
+    "@treeship/cli-darwin-x64": "0.10.4"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.10.3", path = "../core" }
+treeship-core = { version = "0.10.4", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.10.3"
+version = "0.10.4"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.10.2"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.3"
+    "@treeship/core-wasm": "0.10.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.9.2"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.3"
+    "@treeship/core-wasm": "0.10.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/plugins/treeship-dev/.codex-plugin/plugin.json
+++ b/plugins/treeship-dev/.codex-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "treeship-dev",
+  "version": "0.1.0",
+  "description": "Codex contributor skill for working safely in the Treeship source repository.",
+  "author": {
+    "name": "Zerker",
+    "url": "https://treeship.dev"
+  },
+  "homepage": "https://docs.treeship.dev/integrations/codex",
+  "repository": "https://github.com/zerkerlabs/treeship",
+  "license": "Apache-2.0",
+  "keywords": [
+    "treeship",
+    "codex",
+    "agent-skills",
+    "developer-tools",
+    "attestation"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Treeship Dev",
+    "shortDescription": "Work safely in the Treeship repo.",
+    "longDescription": "Loads Treeship contributor guidance for Codex: required repo read order, cryptographic invariants, CLI UX rules, and focused validation commands.",
+    "developerName": "Zerker",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Code",
+      "Review",
+      "Documentation"
+    ],
+    "websiteURL": "https://treeship.dev",
+    "defaultPrompt": [
+      "Use Treeship Dev and review this change.",
+      "Use Treeship Dev and update the CLI docs.",
+      "Use Treeship Dev and fix the failing test."
+    ]
+  }
+}

--- a/plugins/treeship-dev/skills/treeship-dev/SKILL.md
+++ b/plugins/treeship-dev/skills/treeship-dev/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: treeship-dev
+description: Work on the Treeship source repository safely. Use when Codex or another coding agent is asked to modify, review, document, or test the zerkerlabs/treeship repo, especially packages/core, packages/cli, packages/hub, docs, SDKs, MCP bridge, DSSE artifacts, approvals, handoffs, Hub/Dock/DPoP, or cryptographic verification behavior. This skill provides repo scope, required read order, crypto invariants, CLI UX rules, and validation commands for contributors.
+---
+
+# Treeship Dev
+
+## Start Here
+
+Use the local `zerkerlabs/treeship` checkout as the workspace root. Stay scoped to that repo unless the user explicitly asks to inspect sibling repos.
+
+Read these files before code changes:
+
+1. `AGENTS.md`
+2. `ONBOARDING.md`
+
+Treat `AGENTS.md` as the source of truth. If these skill instructions conflict with `AGENTS.md`, follow `AGENTS.md`.
+
+## What Treeship Is
+
+Treeship is a portable trust layer for AI agent workflows. Actions, approvals, handoffs, receipts, bundles, and related records are signed artifacts that must verify without trusting hosted infrastructure.
+
+The core loop is:
+
+```bash
+treeship wrap -- your-command
+treeship hub push <artifact-id>
+```
+
+## Non-Negotiable Invariants
+
+Preserve these exactly:
+
+- DSSE PAE format: `"DSSEv1" SP LEN(payloadType) SP payloadType SP LEN(payload) SP payload`
+- Artifact ID derivation: `artifact_id = "art_" + hex(sha256(PAE_bytes)[..16])`
+- Statement structs do not contain an `id` field. IDs live on records/sign results.
+- Envelope JSON uses DSSE camelCase: `payload`, `payloadType`, `signatures`.
+- Approval nonce binding is enforced: `action.approvalNonce == approval.nonce`.
+- Hub/Dock auth uses DPoP with a separate dock keypair. Do not add session tokens.
+- Rekor anchoring is best-effort and must not make artifact push fail when Rekor is down.
+- TypeScript SDK verification must use the WASM verifier path, not a `treeship` subprocess.
+
+## Repo Map
+
+- `packages/core`: Rust core library, attestation, statements, keys, storage, verifier, Merkle.
+- `packages/cli`: Rust CLI, command tree, wrap/status/verify/hub/ui/otel commands.
+- `packages/hub`: Go Hub server and SQLite-backed API.
+- `packages/core-wasm`: Browser verifier.
+- `packages/sdk-ts`: TypeScript SDK.
+- `packages/sdk-python`: Python SDK.
+- `bridges/mcp`: MCP bridge.
+- `docs`: Fumadocs documentation.
+- `skills`: portable agent skills.
+- `plugins`: Codex plugin candidates.
+
+## Preferred Read Order
+
+For core protocol or CLI work, read:
+
+1. `packages/core/src/attestation/pae.rs`
+2. `packages/core/src/attestation/sign.rs`
+3. `packages/core/src/attestation/verify.rs`
+4. `packages/core/src/statements/mod.rs`
+5. `packages/cli/src/main.rs`
+6. `packages/cli/src/commands/wrap.rs`
+
+For Hub work, read `packages/hub/main.go` and the relevant package under `packages/hub/internal`.
+
+For docs-only work, still read `AGENTS.md`, then edit only the relevant pages under `docs`.
+
+## CLI UX Rules
+
+When changing CLI behavior:
+
+- Keep commands noninteractive.
+- Provide `--format json` where command output needs stable machine-readable output.
+- Return useful exit codes: `0` ok, `1` error, `3` not initialized, `4` usage.
+- Include a concrete fix in errors.
+- Print a dim next-step hint on success.
+- Respect `NO_COLOR` and `--no-color`.
+- `treeship wrap` must propagate the subprocess exit code.
+
+## Validation
+
+Choose focused checks for the files changed:
+
+```bash
+cargo test -p treeship-core
+cargo test -p treeship-cli
+cargo test
+```
+
+For Hub:
+
+```bash
+cd packages/hub
+go test ./...
+go build ./...
+```
+
+For TypeScript or MCP packages, inspect package scripts first, then run the relevant npm test/build command from that package directory.
+
+## Working Style
+
+Keep edits narrow. Do not refactor unrelated crypto, storage, or schema code while solving a task. Avoid changing generated IDs, signed payload shape, schema field casing, or verification semantics unless the user explicitly asks and the change is reconciled with `AGENTS.md`.
+
+Use direct, concise writing. Avoid corporate phrasing.

--- a/skills/treeship-dev/SKILL.md
+++ b/skills/treeship-dev/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: treeship-dev
+description: Work on the Treeship source repository safely. Use when Codex or another coding agent is asked to modify, review, document, or test the zerkerlabs/treeship repo, especially packages/core, packages/cli, packages/hub, docs, SDKs, MCP bridge, DSSE artifacts, approvals, handoffs, Hub/Dock/DPoP, or cryptographic verification behavior. This skill provides repo scope, required read order, crypto invariants, CLI UX rules, and validation commands for contributors.
+---
+
+# Treeship Dev
+
+## Start Here
+
+Use the local `zerkerlabs/treeship` checkout as the workspace root. Stay scoped to that repo unless the user explicitly asks to inspect sibling repos.
+
+Read these files before code changes:
+
+1. `AGENTS.md`
+2. `ONBOARDING.md`
+
+Treat `AGENTS.md` as the source of truth. If these skill instructions conflict with `AGENTS.md`, follow `AGENTS.md`.
+
+## What Treeship Is
+
+Treeship is a portable trust layer for AI agent workflows. Actions, approvals, handoffs, receipts, bundles, and related records are signed artifacts that must verify without trusting hosted infrastructure.
+
+The core loop is:
+
+```bash
+treeship wrap -- your-command
+treeship hub push <artifact-id>
+```
+
+## Non-Negotiable Invariants
+
+Preserve these exactly:
+
+- DSSE PAE format: `"DSSEv1" SP LEN(payloadType) SP payloadType SP LEN(payload) SP payload`
+- Artifact ID derivation: `artifact_id = "art_" + hex(sha256(PAE_bytes)[..16])`
+- Statement structs do not contain an `id` field. IDs live on records/sign results.
+- Envelope JSON uses DSSE camelCase: `payload`, `payloadType`, `signatures`.
+- Approval nonce binding is enforced: `action.approvalNonce == approval.nonce`.
+- Hub/Dock auth uses DPoP with a separate dock keypair. Do not add session tokens.
+- Rekor anchoring is best-effort and must not make artifact push fail when Rekor is down.
+- TypeScript SDK verification must use the WASM verifier path, not a `treeship` subprocess.
+
+## Repo Map
+
+- `packages/core`: Rust core library, attestation, statements, keys, storage, verifier, Merkle.
+- `packages/cli`: Rust CLI, command tree, wrap/status/verify/hub/ui/otel commands.
+- `packages/hub`: Go Hub server and SQLite-backed API.
+- `packages/core-wasm`: Browser verifier.
+- `packages/sdk-ts`: TypeScript SDK.
+- `packages/sdk-python`: Python SDK.
+- `bridges/mcp`: MCP bridge.
+- `docs`: Fumadocs documentation.
+- `skills`: portable agent skills.
+- `plugins`: Codex plugin candidates.
+
+## Preferred Read Order
+
+For core protocol or CLI work, read:
+
+1. `packages/core/src/attestation/pae.rs`
+2. `packages/core/src/attestation/sign.rs`
+3. `packages/core/src/attestation/verify.rs`
+4. `packages/core/src/statements/mod.rs`
+5. `packages/cli/src/main.rs`
+6. `packages/cli/src/commands/wrap.rs`
+
+For Hub work, read `packages/hub/main.go` and the relevant package under `packages/hub/internal`.
+
+For docs-only work, still read `AGENTS.md`, then edit only the relevant pages under `docs`.
+
+## CLI UX Rules
+
+When changing CLI behavior:
+
+- Keep commands noninteractive.
+- Provide `--format json` where command output needs stable machine-readable output.
+- Return useful exit codes: `0` ok, `1` error, `3` not initialized, `4` usage.
+- Include a concrete fix in errors.
+- Print a dim next-step hint on success.
+- Respect `NO_COLOR` and `--no-color`.
+- `treeship wrap` must propagate the subprocess exit code.
+
+## Validation
+
+Choose focused checks for the files changed:
+
+```bash
+cargo test -p treeship-core
+cargo test -p treeship-cli
+cargo test
+```
+
+For Hub:
+
+```bash
+cd packages/hub
+go test ./...
+go build ./...
+```
+
+For TypeScript or MCP packages, inspect package scripts first, then run the relevant npm test/build command from that package directory.
+
+## Working Style
+
+Keep edits narrow. Do not refactor unrelated crypto, storage, or schema code while solving a task. Avoid changing generated IDs, signed payload shape, schema field casing, or verification semantics unless the user explicitly asks and the change is reconciled with `AGENTS.md`.
+
+Use direct, concise writing. Avoid corporate phrasing.


### PR DESCRIPTION
## Summary

Closes the v0.10.3 audit P1 + P2 follow-ups (eight lanes), plus an OpenClaw integration hook-capture fix and the Codex contributor skill that landed alongside.

## What's in this release

**Security (P1s from audit)**
- Approval signing paths no longer fall back to empty bytes on serde encode failure (#93)
- `Ed25519Signer` zeroizes secret key on Drop; ed25519-dalek `zeroize` feature enabled (#94)
- RNG sources unified to `OsRng` in `keys/mod.rs` security paths (#96)
- TOCTOU window closed in keystore `Store::signer()` perm-check; same fix applied to `TrustRootStore::open()` (#97)

**Changed (breaking — P1)**
- Checkpoint canonical signing format bumped to v3, binding `algorithm` and `zk_proof` into the signature. Closes the downgrade vector left open by v0.10.3's v2 (#98). Second canonical break in two patch releases, intentionally landed close together so external verifiers update once.

**Fixed**
- CLI no longer panics on unexpected enum variants in `treeship prove` / `verify --external` (#95)
- OpenClaw plugin now captures tool calls under OpenClaw v0.10.3's camelCase hook API; fixes intent/result event pairing for `read`, `exec`, network calls (commit `41271cd`)

**Internal / Docs (P2s from audit + Codex skill)**
- Toolchain pinning at repo root: `rust-toolchain.toml`, `.rustfmt.toml`, `clippy.toml` (#99)
- Subcrate version policy documented (`docs/architecture/subcrate-versions.md`) (#92)
- Codex contributor skill added: `skills/treeship-dev/SKILL.md` + Codex plugin scaffolding; docs page at `docs/content/docs/integrations/codex.mdx`

## Breaking changes

The checkpoint canonical signing format bump (v2 → v3) is the only breaking wire change. Third-party verifiers that reproduce the canonical string outside Rust core MUST update. `@treeship/verify-js` is a WASM shim and inherits automatically; CLI, SDKs, and the in-browser preview all inherit through `core-wasm`. v0.10.3-era v2 checkpoints continue to verify under v2 dispatch for backwards compat. Pre-v0.10.3 v1 checkpoints continue to verify byte-identically.

`Checkpoint::canonical_for_signing` signature changed and is now `pub(crate)`, so external callers should not be affected. `Ed25519Signer::secret_bytes` return type changed from `[u8; 32]` to `Zeroizing<[u8; 32]>` (auto-deref handles most call sites).

## Test plan

- [x] `cargo test --workspace` green on the merged audit-lanes main (workspace 461+ tests, all suites pass)
- [x] `scripts/check-release-versions.py 0.10.4` passes (23/23 sites)
- [ ] CI green on this PR
- [ ] After merge: tag + push triggers release workflow, distro smoke gate runs on Debian/Ubuntu/Alpine before publishing to npm/PyPI/crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)