### PR TITLE
feat(core): predicate registry with schema validation at attest time

### DIFF
--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -1,4 +1,8 @@
 {
   "title": "Reference",
-  "pages": ["feature-matrix", "schema"]
+  "pages": [
+    "feature-matrix",
+    "schema",
+    "predicates"
+  ]
 }

--- a/docs/content/docs/reference/predicates.mdx
+++ b/docs/content/docs/reference/predicates.mdx
@@ -1,0 +1,80 @@
+---
+title: Predicate registry
+description: Typed, schema-validated receipt payloads. Registered predicate kinds are validated against a JSON Schema at attest time; unregistered kinds attest sign-on-submit, exactly as before.
+---
+
+# Predicate registry
+
+A Treeship receipt (`treeship/receipt/v1`) carries a free-form `kind` and an opaque JSON `payload`. The **predicate registry** makes specific `kind` values *typed*: each registered suffix is bound to a JSON Schema, and at attest time the payload is validated against that schema **before** the receipt is signed. A downstream verifier can then rely on the shape of a registered predicate, not just the signature.
+
+This is additive and backward compatible:
+
+- If `kind` is **registered**, the payload must conform to its schema. A failure rejects the attest with a clear error, nothing is signed.
+- If `kind` is **not registered**, the receipt attests sign-on-submit, exactly as before. Existing artifact types, signing logic, and chain structure are untouched.
+
+```bash
+# Registered: validated, then signed.
+treeship attest receipt --system system://zmem --kind memory.write.v1 \
+  --payload '{"memory_id":"mem_1","content_hash":"sha256:ab","memory_type":"episodic","scope":"tenant://acme"}'
+
+# Missing a required field: rejected before signing.
+treeship attest receipt --system system://zmem --kind memory.write.v1 \
+  --payload '{"memory_id":"mem_1","memory_type":"episodic","scope":"tenant://acme"}'
+# -> predicate validation failed: memory.write.v1: missing required field `content_hash`
+
+# Unregistered kind: still works, sign-on-submit.
+treeship attest receipt --system system://stripe --kind webhook.confirmation --payload '{"...":"..."}'
+```
+
+## Validation depth
+
+Core runs a small, dependency-free **structural** check: every `required` field is present, and each present field whose schema declares a primitive `type` matches it (including unions like `["string","null"]`). That is the *complete* contract for the flat memory predicates below.
+
+`boundary.v1` is a richer schema (`const`/`enum`/`pattern`/`$ref`). Core enforces its required-field and type structure; the full constraint set is delegated to the canonical published schema for external validators. The core validator is kept dependency-free on purpose so the security-critical signing path and the WASM verifier stay lean.
+
+## Registered predicates
+
+### `memory.write.v1`
+
+A specific agent committed a specific memory at a specific time.
+
+| Field | Type | Required |
+|---|---|---|
+| `memory_id` | string | yes |
+| `content_hash` | string | yes |
+| `memory_type` | string | yes |
+| `scope` | string | yes |
+| `activegraph_event_id` | string | no |
+| `activegraph_run_id` | string | no |
+| `supersedes` | string or null | no |
+
+### `memory.read.v1`
+
+Which memories an agent retrieved for an action, and the query that produced them.
+
+| Field | Type | Required |
+|---|---|---|
+| `zmem_receipt_id` | string | yes |
+| `trace_sha256` | string | yes |
+| `query_hash` | string | yes |
+| `retrieval_mode` | string | yes |
+| `memories_returned` | integer | yes |
+| `activegraph_event_id` | string | no |
+| `activegraph_run_id` | string | no |
+| `scope` | string | no |
+
+### `boundary.v1`
+
+A provider-neutral actor-checker evaluation boundary: what a checker was allowed to see, what policy denied, and the decision it reached. See [Actor-Checker Boundaries](/concepts/actor-checker-boundaries) for the model. The full schema is `treeship.boundary.v1`.
+
+## Actor URI schemes
+
+A receipt or statement `actor` is an opaque string; Treeship does not enforce the scheme. These prefixes are the recognized conventions:
+
+| Scheme | Meaning | Example |
+|---|---|---|
+| `human://` | A human principal | `human://alice` |
+| `agent://` | An autonomous agent | `agent://support-bot` |
+| `farcaster://` | A Farcaster identity, addressed by numeric FID | `farcaster://fid:12345` |
+
+`farcaster://fid:<numeric_fid>` works today with no special handling, it is a documented convention, not a validated type.

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -356,6 +356,13 @@ pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::
         .transpose()
         .map_err(|e| format!("receipt payload is not valid JSON: {e}"))?;
 
+    // Typed-predicate validation: if `kind` is a registered predicate, the
+    // payload must conform to its schema before we sign. Unregistered kinds
+    // attest sign-on-submit, exactly as before (backward compatible). This
+    // runs before signing and does not touch the signature path.
+    treeship_core::predicates::validate(&args.kind, payload_val.as_ref())
+        .map_err(|e| format!("predicate validation failed: {e}"))?;
+
     let mut stmt = ReceiptStatement::new(&args.system, &args.kind);
     stmt.payload = payload_val;
     stmt.payload_digest = args.payload_digest.clone();

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod attestation;
+pub mod predicates;
 pub mod statements;
 pub mod keys;
 pub mod storage;

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -1,0 +1,359 @@
+//! Predicate registry: typed, schema-validated payloads for Treeship receipts.
+//!
+//! A Treeship receipt (`treeship/receipt/v1`) carries a free-form `kind` and an
+//! opaque JSON `payload`. The predicate registry makes specific `kind` values
+//! *typed*: each registered suffix is bound to a JSON Schema, and at attest time
+//! the payload is validated against that schema before the receipt is signed
+//! ([`validate`]). A registered predicate that fails validation is rejected, so
+//! a downstream verifier can rely on the shape, not just the signature.
+//!
+//! This is purely additive and backward compatible. A `kind` with no registered
+//! schema attests exactly as before (sign-on-submit); existing artifact types,
+//! signing logic, and chain structure are untouched.
+//!
+//! ## Validation depth, deliberately
+//!
+//! Core does a small, dependency-free **structural** check: every `required`
+//! field is present and each present field whose schema declares a primitive
+//! `type` matches that type (including union types like `["string","null"]`).
+//! That is the *complete* contract for the flat `memory.write.v1` /
+//! `memory.read.v1` predicates, which use only `required` + `type`.
+//!
+//! `boundary.v1` is a richer JSON Schema (`const`/`enum`/`pattern`/`$ref`). Core
+//! enforces its required-field/type structure and ships the full schema as the
+//! canonical published artifact (`schema_json("boundary.v1")`); the complete
+//! constraint set is delegated to that schema for external validators. We keep
+//! the core validator dependency-free on purpose: pulling a full JSON-Schema
+//! engine (and its transitive surface) into the security-critical signing crate,
+//! and into the WASM verifier build, is not worth it for an attest-time check.
+
+use serde_json::Value;
+use std::fmt;
+
+/// Registered predicate suffixes and their JSON Schemas. The suffix is the
+/// receipt `kind`. Schemas are embedded at compile time so there is no runtime
+/// file IO (keeps the WASM build clean).
+const REGISTRY: &[(&str, &str)] = &[
+    (
+        "memory.write.v1",
+        include_str!("schemas/memory.write.v1.json"),
+    ),
+    (
+        "memory.read.v1",
+        include_str!("schemas/memory.read.v1.json"),
+    ),
+    ("boundary.v1", include_str!("schemas/boundary.v1.json")),
+];
+
+/// Returns the raw JSON Schema text for a registered predicate suffix, if any.
+/// This is the canonical published schema for the predicate.
+pub fn schema_json(suffix: &str) -> Option<&'static str> {
+    REGISTRY.iter().find(|(k, _)| *k == suffix).map(|(_, s)| *s)
+}
+
+/// Every registered predicate suffix.
+pub fn registered_suffixes() -> Vec<&'static str> {
+    REGISTRY.iter().map(|(k, _)| *k).collect()
+}
+
+/// A payload that does not conform to its predicate schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PredicateError {
+    /// A `required` field was absent from the payload.
+    MissingField { suffix: String, field: String },
+    /// A present field did not match its declared type.
+    TypeMismatch {
+        suffix: String,
+        field: String,
+        expected: String,
+    },
+    /// The payload was not a JSON object (registered predicates require one).
+    NotAnObject { suffix: String },
+    /// The embedded schema itself failed to parse (a build-time bug).
+    SchemaParse { suffix: String, detail: String },
+}
+
+impl fmt::Display for PredicateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PredicateError::MissingField { suffix, field } => {
+                write!(f, "{suffix}: missing required field `{field}`")
+            }
+            PredicateError::TypeMismatch {
+                suffix,
+                field,
+                expected,
+            } => write!(
+                f,
+                "{suffix}: field `{field}` has the wrong type (expected {expected})"
+            ),
+            PredicateError::NotAnObject { suffix } => {
+                write!(f, "{suffix}: payload must be a JSON object")
+            }
+            PredicateError::SchemaParse { suffix, detail } => {
+                write!(f, "{suffix}: registered schema is invalid JSON: {detail}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PredicateError {}
+
+/// Validate a receipt payload against the registered schema for `suffix`.
+///
+/// - If `suffix` is **not** registered, returns `Ok(())` (backward compatible:
+///   the receipt attests sign-on-submit, exactly as before).
+/// - If `suffix` **is** registered, the payload must be a JSON object that
+///   carries every `required` field and whose present fields match their
+///   declared primitive types. A missing payload is treated as the empty object
+///   and therefore fails any predicate that has required fields.
+pub fn validate(suffix: &str, payload: Option<&Value>) -> Result<(), PredicateError> {
+    let Some(schema_str) = schema_json(suffix) else {
+        return Ok(());
+    };
+    let schema: Value =
+        serde_json::from_str(schema_str).map_err(|e| PredicateError::SchemaParse {
+            suffix: suffix.to_string(),
+            detail: e.to_string(),
+        })?;
+
+    // A registered predicate requires a JSON object. A missing payload is the
+    // empty object, so any predicate with required fields fails closed here.
+    let empty = Value::Object(serde_json::Map::new());
+    let value = payload.unwrap_or(&empty);
+    let map = value
+        .as_object()
+        .ok_or_else(|| PredicateError::NotAnObject {
+            suffix: suffix.to_string(),
+        })?;
+
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        for entry in required {
+            if let Some(name) = entry.as_str() {
+                if !map.contains_key(name) {
+                    return Err(PredicateError::MissingField {
+                        suffix: suffix.to_string(),
+                        field: name.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    if let Some(props) = schema.get("properties").and_then(Value::as_object) {
+        for (field, subschema) in props {
+            let Some(actual) = map.get(field) else {
+                continue; // optional-and-absent; `required` already enforced presence
+            };
+            let Some(type_decl) = subschema.get("type") else {
+                continue; // no declared primitive type (e.g. const/enum/$ref) -> not structurally checked
+            };
+            if !type_matches(actual, type_decl) {
+                return Err(PredicateError::TypeMismatch {
+                    suffix: suffix.to_string(),
+                    field: field.to_string(),
+                    expected: type_decl.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Does `value` satisfy a JSON Schema `type` declaration (a string, or an array
+/// of strings for a union)?
+fn type_matches(value: &Value, type_decl: &Value) -> bool {
+    match type_decl {
+        Value::String(t) => json_is(value, t),
+        Value::Array(types) => types
+            .iter()
+            .any(|t| t.as_str().is_some_and(|t| json_is(value, t))),
+        // A type declaration we don't recognize is not structurally enforced
+        // here; the canonical schema is the full contract.
+        _ => true,
+    }
+}
+
+/// Map a JSON Schema primitive type name onto a `serde_json::Value` shape.
+/// `integer` requires a non-fractional number.
+fn json_is(value: &Value, ty: &str) -> bool {
+    match ty {
+        "string" => value.is_string(),
+        "integer" => value.is_i64() || value.is_u64(),
+        "number" => value.is_number(),
+        "boolean" => value.is_boolean(),
+        "object" => value.is_object(),
+        "array" => value.is_array(),
+        "null" => value.is_null(),
+        // Unknown type keyword: not enforced structurally.
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn registry_lists_the_three_seed_predicates() {
+        let suffixes = registered_suffixes();
+        assert!(suffixes.contains(&"memory.write.v1"));
+        assert!(suffixes.contains(&"memory.read.v1"));
+        assert!(suffixes.contains(&"boundary.v1"));
+        assert!(schema_json("memory.write.v1").is_some());
+        assert!(schema_json("nope.v1").is_none());
+    }
+
+    #[test]
+    fn embedded_schemas_parse() {
+        for s in registered_suffixes() {
+            let raw = schema_json(s).unwrap();
+            serde_json::from_str::<Value>(raw).expect("embedded schema must be valid JSON");
+        }
+    }
+
+    #[test]
+    fn unregistered_suffix_is_backward_compatible() {
+        // No schema -> attest proceeds as today, even with no payload.
+        assert!(validate("custom.kind.v1", None).is_ok());
+        assert!(validate("custom.kind.v1", Some(&json!({"anything": 1}))).is_ok());
+    }
+
+    #[test]
+    fn memory_write_valid_passes() {
+        let payload = json!({
+            "memory_id": "mem_abc",
+            "content_hash": "sha256:deadbeef",
+            "memory_type": "episodic",
+            "scope": "tenant://acme",
+            "activegraph_run_id": "run_1",
+            "supersedes": null
+        });
+        assert!(validate("memory.write.v1", Some(&payload)).is_ok());
+    }
+
+    #[test]
+    fn memory_write_missing_required_fails_closed() {
+        let payload = json!({
+            "memory_id": "mem_abc",
+            "memory_type": "episodic",
+            "scope": "tenant://acme"
+        }); // content_hash missing
+        let err = validate("memory.write.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::MissingField {
+                suffix: "memory.write.v1".into(),
+                field: "content_hash".into()
+            }
+        );
+    }
+
+    #[test]
+    fn memory_write_wrong_type_fails() {
+        let payload = json!({
+            "memory_id": "mem_abc",
+            "content_hash": 12345, // should be string
+            "memory_type": "episodic",
+            "scope": "tenant://acme"
+        });
+        let err = validate("memory.write.v1", Some(&payload)).unwrap_err();
+        assert!(
+            matches!(err, PredicateError::TypeMismatch { field, .. } if field == "content_hash")
+        );
+    }
+
+    #[test]
+    fn memory_write_nullable_supersedes_accepts_string_and_null() {
+        let base = |sup: Value| {
+            json!({
+                "memory_id": "m", "content_hash": "h", "memory_type": "t", "scope": "s",
+                "supersedes": sup
+            })
+        };
+        assert!(validate("memory.write.v1", Some(&base(json!("mem_old")))).is_ok());
+        assert!(validate("memory.write.v1", Some(&base(Value::Null))).is_ok());
+        // a number is neither string nor null
+        assert!(validate("memory.write.v1", Some(&base(json!(7)))).is_err());
+    }
+
+    #[test]
+    fn registered_predicate_requires_a_payload() {
+        let err = validate("memory.write.v1", None).unwrap_err();
+        assert!(matches!(err, PredicateError::MissingField { .. }));
+    }
+
+    #[test]
+    fn memory_read_valid_and_integer_enforced() {
+        let ok = json!({
+            "zmem_receipt_id": "act_1",
+            "trace_sha256": "abcd",
+            "query_hash": "qh",
+            "retrieval_mode": "semantic",
+            "memories_returned": 3
+        });
+        assert!(validate("memory.read.v1", Some(&ok)).is_ok());
+
+        let bad = json!({
+            "zmem_receipt_id": "act_1",
+            "trace_sha256": "abcd",
+            "query_hash": "qh",
+            "retrieval_mode": "semantic",
+            "memories_returned": "three" // must be integer
+        });
+        assert!(matches!(
+            validate("memory.read.v1", Some(&bad)).unwrap_err(),
+            PredicateError::TypeMismatch { field, .. } if field == "memories_returned"
+        ));
+    }
+
+    #[test]
+    fn memory_read_missing_required_fails() {
+        let payload = json!({
+            "zmem_receipt_id": "act_1",
+            "trace_sha256": "abcd",
+            "retrieval_mode": "semantic",
+            "memories_returned": 3
+        }); // query_hash missing
+        assert!(matches!(
+            validate("memory.read.v1", Some(&payload)).unwrap_err(),
+            PredicateError::MissingField { field, .. } if field == "query_hash"
+        ));
+    }
+
+    #[test]
+    fn boundary_structural_required_fields_enforced() {
+        // Structural check: all top-level required present + declared types
+        // match. Field shapes mirror schemas/examples/boundary.v1.memory.valid
+        // (actor/checker are objects, committed_at is an object, diet an array).
+        let valid = json!({
+            "schema": "treeship.boundary.v1",
+            "subject_ref": "art_aabbccdd11223344",
+            "actor": {"uri": "agent://codex", "keyid": "key_aaaa1111"},
+            "checker": {"uri": "human://alice", "keyid": "key_bbbb2222"},
+            "decision": "allow",
+            "policy": {"digest": "sha256:p"},
+            "diet_root": "sha256:r",
+            "diet": [{"type": "memory_bundle", "digest": "sha256:d"}],
+            "committed_at": {"anchor": "merkle://zmem/checkpoint#4821", "ts": "2026-06-06T00:00:00Z"}
+        });
+        assert!(validate("boundary.v1", Some(&valid)).is_ok());
+
+        // A top-level field with the wrong type is caught structurally too.
+        let mut wrong = valid.clone();
+        wrong.as_object_mut().unwrap()["committed_at"] = json!("not-an-object");
+        assert!(matches!(
+            validate("boundary.v1", Some(&wrong)).unwrap_err(),
+            PredicateError::TypeMismatch { field, .. } if field == "committed_at"
+        ));
+
+        let mut missing = valid.clone();
+        missing.as_object_mut().unwrap().remove("decision");
+        assert!(matches!(
+            validate("boundary.v1", Some(&missing)).unwrap_err(),
+            PredicateError::MissingField { field, .. } if field == "decision"
+        ));
+    }
+}

--- a/packages/core/src/predicates/schemas/boundary.v1.json
+++ b/packages/core/src/predicates/schemas/boundary.v1.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/treeship.boundary.v1.json",
+  "title": "treeship.boundary.v1",
+  "description": "Provider-neutral receipt payload recording an actor-checker evaluation boundary: what a checker was allowed to see, what policy denied, and the decision it reached. Carried as the payload of a Treeship receipt artifact. Treeship proves the boundary; the checker draws it. See docs/content/docs/concepts/actor-checker-boundaries.mdx.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "subject_ref",
+    "actor",
+    "checker",
+    "decision",
+    "policy",
+    "diet_root",
+    "diet",
+    "committed_at"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Schema identifier. Must be exactly this value.",
+      "const": "treeship.boundary.v1"
+    },
+    "subject_ref": {
+      "description": "Content-addressed id of the actor-signed proposal this boundary evaluated.",
+      "type": "string",
+      "pattern": "^art_[0-9a-f]{16,}$"
+    },
+    "actor": { "$ref": "#/$defs/party" },
+    "checker": { "$ref": "#/$defs/party" },
+    "decision": {
+      "description": "Neutral verdict. 'abstain' is an explicit non-authorization (enforcers fail closed), not a silent allow.",
+      "type": "string",
+      "enum": ["allow", "deny", "partial", "abstain"]
+    },
+    "outcome": {
+      "description": "Asserted zone. Provider-specific detail about the decision. Not load-bearing for verification.",
+      "type": "object",
+      "properties": {
+        "profile": {
+          "description": "Optional provider profile label, e.g. 'memory.proof'.",
+          "type": "string"
+        }
+      }
+    },
+    "policy": {
+      "description": "Proven. The exact policy applied, bound by content digest rather than a version string.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["digest"],
+      "properties": {
+        "ref": {
+          "description": "Human-readable policy reference, e.g. 'policy://zmem/default#v1'. Narrative; the digest is what binds.",
+          "type": "string"
+        },
+        "digest": { "$ref": "#/$defs/digest" }
+      }
+    },
+    "diet_root": {
+      "description": "Proven. Merkle root over the ordered set of inputs the checker committed to (the information diet).",
+      "$ref": "#/$defs/digest"
+    },
+    "diet": {
+      "description": "Proven. The committed input set composing diet_root. Each entry's class must be permitted by the signed policy; exclusion is derived from policy + this set, never self-reported.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "digest"],
+        "properties": {
+          "type": {
+            "description": "Input class, e.g. 'memory_bundle', 'tool_result', 'query'.",
+            "type": "string"
+          },
+          "digest": { "$ref": "#/$defs/digest" }
+        }
+      }
+    },
+    "committed_at": {
+      "description": "Proven. Anchors the diet before the decision was produced, so inputs are frozen rather than retrofitted (registration before narrative).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor", "ts"],
+      "properties": {
+        "anchor": {
+          "description": "Reference to the anchoring position, e.g. a Merkle checkpoint index.",
+          "type": "string",
+          "minLength": 1
+        },
+        "ts": {
+          "description": "RFC 3339 timestamp of the commitment.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "asserted": {
+      "description": "The narrative zone. Anything the checker or actor says about itself. Recorded faithfully, never load-bearing, never rendered as proof. policy_excludes_echo is a display-only convenience and is NOT evidence of exclusion.",
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "digest": {
+      "description": "A content digest. SHA-256 hex, prefixed with the algorithm.",
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "party": {
+      "description": "An actor or checker. The keyid is what proves separation; the uri is narrative metadata a verifier never trusts.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["keyid"],
+      "properties": {
+        "uri": {
+          "description": "Human-readable label, e.g. 'agent://codex' or 'system://zmem'. Narrative only.",
+          "type": "string"
+        },
+        "keyid": {
+          "description": "The party's signing key id. The checker signs the receipt with its keyid; it must differ from the actor's and be independently rooted.",
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/predicates/schemas/memory.read.v1.json
+++ b/packages/core/src/predicates/schemas/memory.read.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/memory.read.v1.json",
+  "title": "memory.read.v1",
+  "description": "Receipt payload recording a memory read/retrieval: which memories an agent retrieved for an action, and the query that produced them. Carried as the payload of a Treeship receipt artifact with kind=memory.read.v1.",
+  "type": "object",
+  "required": ["zmem_receipt_id", "trace_sha256", "query_hash", "retrieval_mode", "memories_returned"],
+  "properties": {
+    "zmem_receipt_id": {
+      "description": "Identifier of the ZMem (or other provider) retrieval receipt this read corresponds to.",
+      "type": "string"
+    },
+    "trace_sha256": {
+      "description": "SHA-256 over the retrieval trace the producer committed to.",
+      "type": "string"
+    },
+    "activegraph_event_id": {
+      "description": "Optional ActiveGraph event id this read corresponds to.",
+      "type": "string"
+    },
+    "activegraph_run_id": {
+      "description": "Optional ActiveGraph run id this read belongs to.",
+      "type": "string"
+    },
+    "query_hash": {
+      "description": "Hash of the query/prompt that drove the retrieval.",
+      "type": "string"
+    },
+    "retrieval_mode": {
+      "description": "Producer-defined retrieval mode, e.g. 'semantic', 'lexical', 'hybrid'.",
+      "type": "string"
+    },
+    "memories_returned": {
+      "description": "Number of memories returned by the retrieval.",
+      "type": "integer"
+    },
+    "scope": {
+      "description": "Tenant/workspace/session scope the retrieval ran in.",
+      "type": "string"
+    }
+  }
+}

--- a/packages/core/src/predicates/schemas/memory.write.v1.json
+++ b/packages/core/src/predicates/schemas/memory.write.v1.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/memory.write.v1.json",
+  "title": "memory.write.v1",
+  "description": "Receipt payload recording a memory write: a specific agent committed a specific memory at a specific time. Carried as the payload of a Treeship receipt artifact with kind=memory.write.v1.",
+  "type": "object",
+  "required": ["memory_id", "content_hash", "memory_type", "scope"],
+  "properties": {
+    "memory_id": {
+      "description": "Opaque identifier of the memory record in the producing system.",
+      "type": "string"
+    },
+    "content_hash": {
+      "description": "Hash of the memory content (the producer chooses the algorithm; bind it in the value, e.g. sha256:...).",
+      "type": "string"
+    },
+    "memory_type": {
+      "description": "Producer-defined memory class, e.g. 'episodic', 'semantic', 'fact'.",
+      "type": "string"
+    },
+    "scope": {
+      "description": "Tenant/workspace/session scope the memory belongs to.",
+      "type": "string"
+    },
+    "activegraph_event_id": {
+      "description": "Optional ActiveGraph event id this write corresponds to.",
+      "type": "string"
+    },
+    "activegraph_run_id": {
+      "description": "Optional ActiveGraph run id this write belongs to.",
+      "type": "string"
+    },
+    "supersedes": {
+      "description": "Optional memory_id this write replaces, or null if it supersedes nothing.",
+      "type": ["string", "null"]
+    }
+  }
+}


### PR DESCRIPTION
The missing primitive: typed, schema-validated receipt predicates. Turns specific receipt `kind`s from free-form sign-on-submit into typed predicates any system (ZMem, Guard, others) can attest against.

## What
- **`packages/core/src/predicates`** — a registry mapping `kind` suffixes → JSON Schemas (embedded at compile time), plus a small **dependency-free structural validator** (required fields present + declared primitive types match, including unions like `["string","null"]`). 11 unit tests.
- **Attest-time validation** — `attest receipt` validates the payload against the registered schema for its `--kind` **before signing**. Validation failure rejects the attest with a clear error; an unregistered `kind` attests sign-on-submit exactly as before (**backward compatible**).
- **Seed predicates** — `memory.write.v1`, `memory.read.v1`, and `boundary.v1` (folded in from the boundary-proof-schema work).
- **Docs** — `reference/predicates` documents the registry, the three predicates, and the actor URI conventions including `farcaster://fid:<numeric_fid>` (which already works; actor schemes are unvalidated conventions).

## Design notes
- **Additive only.** Doesn't touch existing artifact types, signing logic, or chain structure. Validation runs in the attest path before `sign()` and never enters the signature code.
- **Dependency-free validator, on purpose.** `boundary.v1` is a rich schema (`const`/`enum`/`pattern`/`$ref`); core enforces its required-field/type **structure** and ships the full schema as the canonical artifact (`predicates::schema_json("boundary.v1")`) for external validators. Pulling a full JSON-Schema engine into the security-critical signing crate (and the WASM verifier) isn't worth it for an attest-time check. The flat memory predicates are validated **completely**.
- `policy_ref` stays the architectural anchor for Guard (which consumes this later); Guard is **not** built here.

## Verification
- 363 core tests pass (incl. 11 new predicate tests: valid/missing-required/wrong-type/nullable-union/backward-compat/boundary-structural).
- CLI builds; clippy clean on the new module.
- e2e: valid `memory.write.v1`/`memory.read.v1` attested; missing/wrong-type payloads rejected with clear errors; unregistered kind still attests; `farcaster://fid:12345` actor works.

Note: kept the diff to only the intended files (no crate-wide `cargo fmt` churn; the repo's documented ~1.4k-line fmt drift and 1.94.1 pin mean local rustfmt reformats unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)