### PR TITLE
ci(release): add post-publish smoke job

### DIFF
--- a/.github/scripts/publish-smoke.sh
+++ b/.github/scripts/publish-smoke.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Post-publish smoke: install treeship from npm and treeship-sdk from PyPI
+# the way real users do, then run init → session start → wrap → close → report.
+#
+# The release workflow's `smoke` job mounts the GitHub Release binary
+# directly into containers. This script catches wrapper/optional-dep,
+# postinstall, and PyPI bootstrap/checksum failures that only show up
+# when installing from the registries.
+#
+# Usage: publish-smoke.sh <version>   # e.g. 0.10.3 (no leading v)
+
+set -euo pipefail
+
+VERSION="${1:?usage: $0 <version>}"
+WORKROOT="$(mktemp -d)"
+
+assert_cli_version() {
+  local label="$1"
+  local out="$2"
+  if ! printf '%s' "$out" | grep -Fq "$VERSION"; then
+    echo "::error::${label}: expected version ${VERSION} in output, got: ${out}"
+    exit 1
+  fi
+}
+
+session_roundtrip() {
+  local label="$1"
+  local workdir="$2"
+  mkdir -p "$workdir"
+  cd "$workdir"
+  rm -rf .treeship
+  echo "--- ${label}: init"
+  treeship init
+  echo "--- ${label}: session start"
+  treeship session start --name "publish-smoke-${label}"
+  echo "--- ${label}: wrap"
+  treeship wrap -- echo "publish-smoke-${label}"
+  echo "--- ${label}: session close"
+  treeship session close
+  echo "--- ${label}: session report"
+  REPORT_JSON="$(treeship session report --no-upload --format json)"
+  python3 - <<'PY' "$REPORT_JSON" "$VERSION" "$label"
+import json, sys
+report, version, label = sys.argv[1], sys.argv[2], sys.argv[3]
+data = json.loads(report)
+schema = data.get("schema")
+status = data.get("verification_status")
+if schema != "treeship/share-result/v1":
+    raise SystemExit(f"::error::{label}: unexpected schema {schema!r}")
+if status != "pass":
+    raise SystemExit(f"::error::{label}: verification_status={status!r}")
+print(f"  ✓ {label}: session report schema={schema} verification_status={status}")
+PY
+}
+
+echo "=== publish-smoke ${VERSION} (workroot=${WORKROOT}) ==="
+
+# ---------------------------------------------------------------------------
+# npm: treeship@VERSION (global install, linux x86_64 optional dep)
+# ---------------------------------------------------------------------------
+export HOME="${WORKROOT}/home-npm"
+mkdir -p "$HOME"
+NPM_PREFIX="${WORKROOT}/npm-global"
+export NPM_CONFIG_PREFIX="$NPM_PREFIX"
+export PATH="${NPM_PREFIX}/bin:${PATH}"
+
+echo "--- npm install -g treeship@${VERSION}"
+npm install -g "treeship@${VERSION}"
+
+if ! command -v treeship >/dev/null 2>&1; then
+  echo "::error::npm: treeship not on PATH after global install (prefix=${NPM_PREFIX})"
+  exit 1
+fi
+
+NPM_VERSION_OUT="$(treeship --version)"
+echo "  ${NPM_VERSION_OUT}"
+assert_cli_version "npm" "$NPM_VERSION_OUT"
+session_roundtrip "npm" "${WORKROOT}/work-npm"
+
+# ---------------------------------------------------------------------------
+# PyPI: treeship-sdk==VERSION → bootstrap CLI → same session round-trip
+# ---------------------------------------------------------------------------
+export HOME="${WORKROOT}/home-pypi"
+mkdir -p "$HOME"
+PY_VENV="${WORKROOT}/venv"
+export PATH="/usr/bin:/bin"
+python3 -m venv "$PY_VENV"
+# shellcheck source=/dev/null
+source "${PY_VENV}/bin/activate"
+
+echo "--- pip install treeship-sdk==${VERSION}"
+pip install --no-cache-dir "treeship-sdk==${VERSION}"
+
+SDK_VER="$(python -c "import treeship_sdk; print(treeship_sdk.__version__)")"
+if [ "$SDK_VER" != "$VERSION" ]; then
+  echo "::error::pypi: treeship-sdk version ${SDK_VER} != ${VERSION}"
+  exit 1
+fi
+echo "  ✓ treeship-sdk ${SDK_VER}"
+
+if command -v treeship >/dev/null 2>&1; then
+  echo "::error::pypi: treeship unexpectedly on PATH before bootstrap (would mask bootstrap)"
+  exit 1
+fi
+
+echo "--- python -m treeship_sdk.bootstrap_cli"
+BOOT_JSON="$(python -m treeship_sdk.bootstrap_cli --json)"
+python3 - <<'PY' "$BOOT_JSON" "$VERSION"
+import json, sys
+data = json.loads(sys.argv[1])
+version = sys.argv[2]
+if not data.get("ok"):
+    raise SystemExit(f"::error::pypi bootstrap failed: {data!r}")
+if version not in data.get("version", ""):
+    raise SystemExit(f"::error::pypi bootstrap version {data.get('version')!r} != {version}")
+if data.get("source") not in ("github-release", "cache", "path", "npm"):
+    raise SystemExit(f"::error::pypi bootstrap unexpected source: {data.get('source')!r}")
+print(f"  ✓ bootstrap ok source={data.get('source')} binary={data.get('binary')}")
+PY
+
+BIN="$(python3 -c "import json,sys; print(json.load(sys.stdin)['binary'])" <<<"$BOOT_JSON")"
+export PATH="$(dirname "$BIN"):${PATH}"
+
+PYPI_VERSION_OUT="$(treeship --version)"
+echo "  ${PYPI_VERSION_OUT}"
+assert_cli_version "pypi" "$PYPI_VERSION_OUT"
+session_roundtrip "pypi" "${WORKROOT}/work-pypi"
+
+echo "=== publish-smoke ${VERSION} OK ==="

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -628,3 +628,30 @@ jobs:
 
       - name: Verify treeship-sdk on PyPI
         run: .github/scripts/wait-for-pypi-version.sh treeship-sdk "${GITHUB_REF_NAME#v}"
+
+  # Install from npm and PyPI the way users do — not via a mounted GitHub
+  # Release binary. Catches wrapper/optional-dep/postinstall failures and
+  # PyPI wheel checksum/bootstrap gaps that the `smoke` job cannot see.
+  publish-smoke:
+    needs: [publish-npm, publish-pypi]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Wait for registry versions (belt-and-braces)
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          bash .github/scripts/wait-for-npm-version.sh treeship "$VERSION"
+          bash .github/scripts/wait-for-pypi-version.sh treeship-sdk "$VERSION"
+
+      - name: Fresh-install publish smoke (npm + PyPI)
+        run: bash .github/scripts/publish-smoke.sh "${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## Summary

Adds a `publish-smoke` job that runs after `publish-npm` + `publish-pypi` succeed. Installs treeship from npm and treeship-sdk from PyPI the way real users do, then exercises the full session round-trip (`init → session start → wrap → close → session report`) and asserts the report's schema + verification_status.

## Why

The existing `smoke` job mounts the GitHub Release binary directly into distro containers. That catches binary-level regressions in Debian/Ubuntu/Alpine but **cannot see**:

- the npm wrapper / optional-deps resolution path
- the npm postinstall SHA-256 verification
- the PyPI bootstrap that re-downloads the binary from GitHub Releases
- the wheel-embedded per-platform checksum verification

This is the layer where v0.10.1's PR #72 (npm integrity) and v0.10.3 PR #82 (Python checksum) live. A regression there would happily ship without being noticed until users hit it.

## What changed

- `.github/scripts/publish-smoke.sh` (129 lines, new): driver script. Runs `npm install -g treeship@VERSION`, asserts CLI version, runs session round-trip. Then `pip install treeship-sdk==VERSION`, runs `python -m treeship_sdk.bootstrap_cli --json`, exports the bootstrapped binary onto PATH, runs the same session round-trip. Both paths assert the report's `schema=treeship/share-result/v1` and `verification_status=pass`.
- `.github/workflows/release.yml` (+27 lines): `publish-smoke` job declaration. `needs: [publish-npm, publish-pypi]`. Ubuntu runner.

## Origin

Split out of an in-progress stash on `feat/portable-agent-identity`. The portable-agent feature itself stays in design review on that branch.

## Test plan

- [ ] CI green on this PR (validates the YAML + shell syntax; the actual job runs only on tag push to release.yml)
- [ ] After merge: next release tag triggers the new job and verifies the published artifacts work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)