### PR TITLE
feat: capability-card revocation (agent_card_revocation.v1)

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -21,7 +21,7 @@ use treeship_core::session::event::EventType;
 /// signer is the agent's certified key). Every other actor, and any agent
 /// without a registered/pinned key, signs with the ship's default key, exactly
 /// as before. This is the load-bearing half of per-actor signing.
-fn resolve_actor_signer(
+pub(crate) fn resolve_actor_signer(
     ctx: &ctx::Ctx,
     actor: &str,
 ) -> Result<Box<dyn Signer>, Box<dyn std::error::Error>> {

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -13,7 +13,9 @@
 
 use crate::{ctx, printer::Printer};
 use treeship_core::{
+    attestation::sign,
     statements::{payload_type, ActionStatement, ReceiptStatement},
+    storage::Record,
     trust::{TrustRootKind, TrustRootStore},
 };
 
@@ -112,8 +114,16 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
             }
         });
 
+    // --- Revocation: honor an authorized agent_card_revocation.v1 ----------
+    // A revocation counts only when its signer is the card's own key
+    // (self-revocation) or a Ship trust root (issuer revocation). A stranger
+    // cannot revoke your card.
+    let revocation = find_revocation(&ctx, card_id, card_keyid, &trust);
+
     // --- Report ------------------------------------------------------------
-    let status = if !key_bound {
+    let status = if revocation.is_some() {
+        "REVOKED"
+    } else if !key_bound {
         "self-asserted"
     } else if violations.is_empty() {
         "verified"
@@ -144,6 +154,12 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
             ("status", status),
         ],
     );
+    if let Some((reason, who)) = &revocation {
+        printer.warn(
+            "capability card REVOKED — do not honor",
+            &[("by", who), ("reason", reason)],
+        );
+    }
     if let Some(note) = &anchor_note {
         printer.hint(note);
     }
@@ -168,6 +184,142 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     );
     printer.blank();
     Ok(())
+}
+
+/// `treeship revoke-capability <card_id>` — mint a signed revocation of a card.
+///
+/// The revocation is itself an `agent_card_revocation.v1` receipt, signed with
+/// the agent's own key (self-revocation) when the card's actor has a registered
+/// key, else the ship's default key. verify-capability honors it only when the
+/// signer is authorized (the card's key, or a Ship root), so this is a real
+/// authorization act, not a free-floating note.
+pub fn revoke_capability(
+    card_id: &str,
+    reason: Option<&str>,
+    config: Option<&str>,
+    printer: &Printer,
+) -> CmdResult {
+    let ctx = ctx::open(config)?;
+
+    // Read the card so the revocation records its keyid + actor.
+    let record = ctx.storage.read(card_id)?;
+    let card_stmt: ReceiptStatement = record.envelope.unmarshal_statement()?;
+    if card_stmt.kind != "agent_card.v1" {
+        return Err(format!(
+            "{card_id} is kind `{}`, not an agent_card.v1 receipt",
+            card_stmt.kind
+        )
+        .into());
+    }
+    let card = card_stmt
+        .payload
+        .ok_or("agent_card.v1 receipt has no payload")?;
+    let card_keyid = card.get("keyid").and_then(|v| v.as_str()).unwrap_or("");
+    let card_agent = card.get("agent").and_then(|v| v.as_str()).unwrap_or("");
+
+    let revoked_at = crate::commands::verify::now_rfc3339();
+    let mut payload = serde_json::Map::new();
+    payload.insert("schema".into(), "agent_card_revocation.v1".into());
+    payload.insert("card".into(), card_id.into());
+    payload.insert("keyid".into(), card_keyid.into());
+    if let Some(r) = reason {
+        payload.insert("reason".into(), r.into());
+    }
+    payload.insert("revoked_at".into(), revoked_at.clone().into());
+    let payload = serde_json::Value::Object(payload);
+
+    treeship_core::predicates::validate("agent_card_revocation.v1", Some(&payload))
+        .map_err(|e| format!("invalid revocation: {e}"))?;
+
+    let mut stmt = ReceiptStatement::new("system://registry", "agent_card_revocation.v1");
+    stmt.payload = Some(payload);
+
+    // Sign as the agent (self-revocation) when the card's actor has a key.
+    let signer = crate::commands::attest::resolve_actor_signer(&ctx, card_agent)?;
+    let pt = payload_type("receipt");
+    let result = sign(&pt, &stmt, signer.as_ref())?;
+    ctx.storage.write(&Record {
+        artifact_id:  result.artifact_id.clone(),
+        digest:       result.digest.clone(),
+        payload_type: pt,
+        key_id:       signer.key_id().to_string(),
+        signed_at:    stmt.timestamp.clone(),
+        parent_id:    Some(card_id.to_string()),
+        envelope:     result.envelope,
+        hub_url:      None,
+    })?;
+
+    let self_revoke = signer.key_id() == card_keyid;
+    printer.success(
+        "capability card revoked",
+        &[
+            ("revocation", &result.artifact_id),
+            ("card", card_id),
+            ("agent", card_agent),
+            ("authority", if self_revoke { "self (agent key)" } else { "ship default key" }),
+            ("reason", reason.unwrap_or("(none)")),
+        ],
+    );
+    if !self_revoke {
+        printer.hint(
+            "signed with the ship's default key: verify-capability honors this only if that key is a Ship trust root; otherwise register the agent with --own-key and revoke as the agent.",
+        );
+    }
+    printer.hint(&format!("treeship verify-capability {card_id}"));
+    printer.blank();
+    Ok(())
+}
+
+/// Find an authorized revocation of `card_id`, if any. Authorized = signed by
+/// the card's own key (self-revocation) or a Ship trust root (issuer
+/// revocation); a stranger's revocation is ignored. Returns (reason, who).
+fn find_revocation(
+    ctx: &ctx::Ctx,
+    card_id: &str,
+    card_keyid: &str,
+    trust: &TrustRootStore,
+) -> Option<(String, String)> {
+    let receipt_pt = payload_type("receipt");
+    for entry in ctx.storage.list_by_type(&receipt_pt) {
+        let Ok(rec) = ctx.storage.read(&entry.id) else {
+            continue;
+        };
+        let Ok(stmt) = rec.envelope.unmarshal_statement::<ReceiptStatement>() else {
+            continue;
+        };
+        if stmt.kind != "agent_card_revocation.v1" {
+            continue;
+        }
+        let Some(payload) = stmt.payload else { continue };
+        if payload.get("card").and_then(|v| v.as_str()) != Some(card_id) {
+            continue;
+        }
+        let rsigner = rec
+            .envelope
+            .signatures
+            .first()
+            .map(|s| s.keyid.as_str())
+            .unwrap_or("");
+        let self_revoke = !card_keyid.is_empty() && rsigner == card_keyid;
+        let issuer_revoke = trust
+            .roots()
+            .iter()
+            .any(|r| r.key_id == rsigner && r.kind == TrustRootKind::Ship);
+        if self_revoke || issuer_revoke {
+            let reason = payload
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(no reason given)")
+                .to_string();
+            let who = if self_revoke {
+                "self-revoked".to_string()
+            } else {
+                "issuer (ship) revoked".to_string()
+            };
+            return Some((reason, who));
+        }
+    }
+    None
 }
 
 /// A card is **key-bound** only when its `keyid` is the signer of the envelope

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -132,6 +132,16 @@ enum Command {
     ///   treeship verify-capability art_<agent_card_id>
     VerifyCapability(VerifyCapabilityArgs),
 
+    /// Revoke a capability card (agent_card_revocation.v1)
+    ///
+    /// Mints a signed revocation of an agent_card.v1. Signed with the agent's
+    /// own key when the card's actor has one (self-revocation), else the ship
+    /// key. verify-capability then reports the card as REVOKED.
+    ///
+    /// Example:
+    ///   treeship revoke-capability art_<agent_card_id> --reason key-rotation
+    RevokeCapability(RevokeCapabilityArgs),
+
     /// Create, export, and import artifact bundles
     ///
     /// Bundles group artifacts into a signed, portable package.
@@ -1640,6 +1650,16 @@ struct VerifyCapabilityArgs {
     card_id: String,
 }
 
+#[derive(Args)]
+struct RevokeCapabilityArgs {
+    /// Artifact id of the agent_card.v1 receipt to revoke.
+    card_id: String,
+
+    /// Optional reason, e.g. key-rotation, compromised, decommissioned.
+    #[arg(long, value_name = "REASON")]
+    reason: Option<String>,
+}
+
 // --- keys -------------------------------------------------------------------
 
 #[derive(Subcommand)]
@@ -2432,6 +2452,13 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
         Command::VerifyCapability(a) => {
             commands::capability::verify_capability(&a.card_id, cli.config.as_deref(), printer)
         }
+
+        Command::RevokeCapability(a) => commands::capability::revoke_capability(
+            &a.card_id,
+            a.reason.as_deref(),
+            cli.config.as_deref(),
+            printer,
+        ),
 
         Command::Verify(a) => {
             // External targets (URL, file path to a .treeship/.agent package)

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -47,6 +47,10 @@ const REGISTRY: &[(&str, &str)] = &[
         "agent_card.v1",
         include_str!("schemas/agent_card.v1.json"),
     ),
+    (
+        "agent_card_revocation.v1",
+        include_str!("schemas/agent_card_revocation.v1.json"),
+    ),
 ];
 
 /// Returns the raw JSON Schema text for a registered predicate suffix, if any.
@@ -408,6 +412,31 @@ mod tests {
         assert!(matches!(
             validate("agent_card.v1", Some(&card)).unwrap_err(),
             PredicateError::TypeMismatch { field, .. } if field == "capabilities"
+        ));
+    }
+
+    #[test]
+    fn agent_card_revocation_valid_passes() {
+        let rev = json!({
+            "schema": "agent_card_revocation.v1",
+            "card": "art_deadbeefdeadbeef",
+            "keyid": "key_1",
+            "reason": "key-rotation",
+            "revoked_at": "2026-06-23T00:00:00Z"
+        });
+        assert!(validate("agent_card_revocation.v1", Some(&rev)).is_ok());
+    }
+
+    #[test]
+    fn agent_card_revocation_requires_card_id() {
+        let rev = json!({
+            "schema": "agent_card_revocation.v1",
+            "revoked_at": "2026-06-23T00:00:00Z"
+            // missing `card`
+        });
+        assert!(matches!(
+            validate("agent_card_revocation.v1", Some(&rev)).unwrap_err(),
+            PredicateError::MissingField { field, .. } if field == "card"
         ));
     }
 }

--- a/packages/core/src/predicates/schemas/agent_card_revocation.v1.json
+++ b/packages/core/src/predicates/schemas/agent_card_revocation.v1.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/agent_card_revocation.v1.json",
+  "title": "agent_card_revocation.v1",
+  "description": "Revokes a previously-minted agent_card.v1. Carried as the payload of a Treeship receipt with kind=agent_card_revocation.v1. A revocation is honored by verify-capability only when its signer is authorized: the card's own key (self-revocation) or a Ship trust root (issuer revocation). See docs/specs/agent-capability-cards.md.",
+  "type": "object",
+  "required": ["schema", "card", "revoked_at"],
+  "properties": {
+    "schema": {
+      "description": "Schema identifier. Must be exactly this value.",
+      "const": "agent_card_revocation.v1"
+    },
+    "card": {
+      "description": "Content-addressed id (art_...) of the agent_card.v1 receipt being revoked.",
+      "type": "string"
+    },
+    "keyid": {
+      "description": "Key the revoked card was bound to. Recorded so verify can match a self-revocation (signer == this key) without re-reading the card.",
+      "type": "string"
+    },
+    "reason": {
+      "description": "Optional human-readable reason, e.g. key-rotation, compromised, decommissioned.",
+      "type": "string"
+    },
+    "revoked_at": {
+      "description": "RFC3339 timestamp the revocation was issued.",
+      "type": "string"
+    },
+    "supersedes": {
+      "description": "Optional id of the agent_card.v1 that replaces the revoked one, or null.",
+      "type": ["string", "null"]
+    }
+  }
+}


### PR DESCRIPTION
The last open item in the [agent-capability-cards spec](../blob/main/docs/specs/agent-capability-cards.md): revoke a minted card, with **sound authorization**.

## What's added
- **Predicate `agent_card_revocation.v1`** (registered, schema-validated): required `{schema, card, revoked_at}`, optional `keyid`/`reason`/`supersedes`.
- **`treeship revoke-capability <card_id> --reason …`** mints a signed revocation receipt, signed with the agent's **own** key (self-revocation) when the card's actor has a registered key, else the ship's default key.
- **`verify-capability` honors a revocation only when its signer is authorized**: the card's own key (self) or a `Ship` trust root (issuer). Otherwise ignored. When honored: `status: REVOKED` + a "do not honor" warning.

## Fails closed (per the repo policy)
An unauthorized revocation never flips status. A stranger cannot revoke your card.

## Verified e2e
| step | result |
|---|---|
| mint + verify | `key-bound: yes`, `status: verified` |
| `revoke-capability --reason key-rotation` | `authority: self (agent key)` |
| verify after | `status: REVOKED`, `by: self-revoked` |
| attacker's default-key revocation of an agent-key-bound card | **ignored**, `status: verified` |

Predicate unit tests (valid + missing-`card` fails-closed) pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)