### PR TITLE
fix(toolchain): add cross-compile targets to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -17,7 +17,17 @@
 # Components: rustup automatically installs `clippy` and `rustfmt` for the
 # pinned channel on first cargo invocation, so local devs do not need to run
 # `rustup component add` manually.
+#
+# Targets: the release workflow cross-compiles for x86_64-apple-darwin
+# (from macOS arm64 runners), aarch64-apple-darwin (native), and
+# x86_64-unknown-linux-musl (from ubuntu glibc runners). Without these
+# listed, the `profile = "minimal"` toolchain ships only the runner's
+# native stdlib and cross-compile builds fail with `can't find crate for
+# 'core'`. The initial v0.10.4 release push (commit cf13139, tag pushed
+# 2026-05-18) failed for exactly this reason; this line restores parity
+# with what the dtolnay/rust-toolchain action sets up in CI.
 [toolchain]
 channel    = "1.94.1"
 components = ["clippy", "rustfmt"]
 profile    = "minimal"
+targets    = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
## Summary

One-line fix for the v0.10.4 release failure. The toolchain file landed in v0.10.4 with `profile = "minimal"` and no `targets =`, which stripped the cross-compile stdlibs CI uses. macOS x86_64 and Linux musl builds failed with `can't find crate for 'core'`.

## What changed

`rust-toolchain.toml` now lists the three release targets:
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`
- `x86_64-unknown-linux-musl`

## Test plan

- [x] File is valid TOML (Edit successful, build runs locally)
- [ ] CI green on this PR (validates the toolchain file parses on runners)
- [ ] After merge: retag v0.10.4 at the new merge SHA, push, release workflow rebuilds all three targets cleanly

## Followup

Once merged, retry the v0.10.4 release: delete tag locally + on origin, retag at the fix's merge SHA, push tag. The release workflow will reattempt all the publish jobs. Nothing was published in the failed run (everything downstream of the build jobs skipped), so no yank is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)