### PR TITLE
feat(predicates): register agent_card.v1 (capability cards, slice 1)

### DIFF
--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -43,6 +43,10 @@ const REGISTRY: &[(&str, &str)] = &[
         include_str!("schemas/memory.read.v1.json"),
     ),
     ("boundary.v1", include_str!("schemas/boundary.v1.json")),
+    (
+        "agent_card.v1",
+        include_str!("schemas/agent_card.v1.json"),
+    ),
 ];
 
 /// Returns the raw JSON Schema text for a registered predicate suffix, if any.
@@ -202,6 +206,7 @@ mod tests {
         assert!(suffixes.contains(&"memory.write.v1"));
         assert!(suffixes.contains(&"memory.read.v1"));
         assert!(suffixes.contains(&"boundary.v1"));
+        assert!(suffixes.contains(&"agent_card.v1"));
         assert!(schema_json("memory.write.v1").is_some());
         assert!(schema_json("nope.v1").is_none());
     }
@@ -354,6 +359,55 @@ mod tests {
         assert!(matches!(
             validate("boundary.v1", Some(&missing)).unwrap_err(),
             PredicateError::MissingField { field, .. } if field == "decision"
+        ));
+    }
+
+    #[test]
+    fn agent_card_valid_passes() {
+        let card = json!({
+            "schema": "agent_card.v1",
+            "agent": "agent://deployer",
+            "keyid": "key_9f8e7d6c",
+            "owner": "human://alice",
+            "version": "1.2.0",
+            "capabilities": {
+                "tools": ["file.read", "file.write", "db.*"],
+                "models": ["claude-sonnet-4"],
+                "can_delegate": true
+            },
+            "evidence_anchor": { "receipt_count": 1247, "merkle_root": "mroot_a0be" },
+            "supersedes": null
+        });
+        assert!(validate("agent_card.v1", Some(&card)).is_ok());
+    }
+
+    #[test]
+    fn agent_card_missing_keyid_fails_closed() {
+        // keyid is the binding; a card without it is meaningless.
+        let card = json!({
+            "schema": "agent_card.v1",
+            "agent": "agent://deployer",
+            "version": "1.0.0",
+            "capabilities": { "tools": ["file.read"] }
+        });
+        assert!(matches!(
+            validate("agent_card.v1", Some(&card)).unwrap_err(),
+            PredicateError::MissingField { field, .. } if field == "keyid"
+        ));
+    }
+
+    #[test]
+    fn agent_card_capabilities_must_be_an_object() {
+        let card = json!({
+            "schema": "agent_card.v1",
+            "agent": "agent://deployer",
+            "keyid": "key_1",
+            "version": "1.0.0",
+            "capabilities": ["file.read"] // array, not the required object
+        });
+        assert!(matches!(
+            validate("agent_card.v1", Some(&card)).unwrap_err(),
+            PredicateError::TypeMismatch { field, .. } if field == "capabilities"
         ));
     }
 }

--- a/packages/core/src/predicates/schemas/agent_card.v1.json
+++ b/packages/core/src/predicates/schemas/agent_card.v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/agent_card.v1.json",
+  "title": "agent_card.v1",
+  "description": "A signed, verifiable agent capability card: a key attests an identity and a capability set. Carried as the payload of a Treeship receipt with kind=agent_card.v1. A card is 'key-bound' only when its keyid is the envelope signer pinned under AgentCert; self-signed cards are self-asserted. See docs/specs/agent-capability-cards.md.",
+  "type": "object",
+  "required": ["schema", "agent", "keyid", "version", "capabilities"],
+  "properties": {
+    "schema": {
+      "description": "Schema identifier. Must be exactly this value.",
+      "const": "agent_card.v1"
+    },
+    "agent": {
+      "description": "Actor URI the card claims, e.g. agent://deployer.",
+      "type": "string"
+    },
+    "keyid": {
+      "description": "Key the card binds to. Meaningful only when it equals the envelope signer; AgentCert-pinned = key-bound, otherwise self-asserted.",
+      "type": "string"
+    },
+    "owner": {
+      "description": "Optional URI of the human or org that operates the agent.",
+      "type": "string"
+    },
+    "version": {
+      "description": "Card version (the agent decides the scheme, e.g. semver).",
+      "type": "string"
+    },
+    "supersedes": {
+      "description": "Content-addressed id of the card this one replaces, or null.",
+      "type": ["string", "null"]
+    },
+    "capabilities": {
+      "description": "What the agent claims it can do. Asserted, not proven; checked against evidence by verify-capability. `tools` entries may be exact (file.write) or glob families (file.*).",
+      "type": "object"
+    },
+    "constraints": {
+      "description": "Self-declared operating constraints, e.g. data_access, requires_human_approval. Asserted.",
+      "type": "object"
+    },
+    "attestations": {
+      "description": "References to third-party attestations about this card (audit, compliance). Proven only when the referenced receipt is signed by an independent key.",
+      "type": "array"
+    },
+    "evidence_anchor": {
+      "description": "Optional commitment to the agent's receipt set at mint time (count, latest_receipt_id, merkle_root). Asserted, but commits the agent to a set so post-hoc omission is detectable.",
+      "type": "object"
+    },
+    "policy_ref": {
+      "description": "Optional policy this card operates under. Narrative reference; Guard consumes it at enforcement time.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
First slice of the [agent capability cards spec](../blob/main/docs/specs/agent-capability-cards.md) (#129): register `agent_card.v1` in the predicate registry (#127) so a capability card is **typed and schema-validated at attest time**.

## What
- `schemas/agent_card.v1.json` + one registry entry. Required: `schema`, `agent`, `keyid`, `version`, `capabilities`. `keyid` is the **binding field** (a card is only "key-bound" when `keyid` is the envelope signer pinned under `AgentCert`).
- Minting works today via `treeship attest receipt --kind agent_card.v1 --payload {...}`. A typed `attest card` wrapper and **`verify-capability`** (the evidence cross-check, the real differentiator) are the next slices, per the spec.

## Boundary
Stays in Treeship's prove-and-verify lane: this types and validates a claim. It does not enforce (Guard), route (Gateway), or decide trust (consumer). Registry Identity+Capability primitive, nothing hosted.

## Verified
- Predicate tests pass (14, incl. 3 new: valid card / missing-`keyid` fails closed / `capabilities`-must-be-object).
- e2e: valid card attested; card missing `keyid` rejected (`missing required field keyid`); `capabilities` as array rejected (wrong type).
- clippy clean, additive only (doesn't touch existing predicates, signing, or chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)