### PR TITLE
Release v0.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.10.4"
+    "version": "0.11.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.11.0 (2026-05-28)
+
 ### Added
 
 - **Phase 1 of agent invitations: signed, single-use, expiring grants that let a second agent join an existing session.** Adds two canonical statement types -- `treeship/invitation/v1` and `treeship/session-participant/v1` -- both under `packages/core/src/statements/`. Invitations carry `session_ref`, `issuer` (host pubkey), `invitee_restriction` (one of `Pubkey { fingerprint }`, `Cert { issuer_pubkey, allowed_subjects }`, or `Open`), `granted_capabilities.action_types`, `expires_at`, `max_uses` (always 1 in Phase 1), and a random `nonce`. The canonical signing string mirrors the v0.10.4 pipe-delimited shape (`"v1|invitation|{session_ref}|{issuer}|{restriction_digest}|{capabilities_digest}|{expires_at}|{max_uses}|{nonce_digest}"`); variable-length fields fold into `sha256:<hex>` digests so the canonical stays single-line and unambiguous. Participant envelopes require exactly two DSSE signatures: the joining agent first (assertion of "I'm joining"), then the host countersign over the same canonical bytes (assertion of "I observed this join"); either signature alone is invalid. `verify_participant_envelope` rejects `MissingHostCountersign`, `TooManySignatures`, any sig that doesn't verify, and any countersign whose key doesn't match the invitation's issuer pubkey. Mint-time validation enforces a 7-day protocol ceiling on lifetime (`MAX_INVITATION_LIFETIME_SECS`); the default is 1 hour (`DEFAULT_INVITATION_LIFETIME_SECS`). Spec: [`docs/specs/agent-invitations-rooms.md`](docs/specs/agent-invitations-rooms.md). 14 unit tests in `invitation.rs` + 6 in `session_participant.rs` pin the canonical-binding, signature, expiry, single-use, and immutability properties.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "base64",
  "clap",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4037,7 +4037,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.4"
+    "@treeship/core-wasm": "0.11.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.10.4",
+    "@treeship/core-wasm": "0.11.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.10.4",
-    "@treeship/cli-darwin-arm64": "0.10.4",
-    "@treeship/cli-darwin-x64": "0.10.4"
+    "@treeship/cli-linux-x64": "0.11.0",
+    "@treeship/cli-darwin-arm64": "0.11.0",
+    "@treeship/cli-darwin-x64": "0.11.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.10.4"
+version = "0.11.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.10.4", path = "../core" }
+treeship-core = { version = "0.11.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.10.4"
+version = "0.11.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.10.4"
+version = "0.11.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.10.4"
+version = "0.11.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.10.2"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.4"
+    "@treeship/core-wasm": "0.11.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.10.4",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.9.2"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.10.4",
+  "version": "0.11.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.10.4"
+    "@treeship/core-wasm": "0.11.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## What

Bump Treeship release version sites to 0.11.0 after the local dashboard, agent invitation, and Robinhood receipt-support work landed on main.

## Why

0.11.0 is the first minor release for the new local dashboard/control-plane surface and the expanded multi-agent session direction.

## How tested

- scripts/release.sh prepare 0.11.0
- python3 scripts/check-release-versions.py 0.11.0
- git diff --check

## Risk and rollback

Low mechanical release-bump risk. The publish workflow is still gated by the release PR merge and the explicit v0.11.0 tag push.