### PR TITLE
fix(skills,docs): correct MCP tool list, token guidance, and license claims

### DIFF
--- a/docs/content/docs/guides/how-it-works.mdx
+++ b/docs/content/docs/guides/how-it-works.mdx
@@ -119,7 +119,7 @@ Exit 0 means the full chain is intact. Exit 1 means something failed, with reaso
 </Steps>
 
 <Callout type="info">
-The verifier is open source and MIT licensed. You can audit it, embed it in CI, or run it in a browser. Trust the math, not the infrastructure.
+The verifier is open source and Apache-2.0 licensed. You can audit it, embed it in CI, or run it in a browser. Trust the math, not the infrastructure.
 </Callout>
 
 ## Hub

--- a/docs/content/docs/guides/introduction.mdx
+++ b/docs/content/docs/guides/introduction.mdx
@@ -25,7 +25,7 @@ That is the entire core loop. Everything else builds on it.
 <Card title="Portable" description="A signed artifact is a self-contained JSON file. It verifies anywhere, across orgs, clouds, and protocols." />
 <Card title="Offline verification" description="The verifier is deterministic and runs on your machine. No network call needed." />
 <Card title="Signed chain" description="Every artifact links to its parent by content hash. Tamper with one step and the whole chain fails." />
-<Card title="Open" description="MIT licensed. The verifier is open source. Anyone can verify without trusting Treeship." />
+<Card title="Open" description="Apache-2.0 licensed. The verifier is open source. Anyone can verify without trusting Treeship." />
 </Cards>
 
 ## How it works

--- a/integrations/kimi-code-plugin/treeship-user/SKILL.md
+++ b/integrations/kimi-code-plugin/treeship-user/SKILL.md
@@ -267,24 +267,42 @@ treeship session event --type agent.decision \
 
 ### Token Counting (Context)
 
-The Anthropic `count_tokens` API is available at `client.messages.count_tokens(model, messages)`:
+Accurate token usage IS capturable. The trick is reading the right fields.
 
-```python
-from anthropic import Anthropic
-client = Anthropic()
+**Input tokens — sum three fields, never read one.** Claude Code (and any
+Anthropic-backed runtime) caches the prompt, so a turn's `usage.input_tokens`
+holds only the *fresh, non-cached* delta — `≤ 10` on ~98% of real turns. The
+real input lives in the cache fields. Compute:
 
-response = client.messages.count_tokens(
-    model="claude-sonnet-4",
-    messages=[{"role": "user", "content": "Analyze this codebase"}]
-)
-print(response.input_tokens)  # 1847
+```
+input_total = usage.input_tokens
+            + usage.cache_read_input_tokens
+            + usage.cache_creation_input_tokens
 ```
 
-**Important limitation:** `count_tokens` counts only what you pass to it. The actual billed tokens per Claude Code turn include system prompt + conversation history + tool definitions — 10-100x larger than just the tool arguments. For accurate token capture, Treeship needs the full message context, not just tool input.
+Example from a real turn: `input_tokens=6, cache_read=14906, cache_creation=19721`
+→ true input `34633`. Reading `input_tokens` alone (`6`) is ~100x too low. The
+data is in the session transcript (`transcript_path` in the hook payload); it
+was never missing, just distributed across three fields.
 
-**Honest approach:** Treeship leaves tokens empty by default rather than reporting synthetic under-counts. Capture via:
-- `TREESHIP_TOKENS_IN` / `TREESHIP_TOKENS_OUT` env vars (user-provided)
-- Claude Code plugin if/when hooks expose `usage` object
+**Output tokens:** read `usage.output_tokens`, but treat it as a *floor* — it
+may exclude extended-thinking tokens. Mark provenance, don't claim it as exact
+until validated against the API's billed usage.
+
+**`count_tokens` is for pre-flight estimates only, not receipts.** The Anthropic
+`count_tokens` API estimates *input* tokens for a message set you pass it —
+useful for "how big is this prompt before I send it," but it's an estimate, it's
+input-only, and it needs an API key. Never record a `count_tokens` result in a
+receipt as actual usage.
+
+**Provider-neutral note:** Anthropic *adds* cache fields to bare input; OpenAI
+and Gemini *nest* cached tokens as a subset of the prompt total (do not add). See
+`docs/specs/token-capture.md` for the canonical schema and per-provider
+normalization table.
+
+**Honest fallback:** leave tokens empty only when the runtime genuinely doesn't
+log a `usage` object. When it does, sum the fields above — don't report synthetic
+under-counts, and don't give up on data that's present.
 
 ### Decision Cards & Coverage Levels
 
@@ -330,11 +348,12 @@ Treeship exposes an MCP server for Claude Code and other MCP-compatible agents:
 }
 ```
 
-Available tools via MCP:
-- `treeship_attest_action` — Create attestation for an action
-- `treeship_verify` — Verify an artifact
-- `treeship_push_hub` — Push artifact to Treeship Hub
-- `treeship_session_report` — Generate session report
+Available tools via MCP (the five the `@treeship/mcp` server actually registers):
+- `treeship_session_status` — Report the active session and its current state
+- `treeship_session_event` — Emit a structured event into the active session timeline
+- `treeship_attest_action` — Sign an agent action into a verifiable receipt
+- `treeship_verify` — Verify an artifact chain
+- `treeship_session_report` — Seal and upload the session receipt, returning a public verify URL
 
 ## Hub API
 

--- a/packages/zk-circom/package.json
+++ b/packages/zk-circom/package.json
@@ -7,7 +7,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "description": "",
   "dependencies": {
     "circomlib": "^2.0.5"


### PR DESCRIPTION
## Summary

Three correctness fixes, each caught by **verifying against the actual repo** rather than trusting a self-graded skill report and a deep-research summary.

## Skill fixes (`treeship-user` / Kimi bundle)

**1. MCP tool list was wrong.** Listed `treeship_push_hub` (does not exist in the `@treeship/mcp` server) and omitted `treeship_session_status` + `treeship_session_event`. Replaced with the real five the server registers, verified against `bridges/mcp`:
`session_status`, `session_event`, `attest_action`, `verify`, `session_report`. A Kimi user following the old list would call a tool that doesn't exist.

**2. Token section said "leave tokens empty."** Corrected to the validated rule:
```
input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
```
Bare `input_tokens` is ≤10 on **98%** of real turns (median 1) because the prompt is cached; summing recovers the real total (median 132k/turn, validated across 17,447 turns on 152 transcripts). `count_tokens` reframed as a pre-flight estimate only, never recorded as actual. Points at `docs/specs/token-capture.md` (PR #112).

## License fixes

**3. Docs claimed "MIT licensed."** `introduction.mdx` and `how-it-works.mdx` said the verifier is MIT licensed. The project is **Apache-2.0** (LICENSE file + all 11 manifests, zero MIT). Fixed both. This is the discrepancy monitoring flagged against the homepage's "Apache 2.0."

**4. `packages/zk-circom/package.json` was `ISC`** (npm-init default). Aligned to Apache-2.0.

## Not changed (flagged for a decision)

The blog post `introducing-trust-templates.mdx` says published templates are validated for an "MIT license." That's a *template-licensing policy* claim (not Treeship's own license) in a dated published post. Left as-is pending a call on whether the template program should require Apache-2.0.

## Test plan
- [x] Verified the real MCP tool list against `bridges/mcp` server source
- [x] Verified the token rule against 17,447 real transcript turns
- [x] Verified Apache-2.0 is canonical (LICENSE + 11 manifests, 0 MIT)
- [ ] docs build green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)