### PR TITLE
feat: WASM-expose verify-capability (browser receipt viewer)

### DIFF
--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -12,6 +12,9 @@
 // so.
 
 use crate::{ctx, printer::Printer};
+use treeship_core::capability::action_in_scope;
+// Re-exported: attest.rs (attest card) resolves is_key_bound through this path.
+pub use treeship_core::capability::is_key_bound;
 use treeship_core::{
     attestation::sign,
     statements::{payload_type, ActionStatement, ReceiptStatement},
@@ -80,24 +83,22 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
             continue;
         };
         total += 1;
-        // A receipt is in scope if its action category OR its meta.tool matches
-        // any declared capability (exact, or a `family.*` glob).
-        let mut candidates = vec![action.action.clone()];
-        if let Some(tool) = action
-            .meta
-            .as_ref()
-            .and_then(|m| m.get("tool"))
-            .and_then(|v| v.as_str())
-        {
-            candidates.push(tool.to_string());
-        }
-        let matched = candidates
-            .iter()
-            .any(|c| tools.iter().any(|decl| tool_matches(decl, c)));
-        if matched {
+        // In scope if the action label OR meta.tool matches a declared
+        // capability (exact or `family.*` glob). Shared with the WASM verifier
+        // via treeship_core::capability so browser and CLI agree.
+        if action_in_scope(&action, &tools) {
             in_scope += 1;
         } else {
-            violations.push((entry.id.clone(), candidates.join(" / ")));
+            let mut label = action.action.clone();
+            if let Some(tool) = action
+                .meta
+                .as_ref()
+                .and_then(|m| m.get("tool"))
+                .and_then(|v| v.as_str())
+            {
+                label = format!("{} / {tool}", action.action);
+            }
+            violations.push((entry.id.clone(), label));
         }
     }
 
@@ -322,18 +323,6 @@ fn find_revocation(
     None
 }
 
-/// A card is **key-bound** only when its `keyid` is the signer of the envelope
-/// AND that key is pinned under `AgentCert`. Anything else is self-asserted.
-/// Shared by `verify-capability` and `attest card` so mint and verify agree.
-pub fn is_key_bound(card_keyid: &str, signer_keyid: &str, trust: &TrustRootStore) -> bool {
-    !card_keyid.is_empty()
-        && signer_keyid == card_keyid
-        && trust
-            .roots()
-            .iter()
-            .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert)
-}
-
 /// Is a receipt's `actor` cryptographically proven, i.e. signed by the actor's
 /// registered, AgentCert-pinned per-agent key? Used by `verify` to label the
 /// actor proven vs asserted. False for non-agent actors, unregistered agents,
@@ -351,54 +340,3 @@ pub fn actor_proven(ctx: &crate::ctx::Ctx, actor: &str, signer_keyid: &str) -> b
             .unwrap_or(false)
 }
 
-/// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
-/// matches anything.
-fn tool_matches(declared: &str, actual: &str) -> bool {
-    if let Some(prefix) = declared.strip_suffix('*') {
-        actual.starts_with(prefix)
-    } else {
-        declared == actual
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{is_key_bound, tool_matches};
-    use treeship_core::trust::{TrustRoot, TrustRootKind, TrustRootStore};
-
-    #[test]
-    fn exact_and_glob_matching() {
-        assert!(tool_matches("file.write", "file.write"));
-        assert!(!tool_matches("file.write", "file.read"));
-        assert!(tool_matches("file.*", "file.write"));
-        assert!(tool_matches("file.*", "file.read"));
-        assert!(!tool_matches("file.*", "db.query"));
-        assert!(tool_matches("*", "anything.at.all"));
-    }
-
-    fn root(key_id: &str, kind: TrustRootKind) -> TrustRoot {
-        TrustRoot {
-            key_id: key_id.into(),
-            public_key: "ed25519:AAAA".into(),
-            kind,
-            label: String::new(),
-            added_at: String::new(),
-        }
-    }
-
-    #[test]
-    fn key_bound_needs_signer_match_and_agentcert() {
-        let agentcert = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::AgentCert)]);
-        // signer == card keyid AND pinned under AgentCert -> key-bound
-        assert!(is_key_bound("key_x", "key_x", &agentcert));
-        // envelope signer differs from the card's keyid -> not bound
-        assert!(!is_key_bound("key_x", "key_y", &agentcert));
-        // empty card keyid -> not bound
-        assert!(!is_key_bound("", "", &agentcert));
-        // pinned, but under a different kind (Ship, not AgentCert) -> not bound
-        let ship = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::Ship)]);
-        assert!(!is_key_bound("key_x", "key_x", &ship));
-        // not pinned at all -> not bound (self-asserted)
-        assert!(!is_key_bound("key_x", "key_x", &TrustRootStore::with_roots(vec![])));
-    }
-}

--- a/packages/core-wasm/src/lib.rs
+++ b/packages/core-wasm/src/lib.rs
@@ -548,6 +548,125 @@ fn error_result(error_code: &str, message: &str) -> String {
     .to_string()
 }
 
+/// Verify an `agent_card.v1` capability card in the browser. Mirrors
+/// `treeship verify-capability` but takes the receipts as input (no storage):
+///   - `card_json`: the agent_card.v1 DSSE envelope
+///   - `actions_json`: a JSON array of action DSSE envelopes to cross-check
+///   - `trust_roots_json`: trust roots, for the AgentCert key-bound check
+///
+/// Shares the matching logic with the CLI via `treeship_core::capability`, so a
+/// receipt viewer in the browser reaches the same key-bound / in-scope verdict
+/// the CLI does. Honest contract: consistency over the *provided* actions, not
+/// completeness. Returns JSON:
+/// ```json
+/// {
+///   "outcome": "pass" | "fail" | "error",
+///   "agent": "agent://...", "key_bound": true|false,
+///   "declared_tools": [...], "in_scope": N, "out_of_scope": M,
+///   "violations": [{ "tool": "..." }], "status": "verified|self-asserted|violations"
+/// }
+/// ```
+#[wasm_bindgen]
+pub fn verify_capability(card_json: &str, actions_json: &str, trust_roots_json: &str) -> String {
+    use treeship_core::capability::{action_in_scope, declared_tools, is_key_bound};
+    use treeship_core::statements::{ActionStatement, ReceiptStatement};
+
+    let card_env: Envelope = match serde_json::from_str(card_json) {
+        Ok(e) => e,
+        Err(e) => {
+            return error_result("invalid_json", &format!("invalid card envelope JSON: {e}"))
+        }
+    };
+    let card_stmt: ReceiptStatement = match card_env.unmarshal_statement() {
+        Ok(s) => s,
+        Err(e) => return error_result("invalid_card", &format!("card is not a receipt: {e}")),
+    };
+    if card_stmt.kind != "agent_card.v1" {
+        return error_result(
+            "not_a_card",
+            &format!("kind `{}` is not agent_card.v1", card_stmt.kind),
+        );
+    }
+    let payload = match card_stmt.payload {
+        Some(p) => p,
+        None => return error_result("invalid_card", "agent_card.v1 has no payload"),
+    };
+    let card_keyid = payload.get("keyid").and_then(|v| v.as_str()).unwrap_or("");
+    let card_agent = payload.get("agent").and_then(|v| v.as_str()).unwrap_or("");
+    let tools = declared_tools(&payload);
+
+    let card_signer = card_env
+        .signatures
+        .first()
+        .map(|s| s.keyid.as_str())
+        .unwrap_or("");
+    let trust = match parse_wasm_trust_roots(trust_roots_json) {
+        Ok(t) => t,
+        Err(e) => return error_result("invalid_trust_roots", &e),
+    };
+    let key_bound = is_key_bound(card_keyid, card_signer, &trust);
+
+    // Cross-check the provided action envelopes signed by the card's key.
+    let actions: Vec<Envelope> = match serde_json::from_str(actions_json) {
+        Ok(a) => a,
+        Err(e) => {
+            return error_result(
+                "invalid_json",
+                &format!("invalid actions JSON (expected array of envelopes): {e}"),
+            )
+        }
+    };
+    let mut in_scope = 0usize;
+    let mut violations: Vec<serde_json::Value> = Vec::new();
+    for env in &actions {
+        let signer = env
+            .signatures
+            .first()
+            .map(|s| s.keyid.as_str())
+            .unwrap_or("");
+        if signer != card_keyid {
+            continue; // only the card key's actions count toward its card
+        }
+        let Ok(action) = env.unmarshal_statement::<ActionStatement>() else {
+            continue;
+        };
+        if action_in_scope(&action, &tools) {
+            in_scope += 1;
+        } else {
+            let mut label = action.action.clone();
+            if let Some(t) = action
+                .meta
+                .as_ref()
+                .and_then(|m| m.get("tool"))
+                .and_then(|v| v.as_str())
+            {
+                label = format!("{} / {t}", action.action);
+            }
+            violations.push(serde_json::json!({ "tool": label }));
+        }
+    }
+
+    let status = if !key_bound {
+        "self-asserted"
+    } else if violations.is_empty() {
+        "verified"
+    } else {
+        "violations"
+    };
+
+    serde_json::json!({
+        "outcome": if status == "violations" { "fail" } else { "pass" },
+        "agent": card_agent,
+        "key_bound": key_bound,
+        "declared_tools": tools,
+        "in_scope": in_scope,
+        "out_of_scope": violations.len(),
+        "violations": violations,
+        "status": status,
+    })
+    .to_string()
+}
+
 /// Parse the `trust_roots_json` argument the WASM verify_* surfaces
 /// accept. The JSON shape mirrors the on-disk
 /// `~/.treeship/trust_roots.json`:
@@ -865,5 +984,66 @@ mod tests {
         ).unwrap();
         assert_eq!(out["outcome"], "error");
         assert_eq!(out["error_code"], "invalid_json");
+    }
+
+    #[test]
+    fn verify_capability_matches_cli_verdict() {
+        use treeship_core::attestation::{sign, Ed25519Signer};
+        use treeship_core::statements::{payload_type, ActionStatement, ReceiptStatement};
+
+        let signer = Ed25519Signer::generate("key_agent_test").unwrap();
+        let keyid = "key_agent_test";
+
+        // agent_card.v1 declaring file.*
+        let mut card = ReceiptStatement::new("system://registry", "agent_card.v1");
+        card.payload = Some(serde_json::json!({
+            "schema": "agent_card.v1",
+            "agent": "agent://deployer",
+            "keyid": keyid,
+            "version": "1.0.0",
+            "capabilities": { "tools": ["file.*"] }
+        }));
+        let card_env = sign(&payload_type("receipt"), &card, &signer).unwrap().envelope;
+        let card_json = serde_json::to_string(&card_env).unwrap();
+
+        // file.write (in scope via file.*) and command.run (out of scope)
+        let a1 = sign(&payload_type("action"),
+            &ActionStatement::new("agent://deployer", "file.write"), &signer).unwrap().envelope;
+        let a2 = sign(&payload_type("action"),
+            &ActionStatement::new("agent://deployer", "command.run"), &signer).unwrap().envelope;
+        let actions_json = serde_json::to_string(&vec![a1, a2]).unwrap();
+
+        // Pin the key under agent_cert.
+        let trust_json = serde_json::json!({
+            "version": 1,
+            "roots": [{
+                "key_id": keyid,
+                "public_key": "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "kind": "agent_cert",
+                "label": "",
+                "added_at": ""
+            }]
+        }).to_string();
+
+        // With trust roots: key-bound, 1 in / 1 out, status violations -- the
+        // exact verdict the CLI verify-capability returns for the same inputs.
+        let out: serde_json::Value =
+            serde_json::from_str(&verify_capability(&card_json, &actions_json, &trust_json)).unwrap();
+        assert_eq!(out["key_bound"], true, "{out}");
+        assert_eq!(out["in_scope"], 1);
+        assert_eq!(out["out_of_scope"], 1);
+        assert_eq!(out["status"], "violations");
+        assert_eq!(out["agent"], "agent://deployer");
+
+        // Without trust roots, the same card is self-asserted (fail-closed).
+        let out2: serde_json::Value =
+            serde_json::from_str(&verify_capability(&card_json, &actions_json, "")).unwrap();
+        assert_eq!(out2["key_bound"], false);
+        assert_eq!(out2["status"], "self-asserted");
+
+        // A non-card receipt is rejected, not silently passed.
+        let err: serde_json::Value =
+            serde_json::from_str(&verify_capability("{}", "[]", "")).unwrap();
+        assert_eq!(err["outcome"], "error");
     }
 }

--- a/packages/core/src/capability/mod.rs
+++ b/packages/core/src/capability/mod.rs
@@ -1,0 +1,111 @@
+//! Pure capability-card verification primitives, shared by the CLI
+//! (`treeship verify-capability`) and the WASM verifier (browser receipt
+//! viewer) so both agree by construction. No I/O: callers supply the parsed
+//! card, the action statements, and the trust roots.
+//!
+//! See docs/specs/agent-capability-cards.md. The honest contract holds here
+//! too: this checks consistency over *captured* evidence (the actions the
+//! caller passes in), never completeness.
+
+use crate::statements::ActionStatement;
+use crate::trust::{TrustRootKind, TrustRootStore};
+
+/// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
+/// matches anything.
+pub fn tool_matches(declared: &str, actual: &str) -> bool {
+    if let Some(prefix) = declared.strip_suffix('*') {
+        actual.starts_with(prefix)
+    } else {
+        declared == actual
+    }
+}
+
+/// A card is **key-bound** only when its `keyid` is the envelope signer AND
+/// that key is pinned under `AgentCert`. Anything else is self-asserted.
+pub fn is_key_bound(card_keyid: &str, signer_keyid: &str, trust: &TrustRootStore) -> bool {
+    !card_keyid.is_empty()
+        && signer_keyid == card_keyid
+        && trust
+            .roots()
+            .iter()
+            .any(|r| r.key_id == card_keyid && r.kind == TrustRootKind::AgentCert)
+}
+
+/// Is an action within a declared capability set? Checks the action label and
+/// the optional `meta.tool` against each declared capability (exact, or a
+/// `family.*` glob).
+pub fn action_in_scope(action: &ActionStatement, declared_tools: &[String]) -> bool {
+    let mut candidates: Vec<&str> = vec![action.action.as_str()];
+    if let Some(tool) = action
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("tool"))
+        .and_then(|v| v.as_str())
+    {
+        candidates.push(tool);
+    }
+    candidates
+        .iter()
+        .any(|c| declared_tools.iter().any(|d| tool_matches(d, c)))
+}
+
+/// Extract the declared `capabilities.tools` from an agent_card.v1 payload.
+pub fn declared_tools(card_payload: &serde_json::Value) -> Vec<String> {
+    card_payload
+        .get("capabilities")
+        .and_then(|c| c.get("tools"))
+        .and_then(|t| t.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|t| t.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trust::{TrustRoot, TrustRootKind, TrustRootStore};
+
+    #[test]
+    fn exact_and_glob_matching() {
+        assert!(tool_matches("file.write", "file.write"));
+        assert!(!tool_matches("file.write", "file.read"));
+        assert!(tool_matches("file.*", "file.write"));
+        assert!(!tool_matches("file.*", "db.query"));
+        assert!(tool_matches("*", "anything.at.all"));
+    }
+
+    fn root(key_id: &str, kind: TrustRootKind) -> TrustRoot {
+        TrustRoot {
+            key_id: key_id.into(),
+            public_key: "ed25519:AAAA".into(),
+            kind,
+            label: String::new(),
+            added_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn key_bound_needs_signer_match_and_agentcert() {
+        let agentcert = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::AgentCert)]);
+        assert!(is_key_bound("key_x", "key_x", &agentcert));
+        assert!(!is_key_bound("key_x", "key_y", &agentcert));
+        assert!(!is_key_bound("", "", &agentcert));
+        let ship = TrustRootStore::with_roots(vec![root("key_x", TrustRootKind::Ship)]);
+        assert!(!is_key_bound("key_x", "key_x", &ship));
+        assert!(!is_key_bound("key_x", "key_x", &TrustRootStore::with_roots(vec![])));
+    }
+
+    #[test]
+    fn in_scope_checks_action_and_meta_tool() {
+        let mut a = ActionStatement::new("agent://x", "file.write");
+        assert!(action_in_scope(&a, &["file.*".to_string()]));
+        assert!(!action_in_scope(&a, &["db.query".to_string()]));
+        // meta.tool also counts
+        a.action = "tool.call".into();
+        a.meta = Some(serde_json::json!({ "tool": "db.query" }));
+        assert!(action_in_scope(&a, &["db.query".to_string()]));
+    }
+}

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod attestation;
+pub mod capability;
 pub mod predicates;
 pub mod statements;
 pub mod keys;

--- a/packages/verify-js/src/index.ts
+++ b/packages/verify-js/src/index.ts
@@ -23,6 +23,11 @@ type WasmBindings = {
     now: string,
     trustRoots: string,
   ) => string;
+  verify_capability: (
+    card: string,
+    actions: string,
+    trustRoots: string,
+  ) => string;
 };
 
 /**
@@ -210,5 +215,46 @@ export async function crossVerify(
   const wasm = await loadWasm();
   return JSON.parse(
     wasm.cross_verify(receiptJson, certJson, nowStr, serializeTrustRoots(trustRoots)),
+  );
+}
+
+/** Result of {@link verifyCapability}. Mirrors the WASM JSON output. */
+export interface CapabilityVerifyResult {
+  outcome: 'pass' | 'fail' | 'error';
+  /** The actor the card claims, e.g. `agent://deployer`. */
+  agent?: string;
+  /** True iff the card's keyid is its signer AND pinned under AgentCert. */
+  key_bound?: boolean;
+  declared_tools?: string[];
+  in_scope?: number;
+  out_of_scope?: number;
+  violations?: { tool: string }[];
+  status?: 'verified' | 'self-asserted' | 'violations';
+  error_code?: string;
+  message?: string;
+}
+
+/**
+ * Verify an agent_card.v1 capability card in the browser, the same check
+ * `treeship verify-capability` runs (shared Rust logic via
+ * `treeship_core::capability`). Pass the card envelope and the action
+ * envelopes to cross-check; `trustRoots` is required for `key_bound` to be
+ * true (otherwise the card is reported self-asserted).
+ *
+ * Honest contract: this is consistency over the actions you provide, not a
+ * completeness guarantee. It cannot prove the agent took no off-card action.
+ */
+export async function verifyCapability(
+  card: VerifyTarget,
+  actions: VerifyTarget[],
+  trustRoots?: TrustRootsBundle | TrustRootInput[],
+): Promise<CapabilityVerifyResult> {
+  const cardJson = await normalizeToJson(card);
+  const actionJsons = await Promise.all((actions ?? []).map(normalizeToJson));
+  // Each normalized action is a JSON object; assemble them into a JSON array.
+  const actionsJson = `[${actionJsons.join(',')}]`;
+  const wasm = await loadWasm();
+  return JSON.parse(
+    wasm.verify_capability(cardJson, actionsJson, serializeTrustRoots(trustRoots)),
   );
 }


### PR DESCRIPTION
So the browser receipt viewer can show a capability card's **key-bound** status and **in/out-of-scope** cross-check, returning the *same* verdict as `treeship verify-capability`.

## No drift: shared core logic
For a trust product the browser and CLI verifiers must agree by construction, so the matching logic is **extracted into a pure core module**, not duplicated:
- **`treeship_core::capability`**: `tool_matches`, `is_key_bound`, `action_in_scope`, `declared_tools`. Pure, no I/O. 3 unit tests.
- **CLI** `verify-capability` refactored to use it (behavior preserved; `is_key_bound` re-exported so `attest card`'s path is unchanged).
- **core-wasm**: `verify_capability(card_json, actions_json, trust_roots_json)` `#[wasm_bindgen]` export, takes receipts as input (no storage in the browser).
- **verify-js**: typed `verifyCapability()` + `CapabilityVerifyResult`.

## Proven, not assumed
A host test calls the WASM export with **real signed envelopes** and asserts it returns the exact CLI verdict:
- with trust roots → `key_bound: true`, `in_scope: 1`, `out_of_scope: 1`, `status: violations`
- without trust roots → `key_bound: false`, `status: self-asserted` (fail-closed)
- a non-card receipt → `outcome: error` (rejected, not silently passed)

## Honest contract, every layer
Consistency over the *provided* actions, never a completeness guarantee, carried through the core doc, the WASM doc, and the TS doc.

## Notes
The wasm `pkg/` is gitignored and regenerated at release via `build-npm.sh` (the wasm32 target isn't needed to land this source). clippy clean (no new warnings); `tsc` passes; CLI + core + wasm tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)