### PR TITLE
feat(cli): treeship verify-capability (capability card cross-check, slice 3)

### DIFF
--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -1,0 +1,201 @@
+// `treeship verify-capability <card_id>` — the capability-card cross-check.
+//
+// An agent_card.v1 receipt declares an identity and a capability set. This
+// command answers two questions a descriptor format (A2A, NANDA) cannot:
+//   1. Is the card key-bound? (its keyid is the envelope signer AND that key is
+//      pinned under AgentCert — otherwise it is merely self-asserted.)
+//   2. Are the agent's captured actions within the declared capability set?
+//
+// The honest framing is load-bearing: this proves consistency over *captured*
+// evidence. It does NOT prove the agent took no action outside its card — that
+// completeness gap is Guard's runtime job, never a signature's. The output says
+// so.
+
+use crate::{ctx, printer::Printer};
+use treeship_core::{
+    statements::{payload_type, ActionStatement, ReceiptStatement},
+    trust::{TrustRootKind, TrustRootStore},
+};
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer) -> CmdResult {
+    let ctx = ctx::open(config)?;
+
+    // --- Load and parse the card ------------------------------------------
+    let record = ctx.storage.read(card_id)?;
+    let card_stmt: ReceiptStatement = record.envelope.unmarshal_statement()?;
+    if card_stmt.kind != "agent_card.v1" {
+        return Err(format!(
+            "{card_id} is kind `{}`, not an agent_card.v1 receipt",
+            card_stmt.kind
+        )
+        .into());
+    }
+    let card = card_stmt
+        .payload
+        .ok_or("agent_card.v1 receipt has no payload")?;
+    let card_keyid = card.get("keyid").and_then(|v| v.as_str()).unwrap_or("");
+    let card_agent = card.get("agent").and_then(|v| v.as_str()).unwrap_or("");
+    let tools: Vec<String> = card
+        .get("capabilities")
+        .and_then(|c| c.get("tools"))
+        .and_then(|t| t.as_array())
+        .map(|a| a.iter().filter_map(|t| t.as_str().map(str::to_string)).collect())
+        .unwrap_or_default();
+
+    // --- Binding strength: key-bound vs self-asserted ----------------------
+    // Key-bound iff the card's keyid is the envelope signer AND that key is
+    // pinned under AgentCert. Anything else is self-asserted.
+    let signer_keyid = record
+        .envelope
+        .signatures
+        .first()
+        .map(|s| s.keyid.as_str())
+        .unwrap_or("");
+    let keyid_is_signer = !card_keyid.is_empty() && signer_keyid == card_keyid;
+    let trust = TrustRootStore::open_default_or_empty()?;
+    let agentcert_pinned = trust
+        .roots()
+        .iter()
+        .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert);
+    let key_bound = keyid_is_signer && agentcert_pinned;
+
+    // --- Cross-check captured action receipts signed by this key -----------
+    let action_pt = payload_type("action");
+    let mut in_scope = 0usize;
+    let mut total = 0usize;
+    let mut violations: Vec<(String, String)> = Vec::new();
+    for entry in ctx.storage.list_by_type(&action_pt) {
+        let Ok(arec) = ctx.storage.read(&entry.id) else {
+            continue;
+        };
+        let asigner = arec
+            .envelope
+            .signatures
+            .first()
+            .map(|s| s.keyid.as_str())
+            .unwrap_or("");
+        if asigner != card_keyid {
+            continue; // only this key's actions count toward its card
+        }
+        let Ok(action): Result<ActionStatement, _> = arec.envelope.unmarshal_statement() else {
+            continue;
+        };
+        total += 1;
+        // A receipt is in scope if its action category OR its meta.tool matches
+        // any declared capability (exact, or a `family.*` glob).
+        let mut candidates = vec![action.action.clone()];
+        if let Some(tool) = action
+            .meta
+            .as_ref()
+            .and_then(|m| m.get("tool"))
+            .and_then(|v| v.as_str())
+        {
+            candidates.push(tool.to_string());
+        }
+        let matched = candidates
+            .iter()
+            .any(|c| tools.iter().any(|decl| tool_matches(decl, c)));
+        if matched {
+            in_scope += 1;
+        } else {
+            violations.push((entry.id.clone(), candidates.join(" / ")));
+        }
+    }
+
+    // --- evidence_anchor (optional): committed count vs observed ----------
+    let anchor_note = card
+        .get("evidence_anchor")
+        .and_then(|a| a.get("receipt_count"))
+        .and_then(|c| c.as_u64())
+        .map(|claimed| {
+            if claimed as usize == total {
+                format!("anchor: claims {claimed} receipts, matches {total} observed")
+            } else {
+                format!("anchor: claims {claimed} receipts, observed {total} — MISMATCH (omission or backfill)")
+            }
+        });
+
+    // --- Report ------------------------------------------------------------
+    let status = if !key_bound {
+        "self-asserted"
+    } else if violations.is_empty() {
+        "verified"
+    } else {
+        "violations"
+    };
+    let key_bound_str = if key_bound {
+        "yes (AgentCert)"
+    } else {
+        "no (self-asserted)"
+    };
+    let tools_str = if tools.is_empty() {
+        "(none declared)".to_string()
+    } else {
+        tools.join(", ")
+    };
+    let in_scope_str = in_scope.to_string();
+    let oos_str = violations.len().to_string();
+    printer.success(
+        "capability card",
+        &[
+            ("card", card_id),
+            ("agent", card_agent),
+            ("key-bound", key_bound_str),
+            ("declared tools", &tools_str),
+            ("in-scope actions", &in_scope_str),
+            ("out-of-scope", &oos_str),
+            ("status", status),
+        ],
+    );
+    if let Some(note) = &anchor_note {
+        printer.hint(note);
+    }
+    // Show a bounded sample of violations; summarize the rest rather than
+    // dumping an unbounded list. The count above is always exact.
+    const MAX_SHOWN: usize = 10;
+    for (id, tool) in violations.iter().take(MAX_SHOWN) {
+        printer.warn(
+            "out-of-scope action",
+            &[("artifact", id), ("tool/action", tool)],
+        );
+    }
+    if violations.len() > MAX_SHOWN {
+        printer.hint(&format!(
+            "... and {} more out-of-scope actions (see status above for the full count)",
+            violations.len() - MAX_SHOWN
+        ));
+    }
+    printer.blank();
+    printer.hint(
+        "consistency over captured evidence: proves in/out-of-scope for actions Treeship recorded, not that no off-card action occurred (that is Guard's runtime job).",
+    );
+    printer.blank();
+    Ok(())
+}
+
+/// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
+/// matches anything.
+fn tool_matches(declared: &str, actual: &str) -> bool {
+    if let Some(prefix) = declared.strip_suffix('*') {
+        actual.starts_with(prefix)
+    } else {
+        declared == actual
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_matches;
+
+    #[test]
+    fn exact_and_glob_matching() {
+        assert!(tool_matches("file.write", "file.write"));
+        assert!(!tool_matches("file.write", "file.read"));
+        assert!(tool_matches("file.*", "file.write"));
+        assert!(tool_matches("file.*", "file.read"));
+        assert!(!tool_matches("file.*", "db.query"));
+        assert!(tool_matches("*", "anything.at.all"));
+    }
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod init;
 pub mod attest;
+pub mod capability;
 pub mod verify;
 pub mod verify_external;
 pub mod keys;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -121,6 +121,17 @@ enum Command {
     ///   treeship verify ./export.treeship
     Verify(VerifyArgs),
 
+    /// Verify an agent capability card against the agent's evidence
+    ///
+    /// Reports whether the card is key-bound (its keyid is the envelope signer
+    /// and pinned under AgentCert) and whether the agent's captured actions
+    /// stay within the declared capability set. This is a consistency check
+    /// over captured evidence, not a completeness guarantee.
+    ///
+    /// Example:
+    ///   treeship verify-capability art_<agent_card_id>
+    VerifyCapability(VerifyCapabilityArgs),
+
     /// Create, export, and import artifact bundles
     ///
     /// Bundles group artifacts into a signed, portable package.
@@ -1575,6 +1586,12 @@ struct VerifyArgs {
     full: bool,
 }
 
+#[derive(Args)]
+struct VerifyCapabilityArgs {
+    /// Artifact id of the agent_card.v1 receipt to check.
+    card_id: String,
+}
+
 // --- keys -------------------------------------------------------------------
 
 #[derive(Subcommand)]
@@ -2349,6 +2366,10 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 printer,
             ),
         },
+
+        Command::VerifyCapability(a) => {
+            commands::capability::verify_capability(&a.card_id, cli.config.as_deref(), printer)
+        }
 
         Command::Verify(a) => {
             // External targets (URL, file path to a .treeship/.agent package)


### PR DESCRIPTION
The differentiator from the [capability cards spec](../blob/main/docs/specs/agent-capability-cards.md) (#129): check a signed `agent_card.v1` against the agent's **actual evidence**. No descriptor format (A2A, NANDA) can do this.

## `treeship verify-capability <card_id>` reports
- **`key-bound: yes (AgentCert) | no (self-asserted)`** — key-bound only when the card's `keyid` is the envelope signer **and** pinned under `AgentCert`. Only key-bound earns "verified"; self-signed returns `self-asserted`.
- **in-scope / out-of-scope actions** — every captured action receipt signed by the card's key is checked; its action category or `meta.tool` must match a declared capability (exact or a `family.*` glob).
- **`evidence_anchor`** (if present) — committed `receipt_count` vs observed, so post-hoc omission/backfill is flagged.

## Honest framing (load-bearing)
> consistency over captured evidence: proves in/out-of-scope for actions Treeship recorded, **not** that no off-card action occurred (that is Guard's runtime job).

Violations are shown bounded (first 10) with an exact total, no unbounded dump.

## Verified e2e
Card declaring `[file.*, db.query]` over `file.write` (in, via glob), `db.query` (in, exact), `command.run` (out) → **in-scope 2, out-of-scope 1, anchor matches, self-asserted** (no AgentCert root pinned). Unit test covers glob/exact matching. Clippy clean. Additive: new command + module, touches no existing command.

## Slices
- #130 slice 1 (register `agent_card.v1`) — **merged**.
- This = slice 3 (the cross-check). Minting works via `attest receipt --kind agent_card.v1`; a typed `attest card` wrapper (slice 2 sugar, mint-time key-bound report) is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)