### PR TITLE
feat(cli): treeship attest card (typed capability-card mint, slice 2)

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -400,6 +400,84 @@ pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::
     Ok(())
 }
 
+// --- card -------------------------------------------------------------------
+
+pub struct CardArgs {
+    pub agent:      String,
+    pub tools:      Vec<String>,
+    pub models:     Vec<String>,
+    pub keyid:      Option<String>,
+    pub owner:      Option<String>,
+    pub version:    String,
+    pub policy_ref: Option<String>,
+    pub config:     Option<String>,
+}
+
+/// Mint a signed agent_card.v1 capability card from typed flags. Thin, typed
+/// wrapper over the agent_card.v1 predicate: builds the payload, validates it,
+/// signs it, and reports whether the card is key-bound at mint time.
+pub fn card(args: CardArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(args.config.as_deref())?;
+    let signer = ctx.keys.default_signer()?;
+    // Default the card's keyid to the signing key, so a freshly minted card is
+    // key-bound-eligible by default (pin it under AgentCert to make it strong).
+    let keyid = args.keyid.clone().unwrap_or_else(|| signer.key_id().to_string());
+
+    let mut capabilities = serde_json::Map::new();
+    capabilities.insert("tools".into(), serde_json::json!(args.tools));
+    if !args.models.is_empty() {
+        capabilities.insert("models".into(), serde_json::json!(args.models));
+    }
+
+    let mut card = serde_json::Map::new();
+    card.insert("schema".into(), serde_json::json!("agent_card.v1"));
+    card.insert("agent".into(), serde_json::json!(args.agent));
+    card.insert("keyid".into(), serde_json::json!(keyid));
+    if let Some(owner) = &args.owner {
+        card.insert("owner".into(), serde_json::json!(owner));
+    }
+    card.insert("version".into(), serde_json::json!(args.version));
+    card.insert("capabilities".into(), Value::Object(capabilities));
+    if let Some(policy_ref) = &args.policy_ref {
+        card.insert("policy_ref".into(), serde_json::json!(policy_ref));
+    }
+    let payload = Value::Object(card);
+
+    // Validate against the registered agent_card.v1 schema before signing.
+    treeship_core::predicates::validate("agent_card.v1", Some(&payload))
+        .map_err(|e| format!("invalid capability card: {e}"))?;
+
+    let mut stmt = ReceiptStatement::new("system://registry", "agent_card.v1");
+    stmt.payload = Some(payload);
+
+    let pt = payload_type("receipt");
+    let result = sign(&pt, &stmt, signer.as_ref())?;
+    ctx.storage.write(&Record {
+        artifact_id:  result.artifact_id.clone(),
+        digest:       result.digest.clone(),
+        payload_type: pt,
+        key_id:       signer.key_id().to_string(),
+        signed_at:    stmt.timestamp.clone(),
+        parent_id:    None,
+        envelope:     result.envelope,
+        hub_url:      None,
+    })?;
+    write_last(&ctx.config.storage_dir, &result.artifact_id);
+
+    let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()?;
+    let key_bound = crate::commands::capability::is_key_bound(&keyid, signer.key_id(), &trust);
+
+    printer.success("capability card attested", &[
+        ("id",        &result.artifact_id),
+        ("agent",     &args.agent),
+        ("key-bound", if key_bound { "yes (AgentCert)" } else { "no (self-asserted)" }),
+        ("tools",     &args.tools.join(", ")),
+    ]);
+    printer.hint(&format!("treeship verify-capability {}", result.artifact_id));
+    printer.blank();
+    Ok(())
+}
+
 // --- decision ---------------------------------------------------------------
 
 pub struct DecisionArgs {

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -53,13 +53,8 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
         .first()
         .map(|s| s.keyid.as_str())
         .unwrap_or("");
-    let keyid_is_signer = !card_keyid.is_empty() && signer_keyid == card_keyid;
     let trust = TrustRootStore::open_default_or_empty()?;
-    let agentcert_pinned = trust
-        .roots()
-        .iter()
-        .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert);
-    let key_bound = keyid_is_signer && agentcert_pinned;
+    let key_bound = is_key_bound(card_keyid, signer_keyid, &trust);
 
     // --- Cross-check captured action receipts signed by this key -----------
     let action_pt = payload_type("action");
@@ -175,6 +170,18 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     Ok(())
 }
 
+/// A card is **key-bound** only when its `keyid` is the signer of the envelope
+/// AND that key is pinned under `AgentCert`. Anything else is self-asserted.
+/// Shared by `verify-capability` and `attest card` so mint and verify agree.
+pub fn is_key_bound(card_keyid: &str, signer_keyid: &str, trust: &TrustRootStore) -> bool {
+    !card_keyid.is_empty()
+        && signer_keyid == card_keyid
+        && trust
+            .roots()
+            .iter()
+            .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert)
+}
+
 /// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
 /// matches anything.
 fn tool_matches(declared: &str, actual: &str) -> bool {
@@ -187,7 +194,8 @@ fn tool_matches(declared: &str, actual: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::tool_matches;
+    use super::{is_key_bound, tool_matches};
+    use treeship_core::trust::{TrustRoot, TrustRootKind, TrustRootStore};
 
     #[test]
     fn exact_and_glob_matching() {
@@ -197,5 +205,31 @@ mod tests {
         assert!(tool_matches("file.*", "file.read"));
         assert!(!tool_matches("file.*", "db.query"));
         assert!(tool_matches("*", "anything.at.all"));
+    }
+
+    fn root(key_id: &str, kind: TrustRootKind) -> TrustRoot {
+        TrustRoot {
+            key_id: key_id.into(),
+            public_key: "ed25519:AAAA".into(),
+            kind,
+            label: String::new(),
+            added_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn key_bound_needs_signer_match_and_agentcert() {
+        let agentcert = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::AgentCert)]);
+        // signer == card keyid AND pinned under AgentCert -> key-bound
+        assert!(is_key_bound("key_x", "key_x", &agentcert));
+        // envelope signer differs from the card's keyid -> not bound
+        assert!(!is_key_bound("key_x", "key_y", &agentcert));
+        // empty card keyid -> not bound
+        assert!(!is_key_bound("", "", &agentcert));
+        // pinned, but under a different kind (Ship, not AgentCert) -> not bound
+        let ship = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::Ship)]);
+        assert!(!is_key_bound("key_x", "key_x", &ship));
+        // not pinned at all -> not bound (self-asserted)
+        assert!(!is_key_bound("key_x", "key_x", &TrustRootStore::with_roots(vec![])));
     }
 }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1233,6 +1233,17 @@ enum AttestCommand {
     ///     --payload '{"eventId":"evt_abc","status":"succeeded"}'
     Receipt(AttestReceiptArgs),
 
+    /// Mint a signed agent capability card (agent_card.v1)
+    ///
+    /// Declares an agent's identity and capability set as a typed, signed
+    /// receipt. Reports whether the card is key-bound (pin its key under
+    /// AgentCert to make it strong). Check it later with verify-capability.
+    ///
+    /// Example:
+    ///   treeship attest card --agent agent://deployer \
+    ///     --tools file.*,db.query --models claude-sonnet-4
+    Card(AttestCardArgs),
+
     /// Record an agent's reasoning and decision context
     ///
     /// Examples:
@@ -1412,6 +1423,37 @@ struct AttestReceiptArgs {
     /// Digest of the external payload, for example sha256:<hex>
     #[arg(long, value_name = "DIGEST")]
     payload_digest: Option<String>,
+}
+
+#[derive(Args)]
+struct AttestCardArgs {
+    /// Actor URI the card claims, e.g. agent://deployer
+    #[arg(long, required = true, value_name = "URI")]
+    agent: String,
+
+    /// Capabilities: tool categories or `family.*` globs (comma-separated)
+    #[arg(long, value_name = "TOOLS", value_delimiter = ',')]
+    tools: Vec<String>,
+
+    /// Models the agent uses (comma-separated)
+    #[arg(long, value_name = "MODELS", value_delimiter = ',')]
+    models: Vec<String>,
+
+    /// Key this card binds to. Defaults to the signing key.
+    #[arg(long, value_name = "KEYID")]
+    keyid: Option<String>,
+
+    /// Owner URI, e.g. human://alice
+    #[arg(long, value_name = "URI")]
+    owner: Option<String>,
+
+    /// Card version
+    #[arg(long, default_value = "1.0.0", value_name = "VERSION")]
+    version: String,
+
+    /// Policy this card operates under
+    #[arg(long = "policy-ref", value_name = "REF")]
+    policy_ref: Option<String>,
 }
 
 #[derive(Args)]
@@ -2304,6 +2346,19 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     payload_file:   a.payload_file.clone(),
                     payload_digest: a.payload_digest.clone(),
                     config:         cli.config.clone(),
+                },
+                printer,
+            ),
+            AttestCommand::Card(a) => commands::attest::card(
+                commands::attest::CardArgs {
+                    agent:      a.agent.clone(),
+                    tools:      a.tools.clone(),
+                    models:     a.models.clone(),
+                    keyid:      a.keyid.clone(),
+                    owner:      a.owner.clone(),
+                    version:    a.version.clone(),
+                    policy_ref: a.policy_ref.clone(),
+                    config:     cli.config.clone(),
                 },
                 printer,
             ),


### PR DESCRIPTION
The ergonomic mint, completing the [capability-cards](../blob/main/docs/specs/agent-capability-cards.md) slices (register → verify → mint).

## `treeship attest card`
```
treeship attest card --agent agent://deployer \
  --tools file.*,db.query --models claude-sonnet-4
```
Builds the `agent_card.v1` payload from typed flags, validates against the registered schema, signs, and **reports key-bound at mint time**. The card's `keyid` defaults to the signing key (so a fresh card is key-bound-eligible); pin the key under `AgentCert` to make it strong.

## Shared logic
Factors the key-bound check into `is_key_bound()`, used by **both** `attest card` and `verify-capability`, so mint-time and verify-time agree by construction. Unit test covers both branches: signer-match + AgentCert → bound; mismatch / wrong kind (Ship) / unpinned → self-asserted.

## Verified
- e2e: `attest card` mints (key-bound: no, self-asserted by default); `verify-capability` on it reports the same binding + the in/out-of-scope cross-check.
- Tests pass (glob matching + `is_key_bound` both branches). clippy clean. Additive: new attest subcommand, no change to existing ones.

## Capability cards: complete
- #129 spec, #130 register `agent_card.v1`, #131 `verify-capability` — all merged.
- This = the `attest card` mint ergonomics. The Identity+Capability registry layers are now real, signed, mint-able, and evidence-checkable, entirely in Treeship's prove-and-verify lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)