### PR TITLE
fix(preview): receipt preview stuck on "Verifying receipt..."

### DIFF
--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -1339,11 +1339,14 @@ pub fn render_preview_html(receipt: &SessionReceipt) -> String {
     // This is bulletproof: no HTML parser can see a tag open inside the JSON.
     let safe_json = receipt_json.replace('<', r"\u003c");
 
-    // Only one placeholder: __RECEIPT_JSON__ inside the data block.
-    // The page title is set at runtime from the parsed JSON to avoid
-    // a second replacement pass that could re-inject content.
+    // The only placeholder that must take the receipt JSON is the data
+    // block. replacen(.., 1) substitutes exactly that first occurrence, so
+    // even if the token is ever reused elsewhere in the template (e.g. a JS
+    // placeholder check) the receipt body is never injected into it. The
+    // template's own placeholder check uses a split sentinel for the same
+    // reason. The page title is set at runtime from the parsed JSON.
     PREVIEW_TEMPLATE
-        .replace("__RECEIPT_JSON__", &safe_json)
+        .replacen("__RECEIPT_JSON__", &safe_json, 1)
 }
 
 #[cfg(test)]
@@ -1459,5 +1462,31 @@ mod tests {
         assert!(html.contains("ssn_pkg_test"));
         assert!(html.contains("treeship.dev"));
         assert!(html.contains("Timeline"));
+
+        // Regression: the receipt JSON must land ONLY in the data block,
+        // never in the inline JS. A prior bug used replace() (all matches)
+        // against a template that carried the placeholder token twice (data
+        // slot + a JS placeholder check), injecting the receipt body into a
+        // JS string literal. That produced an uncaught SyntaxError, so the
+        // whole script never ran and the preview hung on "Verifying
+        // receipt...". The JS check now uses a split sentinel that must
+        // survive substitution verbatim, and replacen(.., 1) fills only the
+        // first occurrence.
+        assert!(
+            html.contains("'__RECEIPT'+'_JSON__'"),
+            "JS placeholder check was clobbered by the receipt substitution",
+        );
+        assert!(
+            !html.contains("application/json\">__RECEIPT_JSON__</script>"),
+            "data slot was not substituted with the receipt JSON",
+        );
+        // The session id (a receipt value) must appear inside the data block,
+        // not leak into executable JS, so a quick structural sanity check:
+        // there is exactly one unsubstituted token left at most (none here).
+        assert_eq!(
+            html.matches("__RECEIPT_JSON__").count(),
+            0,
+            "no raw placeholder token should remain after substitution",
+        );
     }
 }

--- a/packages/core/src/session/preview_template.html
+++ b/packages/core/src/session/preview_template.html
@@ -183,7 +183,10 @@ code{font-family:var(--mono);font-size:.75rem;background:var(--surface-2);paddin
 let R=null;
 try{
   const rawReceipt=document.getElementById('receipt-data').textContent.trim();
-  if(rawReceipt==='__RECEIPT_JSON__')throw new Error('template placeholder');
+  // The sentinel is split so the build-time substitution of the data-slot
+  // token only matches the data block above, never this comparison. It
+  // reassembles at runtime to still detect an unsubstituted template.
+  if(rawReceipt==='__RECEIPT'+'_JSON__')throw new Error('template placeholder');
   R=JSON.parse(rawReceipt);
 }catch(e){
   document.getElementById('loading').innerHTML='<div style="max-width:560px;padding:2rem;text-align:left"><div style="font-size:1.15rem;font-weight:700;color:var(--text);margin-bottom:.5rem">This is the receipt template</div><div style="font-size:.86rem;color:var(--muted);line-height:1.7">Open a generated <code>preview.html</code> from a <code>.treeship</code> package, or run <code>treeship dashboard</code> and open a receipt from there. The source template has no embedded <code>receipt.json</code>, so there is nothing to verify yet.</div></div>';


### PR DESCRIPTION
## Problem

The local `treeship dashboard` "Session Receipt" view (and any freshly rendered `preview.html`) stayed stuck on **"Verifying receipt..."** and never rendered.

## Root cause

`render_preview_html` injects the receipt JSON with `str::replace("__RECEIPT_JSON__", ...)`, which replaces **all** matches. The template carried that token **twice**: the `<script id="receipt-data">` data slot **and** a JS placeholder-detection check (`if(rawReceipt==='__RECEIPT_JSON__')`) added alongside the dashboard. The receipt body was injected into the middle of a JS string literal, producing an `Uncaught SyntaxError: Invalid or unexpected token`. That aborted the entire inline verification script, so `render()` never ran and the loading spinner never cleared. Pre-existing sealed previews predate the JS check, which is why only freshly rendered receipts (the dashboard re-renders from the current template via `render_preview_html`) were affected.

## Fix

- **`preview_template.html`**: the JS placeholder check uses a split sentinel `'__RECEIPT'+'_JSON__'` so build-time substitution cannot clobber it; it reassembles at runtime to still detect an unsubstituted template.
- **`package.rs`**: `replacen(.., 1)` fills only the data slot (defense-in-depth against future token reuse).
- **Regression test**: asserts the rendered HTML keeps the split sentinel intact and contains no raw placeholder token. (The previous tests only checked the HTML *contained* strings, so they never caught that the JS failed to parse.)

## Verification

- Real receipt renders end to end (spinner clears, verification section shows), confirmed in a browser.
- Raw/unsubstituted template still shows its friendly "this is the template" message.
- All `session::package` unit tests pass, including the new regression assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)