### PR TITLE
docs: add About section (changelog + publishing)

### DIFF
--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -1,0 +1,67 @@
+---
+title: Changelog
+description: All notable changes to Treeship, newest first. Mirrors CHANGELOG.md at the repo root; the format follows Keep a Changelog and versioning follows Semantic Versioning.
+---
+
+# Changelog
+
+All notable changes to Treeship are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The canonical source is [`CHANGELOG.md`](https://github.com/zerkerlabs/treeship/blob/main/CHANGELOG.md) at the repo root. Edit that file, not this page.
+
+For the complete history back to `0.1.0`, see the [full changelog on GitHub](https://github.com/zerkerlabs/treeship/blob/main/CHANGELOG.md).
+
+## Unreleased
+
+No unreleased changes are pending.
+
+## 0.12.0 (2026-06-06)
+
+### Added
+
+- **`treeship attest receipt --payload-file` and `--payload-digest` for external proof receipts.** Providers can sign a receipt over a JSON payload read from a file (mutually exclusive with `--payload`) and record a `payload_digest` for large or out-of-band payloads. `treeship attest action` gains `--output-digest`, folded into the action's `meta`. The flags are provider-neutral: `--system` and `--kind` accept any value. See the provider contract in [Memory Proofs](/integrations/memory-proofs). ZMem is one worked example, not built-in behavior.
+- **Explicit Hub device-flow states.** `GET /v1/dock/authorized` and `POST /v1/dock/authorize` return a stable `state` field covering `invalid`, `expired`, `pending`, `approved`, `attached`, and `already_attached`, plus provider-neutral `next_steps` on attach. `treeship hub attach` reports distinct poll errors (404 / 410 / 409) and concrete next steps (`status`, `attest receipt`, `hub push`, `verify`).
+
+### Fixed
+
+- **Hub activation no longer flashes "device_code not found" before attaching.** Device-flow finalization deleted the challenge row on consume, so a browser still polling after the CLI finalized received a 404 rendered as "device_code not found" even though attach had succeeded. Finalization now atomically claims the challenge by `dock_id` (preserving the single-use guarantee) and retains the row behind a bounded grace window, so the activation page reads the terminal `attached` state. DPoP and Hub auth invariants are unchanged. (#119)
+
+## 0.11.2 (2026-06-05)
+
+### Fixed
+
+- **Receipt preview no longer hangs on "Verifying receipt...".** A template placeholder token appeared twice (the data slot and a JS placeholder check); a global string replace injected the receipt JSON into a JS string literal and aborted client-side verification with a `SyntaxError`. The check now uses a split sentinel that survives substitution, and only the data slot is filled. Covered by a regression assertion in `session::package` tests. (#118)
+
+## 0.11.1 (2026-05-29)
+
+### Added
+
+- **`treeship session abandon` for wedged sessions.** Quarantines an active or closing session marker plus its event directory under `.treeship/quarantine-*` so a fresh session can start without deleting the evidence needed to debug the failure.
+- **Dangerous-root override for intentional home-scoped sessions.** `treeship session start` refuses to start when the git toplevel is the user's home directory unless `--allow-dangerous-root` is passed.
+
+### Fixed
+
+- **Bounded close-time git reconciliation.** `treeship session close` no longer promotes an unbounded set of untracked files into per-file receipt events. If the untracked scan exceeds the cap, close records an in-band receipt warning and keeps tracked changes bounded.
+- **Clearer report errors for incomplete packages.** `treeship session report` distinguishes an incomplete `.treeship` package missing `receipt.json` from "no closed sessions found."
+
+## 0.11.0 (2026-05-28)
+
+### Added
+
+- **Phase 1 of agent invitations:** signed, single-use, expiring grants that let a second agent join an existing session. Adds two canonical statement types, `treeship/invitation/v1` and `treeship/session-participant/v1`. Participant envelopes require exactly two DSSE signatures: the joining agent first, then the host countersign over the same canonical bytes. Either signature alone is invalid. Mint-time validation enforces a 7-day protocol ceiling on lifetime; the default is 1 hour.
+- **Three new CLI subcommands wire the lifecycle:** `treeship session invite`, `treeship session join`, and `treeship session countersign`.
+- **`SessionHost` trust root kind.** The invitation issuer pubkey must be pinned under this kind before `treeship session join` honors it, so a self-signed forgery is quarantined by trust-root enforcement.
+- **Local Treeship dashboard.** `treeship dashboard`, a localhost-only, read-only browser control plane over sealed `.treeship` session packages, with documented JSON endpoints.
+- **Robinhood Agentic Trading receipt template and docs.** Treeship-side receipt support for agentic trading workflows; brokerage execution and policy enforcement stay outside this repo.
+
+### Changed (breaking)
+
+- **`TrustRootKind` gained the `SessionHost` variant.** Exhaustive `match` arms in third-party code must add the new arm. The on-disk JSON wire format gains `"session_host"` as a permitted `kind` value. No existing roots are migrated; operators add session-host pins explicitly via `treeship trust add`.
+
+## Earlier releases
+
+Full notes for each version live in [`CHANGELOG.md`](https://github.com/zerkerlabs/treeship/blob/main/CHANGELOG.md). Release dates:
+
+- `0.10.4` (2026-05-17), `0.10.3` (2026-05-17), `0.10.2` (2026-05-11), `0.10.1` (2026-05-01), `0.10.0` (2026-04-30)
+- `0.9.11`, `0.9.10`, `0.9.9` (2026-04-30), `0.9.7` (2026-04-29), `0.9.6` (2026-04-27), `0.9.5` (2026-04-25), `0.9.4` (2026-04-21), `0.9.3` (2026-04-20), `0.9.2` (2026-04-20), `0.9.1` (2026-04-18), `0.9.0` (2026-04-18)
+- `0.8.0` (2026-04-18), `0.7.2` (2026-04-15), `0.7.1` / `0.7.0` (2026-04-09), `0.5.0` (2026-04-04), `0.4.0`, `0.3.1`, `0.3.0`, `0.2.1`, `0.1.0` (2026-03-31)

--- a/docs/content/docs/about/meta.json
+++ b/docs/content/docs/about/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "About",
+  "pages": ["changelog", "publishing"]
+}

--- a/docs/content/docs/about/publishing.mdx
+++ b/docs/content/docs/about/publishing.mdx
@@ -1,0 +1,83 @@
+---
+title: Publishing a release
+description: The Treeship release-and-publish workflow. A reproducible procedure so a maintainer, or the next session picking up release work, can cut a release with confidence.
+---
+
+# Publishing a release
+
+This page documents the release-publish workflow. It exists so the maintainer can run a release with confidence and so the next session (human or agent) picking up release work has a reproducible procedure.
+
+Treeship ships from a single repo to three package registries (crates.io, npm, PyPI) plus a hosted Hub and a docs site. Tagging is the irreversible action that triggers the publish pipeline, so the release script splits **prepare** (safe, reversible) from **tag** (gated, audited).
+
+## The two-phase model
+
+The release script (`scripts/release.sh`) is deliberately split so accidental tagging is impossible:
+
+- `scripts/release.sh prepare <version>` bumps every version site, runs preflight, and commits. It **never tags**. Safe to run inside a normal feature workflow.
+- `scripts/release.sh tag <version> --sha <sha> [--yes]` creates the annotated tag. It requires an explicit subcommand, an explicit target SHA (never implicit `HEAD`), a clean working tree, no pre-existing local or remote tag, and either `--yes` or interactive confirmation. It **never pushes**; you run `git push origin v<version>` after reviewing.
+
+This split exists because tagging triggers the entire publish pipeline. It must require an explicit, audited gesture.
+
+## Triggering a release
+
+1. **Bump and verify every version site.** Run the preparer, which bumps the Rust crates, the npm packages (`packages/sdk-ts`, `bridges/mcp`, `bridges/a2a`, `packages/verify-js`), and the npm wrapper (`treeship` plus the `@treeship/*` platform packages), then commits:
+
+   ```bash
+   scripts/release.sh prepare 0.12.0
+   ```
+
+   The preparer runs the version preflight for you. You can also run it directly to confirm every manifest, version file, and internal dependency pin agrees:
+
+   ```bash
+   scripts/check-release-versions.py 0.12.0
+   ```
+
+   It exits `0` when every site matches and `1` (with a table of disagreements) when any disagree.
+
+2. **Update the changelog.** Add a section for the new version with `Added / Changed / Deprecated / Removed / Fixed` subsections, following the existing entries in [`CHANGELOG.md`](https://github.com/zerkerlabs/treeship/blob/main/CHANGELOG.md). The [Changelog](/about/changelog) docs page mirrors this file.
+
+3. **Open the bump + changelog PR and merge to `main`.** Land the version bump as a normal reviewed PR. Do not tag the feature branch.
+
+4. **Tag from the merged `main` SHA.** After CI is green on `main`, create the annotated tag against the explicit merged SHA:
+
+   ```bash
+   git checkout main && git pull
+   scripts/release.sh tag 0.12.0 --sha <merged-main-sha> --yes
+   ```
+
+   The tag string uses the human-facing form (`v0.12.0`); the version strings in the manifests use the same numeric form (`0.12.0`).
+
+5. **Push the tag to start the publish pipeline.** The script does not push for you. Review the tag, then:
+
+   ```bash
+   git push origin v0.12.0
+   ```
+
+   The tag push triggers `.github/workflows/release.yml`, which builds and publishes the crates, npm packages, and PyPI distribution.
+
+## After the publish
+
+1. **Verify the CLI installs from a clean machine** across every supported target. The platform smoke (`scripts/smoke-platform-release.sh`) confirms, per distro, that `npm install -g treeship@<version>` exits `0`, `treeship --version` prints the expected version, `treeship init` succeeds in a tmpdir, and `treeship attest action` signs and returns an artifact id.
+
+   ```bash
+   python -m venv /tmp/verify-publish
+   source /tmp/verify-publish/bin/activate
+   pip install treeship-sdk==0.12.0
+   deactivate && rm -rf /tmp/verify-publish
+   ```
+
+2. **Redeploy the Hub / API** so the hosted device-flow and `/v1/dock/*` endpoints match the released CLI.
+
+3. **Deploy the docs.** `docs.treeship.dev` rebuilds automatically on push to `main` via Vercel's Git integration; no separate publish step is needed there.
+
+4. **Run a fresh customer-path smoke:** activate a dock, attest a receipt, push to the Hub, and verify, so the released CLI, Hub, and docs agree end to end.
+
+If `npm install` or `pip install` fails, the usual causes are: the registry has not indexed the new version yet (transient, usually under a minute), the wheel or package build omitted a required file (check the package manifests), or a version-string mismatch between the tag and the published package.
+
+## Rolling back
+
+Package registries do not allow re-uploading the same version once published. If a release ships broken, **do not delete or yank silently and re-tag the same number.** Cut a new patch version (`0.12.1`) with the fix, run the full prepare → tag → push flow again, and note the superseded release in the changelog. The original tag and its receipts stay in history; the fix moves forward.
+
+## Why a gated tag
+
+The version bump is reversible: it is a commit on a branch, reviewed like any other change. The tag is not. A pushed tag triggers irreversible publishes to crates.io, npm, and PyPI, none of which allow re-uploading a version. The `prepare` / `tag` split, the required explicit `--sha`, the clean-tree guard, and the no-auto-push rule all exist so that the irreversible step is a deliberate, audited gesture, not a side effect of running a script.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -8,6 +8,7 @@
     "sdk",
     "integrations",
     "api",
-    "commerce"
+    "commerce",
+    "about"
   ]
 }


### PR DESCRIPTION
Adds an **About** section to the docs nav (after Commerce) with two pages, the must-have pair for a public framework docs site.

- **`changelog.mdx`** — Keep a Changelog + SemVer. Recent releases (0.12.0 → 0.11.0) filled in from the real `CHANGELOG.md`, a dated index back to 0.1.0, and a pointer to the canonical `CHANGELOG.md` at the repo root.
- **`publishing.mdx`** — the release runbook: the two-phase `release.sh` (`prepare` vs the gated `tag --sha`), `check-release-versions.py` preflight, multi-registry publish (crates.io / npm / PyPI), Hub redeploy, auto docs deploy, the platform smoke, and rollback.

Build verified locally: 231 static pages, `/about/changelog` and `/about/publishing` render clean (plus auto OG cards). Merging deploys both to `docs.treeship.dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)