### PR TITLE
docs(specs): token capture + local dashboard design

### DIFF
--- a/docs/specs/local-dashboard.md
+++ b/docs/specs/local-dashboard.md
@@ -1,0 +1,417 @@
+# Local Dashboard — design
+
+**Status:** working markdown, not committed
+**Last updated:** 2026-05-25
+
+## Short version
+
+A Hermes-style "local dashboard opens in browser" should be treated as a view over an append-only local event/receipt store, not as the source of truth. For Treeship, the equivalent source of truth is the **Session Receipt**: canonical JSON, Merkle-rooted, independently verifiable, portable, shareable. The dashboard is a projection of that receipt, plus optional live local state while a session is still active.
+
+Product rule:
+
+> Hermes dashboard answers "what is the agent doing right now?" Treeship dashboard answers "what happened, why was it allowed, what changed, and can anyone verify it from the receipt?"
+
+The dashboard may include an operator console, but it should be receipt-native first. Live runtime views are convenience projections. The durable product is the receipt-native control plane.
+
+## The receipt inversion (what makes Treeship different from Hermes)
+
+Hermes verified architecture (from their docs):
+- `hermes dashboard` opens `http://127.0.0.1:9119`
+- FastAPI/Uvicorn backend + React 19 frontend
+- "The dashboard runs entirely on your machine — no data leaves localhost"
+- No auth; localhost is the trust boundary; `--insecure` to expose
+- 5-second polling for status/logs; WebSocket+xterm.js for PTY-mirrored chat
+- Three-layer plugin model: themes (YAML), UI plugins (manifest.json + IIFE JS bundle, no build step), backend plugins (Python + FastAPI router)
+- Drop-in `~/.hermes/plugins/`; `window.__HERMES_PLUGIN_SDK__` exposes React, shadcn/ui components, typed API client, slot registration
+
+Six things match what Treeship should do: localhost-only server, no auth, mix of WebSocket and polling, TUI mirrored into the browser, drop-in plugins, config in files (not UI defaults).
+
+One thing **must differ**:
+
+| Hermes | Treeship |
+|---|---|
+| Source of truth = running agent process | Source of truth = signed Session Receipt |
+| Dashboard reads live state from the agent loop | Dashboard reads from `~/.treeship/sessions/` and `receipt.json` |
+| Trust = "the agent on this machine" | Trust = Ed25519 signature + Merkle root + verification chain |
+| Config-editable from UI (form editor for 150+ settings) | Read-only by default; CLI/SDK is the only write path |
+| Account-less because localhost is the boundary | Account-less because receipts are self-verifying |
+
+Hermes's local-only model is a **deployment choice**. Treeship's local-first model is a **trust model**. Same browser-on-localhost architecture serves both, but the implications differ. Hermes can add cloud sync if it wants. Treeship can't, because the receipt's portability is the whole point.
+
+## Projection model
+
+Do not build "logs with a nice UI." Build from receipts and derive the UI:
+
+| Surface | Source |
+|---|---|
+| Receipt feed | `receipt.json`, artifact records, package index |
+| Timeline | `receipt.timeline` |
+| Agent graph | `receipt.agent_graph` |
+| Side effects | `receipt.side_effects` |
+| Approval queue | live pending approvals, then approval artifacts in the sealed receipt |
+| Trust posture | verifier checks, not display parsing |
+| Public proof page | same receipt renderer, fetched from Hub or local package |
+
+The receipt or artifact is the source of truth. Feed, graph, approval state, trust posture, and proof pages are projections.
+
+## What Treeship already has
+
+| Primitive | Where | Role for the dashboard |
+|---|---|---|
+| `treeship ui` (Ratatui TUI) | `packages/cli/src/tui/` | Existing terminal dashboard, reads local store, shows session state, recent artifacts, pending approvals, hub status. 2s refresh loop. Shares its backend with the web SPA. |
+| Session events | `~/.treeship/sessions/<id>/events.jsonl` | Append-only log. Live-mode data source. |
+| Receipt composition | Triggered on `treeship session close` | Composes `receipt.json` from events + artifact chain + agent graph. Builds a `.treeship` package with Merkle data, proofs, render hints, and preview.html. |
+| `preview.html` | Inside every `.treeship` package | Static, self-contained HTML view of the receipt. Already produced. The dashboard becomes this file served from localhost + a small verifier bundle. |
+| `render.json` | Inside every `.treeship` package | Layout hints for `preview.html`. Reused by the web dashboard. |
+| `treeship daemon` | `packages/cli/src/commands/daemon.rs` | Long-lived local process. Already watches files, emits events, processes ZK proof queue. Natural home for the HTTP API. |
+| Receipt verifier | `packages/cli/src/commands/verify_external.rs`, WASM mirror | Computes Merkle root, checks signatures, validates inclusion proofs, asserts timeline ordering. The trust panel reads from this. |
+| Hub receipt URLs | `treeship.dev/receipt/<id>` (human) → `api.treeship.dev/v1/receipt/<id>` (raw JSON) | Public, unauthenticated, permanent. The universal deep link to any shared session. |
+
+## Two modes
+
+The dashboard is fundamentally two different views, and the UI should make the distinction visible.
+
+### Live mode (session is still open)
+
+- Localhost server reads `~/.treeship/sessions/<active_id>/events.jsonl`
+- New events streamed via SSE or WebSocket as the file grows
+- Local artifacts read from `~/.treeship/artifacts/` on demand
+- Trust panel labeled `LIVE — not yet sealed`. Verification checks that can run on partial state are shown (signature counts, partial Merkle, etc.); checks that require seal (Merkle root match, final inclusion-proof count, timeline ordering across all entries) are shown as `pending close`.
+- Clearly labels evidence as in-progress
+
+### Sealed mode (session has been closed)
+
+- Loads `receipt.json` from `~/.treeship/sessions/<id>/<id>.treeship/`
+- Runs the verifier in full:
+  - receipt parses
+  - canonical bytes match (determinism)
+  - Merkle root recomputes
+  - all inclusion proofs valid
+  - leaf count matches artifact count
+  - timeline ordering valid
+  - signature(s) valid against trust roots
+- Renders all views from the receipt only (timeline, agent graph, side effects, artifacts/proofs)
+- This is the mode that also works on a remote receipt URL — fetch the JSON from `api.treeship.dev/v1/receipt/<id>`, verify client-side via WASM, render
+
+The toggle between modes is automatic: dashboard knows which mode it's in by looking at whether the session is active (has an unclosed events.jsonl) or closed (has a `.treeship/receipt.json`).
+
+## v0 strategy: promote `preview.html`
+
+The `.treeship` package already produces a self-contained `preview.html` that renders the receipt. The v0 dashboard is **that file served from localhost**, plus a small client-side verifier bundle that runs on load.
+
+```
+treeship dashboard open [session_id]
+```
+
+Implementation shape:
+
+```
+.treeship/sessions/ssn_xxx.treeship/
+  receipt.json          authoritative data
+  render.json           layout hints
+  preview.html          static local UI
+  proofs/               inclusion proofs
+
+http://127.0.0.1:<port>/session/ssn_xxx
+  serves the package files + verifier bundle
+```
+
+Why this beats building a new SPA:
+- The artifact already exists and is generated on every `session close`
+- Same HTML is used locally, by Hub for public receipt pages, and in shared links
+- No framework, no build step, no `node_modules`
+- Survives any UI redesign because the data shape is what matters
+
+The dashboard becomes a thin orchestrator: routing, file serving, the verifier bundle, the live-mode event streaming. Not a UI rewrite.
+
+## Trust panel as first-class
+
+The dashboard's reason to exist: answer "can I trust this receipt?" in one glance.
+
+Top-level verdict block on every session detail page:
+
+```
+Trust
+  ✓ receipt parses
+  ✓ deterministic bytes
+  ✓ Merkle root matches
+  ✓ 42/42 artifacts included
+  ✓ timeline ordering valid
+  ⚠ 0 malformed events skipped
+```
+
+Failure mode: any check fails → the receipt's status visibly downgrades. The receipt's name in the sidebar gets a red dot. The detail header shows the failure prominently. The user doesn't have to dig.
+
+The verifier already produces these checks. The dashboard just renders them.
+
+Important boundary: display parsing can be forgiving, but trust logic cannot. The current TUI decodes payloads for human-friendly display and can fall back when fields are missing or malformed. That behavior is fine for an operator panel. The browser dashboard's trust posture must call the verifier path and render its results directly.
+
+Trust language should be precise:
+
+| Signal | Meaning |
+|---|---|
+| Stored by Hub | Hub has a copy or index row |
+| Verified locally | Local verifier passed the receipt or artifact checks |
+| Signature valid | DSSE signature verifies against the expected key material |
+| Chain complete | Parent links and referenced artifacts are present |
+| Merkle proof valid | Included leaf recomputes to the stored root |
+| Approval binding satisfied | Approval nonce and target action match |
+| Unsealed | Live state exists, but no final receipt has been closed |
+| Unattested | A visible event/action has no corresponding artifact or receipt evidence |
+
+Never render "trusted because Hub says so." Hub can make data easy to find. It cannot make data trustworthy.
+
+## Hub as index, never trust root
+
+Hub stores receipts and serves them via two endpoints:
+
+- `treeship.dev/receipt/<session_id>` — human page; fetches raw JSON, verifies client-side, renders
+- `api.treeship.dev/v1/receipt/<session_id>` — raw JSON, unauthenticated, permanent
+
+Hub indexes (recent sessions, agents seen, last activity, session status, receipt URL) are useful for **navigation**. They are not authoritative for **trust**.
+
+When a user opens a session detail page, the dashboard fetches the receipt and renders from the receipt. Hub's session row is a pointer, not a record.
+
+This means the same dashboard works in three places without changing the trust model:
+
+1. **Locally** — read receipt from `~/.treeship/sessions/<id>/`
+2. **Hub** — fetch receipt from `api.treeship.dev/v1/receipt/<id>`, verify client-side, render
+3. **Shared link** — same as Hub mode; receive URL, fetch raw JSON, verify, render
+
+## What "view from just the receipt" should mean
+
+A receipt-only dashboard works with no account, no database, no Hub trust. Given only:
+
+```
+https://treeship.dev/receipt/ssn_xxx
+```
+
+or:
+
+```
+receipt.json
+```
+
+The dashboard renders:
+
+**Overview** — session_id, name, status, start/end timestamps, duration, ship_id, token totals, high-level narrative. All from the `session` block.
+
+**Agent graph** — root agent, spawned subagents, handoffs, returns, collaboration edges, max depth, final output agent. All from the `agent_graph` block (nodes + edges with edge types: parent-child, handoff, collaboration, return).
+
+**Timeline** — every event with sequence number, timestamp, event_id, event_type, agent_instance_id, agent_name, host_id, summary. Session, agent, tool, file, network, port, and process events.
+
+**Side effects** — files read/written, ports opened, network connections, processes, tool invocations. The `side_effects` block is a convenience index over the timeline, grouped by kind, with back-references to the agent that performed each.
+
+**Artifacts and proofs** — artifact_ids, payload_types, digests, signed timestamps, Merkle inclusion proof status. Merkle tree built over content-addressed artifact_ids; anyone can recompute and check the stored root.
+
+## Recommended v1 dashboard shape
+
+### Default home: Receipt Feed
+
+Each row is a receipt or artifact projection:
+
+- id
+- type
+- actor
+- action
+- timestamp
+- parent
+- verification status
+- Hub URL
+- Rekor or Merkle badge
+- approval-required, approved, denied, failed, or unattested badges
+
+### Detail page: Artifact/Receipt Inspector
+
+For a selected `art_...` or `ssn_...`:
+
+- canonical JSON
+- decoded statement
+- signature details
+- chain position
+- parent and children
+- verification checks
+- Hub or public URL
+- proof bundle export action
+
+This extends the current TUI artifact detail surface, but uses verifier output for trust posture.
+
+### Provenance Graph
+
+Build graph edges from:
+
+- artifact `parentId`
+- approval/action nonce links
+- session `agent_graph`
+- session timeline
+- handoff artifacts
+
+### Approval Queue
+
+The browser version should show:
+
+- risk label
+- actor
+- command or tool request
+- affected files and resources
+- previous approvals
+- policy badge
+- approve or deny action that creates its own signed artifact
+
+### Trust Posture View
+
+The trust posture should be loud and binary:
+
+- chain complete
+- signature valid
+- Merkle inclusion valid
+- deterministic receipt round-trip valid
+- broken parent link
+- signature mismatch
+- modified receipt
+- unsealed live session
+- out-of-band action
+
+## Three-piece architecture
+
+```
+Local agent / session
+  → events.jsonl while active
+  → artifacts in .treeship/artifacts
+  → session close
+  → receipt.json + proofs + preview.html
+  → optional hub upload
+
+Browser dashboard
+  live mode:
+    localhost server reads events.jsonl + local artifacts
+    labels view as unsealed
+  sealed mode:
+    reads receipt.json only
+    runs verifier
+    renders timeline, graph, effects, proofs
+
+Hub control plane
+  indexes sessions and agents from uploaded receipts
+  serves raw receipt JSON
+  renders public receipt page from receipt JSON
+  never becomes the trust root
+```
+
+## CLI surface
+
+```
+treeship dashboard open [session_id]   # active session if omitted
+treeship dashboard list                # recent sessions, formatted for terminal
+treeship dashboard verify <receipt-url-or-path>   # run the verifier, output trust panel
+```
+
+Each maps to existing primitives. `open` launches the daemon's HTTP server if not running, serves `preview.html` + verifier bundle, opens the browser. `list` reads `~/.treeship/sessions/` index. `verify` runs the WASM verifier against a remote URL or local file.
+
+## Hermes-style plugin model (out of v0, named here)
+
+Treeship can adopt Hermes's plugin pattern when there's a real need. The shape:
+
+- **Themes** — YAML files in `~/.treeship/themes/` that repaint palette, typography, layout
+- **UI plugins** — `~/.treeship/plugins/<name>/manifest.json` + IIFE JS bundle (no build step)
+- **Backend plugins** — Rust trait that plugins implement, dynamically loaded at daemon startup (or, simpler: subprocess plugins that the daemon proxies to)
+- **Plugin SDK** at `window.__TREESHIP_PLUGIN_SDK__` exposing typed API client, slot registration, helper components
+
+Explicitly out of v0. The pattern is recorded so contributors don't reinvent it later.
+
+## What's explicitly NOT v0
+
+- Remote / cloud-hosted dashboard (the Hub dashboard is its own product)
+- Multi-user / RBAC (single-user local tool)
+- Editing trust roots, certs, or workflows from the UI (UI is observational; CLI/SDK is the write path)
+- Alerting / notifications / email (separate scope)
+- Mobile / PWA (desktop browser only)
+- Public exposure (binds 127.0.0.1; refuses non-localhost connections)
+- Telemetry / usage tracking (local-only ethos)
+- Plugin system (named above as roadmap)
+- Receipt diffing (good idea; later release)
+- Policy overlays (undeclared tool use, suspicious network, file write outside workspace, missing approvals — derivable from the receipt but not v0)
+
+## Implementation phases
+
+**Phase 1 — sealed mode against preview.html (~2 days)**
+
+- New daemon HTTP route: `GET /session/<id>` serves `preview.html` for the requested session's package
+- `GET /api/receipt/<id>` returns the raw `receipt.json`
+- `GET /api/verify/<id>` runs the verifier and returns the trust-panel JSON
+- New CLI: `treeship dashboard open [session_id]` starts daemon if needed, opens browser
+- Verifier bundle: client-side WASM call to `verify_receipt` that produces the trust panel rows
+- Default home: receipt feed over closed local packages
+- Detail route: artifact/receipt inspector backed by canonical JSON and verifier checks
+
+**Phase 2 — live mode (~3 days)**
+
+- `events.jsonl` is tailed; new lines emit SSE events to the browser
+- "Unsealed" badge on the trust panel
+- Verification checks that can run on partial state are shown; full-seal checks marked `pending close`
+- Browser auto-switches to sealed mode when the package directory appears
+- Approval queue mirrors current TUI state and creates signed approval/denial artifacts for control actions
+
+**Phase 3 — receipt URL deep links (~1 day)**
+
+- `treeship dashboard verify <url>` works on remote URLs
+- Browser receives a `?receipt=<url>` query param, fetches, verifies, renders
+- Same UI as local sealed mode
+- Hub verification is displayed as a convenience signal only; local/WASM verification remains the trust source
+
+**Phase 4 — Hub-side preview page (~separate scope)**
+
+- `treeship.dev/receipt/<id>` server-renders the same `preview.html` with the fetched receipt
+- Client-side verifier runs after load
+- Same UI as the local dashboard
+
+After all four phases, the same `preview.html` renders the receipt in three contexts: locally, on shared URLs, on Hub. One UI, three deployment surfaces, one trust model.
+
+## Open questions
+
+**Q1: Does `treeship daemon` host the dashboard HTTP, or a separate `treeship dashboard-server` process?**
+
+Recommendation: extend `treeship daemon`. It already runs a 2s file-watcher loop (the natural slot for an SSE pump). Two processes mean two `flock` contenders on `events.jsonl.lock` and two PIDs. Single process wins.
+
+**Q2: TUI keep its 2s poll, or refactor to share the SSE pipeline?**
+
+Recommendation: keep the TUI on 2s poll. It shares the process with the daemon; there's no socket to push over. Refactoring to use an internal channel is a needless rewrite.
+
+**Q3: How does the dashboard discover the daemon's port?**
+
+Recommendation: `~/.treeship/daemon.port` file written on daemon startup. CLI reads it. No discovery beacons, no `--port` flag required (configurable for advanced cases).
+
+**Q4: What does v0 do if no session is closed yet (no receipt exists)?**
+
+Recommendation: empty state with a hint to run `treeship wrap -- <cmd>` and `treeship session close`. Don't lazy-construct a synthetic receipt from live events; that would blur the live/sealed boundary.
+
+## How this composes with other in-flight work
+
+- **PR #107 workflow declarations** — when those land, the dashboard adds a "Workflow Conformance" row to the trust panel (per-action: was this in the authorized workflow?). New page possibly.
+- **PR #109 invitations/rooms** — when rooms land, the session detail page shows participants[] with their join events and signing keys. Multi-agent dashboards become non-trivial; the agent_graph already exists in receipts so the render is straightforward.
+- **PR #111 invitations Phase 1 (real code)** — the dashboard can show invitations issued and consumed once participant events appear in receipts.
+
+The dashboard doesn't need any of these to ship. Sealed mode against existing single-agent receipts is enough for Phase 1. Later phases gain new views as the underlying artifacts gain new fields.
+
+## What this proposal explicitly rejects
+
+- **Building a new SPA from scratch.** The `preview.html` artifact is the dashboard. Replacing it with a Next.js app or similar requires authentication, server state, and centralization that breaks Treeship's trust model.
+- **Conflating the dashboard with Treeship Hub Saas.** Hub stores and serves receipts. The dashboard renders them. They are not the same product.
+- **Making the dashboard authoritative.** It is a view. The receipt is the artifact. If the dashboard disagrees with the verifier, the verifier is right.
+- **Making Hub authoritative.** Hub indexes are derived. The receipt is the source of truth. A dashboard that "trusts the Hub" stops being a Treeship dashboard.
+
+## What this proposal accepts
+
+- **Localhost server + browser on localhost** is the right deployment shape. Hermes proves it works.
+- **Two modes** is the right architectural axis. Live mode for in-progress sessions; sealed mode for receipts.
+- **`preview.html` is the dashboard UI**. The most leveraged decision in the design.
+- **Trust panel is the most important panel**. Everything else is secondary.
+- **Same UI everywhere**. Local, Hub, shared links — one renderer, three deployment surfaces.
+
+## Next concrete moves
+
+1. **Settle the four open questions** (Q1–Q4 above).
+2. **Sketch the trust panel UX** as a short markdown or ASCII mockup. Load-bearing surface; getting it right matters more than any other UI decision.
+3. **Phase 1 implementation** (~2 days) once Q1–Q4 land.
+
+End.

--- a/docs/specs/token-capture.md
+++ b/docs/specs/token-capture.md
@@ -1,0 +1,140 @@
+# Token Capture — design
+
+**Status:** working markdown, not committed
+**Last updated:** 2026-05-25
+
+## The problem
+
+A Treeship receipt should record how many tokens a model actually used — input and output — so the model-provenance claim ("this model did this work at this cost") is real. Getting an accurate count is harder than it looks, and three different wrong answers have been proposed:
+
+1. **"Leave tokens empty"** (the current skill) — gives up; records nothing.
+2. **"Read `input_tokens` from the transcript"** (an earlier recommendation) — wrong 98% of the time.
+3. **"JSONL is unreliable, use a statusline script / proxy instead"** (a research report) — abandons a source that actually works.
+
+All three are wrong for the same reason: they read (or refuse to read) one field. The correct answer is to **sum the right fields from the transcript.**
+
+## What the data actually shows
+
+Empirically, across 152 Claude Code transcripts / 17,447 assistant turns on a real machine:
+
+| Field | Behavior |
+|---|---|
+| bare `input_tokens` | ≤ 10 on **98%** of turns (median **1**). It is only the *fresh, non-cached* input for the turn. Useless alone. |
+| `cache_read_input_tokens` | accurate. The cached prefix (system prompt + history + tool defs) read this turn. |
+| `cache_creation_input_tokens` | accurate. Newly-cached input this turn. |
+| `input_tokens + cache_read + cache_creation` | **> 1000 on 99%** of turns (median **132,162**). This is the real input the model processed. |
+| `output_tokens` | median 235, max ~18k. Mostly reliable, but may exclude extended-thinking tokens (unverified — see caveats). |
+
+A single real turn:
+```json
+{ "input_tokens": 6, "cache_creation_input_tokens": 19721,
+  "cache_read_input_tokens": 14906, "output_tokens": 316 }
+// true input = 6 + 19721 + 14906 = 34,633
+```
+
+The "100x undercount" some research flagged is real for the bare field and fully resolved by summing. The data was never missing; it was distributed across three fields because Claude Code aggressively caches the prompt.
+
+## The rule
+
+```
+input_tokens_total = input_tokens
+                   + cache_read_input_tokens
+                   + cache_creation_input_tokens
+```
+
+Never record bare `input_tokens` as "the input." Always sum. Preserve the breakdown (below) because the three components bill at different rates.
+
+## Canonical usage schema (provider-neutral)
+
+The receipt records one canonical shape per agent node, regardless of provider or runtime:
+
+```jsonc
+{
+  "input_tokens": 34633,            // the SUMMED total — what the model processed
+  "input_breakdown": {              // preserved because each bills differently
+    "fresh": 6,
+    "cache_read": 14906,
+    "cache_creation": 19721
+  },
+  "output_tokens": 316,
+  "output_complete": false,         // true only once thinking-token inclusion is verified
+  "total_tokens": 34949,
+  "model": "claude-opus-4-7",
+  "provider": "anthropic",
+  "source": "transcript"            // transcript | statusline | proxy | hook | estimate
+}
+```
+
+Two fields carry the honesty:
+- **`source`** — provenance of the number itself. A receipt must not blur actual (transcript/proxy) with estimate (count_tokens).
+- **`output_complete`** — whether output is known to include thinking tokens. `false` means the value is a floor, not exact.
+
+## Cross-provider normalization
+
+The summing rule is Anthropic-shaped (it has cache fields). Other providers differ. Normalization is isolated to one table; the canonical schema above is what everything maps into.
+
+| Provider | input (sum these) | output | notes |
+|---|---|---|---|
+| Anthropic | `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` | `output_tokens` | cache fields are the bulk; bare input is the delta |
+| OpenAI | `usage.prompt_tokens` (+ `prompt_tokens_details.cached_tokens` already included) | `usage.completion_tokens` | cached tokens are a *subset* of prompt_tokens, not additive |
+| Google Gemini | `usageMetadata.promptTokenCount` | `usageMetadata.candidatesTokenCount` | cachedContentTokenCount is a subset |
+| Cohere | `meta.billed_units.input_tokens` | `meta.billed_units.output_tokens` | |
+| Ollama / llama.cpp | `prompt_eval_count` | `eval_count` | no caching concept |
+
+**Critical per-provider subtlety:** Anthropic *adds* cache fields to bare input (they're separate). OpenAI/Gemini *nest* cached tokens *inside* the prompt total (they're a subset, do NOT add). Getting this wrong double-counts on OpenAI or under-counts on Anthropic. The normalization table must encode "additive vs subset" per provider.
+
+## Two capture positions
+
+**Position A — transcript reader (default, post-hoc).**
+The runtime already received the provider `usage` object and wrote it to its transcript. Per-runtime adapter reads it, applies the provider's summing rule, emits canonical usage. Works offline, no API key, authoritative for what happened.
+- Claude Code: `transcript_path` (from the hook payload) → JSONL → sum the three input fields
+- OpenClaw: session transcript → normalized fields
+- Others: per-runtime adapter
+
+**Position B — attestation proxy (opt-in, inline).**
+Treeship sits in the request path (OpenAI-compatible local proxy), reads the raw provider response `usage`, normalizes, attests, forwards. Guarantees capture regardless of runtime; adds a network hop. The right answer for runtimes that don't log usage.
+
+## Cross-checks (not replacements)
+
+The research surfaced two other accurate sources. They're useful as **validation**, not as the primary path:
+- **Statusline script** — Claude Code pipes session-level context to a statusline script at ~1.0x to the API. Good for session totals and for validating the summed transcript figure.
+- **Agent-tool PostToolUse hook** — for subagent turns, this hook *does* expose `usage` (input/output/cache). Useful for per-subagent granularity. (Regular-tool hooks don't expose usage yet — that's the legitimate upstream ask, FR #11008.)
+
+If the summed-transcript input disagrees materially with the statusline session total, the receipt should surface the discrepancy rather than silently pick one.
+
+## The output-token caveat (unresolved)
+
+A research report claims `output_tokens` undercounts by 10-17x because it excludes extended-thinking tokens. This is **not yet verified** — it requires cross-checking transcript `output_tokens` against the API's actual billed `output_tokens`, which needs API billing access or the statusline session totals. Until verified:
+- Treat output as a **floor**, mark `output_complete: false`
+- Do not claim an exact output cost in a receipt
+- Validating this is the prerequisite before output tokens are trusted as exact
+
+## What the skill must say (the fix)
+
+The current skill says "leave tokens empty" and references `count_tokens`. Replace with:
+- **Input:** sum `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` from the transcript. Bare `input_tokens` alone is wrong 98% of the time.
+- **Output:** read `output_tokens`; treat as a floor pending thinking-token verification.
+- **count_tokens:** an input-only *estimate* requiring an API key. Use for pre-flight cost estimation, never recorded in a receipt as actual.
+- **Cross-provider:** the canonical schema + normalization table; mind additive (Anthropic) vs subset (OpenAI/Gemini) cache accounting.
+
+## Honest status
+
+| Claim | Status |
+|---|---|
+| Accurate input tokens | ✅ Solved — sum transcript fields (validated, 17k turns) |
+| Cross-provider input | ✅ Solved — normalization table, mind additive-vs-subset |
+| Accurate output tokens | ⚠️ Floor only — thinking-token inclusion unverified |
+| Pre-flight estimate | ✅ count_tokens (Anthropic), input-only, estimate, needs key |
+| Real-time push to Treeship without reading files | ⏸️ Upstream (FR #11008 for all-tool hooks) — convenience, not a gap |
+
+## Implementation phases
+
+1. **Transcript reader for Claude Code** — sum the three input fields, emit canonical usage on `agent.decision` / a new `agent.usage` event. Validate summed input against statusline on a few sessions.
+2. **Resolve the output caveat** — cross-check transcript output vs billed/statusline; set `output_complete` accordingly.
+3. **Cross-provider normalization table** — OpenAI, Gemini, Ollama adapters with additive-vs-subset encoded.
+4. **OpenClaw + other runtime adapters.**
+5. **Attestation proxy (Position B)** — separate, larger scope; guarantees capture for runtimes that don't log usage.
+
+## The lesson baked in
+
+Three confident answers ("leave empty," "read input_tokens," "JSONL unreliable") were all wrong, and one `python3` read of one transcript — then 152 of them — settled it. The data was in the file the whole time. Verify against the data before writing the guidance.


### PR DESCRIPTION
## Summary

Two design specs (drafts, not implementations) from the receipt-provenance + control-plane work this cycle.

### `docs/specs/token-capture.md`

The validated answer to "how does a receipt record real token usage?"

**Key rule, checked against 17,447 real Claude Code assistant turns across 152 transcripts:**
```
input_tokens_total = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
```
Bare `input_tokens` is ≤10 on **98%** of turns (median **1**) because Claude Code caches the prompt. Summing the three fields recovers the real total (median **132k**/turn). Three prior answers were all wrong for reading one field: "leave tokens empty" (skill), "read input_tokens" (earlier advice), "JSONL unreliable, abandon it" (a research report — but its own admission that cache tokens are accurate disproves it).

Also: provider-neutral canonical schema (`input_breakdown`, `source`, `output_complete`), cross-provider normalization table with the **additive-vs-subset** subtlety (Anthropic *adds* cache fields; OpenAI/Gemini *nest* them as a subset), two capture positions (transcript reader / attestation proxy), and the **open output-token caveat** (may exclude thinking tokens; unverified pending an API-billed cross-check).

### `docs/specs/local-dashboard.md`

Receipt-first control plane. Source of truth = signed Session Receipt; dashboard = projection. Two modes (live tails `events.jsonl`, sealed reads `receipt.json`). v0 promotes the existing `preview.html` rather than building a new SPA. Trust panel first-class. Hub is an index, never a trust root. Same renderer across local / Hub / shared links. Explicitly rejects the account-based SaaS dashboard direction (wrong trust model for a self-verifying receipt).

## Status

Design drafts. Each carries open questions for maintainer decisions before any code lands. Companion to the workflow-declarations and agent-invitations-rooms specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)