### PR TITLE
feat(cli): finish per-actor signing (decision/handoff + actor proof in verify)

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -25,16 +25,9 @@ fn resolve_actor_signer(
     ctx: &ctx::Ctx,
     actor: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {
-    let Some(name) = actor.strip_prefix("agent://") else {
-        return Ok(ctx.keys.default_signer()?);
-    };
     let agents_dir = crate::commands::cards::agents_dir_for(&ctx.config_path);
-    let key_id = crate::commands::cards::list(&agents_dir)
-        .unwrap_or_default()
-        .into_iter()
-        .find(|c| c.agent_name == name && c.key_id.is_some())
-        .and_then(|c| c.key_id);
-    let Some(key_id) = key_id else {
+    let Some(key_id) = crate::commands::cards::registered_key_for_actor(&agents_dir, actor)
+    else {
         return Ok(ctx.keys.default_signer()?);
     };
     // Only sign as the agent if its key is actually pinned under AgentCert.
@@ -341,7 +334,8 @@ pub fn handoff(args: HandoffArgs, printer: &Printer) -> Result<(), Box<dyn std::
     stmt.approval_ids = args.approvals.clone();
     stmt.obligations  = args.obligations.clone();
 
-    let signer = ctx.keys.default_signer()?;
+    // The handing-off agent (`from`) signs; use its own key when registered.
+    let signer = resolve_actor_signer(&ctx, &args.from)?;
     let pt     = payload_type("handoff");
     let result = sign(&pt, &stmt, signer.as_ref())?;
 
@@ -539,7 +533,8 @@ pub struct DecisionArgs {
 
 pub fn decision(args: DecisionArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = ctx::open(args.config.as_deref())?;
-    let signer = ctx.keys.default_signer()?;
+    // The deciding agent signs; use its own key when registered.
+    let signer = resolve_actor_signer(&ctx, &args.actor)?;
 
     let mut stmt = DecisionStatement::new(&args.actor);
     stmt.model = args.model.clone();

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -182,6 +182,23 @@ pub fn is_key_bound(card_keyid: &str, signer_keyid: &str, trust: &TrustRootStore
             .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert)
 }
 
+/// Is a receipt's `actor` cryptographically proven, i.e. signed by the actor's
+/// registered, AgentCert-pinned per-agent key? Used by `verify` to label the
+/// actor proven vs asserted. False for non-agent actors, unregistered agents,
+/// a signer that isn't the registered key, or an unpinned key.
+pub fn actor_proven(ctx: &crate::ctx::Ctx, actor: &str, signer_keyid: &str) -> bool {
+    let agents_dir = crate::commands::cards::agents_dir_for(&ctx.config_path);
+    let Some(registered) =
+        crate::commands::cards::registered_key_for_actor(&agents_dir, actor)
+    else {
+        return false;
+    };
+    registered == signer_keyid
+        && TrustRootStore::open_default_or_empty()
+            .map(|t| is_key_bound(signer_keyid, signer_keyid, &t))
+            .unwrap_or(false)
+}
+
 /// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
 /// matches anything.
 fn tool_matches(declared: &str, actual: &str) -> bool {

--- a/packages/cli/src/commands/cards.rs
+++ b/packages/cli/src/commands/cards.rs
@@ -311,6 +311,20 @@ pub fn list(agents_dir: &Path) -> Result<Vec<AgentCard>, CardError> {
     Ok(out)
 }
 
+/// The registered per-agent signing key for an `agent://<name>` actor, if any
+/// card carries one. None for non-agent actors (`human://`, `farcaster://`)
+/// or agents registered without a per-agent key. This is the actor -> key
+/// binding `attest` resolves to sign, and `verify` checks to label the actor
+/// proven vs asserted.
+pub fn registered_key_for_actor(agents_dir: &Path, actor: &str) -> Option<String> {
+    let name = actor.strip_prefix("agent://")?;
+    list(agents_dir)
+        .ok()?
+        .into_iter()
+        .find(|c| c.agent_name == name && c.key_id.is_some())
+        .and_then(|c| c.key_id)
+}
+
 /// Load one card by ID.
 pub fn load(agents_dir: &Path, agent_id: &str) -> Result<AgentCard, CardError> {
     let path = card_path(agents_dir, agent_id);

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -178,8 +178,27 @@ pub fn run(
             let mut fields: Vec<(&str, String)> = Vec::new();
             fields.push(("target", short_id(target)));
 
+            // Whether the actor is proven (signed by the actor's registered,
+            // AgentCert-pinned per-agent key) or merely asserted (free-text
+            // label signed by the shared key). The signer is the envelope's key.
+            let signer_kid = env
+                .signatures
+                .first()
+                .map(|s| s.keyid.clone())
+                .unwrap_or_default();
+            let proof = |actor: &str| -> (&'static str, String) {
+                let label = if crate::commands::capability::actor_proven(&ctx, actor, &signer_kid)
+                {
+                    "proven (key-bound)".to_string()
+                } else {
+                    "asserted".to_string()
+                };
+                ("actor proof", label)
+            };
+
             if let Ok(action) = env.unmarshal_statement::<ActionStatement>() {
                 fields.push(("actor", action.actor.clone()));
+                fields.push(proof(&action.actor));
                 fields.push(("action", action.action.clone()));
                 fields.push(("time", action.timestamp.clone()));
                 // Check for approval
@@ -193,12 +212,14 @@ pub fn run(
                 fields.push(("time", approval.timestamp.clone()));
             } else if let Ok(handoff) = env.unmarshal_statement::<HandoffStatement>() {
                 fields.push(("actor", format!("{} -> {}", handoff.from, handoff.to)));
+                fields.push(proof(&handoff.from));
                 fields.push(("time", handoff.timestamp.clone()));
             } else if let Ok(receipt) = env.unmarshal_statement::<ReceiptStatement>() {
                 fields.push(("system", receipt.system.clone()));
                 fields.push(("time", receipt.timestamp.clone()));
             } else if let Ok(decision) = env.unmarshal_statement::<DecisionStatement>() {
                 fields.push(("actor", decision.actor.clone()));
+                fields.push(proof(&decision.actor));
                 if let Some(ref model) = decision.model {
                     fields.push(("model", model.clone()));
                 }


### PR DESCRIPTION
Completes [per-actor signing](../blob/main/docs/specs/per-actor-signing.md). Two parts:

## 1. Resolver extended to decision + handoff
`attest decision` signs as `--actor`, `attest handoff` signs as `--from`. Now every actor-bearing receipt can be signed by the agent's own key, not just `attest action`/`attest card`.

## 2. `treeship verify` shows actor proof
```
actor:         agent://deployer
actor proof:   proven (key-bound)      # signer IS the actor's pinned AgentCert key
```
vs `asserted` for a free-text label signed by the shared key. Reported for action/decision/handoff.

**Display label only** — per the repo's AI-assisted-development policy, this never changes whether `verify` returns Ok/fail. Signature check, artifact-id recompute, and key-trust are untouched. It surfaces the binding strength the signature already carries, honestly (never claims more than the crypto proves).

## Shared logic
Factors the actor→key lookup into `cards::registered_key_for_actor`, used by both the attest resolver and the new `capability::actor_proven` check, so signing and verification agree by construction.

## Verified e2e
| receipt | actor proof |
|---|---|
| registered agent — action | proven (key-bound) |
| registered agent — decision | proven (key-bound) |
| unregistered agent | asserted |
| `human://` actor | asserted |

Tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)