### PR TITLE
Treeship memory proof receipts and Hub activation state UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ npm/@treeship/cli-*/expected-checksum.txt
 # the bootstrap can verify the GitHub Release download against a
 # PyPI-delivered hash. Never committed.
 packages/sdk-python/treeship_sdk/_data/expected-checksum-*.txt
+.gstack/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 package-lock.json
 next-env.d.ts
 .source/
+*.tsbuildinfo

--- a/docs/content/docs/api/dock-authorize.mdx
+++ b/docs/content/docs/api/dock-authorize.mdx
@@ -30,19 +30,21 @@ Content-Type: application/json
 
 ```json
 {
+  "state": "approved",
   "status": "approved"
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `status` | string | Approval status. Always `"approved"` on success. |
+| `state` | string | Device-flow state. `"approved"` once the browser approves. |
+| `status` | string | Legacy alias for `state`, kept for older clients. |
 
 No hub_id is returned. The browser's job is just to approve -- the CLI completes registration in the next step.
 
 ## CLI call (with keys)
 
-When the CLI calls this endpoint with Treeship and hub public keys, Hub verifies the challenge is already browser-approved, validates the nonce, atomically consumes the challenge, creates the Treeship record (if new), and returns a hub_id.
+When the CLI calls this endpoint with Treeship and hub public keys, Hub verifies the challenge is already browser-approved, validates the nonce, atomically claims the challenge for a new `dock_id`, creates the Treeship record, and returns it. The claim is single-use: a concurrent or replayed finalize is rejected as `already_attached`.
 
 The challenge **must** already be approved by the browser before the CLI calls this endpoint. The CLI must also provide the `nonce` that was returned by `GET /v1/hub/challenge`.
 
@@ -73,27 +75,42 @@ Content-Type: application/json
 
 ```json
 {
-  "hub_id": "hub_9f8e7d6c"
+  "state": "attached",
+  "dock_id": "hub_9f8e7d6c",
+  "next_steps": [
+    "treeship status",
+    "treeship attest receipt --system system://<your-system> --kind <kind> --payload-file <file>",
+    "treeship hub push <artifact-id>",
+    "treeship verify <artifact-id>"
+  ],
+  "example": "treeship attest receipt --system system://zmem --kind memory.proof --payload-file proof.json"
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `hub_id` | string | Unique identifier for this hub connection (format: `hub_` + 32 hex chars) |
+| `state` | string | `"attached"` on success. |
+| `dock_id` | string | Unique identifier for this hub connection (format: `dck_`/`hub_` + 32 hex chars) |
+| `next_steps` | string[] | Provider-neutral command templates to surface on the success page. |
+| `example` | string | One illustrative invocation. The placeholders are real; `system://zmem` and `memory.proof` are an example customer's memory-proof workflow, not built-in behavior. `--system` and `--kind` accept any value. |
+
+The challenge is **claimed**, not deleted, on success. The row is retained (with its `dock_id`) until well past expiry so a still-polling activation page reports `attached` rather than a misleading `not found`.
 
 ## Errors
 
-| Status | Body | Cause |
-|--------|------|-------|
-| `400` | `{"error": "missing device_code"}` | Request body is missing the `device_code` field |
-| `400` | `{"error": "missing nonce -- required for hub finalization"}` | CLI sent keys but omitted the `nonce` field |
-| `400` | `{"error": "invalid ship_public_key hex"}` | `ship_public_key` is not valid hex |
-| `400` | `{"error": "invalid hub_public_key hex"}` | `hub_public_key` is not valid hex |
-| `403` | `{"error": "challenge not yet approved -- complete browser activation first"}` | Keys were sent but the browser has not approved the challenge yet |
-| `403` | `{"error": "nonce mismatch"}` | The `nonce` does not match the one stored with the challenge |
-| `404` | `{"error": "device_code not found"}` | No challenge exists for this device code |
-| `409` | `{"error": "challenge already consumed"}` | Another request already consumed this challenge (prevents double-registration) |
-| `410` | `{"error": "device_code expired"}` | The challenge has passed its 5-minute expiry window |
+Every state-bearing response carries a stable `state` field so the activation page can distinguish outcomes precisely.
+
+| Status | Body | State | Cause |
+|--------|------|-------|-------|
+| `400` | `{"error": "missing device_code"}` | -- | Request body is missing the `device_code` field |
+| `400` | `{"error": "missing nonce -- required for dock finalization"}` | -- | CLI sent keys but omitted the `nonce` field |
+| `400` | `{"error": "invalid ship_public_key hex"}` | -- | `ship_public_key` is not valid hex |
+| `400` | `{"error": "invalid dock_public_key hex"}` | -- | `dock_public_key` is not valid hex |
+| `403` | `{"state": "pending", "error": "challenge not yet approved -- complete browser activation first"}` | `pending` | Keys were sent but the browser has not approved the challenge yet |
+| `403` | `{"error": "nonce mismatch"}` | -- | The `nonce` does not match the one stored with the challenge |
+| `404` | `{"state": "invalid", "error": "device_code not found"}` | `invalid` | No challenge exists for this device code |
+| `409` | `{"state": "already_attached", "error": "device code already used"}` | `already_attached` | This challenge was already finalized (prevents double-registration) |
+| `410` | `{"state": "expired", "error": "device_code expired"}` | `expired` | The challenge has passed its 5-minute expiry window |
 
 ## Examples
 
@@ -125,6 +142,6 @@ curl -X POST https://api.treeship.dev/v1/hub/authorize \
 - The Treeship public key and hub public key must be different Ed25519 keys
 - The Treeship key is stored for identification only. Hub never receives any private key
 - The hub key is used to verify DPoP JWT signatures on subsequent API requests
-- Each device code can only be authorized once -- the nonce is atomically consumed on success
+- Each device code can only be authorized once -- the challenge is atomically claimed (by `dock_id`) on success, and the row is kept so the activation page can still poll and read `attached`
 - If the `ship_public_key` already exists on Hub, the existing Treeship record is reused and a new hub connection is attached to it
 - The `nonce` field prevents replay attacks and binds the CLI request to the specific challenge session

--- a/docs/content/docs/api/hub-openapi.yaml
+++ b/docs/content/docs/api/hub-openapi.yaml
@@ -57,15 +57,43 @@ paths:
           schema: { type: string }
       responses:
         '200':
-          description: Approved
+          description: |
+            Browser approved (state `approved`) or device attached (state
+            `attached`). `attached` includes `dock_id` plus provider-neutral
+            `next_steps` and an illustrative `example`.
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  hub_id: { type: string, example: "hub_9f8e7d6c" }
+                  state:      { type: string, enum: [approved, attached] }
+                  dock_id:    { type: string, example: "hub_9f8e7d6c" }
+                  next_steps: { type: array, items: { type: string } }
+                  example:    { type: string }
         '202':
           description: Pending -- user has not approved yet
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state: { type: string, example: "pending" }
+        '404':
+          description: Unknown device code (never issued, or purged past expiry)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state: { type: string, example: "invalid" }
+        '410':
+          description: Device code expired before it was attached
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state: { type: string, example: "expired" }
 
   /v1/hub/authorize:
     post:
@@ -86,13 +114,34 @@ paths:
                 hub_public_key:   { type: string, description: "hex-encoded Ed25519 public key" }
       responses:
         '200':
-          description: Attached
+          description: |
+            Browser approval (state `approved`) or device attached
+            (state `attached`, with `dock_id`, `next_steps`, `example`).
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  hub_id: { type: string }
+                  state:      { type: string, enum: [approved, attached] }
+                  dock_id:    { type: string }
+                  next_steps: { type: array, items: { type: string } }
+                  example:    { type: string }
+        '409':
+          description: Device code already used (challenge already finalized)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state: { type: string, example: "already_attached" }
+        '410':
+          description: Device code expired
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state: { type: string, example: "expired" }
 
   /v1/artifacts:
     post:

--- a/docs/content/docs/cli/attest.mdx
+++ b/docs/content/docs/cli/attest.mdx
@@ -200,6 +200,16 @@ treeship attest receipt \
   --payload '{"eventId":"evt_abc","status":"succeeded"}'
 ```
 
+For larger structured receipts, read the payload from a file:
+
+```bash
+treeship attest receipt \
+  --system system://acme-memory \
+  --kind memory.proof \
+  --payload-file memory-proof.json \
+  --payload-digest sha256:...
+```
+
 ### Options
 
 | Option | Description |
@@ -208,5 +218,7 @@ treeship attest receipt \
 | `--kind <type>` | Receipt kind: confirmation, timestamp, inclusion, webhook (required) |
 | `--subject <id>` | Subject artifact ID |
 | `--payload <json>` | Receipt payload as a JSON object |
+| `--payload-file <path>` | Read receipt payload JSON from a file |
+| `--payload-digest <digest>` | Digest of the external payload, for example `sha256:<hex>` |
 </Tab>
 </Tabs>

--- a/docs/content/docs/cli/hub.mdx
+++ b/docs/content/docs/cli/hub.mdx
@@ -42,8 +42,22 @@ attached
   name:      default
   hub id:    hub_661e5463912d
   endpoint:  api.treeship.dev
-  workspace: treeship.dev/workspace/hub_661e5463912d
+
+next steps:
+  treeship status                                check ship + hub state
+  treeship attest receipt --system system://<your-system> \
+    --kind <kind> --payload-file <file>          sign an external receipt
+  treeship hub push <artifact-id>                share a signed artifact
+  treeship verify <artifact-id>                  verify it anywhere
+
+  example (memory proof):
+    treeship attest receipt --system system://zmem --kind memory.proof \
+      --payload-file proof.json
+
+  view your workspace: treeship hub open
 ```
+
+The `next steps` commands are provider-neutral templates. The example shows one customer's memory-proof workflow (`system://zmem`, `memory.proof`); `--system` and `--kind` accept any value.
 </Tab>
 <Tab value="Named">
 ```bash

--- a/docs/content/docs/cli/session.mdx
+++ b/docs/content/docs/cli/session.mdx
@@ -46,6 +46,76 @@ Outputs session id, name, actor, started-at timestamp, artifact count verified a
 
 If no session is active, exits cleanly with a hint to run `session start`.
 
+## treeship session invite
+
+Mint a single-use, expiring invitation that lets a second agent join an existing session. This is the host side of the [multi-agent session](/docs/concepts/multi-agent-sessions) lifecycle.
+
+```bash
+treeship session invite ssn_abc --invitee-cert "ed25519:ISSUER:org-x" --expires 1h
+treeship session invite ssn_abc --invitee-pubkey deadbeefdeadbeef --capabilities tool.call
+treeship session invite ssn_abc --open --expires 30m
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `[session_id]` | Session to mint the invitation for. Defaults to the active session. |
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--invitee-cert <issuer:subjects>` | Cert-restricted invitation. Format is `<issuer_pubkey>:<subject1,subject2,...>`. |
+| `--invitee-pubkey <fp-or-pubkey>` | Pubkey-restricted invitation. A 16-hex fingerprint or a full canonical pubkey. |
+| `--open` | Open invitation that anyone holding the blob can redeem. Opt-in only. |
+| `--capabilities <types>` | Comma-separated action types to grant. Defaults to `tool.call`. |
+| `--expires <duration>` | Lifetime such as `30s`, `5m`, `1h`, `7d`. Defaults to 1 hour. The protocol max is 7 days. |
+| `--format <text\|json>` | Output format. JSON returns `{ invitation_id, bootstrap_blob, session_ref, expires_at }`. |
+| `--no-armor` | Emit raw JSON instead of the armored blob. |
+
+Exactly one of `--invitee-cert`, `--invitee-pubkey`, or `--open` is required. The command signs the invitation with the keystore's default key (the session host), persists it under the artifact store, and prints an armored `-----BEGIN TREESHIP INVITATION-----` bootstrap blob on stdout.
+
+<Callout type="info">
+A joining agent only honors the invitation if the host's issuer key is pinned locally as a `session_host` trust root. Pin it with `treeship trust add <key_id> ed25519:<pubkey> --kind session_host --yes`. See [Multi-Agent Sessions](/docs/concepts/multi-agent-sessions#the-sessionhost-trust-root).
+</Callout>
+
+## treeship session join
+
+Redeem an invitation and emit a pending participant event. This is the joiner side of the lifecycle.
+
+```bash
+treeship session join --invite-file ./invite.blob --actor agent://researcher
+cat ./invite.blob | treeship session join --invite - --actor agent://qa
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--invite <blob>` | Paste the bootstrap blob inline. Use `-` to read from stdin. |
+| `--invite-file <path>` | Read the bootstrap blob from a file. |
+| `--actor <uri>` | Joining agent's actor URI, such as `agent://researcher` (required). |
+| `--format <text\|json>` | Output format. |
+
+The command pins the issuer against the local `SessionHost` trust roots, verifies the invitation signature, checks expiry and restriction, records the nonce in the Approval Use Journal with `max_uses=1`, and emits a single-signature participant envelope that is pending the host countersign. It prints the participant artifact id to pass to `session countersign`. A second join against the same invitation fails through the journal's single-use path.
+
+## treeship session countersign
+
+Host countersigns a pending participant event. After this runs, the participant envelope carries two signatures (joining agent plus host) and verifies as a finalized join.
+
+```bash
+treeship session countersign art_part_abc123
+```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `participant_id` | Participant artifact id produced by `session join`. |
+
+The command confirms the running default key matches the invitation's issuer, attaches the host countersign over the same canonical bytes, self-verifies, and overwrites the storage record with the finalized two-signature envelope. A participant envelope is invalid until both signatures are present.
+
 ## treeship session close
 
 Close the active session, compose the Session Receipt, and write a `.treeship` package.

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["trust-fabric", "trust-model", "agent-cards", "harnesses", "approval-authority", "approval-use-journal", "artifacts", "session-receipts", "room-sessions", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
+  "pages": ["trust-fabric", "trust-model", "agent-cards", "harnesses", "approval-authority", "approval-use-journal", "artifacts", "session-receipts", "room-sessions", "multi-agent-sessions", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
 }

--- a/docs/content/docs/concepts/multi-agent-sessions.mdx
+++ b/docs/content/docs/concepts/multi-agent-sessions.mdx
@@ -1,0 +1,65 @@
+---
+title: Multi-Agent Sessions
+description: Let a second agent join an existing session through a signed, single-use, expiring invitation that the host countersigns.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A multi-agent session lets a second agent join a session that another agent already started, with the join recorded as a signed, verifiable fact. Phase 1 of this model ships three CLI subcommands that wire one lifecycle: the host mints an invitation, a second agent joins against it, and the host countersigns the join.
+
+The result is a participant envelope that carries two signatures: the joining agent's assertion of "I am joining" and the host's countersign of "I observed this join." Either signature alone is invalid, so a join cannot be forged by the joiner and cannot be fabricated by the host after the fact.
+
+## The lifecycle
+
+```text
+host:    treeship session invite <session_id>   ->  prints an invitation blob
+joiner:  treeship session join --invite <blob> --actor agent://...
+host:    treeship session countersign <participant_artifact_id>
+```
+
+### 1. Invite
+
+The host runs [`treeship session invite`](/docs/cli/session#treeship-session-invite) against the active session. It mints and signs an invitation with the keystore's default key, persists it under the artifact store, and prints an armored bootstrap blob beginning with `-----BEGIN TREESHIP INVITATION-----`.
+
+Every invitation is restricted. You pick exactly one restriction:
+
+| Restriction | Flag | Who can redeem |
+|-------------|------|----------------|
+| Certificate | `--invitee-cert <issuer_pubkey>:<subjects>` | A holder whose certificate is issued by the named issuer for one of the allowed subjects. |
+| Public key | `--invitee-pubkey <fingerprint-or-pubkey>` | The single agent that holds the named key. |
+| Open | `--open` | Anyone holding the blob. Opt-in only, because it accepts any holder. |
+
+An invitation also carries the granted capability action types, an expiry, a `max_uses` of 1, and a random nonce. The default lifetime is 1 hour and the protocol ceiling is 7 days.
+
+### 2. Join
+
+The second agent runs [`treeship session join`](/docs/cli/session#treeship-session-join) with the blob and its own actor URI. The command:
+
+- Decodes the blob and pins the issuer against the local `SessionHost` trust roots.
+- Verifies the invitation signature, then checks expiry and restriction.
+- Writes the invitation's nonce into the Approval Use Journal with `max_uses=1`, so a second join attempt fails through the journal's existing single-use path.
+- Emits a single-signature, pending-countersign participant envelope and prints its artifact id.
+
+### 3. Countersign
+
+The host runs [`treeship session countersign`](/docs/cli/session#treeship-session-countersign) with that participant artifact id. The command confirms the running default key matches the invitation's issuer, attaches the host countersign over the same canonical bytes, self-verifies, and overwrites the storage record with the finalized two-signature envelope.
+
+A participant envelope is only valid once both signatures are present. Verification rejects an envelope that is missing the host countersign, carries too many signatures, has any signature that does not verify, or whose countersign key does not match the invitation's issuer.
+
+## The SessionHost trust root
+
+The invitation issuer's public key is embedded in every invitation. Before `treeship session join` honors an invitation, that key must be pinned locally as a `session_host` trust root. Without the pin, a self-signed forgery would verify cryptographically but be quarantined by trust-root enforcement.
+
+Pin a host with:
+
+```bash
+treeship trust add <key_id> ed25519:<pubkey> --kind session_host --yes
+```
+
+<Callout type="info">
+`session_host` is a separate trust kind from `ship`, `hub_checkpoint`, and `agent_cert`. A machine can trust a hub org's checkpoints without implicitly trusting that org to host multi-agent sessions. The trust kinds do not cross over.
+</Callout>
+
+## Inspecting sessions locally
+
+[`treeship dashboard`](/docs/cli/dashboard) is the read-only, localhost-only way to inspect sessions and their participants. It reads sealed `.treeship` packages from disk and surfaces trust status, agent membership, receipts, reports, and capabilities without requiring a hub. It also exposes JSON endpoints so the same data is scriptable.

--- a/docs/content/docs/integrations/memory-proofs.mdx
+++ b/docs/content/docs/integrations/memory-proofs.mdx
@@ -1,0 +1,165 @@
+---
+title: Memory Providers
+description: Use Treeship as the portable proof layer for agent memory systems.
+---
+
+# Memory Providers
+
+Agent memory systems should own memory selection, ranking, policy, storage, and local recall. Treeship should own portable proof: signed artifacts, offline verification, bundles, handoffs, and Hub sharing.
+
+This page is a provider contract. ZMem can use it, but so can Mem0, Zep, Letta, a SQLite memory store, or an in-house retrieval layer.
+
+The rule is simple:
+
+- Use a Treeship action artifact for the memory operation itself.
+- Use a Treeship receipt artifact when the memory provider already produced its own local proof and wants that proof to travel.
+- Sign URIs, digests, and proof summaries by default. Do not put raw private memories, embeddings, or prompts into Treeship artifacts unless the operator explicitly chooses to.
+
+## Provider Identity
+
+Each provider chooses a stable system URI:
+
+```text
+system://zmem
+system://mem0
+system://zep
+system://letta
+system://acme-memory
+```
+
+Use that URI consistently in receipt artifacts and metadata. For individual memory subjects, use stable memory URIs:
+
+```text
+memory://zmem/default/task-preferences
+memory://mem0/users/u_123/facts/fact_456
+memory://zep/sessions/s_123/messages/m_456
+memory://acme-memory/project-alpha/decision/d_789
+```
+
+The URI names the thing. The digest proves which private content or query/result payload was used.
+
+## Memory Actions
+
+Memory providers can attest reads, writes, deletes, compactions, retrievals, and injections without exposing private memory content:
+
+```bash
+treeship attest action \
+  --actor agent://codex \
+  --action memory.read \
+  --subject memory://<provider>/<namespace>/<key> \
+  --input-digest sha256:... \
+  --output-digest sha256:... \
+  --meta '{"memory_provider":"system://<provider>","namespace":"default","query_digest":"sha256:...","result_digest":"sha256:..."}'
+```
+
+Treeship signs the actor, operation, subject URI, input digest, output digest, timestamp, and metadata. The memory provider decides what the digests mean and how to re-check them.
+
+Recommended action labels:
+
+```text
+memory.read
+memory.write
+memory.delete
+memory.query
+memory.retrieve
+memory.inject
+memory.compact
+memory.handoff
+```
+
+For sensitive writes or deletes, mint a scoped approval first:
+
+```bash
+treeship attest approval \
+  --approver human://owner \
+  --allowed-action memory.delete \
+  --allowed-subject memory://<provider>/<namespace>/<key> \
+  --max-uses 1
+```
+
+The memory system can then consume the approval nonce when it signs the action.
+
+## Provider Receipts
+
+Use provider receipts when the memory system has its own local proof, such as a Merkle root, append-only event log checkpoint, policy decision, retrieval trace, or index commit.
+
+Use:
+
+```text
+system = system://<provider>
+kind   = memory.proof
+```
+
+The receipt payload should be a JSON object with enough information for a verifier to understand the memory decision without trusting the provider UI:
+
+```json
+{
+  "schema": "com.example.memory.proof.v1",
+  "provider": "system://acme-memory",
+  "subject": {
+    "type": "memory_action",
+    "id": "mem_action_123",
+    "agent_id": "codex"
+  },
+  "object": {
+    "retrieved_memory_ids": ["mem_a", "mem_b"],
+    "injected_memory_ids": ["mem_a"],
+    "withheld_memory_ids": []
+  },
+  "evidence": {
+    "query_digest": "sha256:...",
+    "result_digest": "sha256:...",
+    "merkle_root": "...",
+    "event_log_checkpoint": "..."
+  }
+}
+```
+
+Then sign it:
+
+```bash
+treeship attest receipt \
+  --system system://acme-memory \
+  --kind memory.proof \
+  --payload-file memory-proof.json \
+  --payload-digest sha256:...
+```
+
+The resulting Treeship artifact is the portable proof handle. Push it to Hub when you need a shareable URL:
+
+```bash
+treeship hub push art_...
+```
+
+## ZMem Example
+
+ZMem uses the same provider contract with:
+
+```text
+system = system://zmem
+kind   = memory.proof
+```
+
+Its receipt payload includes the ZMem action id, retrieved/injected/withheld memory ids, policy checks, event Merkle root, bundle hash, and local verification result. Treeship does not need to understand those ZMem semantics; it signs and verifies the receipt payload, then makes it portable.
+
+## Division Of Responsibility
+
+A memory provider proves:
+
+- which memories were retrieved,
+- which memories were injected,
+- which memories were withheld,
+- which policy checks ran,
+- which event logs, index commits, Merkle roots, or local receipts backed the decision.
+
+Treeship proves:
+
+- which actor signed a memory operation,
+- which memory URI or digest the operation targeted,
+- who signed the memory proof,
+- when it was signed,
+- that the payload was not modified,
+- that the proof can be verified offline,
+- that the proof can be bundled, handed off, or shared.
+
+Do not duplicate provider-specific memory semantics inside Treeship. Treeship signs and verifies the memory proof payload; the provider remains responsible for recall, policy, indexing, and proof interpretation.

--- a/docs/content/docs/integrations/meta.json
+++ b/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["agent-skills", "codex", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "lobster-cash", "robinhood-agentic-trading", "verifiable-intent"]
+  "pages": ["agent-skills", "codex", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "memory-proofs", "lobster-cash", "robinhood-agentic-trading", "verifiable-intent"]
 }

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -95,6 +95,15 @@ pub fn action(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std
         obj.insert("approval_use_id".into(), Value::String(use_id.clone()));
         meta = Some(Value::Object(obj));
     }
+    if let Some(ref output_digest) = args.output_digest {
+        let mut obj = match meta.take() {
+            Some(Value::Object(map)) => map,
+            Some(_other) => return Err("--meta must be a JSON object when --output-digest is set".into()),
+            None => serde_json::Map::new(),
+        };
+        obj.insert("output_digest".into(), Value::String(output_digest.clone()));
+        meta = Some(Value::Object(obj));
+    }
     stmt.meta = meta;
 
     let signer = ctx.keys.default_signer()?;
@@ -323,23 +332,33 @@ pub fn handoff(args: HandoffArgs, printer: &Printer) -> Result<(), Box<dyn std::
 // --- receipt ----------------------------------------------------------------
 
 pub struct ReceiptArgs {
-    pub system:     String,
-    pub kind:       String,
-    pub subject_id: Option<String>,
-    pub payload:    Option<String>,
-    pub config:     Option<String>,
+    pub system:         String,
+    pub kind:           String,
+    pub subject_id:     Option<String>,
+    pub payload:        Option<String>,
+    pub payload_file:   Option<String>,
+    pub payload_digest: Option<String>,
+    pub config:         Option<String>,
 }
 
 pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = ctx::open(args.config.as_deref())?;
 
-    let payload_val: Option<Value> = args.payload.as_deref()
+    let payload_text = match (&args.payload, &args.payload_file) {
+        (Some(payload), None) => Some(payload.clone()),
+        (None, Some(path)) => Some(std::fs::read_to_string(path)
+            .map_err(|e| format!("could not read --payload-file {path}: {e}"))?),
+        (None, None) => None,
+        (Some(_), Some(_)) => return Err("--payload and --payload-file cannot be used together".into()),
+    };
+    let payload_val: Option<Value> = payload_text.as_deref()
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| format!("--payload is not valid JSON: {e}"))?;
+        .map_err(|e| format!("receipt payload is not valid JSON: {e}"))?;
 
     let mut stmt = ReceiptStatement::new(&args.system, &args.kind);
     stmt.payload = payload_val;
+    stmt.payload_digest = args.payload_digest.clone();
     if let Some(id) = &args.subject_id {
         stmt.subject = Some(SubjectRef {
             artifact_id: Some(id.clone()),

--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -107,8 +107,19 @@ pub fn attach(
                 }
                 // 202 = pending, keep polling
             }
-            Err(ureq::Error::Status(404, _)) => {
-                return Err("device code expired or not found\n\n  Fix: run treeship hub attach again to get a new code".into());
+            Err(ureq::Error::Status(code, _)) => {
+                // The Hub reports distinct terminal states so we can tell the
+                // user exactly what happened instead of a catch-all message.
+                //   404 unknown code   410 expired   409 already used
+                let reason = match code {
+                    404 => "device code not found",
+                    410 => "device code expired",
+                    409 => "device code already used",
+                    _   => "hub activation failed",
+                };
+                return Err(format!(
+                    "{reason}\n\n  Fix: run treeship hub attach again to get a new code"
+                ).into());
             }
             Err(e) => {
                 return Err(format!("polling error: {e}").into());
@@ -167,10 +178,33 @@ pub fn attach(
         ("hub id",   &final_hub_id),
         ("endpoint", &endpoint),
     ]);
+    printer.blank();
+    print_attach_next_steps(printer);
     printer.hint("view your workspace: treeship hub open");
     printer.blank();
 
     Ok(())
+}
+
+/// Print concrete next steps after a successful attach.
+///
+/// The commands are provider-neutral templates: signing an external system
+/// receipt, pushing it, and verifying it anywhere. The example uses
+/// `system://zmem` with a `memory.proof` kind purely to illustrate one
+/// customer's memory-proof workflow -- ZMem is an example, not built-in
+/// behavior, and `--system`/`--kind` accept any value.
+fn print_attach_next_steps(printer: &Printer) {
+    printer.info("next steps:");
+    printer.info("  treeship status                                check ship + hub state");
+    printer.info("  treeship attest receipt --system system://<your-system> \\");
+    printer.info("    --kind <kind> --payload-file <file>          sign an external receipt");
+    printer.info("  treeship hub push <artifact-id>                share a signed artifact");
+    printer.info("  treeship verify <artifact-id>                  verify it anywhere");
+    printer.blank();
+    printer.dim_info("  example (memory proof):");
+    printer.dim_info("    treeship attest receipt --system system://zmem --kind memory.proof \\");
+    printer.dim_info("      --payload-file proof.json");
+    printer.blank();
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1393,6 +1393,14 @@ struct AttestReceiptArgs {
     /// Receipt payload as a JSON object
     #[arg(long, value_name = r#"'{"key":"val"}'"#)]
     payload: Option<String>,
+
+    /// Read receipt payload JSON from a file
+    #[arg(long, value_name = "PATH", conflicts_with = "payload")]
+    payload_file: Option<String>,
+
+    /// Digest of the external payload, for example sha256:<hex>
+    #[arg(long, value_name = "DIGEST")]
+    payload_digest: Option<String>,
 }
 
 #[derive(Args)]
@@ -2272,11 +2280,13 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             ),
             AttestCommand::Receipt(a) => commands::attest::receipt(
                 commands::attest::ReceiptArgs {
-                    system:     a.system.clone(),
-                    kind:       a.kind.clone(),
-                    subject_id: a.subject.clone(),
-                    payload:    a.payload.clone(),
-                    config:     cli.config.clone(),
+                    system:         a.system.clone(),
+                    kind:           a.kind.clone(),
+                    subject_id:     a.subject.clone(),
+                    payload:        a.payload.clone(),
+                    payload_file:   a.payload_file.clone(),
+                    payload_digest: a.payload_digest.clone(),
+                    config:         cli.config.clone(),
                 },
                 printer,
             ),

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	_ "modernc.org/sqlite"
 )
@@ -36,7 +37,13 @@ CREATE TABLE IF NOT EXISTS dock_challenges (
   expires_at      INTEGER NOT NULL,
   approved        INTEGER DEFAULT 0,
   dock_public_key BLOB,
-  ship_public_key BLOB
+  ship_public_key BLOB,
+  -- dock_id is NULL until the CLI finalizes the device flow. A non-NULL
+  -- dock_id is the terminal "attached" state: the challenge has been
+  -- consumed and the ship record created. We keep the row (rather than
+  -- deleting on finalize) so the browser activation page can poll and see
+  -- "attached" instead of a misleading "not found" 404.
+  dock_id         TEXT
 );
 
 CREATE TABLE IF NOT EXISTS dpop_jtis (
@@ -146,7 +153,32 @@ func Open() (*sql.DB, error) {
 		return nil, fmt.Errorf("apply schema: %w", err)
 	}
 
+	if err := migrate(db); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("migrate: %w", err)
+	}
+
 	return db, nil
+}
+
+// migrate applies idempotent schema additions for databases created before a
+// column existed. CREATE TABLE IF NOT EXISTS never alters an existing table,
+// so new columns must be added explicitly. Each ALTER tolerates the
+// "duplicate column name" error so re-running against an up-to-date DB is a
+// no-op.
+func migrate(db *sql.DB) error {
+	addColumns := []string{
+		`ALTER TABLE dock_challenges ADD COLUMN dock_id TEXT`,
+	}
+	for _, stmt := range addColumns {
+		if _, err := db.Exec(stmt); err != nil {
+			if strings.Contains(err.Error(), "duplicate column name") {
+				continue
+			}
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	return nil
 }
 
 // --- dock_challenges ---
@@ -168,23 +200,24 @@ func InsertChallenge(db *sql.DB, deviceCode, nonce string, expiresAt int64) erro
 }
 
 func GetChallenge(db *sql.DB, deviceCode string) (*Challenge, error) {
+	const cols = `device_code, nonce, expires_at, approved, COALESCE(dock_id, '')`
 	// Try exact match first (full 16-char code).
 	row := db.QueryRow(
-		`SELECT device_code, nonce, expires_at, approved FROM dock_challenges WHERE device_code = ?`,
+		`SELECT `+cols+` FROM dock_challenges WHERE device_code = ?`,
 		deviceCode,
 	)
 	c := &Challenge{}
 	var approved int
-	if err := row.Scan(&c.DeviceCode, &c.Nonce, &c.ExpiresAt, &approved); err != nil {
+	if err := row.Scan(&c.DeviceCode, &c.Nonce, &c.ExpiresAt, &approved, &c.DockID); err != nil {
 		// If exact match fails and input is 8 chars (legacy CLI prefix),
 		// try prefix match. LIKE is safe here because we already validated
 		// the input as ^[0-9a-f]{8,16}$ before calling this function.
 		if len(deviceCode) < 16 {
 			row = db.QueryRow(
-				`SELECT device_code, nonce, expires_at, approved FROM dock_challenges WHERE device_code LIKE ? LIMIT 1`,
+				`SELECT `+cols+` FROM dock_challenges WHERE device_code LIKE ? LIMIT 1`,
 				deviceCode+"%",
 			)
-			if err2 := row.Scan(&c.DeviceCode, &c.Nonce, &c.ExpiresAt, &approved); err2 != nil {
+			if err2 := row.Scan(&c.DeviceCode, &c.Nonce, &c.ExpiresAt, &approved, &c.DockID); err2 != nil {
 				return nil, err // return original error
 			}
 			c.Approved = approved == 1
@@ -209,12 +242,23 @@ func DeleteChallenge(db *sql.DB, deviceCode string) error {
 	return err
 }
 
-// ConsumeChallenge atomically deletes a challenge by device_code + nonce.
-// Returns true if exactly one row was deleted (single-use guarantee).
-func ConsumeChallenge(db *sql.DB, deviceCode string, nonce string) (bool, error) {
+// FinalizeChallenge atomically claims an approved challenge for a dock_id.
+// It is the single-use gate for the device flow: the UPDATE only matches when
+// the challenge is approved and not yet finalized (dock_id IS NULL), so a
+// concurrent or replayed finalize sees zero rows affected and must be rejected.
+//
+// This replaces the previous delete-on-consume behavior. Keeping the row and
+// recording the resulting dock_id lets GET /v1/dock/authorized report a
+// terminal "attached" state instead of a misleading "not found" once the CLI
+// has completed, which was the source of the dogfooded "device_code not found
+// then Attached" flash on the activation page.
+//
+// Returns true if this call won the claim (exactly one row updated).
+func FinalizeChallenge(db *sql.DB, deviceCode string, nonce string, dockID string) (bool, error) {
 	result, err := db.Exec(
-		`DELETE FROM dock_challenges WHERE device_code = ? AND nonce = ? AND approved = 1`,
-		deviceCode, nonce,
+		`UPDATE dock_challenges SET dock_id = ?
+		 WHERE device_code = ? AND nonce = ? AND approved = 1 AND dock_id IS NULL`,
+		dockID, deviceCode, nonce,
 	)
 	if err != nil {
 		return false, err
@@ -224,6 +268,29 @@ func ConsumeChallenge(db *sql.DB, deviceCode string, nonce string) (bool, error)
 		return false, err
 	}
 	return rows == 1, nil
+}
+
+// ReleaseChallenge clears a previously claimed dock_id. It is a best-effort
+// rollback used only when ship creation fails after FinalizeChallenge has
+// already claimed the challenge, so the device code is not left stuck in a
+// half-finalized state pointing at a ship that was never created.
+func ReleaseChallenge(db *sql.DB, deviceCode string, dockID string) error {
+	_, err := db.Exec(
+		`UPDATE dock_challenges SET dock_id = NULL WHERE device_code = ? AND dock_id = ?`,
+		deviceCode, dockID,
+	)
+	return err
+}
+
+// CleanExpiredChallenges purges challenge rows whose expiry has passed beyond a
+// grace window. The grace window keeps recently-expired and recently-attached
+// codes queryable long enough for in-flight activation pages to render a
+// precise "expired" or "attached" state before the row disappears. Once a code
+// is well past expiry it is purged, after which it correctly reads as an
+// unknown (invalid) code.
+func CleanExpiredChallenges(db *sql.DB, before int64) error {
+	_, err := db.Exec(`DELETE FROM dock_challenges WHERE expires_at < ?`, before)
+	return err
 }
 
 // --- ships ---
@@ -386,16 +453,16 @@ func CleanExpiredWorkspaceSessions(db *sql.DB, now int64) error {
 // --- merkle_checkpoints ---
 
 type MerkleCheckpoint struct {
-	ID            int64   `json:"id"`
-	RootHex       string  `json:"root"`
-	TreeSize      int64   `json:"tree_size"`
-	Height        int     `json:"height"`
-	SignedAt      string  `json:"signed_at"`
-	SignerKeyID   string  `json:"signer"`
-	SignatureB64  string  `json:"signature"`
-	PublicKeyB64  string  `json:"public_key"`
-	RekorIndex    *int64  `json:"rekor_index"`
-	DockID        *string `json:"dock_id"`
+	ID           int64   `json:"id"`
+	RootHex      string  `json:"root"`
+	TreeSize     int64   `json:"tree_size"`
+	Height       int     `json:"height"`
+	SignedAt     string  `json:"signed_at"`
+	SignerKeyID  string  `json:"signer"`
+	SignatureB64 string  `json:"signature"`
+	PublicKeyB64 string  `json:"public_key"`
+	RekorIndex   *int64  `json:"rekor_index"`
+	DockID       *string `json:"dock_id"`
 }
 
 func InsertCheckpoint(database *sql.DB, cp *MerkleCheckpoint, dockID string) (int64, error) {
@@ -445,11 +512,11 @@ func GetLatestCheckpoint(database *sql.DB, dockID string) (*MerkleCheckpoint, er
 // --- merkle_proofs ---
 
 type MerkleProof struct {
-	ArtifactID   string `json:"artifact_id"`
-	CheckpointID int64  `json:"checkpoint_id"`
-	LeafIndex    int64  `json:"leaf_index"`
-	LeafHash     string `json:"leaf_hash"`
-	ProofJSON    string `json:"proof_json"`
+	ArtifactID   string  `json:"artifact_id"`
+	CheckpointID int64   `json:"checkpoint_id"`
+	LeafIndex    int64   `json:"leaf_index"`
+	LeafHash     string  `json:"leaf_hash"`
+	ProofJSON    string  `json:"proof_json"`
 	DockID       *string `json:"dock_id"`
 }
 
@@ -467,17 +534,17 @@ func InsertProof(database *sql.DB, artifactID string, checkpointID int64, leafIn
 // Session represents a row in the sessions table.
 // ReceiptJSON is nil when the session is open (registered but no receipt yet).
 type Session struct {
-	SessionID    string
-	DockID       string
-	Name         *string
-	StartedAt    *string
-	EndedAt      *string
-	DurationMS   *int64
-	Status       string
-	AgentCount   int
-	ActionCount  int
-	ReceiptJSON  *string
-	UploadedAt   *int64
+	SessionID   string
+	DockID      string
+	Name        *string
+	StartedAt   *string
+	EndedAt     *string
+	DurationMS  *int64
+	Status      string
+	AgentCount  int
+	ActionCount int
+	ReceiptJSON *string
+	UploadedAt  *int64
 }
 
 // InsertSessionWriteOnce atomically inserts a session with its receipt.

--- a/packages/hub/internal/dock/dock.go
+++ b/packages/hub/internal/dock/dock.go
@@ -34,6 +34,12 @@ func jsonError(w http.ResponseWriter, msg string, code int) {
 
 // Challenge handles GET /v1/dock/challenge
 func (h *Handlers) Challenge(w http.ResponseWriter, r *http.Request) {
+	// Opportunistically purge challenges well past expiry. A 1-hour grace
+	// window keeps recently-expired and recently-attached codes queryable so
+	// in-flight activation pages still see a precise state. Mirrors the
+	// per-request cleanup used for dpop_jtis and workspace_sessions.
+	_ = db.CleanExpiredChallenges(h.DB, time.Now().Unix()-3600)
+
 	nonce := randomHex(16)
 	deviceCode := randomHex(8)
 	expiresAt := time.Now().Unix() + 300
@@ -51,51 +57,100 @@ func (h *Handlers) Challenge(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// writeJSON writes a JSON body with an explicit status code.
+func writeJSON(w http.ResponseWriter, code int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// attachGuidance returns provider-neutral next steps shown after a device is
+// attached. The commands use placeholders (<your-system>, <kind>, <file>,
+// <artifact-id>) so the guidance describes Treeship behavior, not any one
+// customer. `example` is a single illustrative invocation; ZMem is an example
+// customer here, not built-in product behavior.
+func attachGuidance() map[string]interface{} {
+	return map[string]interface{}{
+		"next_steps": []string{
+			"treeship status",
+			"treeship attest receipt --system system://<your-system> --kind <kind> --payload-file <file>",
+			"treeship hub push <artifact-id>",
+			"treeship verify <artifact-id>",
+		},
+		"example": "treeship attest receipt --system system://zmem --kind memory.proof --payload-file proof.json",
+	}
+}
+
 // Authorized handles GET /v1/dock/authorized?device_code=XXX
+//
+// It reports a single, unambiguous `state` for the device code so the
+// activation page can render distinct messaging instead of collapsing several
+// outcomes into one "not found":
+//
+//	invalid  (400) malformed device_code
+//	invalid  (404) no such challenge (never issued, or purged long after expiry)
+//	attached (200) terminal success -- the CLI finalized; dock_id is present
+//	expired  (410) the challenge passed its expiry window before being attached
+//	pending  (202) issued, browser has not approved yet
+//	approved (200) browser approved; the CLI has not finalized yet
+//
+// `attached` is checked before `expired` so a device that completed near the
+// expiry boundary still reports success rather than flipping to expired.
 func (h *Handlers) Authorized(w http.ResponseWriter, r *http.Request) {
 	deviceCode := r.URL.Query().Get("device_code")
 	if deviceCode == "" || !isValidDeviceCode(deviceCode) {
-		jsonError(w, "missing or invalid device_code", http.StatusBadRequest)
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"state": "invalid",
+			"error": "missing or invalid device_code",
+		})
 		return
 	}
 
 	challenge, err := db.GetChallenge(h.DB, deviceCode)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"state": "invalid",
+			"error": "unknown device code",
+		})
+		return
+	}
+
+	// Terminal success. Checked before expiry so a just-attached device near
+	// the expiry boundary does not momentarily read as expired.
+	if challenge.DockID != "" {
+		body := map[string]interface{}{
+			"state":   "attached",
+			"dock_id": challenge.DockID,
+		}
+		for k, v := range attachGuidance() {
+			body[k] = v
+		}
+		writeJSON(w, http.StatusOK, body)
 		return
 	}
 
 	if time.Now().Unix() > challenge.ExpiresAt {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "expired"})
+		writeJSON(w, http.StatusGone, map[string]string{
+			"state": "expired",
+			"error": "device code expired",
+		})
 		return
 	}
 
 	if !challenge.Approved {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusAccepted)
-		json.NewEncoder(w).Encode(map[string]string{"status": "pending"})
+		writeJSON(w, http.StatusAccepted, map[string]string{
+			"state":  "pending",
+			"status": "pending", // legacy field, kept for existing clients
+		})
 		return
 	}
 
-	// Challenge is approved. Return 200 with status "approved".
-	w.Header().Set("Content-Type", "application/json")
-
-	row := h.DB.QueryRow(
-		`SELECT s.dock_id FROM ships s
-		 JOIN dock_challenges dc ON dc.ship_public_key = s.ship_public_key AND dc.dock_public_key = s.dock_public_key
-		 WHERE dc.device_code = ?`, challenge.DeviceCode,
-	)
-	var dockID string
-	if err := row.Scan(&dockID); err != nil {
-		json.NewEncoder(w).Encode(map[string]string{"status": "approved"})
-		return
-	}
-
-	json.NewEncoder(w).Encode(map[string]string{"dock_id": dockID})
+	// Browser approved; the CLI has not finalized yet. 200 so the CLI poll
+	// loop (which breaks on HTTP 200) proceeds to the authorize step.
+	writeJSON(w, http.StatusOK, map[string]string{
+		"state":  "approved",
+		"status": "approved", // legacy field, kept for existing clients
+	})
 }
 
 type authorizeRequest struct {
@@ -118,18 +173,32 @@ func (h *Handlers) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify device_code exists and not expired.
+	// Verify device_code exists.
 	challenge, err := db.GetChallenge(h.DB, req.DeviceCode)
 	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		json.NewEncoder(w).Encode(map[string]string{"error": "device_code not found"})
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"state": "invalid",
+			"error": "device_code not found",
+		})
 		return
 	}
+
+	// If the device was already finalized, report the terminal state instead
+	// of a generic error. A browser that re-submits, or a duplicate CLI
+	// finalize, lands here. This is the "already-used" case.
+	if challenge.DockID != "" {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"state": "already_attached",
+			"error": "device code already used",
+		})
+		return
+	}
+
 	if time.Now().Unix() > challenge.ExpiresAt {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusGone)
-		json.NewEncoder(w).Encode(map[string]string{"error": "device_code expired"})
+		writeJSON(w, http.StatusGone, map[string]string{
+			"state": "expired",
+			"error": "device_code expired",
+		})
 		return
 	}
 
@@ -139,39 +208,33 @@ func (h *Handlers) Authorize(w http.ResponseWriter, r *http.Request) {
 			jsonError(w, "failed to approve challenge", http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "approved"})
+		writeJSON(w, http.StatusOK, map[string]string{
+			"state":  "approved",
+			"status": "approved", // legacy field, kept for existing clients
+		})
 		return
 	}
 
 	// CLI flow: keys provided. Challenge MUST already be approved by browser.
 	if !challenge.Approved {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		json.NewEncoder(w).Encode(map[string]string{"error": "challenge not yet approved -- complete browser activation first"})
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"state": "pending",
+			"error": "challenge not yet approved -- complete browser activation first",
+		})
 		return
 	}
 
 	// Nonce is mandatory for key-bearing finalization.
 	if req.Nonce == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "missing nonce -- required for dock finalization"})
+		writeJSON(w, http.StatusBadRequest, map[string]string{
+			"error": "missing nonce -- required for dock finalization",
+		})
 		return
 	}
 	if req.Nonce != challenge.Nonce {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		json.NewEncoder(w).Encode(map[string]string{"error": "nonce mismatch"})
-		return
-	}
-
-	// Atomically consume the challenge so concurrent requests cannot reuse it.
-	consumed, err := db.ConsumeChallenge(h.DB, challenge.DeviceCode, challenge.Nonce)
-	if err != nil || !consumed {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusConflict)
-		json.NewEncoder(w).Encode(map[string]string{"error": "challenge already consumed"})
+		writeJSON(w, http.StatusForbidden, map[string]string{
+			"error": "nonce mismatch",
+		})
 		return
 	}
 
@@ -186,16 +249,41 @@ func (h *Handlers) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create the ship record.
+	// Atomically claim the challenge for this dock_id. The claim is the
+	// single-use gate: only one caller can transition an approved challenge
+	// from unclaimed (dock_id NULL) to claimed, so concurrent or replayed
+	// finalizes are rejected as "already used".
 	dockID := "dck_" + randomHex(16)
+	claimed, err := db.FinalizeChallenge(h.DB, challenge.DeviceCode, challenge.Nonce, dockID)
+	if err != nil {
+		jsonError(w, "failed to finalize challenge", http.StatusInternalServerError)
+		return
+	}
+	if !claimed {
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"state": "already_attached",
+			"error": "device code already used",
+		})
+		return
+	}
+
+	// Create the ship record. If this fails, release the claim so the device
+	// code is not stranded pointing at a ship that does not exist.
 	now := time.Now().Unix()
 	if err := db.InsertShip(h.DB, dockID, shipPubKey, dockPubKey, now); err != nil {
+		_ = db.ReleaseChallenge(h.DB, challenge.DeviceCode, dockID)
 		jsonError(w, "failed to create ship", http.StatusInternalServerError)
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"dock_id": dockID})
+	body := map[string]interface{}{
+		"state":   "attached",
+		"dock_id": dockID,
+	}
+	for k, v := range attachGuidance() {
+		body[k] = v
+	}
+	writeJSON(w, http.StatusOK, body)
 }
 
 func randomHex(n int) string {

--- a/packages/hub/internal/dock/dock_test.go
+++ b/packages/hub/internal/dock/dock_test.go
@@ -1,0 +1,262 @@
+package dock
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/treeship/hub/internal/db"
+)
+
+// newTestHandlers spins up an isolated SQLite-backed Handlers for one test.
+func newTestHandlers(t *testing.T) *Handlers {
+	t.Helper()
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return &Handlers{DB: database}
+}
+
+func issueChallenge(t *testing.T, h *Handlers) (deviceCode, nonce string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.Challenge(rec, httptest.NewRequest(http.MethodGet, "/v1/dock/challenge", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("challenge status = %d, want 200", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode challenge: %v", err)
+	}
+	if body["device_code"] == "" || body["nonce"] == "" {
+		t.Fatalf("challenge missing device_code/nonce: %v", body)
+	}
+	return body["device_code"], body["nonce"]
+}
+
+func getAuthorized(t *testing.T, h *Handlers, code string) (int, map[string]interface{}) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/dock/authorized?device_code="+url.QueryEscape(code), nil)
+	rec := httptest.NewRecorder()
+	h.Authorized(rec, req)
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	return rec.Code, body
+}
+
+func postAuthorize(t *testing.T, h *Handlers, payload map[string]string) (int, map[string]interface{}) {
+	t.Helper()
+	b, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/v1/dock/authorize", bytes.NewReader(b))
+	rec := httptest.NewRecorder()
+	h.Authorize(rec, req)
+	var body map[string]interface{}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	return rec.Code, body
+}
+
+// Two distinct, valid 32-byte hex keys for the CLI finalize step. The handler
+// stores them verbatim; it does not validate them as curve points.
+const (
+	testShipPubHex = "abababababababababababababababababababababababababababababababab" + "ab"
+	testDockPubHex = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd" + "cd"
+)
+
+func TestAuthorized_InvalidFormat(t *testing.T) {
+	h := newTestHandlers(t)
+	code, body := getAuthorized(t, h, "not-hex!")
+	if code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", code)
+	}
+	if body["state"] != "invalid" {
+		t.Fatalf("state = %v, want invalid", body["state"])
+	}
+}
+
+func TestAuthorized_UnknownCode(t *testing.T) {
+	h := newTestHandlers(t)
+	// Well-formed but never issued.
+	code, body := getAuthorized(t, h, strings.Repeat("a", 16))
+	if code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", code)
+	}
+	if body["state"] != "invalid" {
+		t.Fatalf("state = %v, want invalid", body["state"])
+	}
+}
+
+func TestAuthorized_Pending(t *testing.T) {
+	h := newTestHandlers(t)
+	code, _ := issueChallenge(t, h)
+	status, body := getAuthorized(t, h, code)
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", status)
+	}
+	if body["state"] != "pending" {
+		t.Fatalf("state = %v, want pending", body["state"])
+	}
+}
+
+func TestAuthorized_Approved(t *testing.T) {
+	h := newTestHandlers(t)
+	code, _ := issueChallenge(t, h)
+
+	// Browser approves with no keys.
+	status, body := postAuthorize(t, h, map[string]string{"device_code": code})
+	if status != http.StatusOK || body["state"] != "approved" {
+		t.Fatalf("browser approve = %d %v, want 200 approved", status, body)
+	}
+
+	status, body = getAuthorized(t, h, code)
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if body["state"] != "approved" {
+		t.Fatalf("state = %v, want approved", body["state"])
+	}
+}
+
+// TestAuthorized_AttachedNotNotFound is the regression test for the dogfooded
+// "device_code not found then Attached" flash. After the CLI finalizes, the
+// browser keeps polling /authorized. Previously the challenge row was deleted
+// on consume, so the poll returned 404 "not found" even though attach
+// succeeded. It must now report the terminal "attached" state.
+func TestAuthorized_AttachedNotNotFound(t *testing.T) {
+	h := newTestHandlers(t)
+	code, nonce := issueChallenge(t, h)
+
+	// Browser approval.
+	if status, _ := postAuthorize(t, h, map[string]string{"device_code": code}); status != http.StatusOK {
+		t.Fatalf("browser approve status = %d, want 200", status)
+	}
+
+	// CLI finalize with keys.
+	status, body := postAuthorize(t, h, map[string]string{
+		"device_code":     code,
+		"ship_public_key": testShipPubHex,
+		"dock_public_key": testDockPubHex,
+		"nonce":           nonce,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("finalize status = %d, want 200", status)
+	}
+	if body["state"] != "attached" {
+		t.Fatalf("finalize state = %v, want attached", body["state"])
+	}
+	dockID, _ := body["dock_id"].(string)
+	if !strings.HasPrefix(dockID, "dck_") {
+		t.Fatalf("dock_id = %q, want dck_ prefix", dockID)
+	}
+
+	// Browser still polling after finalize -- must see attached, not 404.
+	pollStatus, pollBody := getAuthorized(t, h, code)
+	if pollStatus != http.StatusOK {
+		t.Fatalf("post-finalize poll status = %d, want 200 (regression: was 404)", pollStatus)
+	}
+	if pollBody["state"] != "attached" {
+		t.Fatalf("post-finalize state = %v, want attached", pollBody["state"])
+	}
+	if pollBody["dock_id"] != dockID {
+		t.Fatalf("post-finalize dock_id = %v, want %s", pollBody["dock_id"], dockID)
+	}
+}
+
+// TestFinalize_SingleUse confirms the single-use invariant survives the switch
+// from delete-on-consume to claim-by-dock_id: a second finalize is rejected and
+// no second ship is minted.
+func TestFinalize_SingleUse(t *testing.T) {
+	h := newTestHandlers(t)
+	code, nonce := issueChallenge(t, h)
+	postAuthorize(t, h, map[string]string{"device_code": code})
+
+	finalize := map[string]string{
+		"device_code":     code,
+		"ship_public_key": testShipPubHex,
+		"dock_public_key": testDockPubHex,
+		"nonce":           nonce,
+	}
+
+	status, first := postAuthorize(t, h, finalize)
+	if status != http.StatusOK || first["state"] != "attached" {
+		t.Fatalf("first finalize = %d %v, want 200 attached", status, first)
+	}
+
+	status, second := postAuthorize(t, h, finalize)
+	if status != http.StatusConflict {
+		t.Fatalf("second finalize status = %d, want 409", status)
+	}
+	if second["state"] != "already_attached" {
+		t.Fatalf("second finalize state = %v, want already_attached", second["state"])
+	}
+}
+
+func TestAuthorized_Expired(t *testing.T) {
+	h := newTestHandlers(t)
+	// Insert a challenge that is already expired. Format must pass validation.
+	code := strings.Repeat("ab", 8) // 16 hex chars
+	if err := db.InsertChallenge(h.DB, code, "deadbeef", time.Now().Unix()-10); err != nil {
+		t.Fatalf("insert expired challenge: %v", err)
+	}
+	status, body := getAuthorized(t, h, code)
+	if status != http.StatusGone {
+		t.Fatalf("status = %d, want 410", status)
+	}
+	if body["state"] != "expired" {
+		t.Fatalf("state = %v, want expired", body["state"])
+	}
+}
+
+// TestAttachGuidanceProviderNeutral locks the provider-neutral contract: the
+// canonical next_steps are placeholder templates (no customer baked in), while
+// the single illustrative example may name ZMem.
+func TestAttachGuidanceProviderNeutral(t *testing.T) {
+	h := newTestHandlers(t)
+	code, nonce := issueChallenge(t, h)
+	postAuthorize(t, h, map[string]string{"device_code": code})
+	_, body := postAuthorize(t, h, map[string]string{
+		"device_code":     code,
+		"ship_public_key": testShipPubHex,
+		"dock_public_key": testDockPubHex,
+		"nonce":           nonce,
+	})
+
+	steps, ok := body["next_steps"].([]interface{})
+	if !ok || len(steps) == 0 {
+		t.Fatalf("next_steps missing or empty: %v", body["next_steps"])
+	}
+	for _, s := range steps {
+		if str, _ := s.(string); strings.Contains(str, "zmem") {
+			t.Fatalf("next_steps must stay provider-neutral, found customer name: %q", str)
+		}
+	}
+	wantCmds := []string{"treeship status", "treeship attest receipt", "treeship hub push", "treeship verify"}
+	joined := strings.Join(toStrings(steps), "\n")
+	for _, want := range wantCmds {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("next_steps missing %q; got:\n%s", want, joined)
+		}
+	}
+	example, _ := body["example"].(string)
+	if !strings.Contains(example, "system://zmem") || !strings.Contains(example, "memory.proof") {
+		t.Fatalf("example should illustrate the zmem memory-proof case, got %q", example)
+	}
+}
+
+func toStrings(in []interface{}) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

A coherent memory-proofs / customer-dogfood changeset spanning the CLI, the Go Hub, and docs. It finishes provider proof-receipt support and fixes the Hub activation polling UX surfaced during ZMem dogfooding.

- **Adds/finishes `attest receipt --payload-file`** (and `--payload-digest`, plus `attest action --output-digest`) so providers can sign external proof receipts from a file.
- **Adds provider-neutral memory-proof docs** (`integrations/memory-proofs`, `concepts/multi-agent-sessions`). The page is written as a provider contract usable by Mem0, Zep, Letta, a SQLite store, or an in-house layer.
- **Fixes Hub activation polling** by preserving the terminal attached/consumed state. Finalize now atomically *claims* the challenge by `dock_id` instead of deleting it, so a still-polling activation page reads `attached` instead of a misleading `device_code not found` 404 (the exact dogfooded flash).
- **Adds explicit activation states**: `invalid`, `expired`, `pending`, `approved`, `attached`, `already_attached`, returned as a stable `state` field from `/v1/dock/authorized` and `/v1/dock/authorize`.
- **Improves CLI attach** with distinct poll-error messages (404 / 410 / 409) and concrete next steps after attach (`treeship status`, `attest receipt`, `hub push`, `verify`).
- **Keeps ZMem as an example customer, not hardcoded behavior** — `--system`/`--kind` accept any value; the canonical `next_steps` use placeholders and only a single labeled `example` names ZMem.

## Invariants preserved

- **DPoP** auth path untouched; ship/dock keys still stored via `InsertShip`.
- **Single-use** device codes still enforced, now by an atomic claim (`UPDATE … WHERE approved=1 AND dock_id IS NULL`) instead of delete-on-consume. A concurrent/replayed finalize is rejected as `already_attached`.
- Idempotent `ALTER TABLE` migration adds the `dock_id` column to existing Hub DBs; `CleanExpiredChallenges` bounds table growth with a grace window.

## Tests

New `packages/hub/internal/dock/dock_test.go` (7 tests): invalid-format, unknown-code, pending, approved, **the dogfood regression** (`TestAuthorized_AttachedNotNotFound` — post-finalize poll must return `attached`, not 404), single-use rejection, expired, and a provider-neutrality lock asserting `next_steps` never names a customer while `example` may.

## Validation

- `cargo test -p treeship-cli` — 95 unit + 3 integration, 0 failed
- `packages/hub` `go build` / `go vet` / `go test` — pass
- `docs npm run build` — 137 pages, compiled successfully
- `scripts/check-release-versions.py --consistency` — 23/23 at 0.11.2

## Release

No version bump and no tag in this PR. After merge to `main`, the official flow is:

\`\`\`
python3 scripts/check-release-versions.py --consistency
scripts/release.sh prepare <version>
scripts/release.sh tag <version> --sha <merged-main-sha>
git push origin v<version>
\`\`\`

Note: the Hub changes take effect only when the Go Hub server (api.treeship.dev) is redeployed; CLI changes ship via a CLI release; docs auto-deploy on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)