### PR TITLE
docs: blog + docs + changelog for the agent-identity arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- **Predicate registry: typed, schema-validated receipt payloads.** Registered `kind` suffixes are bound to a JSON Schema and validated at attest time, **before** the receipt is signed; unregistered kinds attest sign-on-submit exactly as before (additive, backward compatible). Registered predicates: `memory.write.v1`, `memory.read.v1`, `boundary.v1`, `agent_card.v1`, `agent_card_revocation.v1`. The validator is dependency-free on purpose so the signing path and the WASM verifier stay lean. See [`reference/predicates`](docs/content/docs/reference/predicates.mdx).
+- **Agent capability cards (`agent_card.v1`).** `treeship attest card` mints a signed, typed card declaring an agent's identity and capability set; `treeship verify-capability <card>` checks it against the agent's captured action receipts. The card is **key-bound** only when its `keyid` is the envelope signer pinned under `AgentCert`; otherwise it is reported `self-asserted`. The cross-check reports in-scope / out-of-scope actions (exact or `family.*` glob) plus an optional `evidence_anchor`. Honest contract: consistency over captured evidence, never a completeness guarantee. (#127, #129, #130, #131, #132)
+- **Per-actor signing: a provable `actor`.** `treeship agent register --own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it under `AgentCert`. `treeship attest action` / `attest card` / `attest decision` / `attest handoff` then sign with the **agent's own key** when the actor has one, so the `actor` is cryptographically provable rather than an asserted label. `treeship verify` reports `actor proof: proven (key-bound) | asserted`. Strictly additive: agents without a per-agent key sign with the ship key exactly as before. (#134, #135, #136)
+- **Capability-card revocation (`agent_card_revocation.v1`).** `treeship revoke-capability <card> --reason …` mints a signed revocation. `verify-capability` honors it **only when its signer is authorized** (the card's own key, or a `Ship` trust root) and then reports `status: REVOKED`; an unauthorized revocation is ignored (fail-closed). (#137)
+- **Browser verification of capability cards.** A new `verify_capability(card, actions, trust_roots)` WASM export and a typed `verifyCapability()` in `@treeship/verify-js` let a browser receipt viewer show key-bound status and the in/out-of-scope cross-check, returning the **same verdict the CLI does**. The matching logic lives in a shared `treeship_core::capability` module so the browser and CLI verifiers cannot drift. (#138)
+
 ## 0.12.0 (2026-06-06)
 
 ### Added

--- a/docs/content/blog/proving-what-an-agent-can-do.mdx
+++ b/docs/content/blog/proving-what-an-agent-can-do.mdx
@@ -1,0 +1,146 @@
+---
+title: "Capability Cards: Proving What an Agent Can Do, Not Just What It Says"
+description: "Descriptor formats like A2A's AgentCard tell you what an agent claims it can do. None of them tell you whether the claim is bound to a key you trust, or whether the agent's actual behavior matches. Here is the arc we shipped to close that gap: a predicate registry, signed capability cards, per-actor signing that makes an agent's identity provable, revocation, and the same verdict in the browser as on the command line."
+date: 2026-06-24
+tags: ["agents", "attestation", "capability", "identity", "trust", "verification"]
+readTime: "12 min read"
+---
+
+Every agent framework now has a way for an agent to describe itself. A2A has the `AgentCard`. NANDA has its registry entries. Model cards, tool manifests, skill descriptors, the list keeps growing. They all answer the same question: *what does this agent say it can do?*
+
+None of them answer the two questions that actually matter when you are about to let an agent touch production:
+
+1. Is that claim **bound to a key you trust**, or could anyone have written it?
+2. Does the agent's **actual behavior** match what it claimed?
+
+A descriptor is a business card. It is a starting point for a conversation, not evidence. This post walks through the arc we just shipped in Treeship to turn the business card into something you can verify, mint it, bind it to a key, check it against real evidence, revoke it, and get the same answer in a browser that you get on the command line.
+
+## Start with the honest version of the problem
+
+Here is the uncomfortable default in almost every agent system today. An agent says "I am `agent://deployer` and I am allowed to write files and query the database." You write that down. Later, a receipt shows up that says `actor: agent://deployer, action: command.run`. Was that really the deployer? Was `command.run` ever in its remit?
+
+In a system where one shared key signs everything, you cannot tell. The `actor` field is a free-text label. Any process holding the signing key can write any label it likes. The capability list is a claim with nothing behind it. This is not a Treeship-specific problem, it is the structural ceiling of every descriptor format: a description is not a proof.
+
+We shipped four layers to raise that ceiling. Each one is additive, each one fails closed, and each one is honest about exactly what it does and does not prove.
+
+## Layer 1: Typed receipts (the predicate registry)
+
+A Treeship receipt carries a free-form `kind` and an opaque JSON `payload`. That flexibility is good, it means any provider can record any kind of proof, but it means a verifier can only check the signature, not the shape.
+
+The **predicate registry** makes specific `kind` values typed. A registered suffix is bound to a JSON Schema, and at attest time the payload is validated against that schema *before* the receipt is signed. If it does not conform, nothing is signed and you get a clear error. Unregistered kinds keep working exactly as before, this is strictly additive.
+
+```bash
+treeship attest receipt --system system://example --kind memory.write.v1 \
+  --payload '{"memory_id":"m1"}'
+# -> predicate validation failed: memory.write.v1: missing required field `content_hash`
+```
+
+We kept the validator dependency-free on purpose. The security-critical signing path and the WASM verifier both stay lean, and there is no schema-validation library sitting in the trusted computing base. `agent_card.v1` is one of the registered predicates, which is what makes the next layer possible.
+
+## Layer 2: Capability cards
+
+A **capability card** is a signed receipt in which a key declares an agent's identity and capability set. You mint one with a single command:
+
+```bash
+treeship attest card \
+  --agent agent://deployer \
+  --tools file.*,db.query \
+  --models claude-sonnet-4
+```
+
+That validates against the `agent_card.v1` schema, signs it, and tells you something a descriptor format never does, **whether the card is key-bound**. A card is key-bound only when its `keyid` is the key that signed it *and* that key is pinned as a trusted agent certificate. Otherwise it is `self-asserted`, and we say so. The binding strength is reported on every card, every time. It is never silently assumed.
+
+Then you check the card against the agent's actual evidence:
+
+```bash
+treeship verify-capability art_<card_id>
+```
+
+```
+✓ capability card
+  agent:             agent://deployer
+  key-bound:         yes (AgentCert)
+  declared tools:    file.*, db.query
+  in-scope actions:  2
+  out-of-scope:      1
+  status:            verified
+```
+
+Every action receipt signed by the card's key gets checked: its action label, or its `meta.tool`, has to match a declared capability, either exactly (`db.query`) or as a glob family (`file.*` covers `file.write`). You get an in-scope and out-of-scope count, and an optional `evidence_anchor` lets the agent commit to a receipt set at mint time so later omission is detectable.
+
+### The contract we refuse to overstate
+
+verify-capability proves **consistency over captured evidence**. It tells you the actions Treeship recorded are in or out of scope. It does **not** prove the agent took no off-card action, that completeness guarantee belongs to runtime enforcement, and no signature can deliver it. We print that caveat on every run, because the fastest way to lose a trust product is to let it imply more than it proves.
+
+## Layer 3: Per-actor signing, the part that makes it real
+
+Here is the subtle thing. Everything above is only as strong as the key behind the card. If every agent in a workspace signs with one shared key, then every card's `keyid` is that shared key, and every card is forever `self-asserted`. The cross-check still works, but the identity is asserted, not proven.
+
+So we made the agent's identity provable. Registering with `--own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it as a trusted agent certificate:
+
+```bash
+treeship agent register --name deployer --tools file.write --own-key
+```
+
+Now `treeship attest action --actor agent://deployer …` signs with the agent's *own* key. The `actor` stops being a label and becomes a signature. `treeship verify` reports it directly:
+
+```
+actor:         agent://deployer
+actor proof:   proven (key-bound)
+```
+
+`proven` means the receipt was signed by the actor's registered, pinned key. `asserted` means a free-text label signed by the shared key. And critically, this is a display label, it never changes whether `verify` itself returns pass or fail. The cryptography decides validity; the label just tells you how much the `actor` is worth.
+
+This is the layer that closes the actor-forgery gap. Once an agent has its own pinned key, a card minted for it is key-bound, its actions are provable, and a different process holding the shared key can no longer impersonate it.
+
+It is also strictly additive. An agent without a per-agent key signs with the ship key exactly as before, and every existing receipt keeps verifying. You opt into stronger identity when you want it.
+
+## Layer 4: Revocation, with real authorization
+
+Keys rotate. Agents get decommissioned. Cards get compromised. So a card you can mint is a card you need to be able to revoke:
+
+```bash
+treeship revoke-capability art_<card_id> --reason key-rotation
+```
+
+The interesting design question is not *how to revoke*, it is *who is allowed to*. A revocation is honored only when its signer is authorized: the card's own key (self-revocation) or a ship trust root (issuer revocation). A revocation signed by any other key is ignored. A stranger cannot revoke your card, and we tested exactly that, an attacker's revocation of an agent-key-bound card leaves the status untouched. Fail closed, every time.
+
+## Same verdict in the browser
+
+A trust property that only holds on your machine is not a trust property, it is a convenience. So the capability check runs client-side too. `@treeship/verify-js` exposes `verifyCapability(card, actions, trustRoots)`, backed by a WASM build, that returns the **same verdict the CLI does**:
+
+```ts
+import { verifyCapability } from '@treeship/verify-js';
+
+const result = await verifyCapability(cardEnvelope, actionEnvelopes, trustRoots);
+// { key_bound: true, in_scope: 2, out_of_scope: 1, status: 'verified', ... }
+```
+
+The way we guarantee "same verdict" is not by being careful to keep two implementations in sync, that always drifts. The matching logic lives in exactly one place, a shared Rust module compiled into both the CLI and the WASM verifier. A browser receipt viewer and the command line are running the same code. We proved it with a test that signs real envelopes and asserts the browser path returns the identical key-bound, in-scope, and out-of-scope result, fails closed without trust roots, and rejects a non-card rather than passing it.
+
+## Where this leaves Treeship
+
+Step back and the arc is one straight line:
+
+```
+typed receipts  →  signed capability cards  →  provable actor (per-actor signing)
+                →  authorized revocation     →  same verdict in the browser
+```
+
+It takes Treeship from "we stamp receipts" to "an agent's identity and capability set are mint-able, verifiable, revocable, and browser-checkable, with a key binding you can trust." And it does it without stepping outside the lane: Treeship proves things. It does not enforce them at runtime, it does not store your memories, it does not decide your policy. Those are other layers' jobs, and the honest contract on every command says exactly where the line is.
+
+A descriptor tells you what an agent claims. A capability card, bound to a key, checked against evidence, lets you decide whether to believe it. That difference is the whole point.
+
+## Try it
+
+Everything in this post runs on a clean machine with no network call:
+
+```bash
+treeship init
+treeship agent register --name deployer --tools file.write,db.query --own-key
+treeship attest card --agent agent://deployer --tools file.*,db.query
+treeship attest action --actor agent://deployer --action file.write
+treeship verify-capability art_<card_id>
+```
+
+See [Capability Cards](/docs/concepts/capability-cards) for the full model, and the [predicate registry](/docs/reference/predicates) for the schemas.

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -12,6 +12,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+### Added
+
+- **Predicate registry: typed, schema-validated receipt payloads.** Registered `kind` suffixes are bound to a JSON Schema and validated at attest time, **before** the receipt is signed; unregistered kinds attest sign-on-submit exactly as before (additive, backward compatible). Registered predicates: `memory.write.v1`, `memory.read.v1`, `boundary.v1`, `agent_card.v1`, `agent_card_revocation.v1`. The validator is dependency-free on purpose so the signing path and the WASM verifier stay lean. See [`reference/predicates`](docs/content/docs/reference/predicates.mdx).
+- **Agent capability cards (`agent_card.v1`).** `treeship attest card` mints a signed, typed card declaring an agent's identity and capability set; `treeship verify-capability <card>` checks it against the agent's captured action receipts. The card is **key-bound** only when its `keyid` is the envelope signer pinned under `AgentCert`; otherwise it is reported `self-asserted`. The cross-check reports in-scope / out-of-scope actions (exact or `family.*` glob) plus an optional `evidence_anchor`. Honest contract: consistency over captured evidence, never a completeness guarantee. (#127, #129, #130, #131, #132)
+- **Per-actor signing: a provable `actor`.** `treeship agent register --own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it under `AgentCert`. `treeship attest action` / `attest card` / `attest decision` / `attest handoff` then sign with the **agent's own key** when the actor has one, so the `actor` is cryptographically provable rather than an asserted label. `treeship verify` reports `actor proof: proven (key-bound) | asserted`. Strictly additive: agents without a per-agent key sign with the ship key exactly as before. (#134, #135, #136)
+- **Capability-card revocation (`agent_card_revocation.v1`).** `treeship revoke-capability <card> --reason …` mints a signed revocation. `verify-capability` honors it **only when its signer is authorized** (the card's own key, or a `Ship` trust root) and then reports `status: REVOKED`; an unauthorized revocation is ignored (fail-closed). (#137)
+- **Browser verification of capability cards.** A new `verify_capability(card, actions, trust_roots)` WASM export and a typed `verifyCapability()` in `@treeship/verify-js` let a browser receipt viewer show key-bound status and the in/out-of-scope cross-check, returning the **same verdict the CLI does**. The matching logic lives in a shared `treeship_core::capability` module so the browser and CLI verifiers cannot drift. (#138)
+
 ## 0.12.0 (2026-06-06)
 
 ### Added

--- a/docs/content/docs/concepts/agent-identity.mdx
+++ b/docs/content/docs/concepts/agent-identity.mdx
@@ -153,6 +153,16 @@ The function takes `now` as an explicit argument so the check is deterministic a
 
 The agent card at `treeship.dev/agent/<slug>` runs this on every recent receipt and surfaces the result as a `✓ no unauthorized calls` badge per row.
 
+## Per-actor signing: making the `actor` provable
+
+By default an agent's actions are signed by the shared ship key, so the `actor` on a receipt (`agent://deployer`) is an asserted label, anyone holding the ship key could write it. **Per-actor signing** closes that gap. Registering with `--own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it under `AgentCert`:
+
+```bash
+treeship agent register --name deployer --tools file.write --own-key
+```
+
+After that, `treeship attest action --actor agent://deployer …` signs with the agent's own key, and `treeship verify` reports `actor proof: proven (key-bound)` instead of `asserted`. The same key makes a [capability card](/docs/concepts/capability-cards) key-bound rather than self-asserted. It is strictly additive: agents without a per-agent key keep signing with the ship key. See [Capability Cards](/docs/concepts/capability-cards) for the full mint → sign → verify → revoke flow.
+
 ## Initial scope: how `bounded_actions` gets determined
 
 Three sources, in order of trust:

--- a/docs/content/docs/concepts/capability-cards.mdx
+++ b/docs/content/docs/concepts/capability-cards.mdx
@@ -1,0 +1,103 @@
+---
+title: Capability Cards
+description: A signed, verifiable agent capability card. A key attests what an agent is and what it can do, and verify-capability checks that claim against the agent's actual evidence. Covers agent_card.v1, key binding, per-actor signing, revocation, and browser verification.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A **capability card** is a signed receipt in which a key declares an agent's identity and its capability set, carried as the payload of an `agent_card.v1` receipt. It answers a question no static descriptor format (A2A's `AgentCard`, NANDA) can: not just *what does this agent claim it can do*, but *does its actual evidence match the claim, and is the claim cryptographically bound to a key you trust?*
+
+<Callout title="Two different things called a card">
+This page is about the typed, signed **capability card** (`agent_card.v1`), a portable proof object. It is distinct from the local [Agent Card](/docs/concepts/agent-cards), which is a workspace trust object Treeship keeps on disk to track an agent's lifecycle. A capability card is something you mint, verify, and revoke; an Agent Card is local inventory.
+</Callout>
+
+## The two questions
+
+`treeship verify-capability <card>` answers two things:
+
+1. **Is the card key-bound?** A card is *key-bound* only when its `keyid` is the key that signed the envelope **and** that key is pinned under `AgentCert`. Otherwise the card is **self-asserted**, a claim anyone holding the signing key could have made. Binding strength is always reported; it is never silently assumed.
+2. **Do the agent's captured actions stay within the declared capability set?** Every action receipt signed by the card's key is checked: its action label or `meta.tool` must match a declared capability, either exactly (`db.query`) or as a `family.*` glob (`file.*` matches `file.write`). The result is an in-scope / out-of-scope count.
+
+<Callout type="warn" title="The honest contract">
+verify-capability proves **consistency over captured evidence**: that the actions Treeship recorded are in or out of scope. It does **not** prove the agent took no off-card action, that completeness guarantee is a runtime enforcement job, not something a signature can deliver. The output says so on every run.
+</Callout>
+
+## Minting a card
+
+```bash
+treeship attest card \
+  --agent agent://deployer \
+  --tools file.*,db.query \
+  --models claude-sonnet-4
+```
+
+This builds the `agent_card.v1` payload from typed flags, validates it against the [registered predicate](/docs/reference/predicates#agent_cardv1), signs it, and reports whether the card is key-bound at mint time. The card's `keyid` defaults to the signing key.
+
+## Key binding and per-actor signing
+
+A card is only as strong as the key behind it. By default every action in a workspace is signed by the single ship key, so a card's `keyid` is the shared key and the card is `self-asserted`. **Per-actor signing** makes the binding real:
+
+```bash
+# Give the agent its own key, certified by the ship and pinned under AgentCert.
+treeship agent register --name deployer --tools file.write --own-key
+```
+
+`--own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), pins it under `AgentCert`, and records it on the agent card. After that, `treeship attest action --actor agent://deployer …` and `treeship attest card --agent agent://deployer …` sign with the **agent's own key**. Now the card's `keyid` is the agent's pinned key, and verify-capability reports `key-bound: yes`.
+
+The same binding makes a plain action's `actor` provable. `treeship verify <action>` reports:
+
+```
+actor:         agent://deployer
+actor proof:   proven (key-bound)
+```
+
+`proven` means the receipt's signer is the actor's registered, `AgentCert`-pinned key. `asserted` means a free-text label signed by the shared key. This is a display label only, it never changes whether `verify` returns pass or fail.
+
+<Callout title="Strictly additive">
+Per-actor signing is opt-in. An agent without a registered per-agent key signs with the ship key exactly as before, and existing receipts keep verifying. See [Agent Identity](/docs/concepts/agent-identity) for the certificate model the per-agent key plugs into.
+</Callout>
+
+## Verifying a card
+
+```bash
+treeship verify-capability art_<agent_card_id>
+```
+
+```
+✓ capability card
+  card:              art_…
+  agent:             agent://deployer
+  key-bound:         yes (AgentCert)
+  declared tools:    file.*, db.query
+  in-scope actions:  2
+  out-of-scope:      1
+  status:            verified
+```
+
+The optional `evidence_anchor` on a card commits the agent to a receipt set (a count, a tip, a Merkle root) at mint time, so post-hoc omission or backfill is detectable, verify-capability flags a mismatch between the committed count and what it observes.
+
+## Revoking a card
+
+```bash
+treeship revoke-capability art_<agent_card_id> --reason key-rotation
+```
+
+This mints a signed `agent_card_revocation.v1` receipt. verify-capability honors a revocation **only when its signer is authorized**: the card's own key (self-revocation) or a `Ship` trust root (issuer revocation). An unauthorized revocation, signed by any other key, is ignored. When an authorized revocation is present the card's status becomes `REVOKED` and a "do not honor" warning is shown. A stranger cannot revoke your card.
+
+## Verifying in the browser
+
+The same check runs client-side. `@treeship/verify-js` exposes `verifyCapability(card, actions, trustRoots)`, backed by a WASM export, that returns the **same verdict the CLI does**, key-bound status, declared tools, and the in/out-of-scope cross-check. The matching logic lives in one shared Rust module (`treeship_core::capability`) used by both the CLI and the WASM verifier, so a browser receipt viewer and the command line cannot disagree.
+
+```ts
+import { verifyCapability } from '@treeship/verify-js';
+
+const result = await verifyCapability(cardEnvelope, actionEnvelopes, trustRoots);
+// { key_bound: true, in_scope: 2, out_of_scope: 1, status: 'verified', ... }
+```
+
+## See also
+
+- [Predicate registry](/docs/reference/predicates) — the `agent_card.v1` and `agent_card_revocation.v1` schemas
+- [Agent Identity](/docs/concepts/agent-identity) — the certificate that binds an agent to its key
+- [Agent Cards](/docs/concepts/agent-cards) — the local workspace trust object (a different thing)
+- [Trust fabric](/docs/concepts/trust-fabric) — how identity, capability, and receipts compose

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Concepts",
-  "pages": ["trust-fabric", "trust-model", "actor-checker-boundaries", "agent-cards", "harnesses", "approval-authority", "approval-use-journal", "artifacts", "session-receipts", "room-sessions", "multi-agent-sessions", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
+  "pages": ["trust-fabric", "trust-model", "actor-checker-boundaries", "agent-cards", "capability-cards", "harnesses", "approval-authority", "approval-use-journal", "artifacts", "session-receipts", "room-sessions", "multi-agent-sessions", "agent-identity", "cross-verification", "command-artifacts", "zero-knowledge", "glossary", "security"]
 }

--- a/docs/content/docs/integrations/memory-proofs.mdx
+++ b/docs/content/docs/integrations/memory-proofs.mdx
@@ -9,6 +9,8 @@ Agent memory systems should own memory selection, ranking, policy, storage, and 
 
 This page is a provider contract. ZMem can use it, but so can Mem0, Zep, Letta, a SQLite memory store, or an in-house retrieval layer.
 
+**The clean split.** The memory provider is the *memory authority*: it answers what memory was available, injected, withheld, revoked, restored, and handed off. Treeship is the *proof authority*: it answers who signed the proof, when, what payload digest was attested, and whether it verifies offline. Treeship does not prove that a memory is semantically true, only that a specific signer attested a specific digest at a specific time. Keep that line crisp and Treeship stays the portable proof rail rather than any one provider's helper.
+
 The rule is simple:
 
 - Use a Treeship action artifact for the memory operation itself.
@@ -54,18 +56,29 @@ treeship attest action \
 
 Treeship signs the actor, operation, subject URI, input digest, output digest, timestamp, and metadata. The memory provider decides what the digests mean and how to re-check them.
 
-Recommended action labels:
+Recommended action labels. Memory is not just CRUD, it has a lifecycle, so the transition verbs are first-class: a proof should say whether a memory was *proposed*, *promoted*, *rejected*, or *forgotten*, not just "written" or "deleted".
 
 ```text
+# access
 memory.read
-memory.write
-memory.delete
 memory.query
 memory.retrieve
 memory.inject
-memory.compact
-memory.handoff
+
+# lifecycle / transitions
+memory.write       # commit a memory
+memory.propose     # suggest a memory, not yet authoritative
+memory.promote     # elevate a proposed memory to authoritative
+memory.reject      # decline a proposed memory
+memory.revoke      # withdraw a previously authoritative memory
+memory.forget      # delete / expire a memory
+memory.restore     # bring back a revoked or forgotten memory
+
+# movement
+memory.handoff     # transfer memory between agents/sessions
 ```
+
+These are conventions, not enforced types, `--action` accepts any string. Treeship signs the verb, the subject, and the digests; the memory provider decides what each transition means and how to re-check it. Treeship does not assert the memory is semantically true, only that this signer attested this transition over this digest at this time.
 
 For sensitive writes or deletes, mint a scoped approval first:
 

--- a/docs/content/docs/reference/predicates.mdx
+++ b/docs/content/docs/reference/predicates.mdx
@@ -67,6 +67,37 @@ Which memories an agent retrieved for an action, and the query that produced the
 
 A provider-neutral actor-checker evaluation boundary: what a checker was allowed to see, what policy denied, and the decision it reached. See [Actor-Checker Boundaries](/concepts/actor-checker-boundaries) for the model. The full schema is `treeship.boundary.v1`.
 
+### `agent_card.v1`
+
+A signed, verifiable agent capability card: a key attests an identity and a capability set. Carried as the payload of a receipt with `kind=agent_card.v1`. A card is **key-bound** only when its `keyid` is the envelope signer pinned under `AgentCert`; self-signed cards are reported `self-asserted`. Mint with `treeship attest card`; check against captured evidence with `treeship verify-capability`. See [Capability Cards](/docs/concepts/capability-cards).
+
+| Field | Type | Required |
+|---|---|---|
+| `schema` | const `agent_card.v1` | yes |
+| `agent` | string (actor URI) | yes |
+| `keyid` | string | yes |
+| `version` | string | yes |
+| `capabilities` | object (`tools`: exact or `family.*`) | yes |
+| `owner` | string | no |
+| `supersedes` | string or null | no |
+| `constraints` | object | no |
+| `attestations` | array | no |
+| `evidence_anchor` | object | no |
+| `policy_ref` | string | no |
+
+### `agent_card_revocation.v1`
+
+Revokes a previously-minted `agent_card.v1`. Mint with `treeship revoke-capability`. `verify-capability` honors a revocation **only when its signer is authorized** — the card's own key (self-revocation) or a `Ship` trust root (issuer revocation); any other signer is ignored (fail-closed).
+
+| Field | Type | Required |
+|---|---|---|
+| `schema` | const `agent_card_revocation.v1` | yes |
+| `card` | string (`art_…` of the revoked card) | yes |
+| `revoked_at` | string (RFC3339) | yes |
+| `keyid` | string | no |
+| `reason` | string | no |
+| `supersedes` | string or null | no |
+
 ## Actor URI schemes
 
 A receipt or statement `actor` is an opaque string; Treeship does not enforce the scheme. These prefixes are the recognized conventions:


### PR DESCRIPTION
Documents everything shipped this cycle and folds in the memory-provider guidance.

## Blog
New post: **"Capability Cards: Proving What an Agent Can Do, Not Just What It Says"** — the narrative of the arc (typed receipts → signed cards → provable actor → authorized revocation → same verdict in the browser), with runnable examples and the honest contract.

## Docs
- **New** `concepts/capability-cards.mdx`: the full mint → key-bound/self-asserted → verify-capability → per-actor signing → revocation → browser flow. Explicitly distinguished from the local [Agent Card](../blob/main/docs/content/docs/concepts/agent-cards.mdx).
- `reference/predicates.mdx`: `agent_card.v1` + `agent_card_revocation.v1` schemas.
- `concepts/agent-identity.mdx`: per-actor signing section (provable `actor`).
- `integrations/memory-proofs.mdx`: the **clean split** made explicit (memory provider = memory authority, Treeship = proof authority) + first-class **memory transition verbs** (propose/promote/reject/revoke/forget/restore).

## Changelog
`Unreleased` entries for the predicate registry, capability cards, per-actor signing, revocation, and WASM `verify_capability`. Docs changelog regenerated via `sync:changelog`.

## ZMem P0/P1 status (from the integration doc)
- **P0.1** `attest receipt --payload-file` — **already live**, shipped in v0.12.0 (current published version).
- **P0.4** provider-neutral examples — **already present** (`system://zmem|mem0|zep|letta`, `memory://…`), sharpened here.
- **P1.7** payload-digest safe defaults — **already documented** ("sign URIs, digests, summaries; not raw memories/embeddings/prompts").
- **P1.6** memory transition verbs — **added** as conventions.
- Still open (separate work, flagged in the PR thread): P0.2 memory.proof verify-page UI, P0.3 api.treeship.dev redeploy verification, P1.5 boundary proven/asserted/policy-derived split.

Docs site builds clean (`next build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)