### PR TITLE
feat(cli): agent register --own-key (per-agent signing key, slice 1)

### DIFF
--- a/packages/cli/src/commands/agent.rs
+++ b/packages/cli/src/commands/agent.rs
@@ -12,6 +12,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use sha2::{Digest, Sha256};
 
 use treeship_core::agent::*;
+use treeship_core::trust::{TrustRoot, TrustRootKind, TrustRootStore};
 
 use crate::commands::cards::{self, AgentCard, CardCapabilities, CardProvenance, CardStatus};
 use crate::commands::discovery::{
@@ -95,10 +96,12 @@ pub fn register(
     description: Option<String>,
     forbidden: Vec<String>,
     escalation: Vec<String>,
+    own_key: bool,
     config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = ctx::open(config)?;
+    // The ship's default key is the issuer: it signs the certificate.
     let signer = ctx.keys.default_signer()?;
 
     let now_secs = std::time::SystemTime::now()
@@ -109,14 +112,26 @@ pub fn register(
         now_secs + (valid_days as u64) * 86400,
     );
 
-    let pub_key_bytes = signer.public_key_bytes();
-    let pub_key_b64 = URL_SAFE_NO_PAD.encode(&pub_key_bytes);
+    let ship_pub_b64 = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
 
-    // Build identity
+    // Subject key. With --own-key, mint a dedicated per-agent key and certify
+    // THAT as the agent's identity (the ship still signs as issuer). Without
+    // the flag, the subject is the ship key -- the legacy behavior, unchanged.
+    let (subject_pub_b64, agent_key_id) = if own_key {
+        let agent_key = ctx.keys.generate(false)?;
+        (
+            URL_SAFE_NO_PAD.encode(&agent_key.public_key),
+            Some(agent_key.id.to_string()),
+        )
+    } else {
+        (ship_pub_b64.clone(), None)
+    };
+
+    // Build identity (subject = the agent's own key when --own-key)
     let identity = AgentIdentity {
         agent_name: name.into(),
         ship_id: ctx.config.ship_id.clone(),
-        public_key: pub_key_b64.clone(),
+        public_key: subject_pub_b64.clone(),
         issuer: format!("ship://{}", ctx.config.ship_id),
         issued_at: issued_at.clone(),
         valid_until: valid_until.clone(),
@@ -159,8 +174,9 @@ pub fn register(
         declaration: declaration.clone(),
         signature: CertificateSignature {
             algorithm: "ed25519".into(),
+            // Issuer = the ship's key (it signed the canonical bytes).
             key_id: signer.key_id().to_string(),
-            public_key: pub_key_b64,
+            public_key: ship_pub_b64.clone(),
             signature: sig_b64,
             signed_fields: "identity+capabilities+declaration".into(),
         },
@@ -236,6 +252,22 @@ pub fn register(
     };
 
     let now = now_rfc3339();
+
+    // Pin the per-agent key under AgentCert (only with --own-key) so that
+    // verify (and verify-capability) can treat this agent's actions as
+    // key-bound rather than self-asserted, once attest signs with it.
+    if let Some(kid) = &agent_key_id {
+        let mut trust = TrustRootStore::open_default_or_empty()?;
+        trust.add(TrustRoot {
+            key_id:     kid.clone(),
+            public_key: format!("ed25519:{subject_pub_b64}"),
+            kind:       TrustRootKind::AgentCert,
+            label:      name.to_string(),
+            added_at:   now.clone(),
+        });
+        trust.save(&TrustRootStore::default_path())?;
+    }
+
     let card = AgentCard {
         agent_id,
         agent_name:            name.to_string(),
@@ -254,6 +286,7 @@ pub fn register(
         model:                 model.clone(),
         description:           description.clone(),
         certificate_digest:    Some(cert_digest),
+        key_id:                agent_key_id.clone(),
         // surface.kind() ("cursor-agent") and harness_id ("cursor") are
         // distinct namespaces; harnesses::recommended_id is the right
         // lookup so cards always point at a real entry in HARNESSES.
@@ -296,6 +329,9 @@ pub fn register(
     printer.info(&format!("  valid:      {} days (until {})", valid_days, valid_until));
     printer.info(&format!("  package:    {}", pkg_dir.display()));
     printer.info(&format!("  card:       {} ({})", merged.agent_id, merged.status.label()));
+    if let Some(kid) = &agent_key_id {
+        printer.info(&format!("  agent key:  {kid} (pinned under AgentCert)"));
+    }
     printer.blank();
     printer.hint(&format!("open {}/certificate.html", pkg_dir.display()));
     printer.dim_info(&format!("  review with: treeship agents review {}", merged.agent_id));

--- a/packages/cli/src/commands/cards.rs
+++ b/packages/cli/src/commands/cards.rs
@@ -157,6 +157,13 @@ pub struct AgentCard {
     /// confirm the on-disk cert hasn't drifted from the card's claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub certificate_digest: Option<String>,
+    /// Key id of the agent's own signing key, when registered with a
+    /// per-agent key (`agent register --own-key`). This is the binding
+    /// `attest` resolves to sign an agent's actions with its own key, and
+    /// what makes the agent's `actor` provable rather than asserted. None
+    /// for agents that sign with the shared default key (the legacy path).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<String>,
     /// Harness this card is attached through (PR 5). For cards born
     /// from discovery, defaults to `DiscoveredAgent::recommended_harness_id`.
     /// For cards born from `treeship agent register`, the surface
@@ -199,6 +206,7 @@ impl AgentCard {
             model:                  None,
             description:            agent.note.clone(),
             certificate_digest:     None,
+            key_id:                 None,
             active_harness_id:      Some(agent.recommended_harness_id().to_string()),
             latest_session_id:      None,
             latest_receipt_digest:  None,
@@ -374,6 +382,9 @@ pub fn upsert(
                 latest_session_id:      existing.latest_session_id.or(incoming.latest_session_id.clone()),
                 latest_receipt_digest:  existing.latest_receipt_digest.or(incoming.latest_receipt_digest.clone()),
                 certificate_digest:     incoming.certificate_digest.clone().or(existing.certificate_digest),
+                // Preserve a registered per-agent key binding across upserts;
+                // a later discovery upsert must not wipe it.
+                key_id:                 incoming.key_id.clone().or(existing.key_id),
                 ..incoming
             }
         }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1123,6 +1123,12 @@ struct AgentRegisterArgs {
     /// Comma-separated list of actions requiring escalation
     #[arg(long, value_name = "ACTIONS", value_delimiter = ',')]
     escalation: Vec<String>,
+
+    /// Mint a dedicated per-agent signing key and pin it under AgentCert,
+    /// instead of certifying the shared ship key. Makes the agent's actor
+    /// provable once it signs with that key (see verify-capability).
+    #[arg(long, default_value_t = false)]
+    own_key: bool,
 }
 
 // --- declare ---------------------------------------------------------------
@@ -2182,6 +2188,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 a.description.clone(),
                 a.forbidden.clone(),
                 a.escalation.clone(),
+                a.own_key,
                 cli.config.as_deref(),
                 printer,
             ),


### PR DESCRIPTION
Slice 1 of [per-actor signing](../blob/main/docs/specs/per-actor-signing.md) (#133): give an agent its **own** signing key instead of sharing the ship key.

## `treeship agent register --own-key`
Mints a dedicated per-agent key, certifies **that** key as the agent's identity (the ship signs as issuer), pins it under `AgentCert`, and records the key id on the agent card.

Without the flag, behavior is **byte-for-byte unchanged** (ship key is the subject, no new key, no pin) — strictly additive, opt-in.

## What changed
- `cards.rs`: `AgentCard` gains an optional `key_id` (serde-default, preserved across upserts) — the home for the actor→key binding that `attest` (slice 2) resolves to sign an agent's actions with its own key.
- `agent.rs` `register`: opt-in subject key; the cert's `identity.public_key` is the agent key while `signature.public_key`/`key_id` stay the ship (the issuer); pins the agent key under `AgentCert`; sets `card.key_id`.

## Verified
- e2e: `--own-key` mints a key, pins it under `AgentCert` (confirmed in `trust list`), sets `card.key_id`; the no-flag path mints no key and leaves `key_id` None.
- Legacy `agent` (6) + `cards` (15) tests pass; clippy clean.

## Slice 2 design note (surfaced by the e2e)
The agent card is keyed on **surface+host+workspace**, not the actor URI, so two registrations with the same surface collapse to one card. Actor→key resolution at attest time (slice 2) must reconcile the actor URI with the surface-keyed card. Flagged in the spec's open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)