### PR TITLE
feat(cli): treeship resolve (agent resolver slice 1, local + offline)

### DIFF
--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -274,7 +274,7 @@ pub fn revoke_capability(
 /// Find an authorized revocation of `card_id`, if any. Authorized = signed by
 /// the card's own key (self-revocation) or a Ship trust root (issuer
 /// revocation); a stranger's revocation is ignored. Returns (reason, who).
-fn find_revocation(
+pub(crate) fn find_revocation(
     ctx: &ctx::Ctx,
     card_id: &str,
     card_keyid: &str,

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod init;
 pub mod attest;
 pub mod capability;
+pub mod resolve;
 pub mod verify;
 pub mod verify_external;
 pub mod keys;

--- a/packages/cli/src/commands/resolve.rs
+++ b/packages/cli/src/commands/resolve.rs
@@ -1,0 +1,167 @@
+//! `treeship resolve <agent>` — resolve an agent URI to a verifiable bundle.
+//!
+//! The local, offline half of the agent resolver (docs/specs/agent-resolver.md):
+//! given an agent URI, assemble its current capability card, revocation status,
+//! and the provenance grade of each fact (captured / checked / asserted) from
+//! locally-held artifacts, re-deriving every grade from the bytes rather than
+//! trusting a stored verdict. The Hub endpoint will serve the same bundle; the
+//! invariant is that the client, not the server, decides what to believe.
+
+use crate::{ctx, printer::Printer};
+use treeship_core::capability::{action_in_scope, declared_tools, is_key_bound};
+use treeship_core::statements::{payload_type, ActionStatement, ReceiptStatement};
+use treeship_core::trust::TrustRootStore;
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+pub fn resolve(agent: &str, config: Option<&str>, printer: &Printer) -> CmdResult {
+    let ctx = ctx::open(config)?;
+    let trust = TrustRootStore::open_default_or_empty()?;
+
+    // --- Identity: the agent's per-agent key --------------------------------
+    let agents_dir = crate::commands::cards::agents_dir_for(&ctx.config_path);
+    let key_id = crate::commands::cards::registered_key_for_actor(&agents_dir, agent);
+    let key_bound = key_id
+        .as_deref()
+        .map(|k| is_key_bound(k, k, &trust))
+        .unwrap_or(false);
+    let key_grade = match (&key_id, key_bound) {
+        (Some(_), true) => "captured (key-bound under AgentCert)",
+        (Some(_), false) => "asserted (registered, not pinned)",
+        (None, _) => "asserted (no per-agent key)",
+    };
+
+    // --- Current card: latest agent_card.v1 for this agent, signed by its key -
+    let receipt_pt = payload_type("receipt");
+    let mut current: Option<(String, serde_json::Value, String, String)> = None;
+    for entry in ctx.storage.list_by_type(&receipt_pt) {
+        let Ok(rec) = ctx.storage.read(&entry.id) else {
+            continue;
+        };
+        let Ok(stmt) = rec.envelope.unmarshal_statement::<ReceiptStatement>() else {
+            continue;
+        };
+        if stmt.kind != "agent_card.v1" {
+            continue;
+        }
+        let Some(payload) = stmt.payload else { continue };
+        if payload.get("agent").and_then(|v| v.as_str()) != Some(agent) {
+            continue;
+        }
+        let signer = rec
+            .envelope
+            .signatures
+            .first()
+            .map(|s| s.keyid.clone())
+            .unwrap_or_default();
+        // If the agent has a registered key, only count cards it actually signed.
+        if let Some(kid) = &key_id {
+            if &signer != kid {
+                continue;
+            }
+        }
+        let newer = current
+            .as_ref()
+            .map(|(_, _, _, t)| entry.signed_at > *t)
+            .unwrap_or(true);
+        if newer {
+            current = Some((entry.id.clone(), payload, signer, entry.signed_at.clone()));
+        }
+    }
+
+    let Some((card_id, card, card_signer, _)) = current else {
+        printer.warn("no capability card", &[("agent", agent)]);
+        printer.hint(
+            "this agent has no agent_card.v1 in the local store; mint one with `treeship attest card`.",
+        );
+        printer.blank();
+        return Ok(());
+    };
+
+    let card_keyid = card.get("keyid").and_then(|v| v.as_str()).unwrap_or("");
+    let tools = declared_tools(&card);
+
+    // --- Revocation (authorized only) ---------------------------------------
+    let revocation = crate::commands::capability::find_revocation(&ctx, &card_id, card_keyid, &trust);
+
+    // --- Capabilities grade: cross-check captured actions -------------------
+    let action_pt = payload_type("action");
+    let (mut in_scope, mut total) = (0usize, 0usize);
+    for entry in ctx.storage.list_by_type(&action_pt) {
+        let Ok(arec) = ctx.storage.read(&entry.id) else {
+            continue;
+        };
+        let asigner = arec
+            .envelope
+            .signatures
+            .first()
+            .map(|s| s.keyid.as_str())
+            .unwrap_or("");
+        if asigner != card_keyid {
+            continue;
+        }
+        let Ok(action) = arec.envelope.unmarshal_statement::<ActionStatement>() else {
+            continue;
+        };
+        total += 1;
+        if action_in_scope(&action, &tools) {
+            in_scope += 1;
+        }
+    }
+    let out_of_scope = total - in_scope;
+    let card_key_bound = is_key_bound(card_keyid, &card_signer, &trust);
+
+    let cap_grade = if revocation.is_some() {
+        "revoked".to_string()
+    } else if card_key_bound && out_of_scope == 0 {
+        format!("checked ({in_scope}/{total} captured actions in scope)")
+    } else if card_key_bound {
+        format!("checked with violations ({out_of_scope} of {total} out of scope)")
+    } else {
+        "asserted (card not key-bound)".to_string()
+    };
+    let status = if revocation.is_some() {
+        "REVOKED"
+    } else if card_key_bound && out_of_scope == 0 {
+        "resolved (verified)"
+    } else if card_key_bound {
+        "resolved (violations)"
+    } else {
+        "resolved (self-asserted)"
+    };
+
+    // --- Report --------------------------------------------------------------
+    let key_str = key_id.as_deref().unwrap_or("(none)").to_string();
+    let tools_str = if tools.is_empty() {
+        "(none)".to_string()
+    } else {
+        tools.join(", ")
+    };
+    let behavior_str =
+        format!("{total} captured actions ({in_scope} in scope, {out_of_scope} out)");
+    printer.success(
+        "agent resolved",
+        &[
+            ("agent", agent),
+            ("key", &key_str),
+            ("key provenance", key_grade),
+            ("current card", &card_id),
+            ("declared tools", &tools_str),
+            ("capabilities", &cap_grade),
+            ("behavior", &behavior_str),
+            ("status", status),
+        ],
+    );
+    if let Some((reason, who)) = &revocation {
+        printer.warn(
+            "card REVOKED — do not honor",
+            &[("by", who), ("reason", reason)],
+        );
+    }
+    printer.blank();
+    printer.hint(
+        "every field is re-derived from local artifacts, not a stored verdict. captured = the machine observed it; checked = a claim cross-verified against captured evidence; asserted = a bare claim.",
+    );
+    printer.blank();
+    Ok(())
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -142,6 +142,13 @@ enum Command {
     ///   treeship revoke-capability art_<agent_card_id> --reason key-rotation
     RevokeCapability(RevokeCapabilityArgs),
 
+    /// Resolve an agent URI to a verifiable bundle (identity, current card,
+    /// revocation, provenance grades), re-derived from local artifacts
+    ///
+    /// Example:
+    ///   treeship resolve agent://deployer
+    Resolve(ResolveArgs),
+
     /// Create, export, and import artifact bundles
     ///
     /// Bundles group artifacts into a signed, portable package.
@@ -1660,6 +1667,12 @@ struct RevokeCapabilityArgs {
     reason: Option<String>,
 }
 
+#[derive(Args)]
+struct ResolveArgs {
+    /// Agent URI to resolve, e.g. agent://deployer.
+    agent: String,
+}
+
 // --- keys -------------------------------------------------------------------
 
 #[derive(Subcommand)]
@@ -2459,6 +2472,10 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             cli.config.as_deref(),
             printer,
         ),
+
+        Command::Resolve(a) => {
+            commands::resolve::resolve(&a.agent, cli.config.as_deref(), printer)
+        }
 
         Command::Verify(a) => {
             // External targets (URL, file path to a .treeship/.agent package)


### PR DESCRIPTION
Slice 1 of the [agent resolver](../blob/main/docs/specs/agent-resolver.md) (#140): the local, offline half. Turn an agent URI into a **verifiable bundle, re-derived from local artifacts** — the client-side re-verification engine the whole invariant rests on.

## `treeship resolve agent://deployer`
```
✓ agent resolved
  agent:           agent://deployer
  key:             key_95e904…
  key provenance:  captured (key-bound under AgentCert)
  current card:    art_…
  declared tools:  file.*
  capabilities:    checked with violations (1 of 2 out of scope)
  behavior:        2 captured actions (1 in scope, 1 out)
  status:          resolved (violations)
```

## Provenance, not assertions
Every field is re-derived from the bytes, never a stored verdict. The bundle carries the grade:
- **captured** — key-bound under AgentCert
- **checked** — cross-checked against captured action receipts (in/out of scope)
- **asserted** — card not key-bound / no per-agent key
- **revoked** — authorized revocation present

## Verified e2e
| case | result |
|---|---|
| key-bound agent | `captured` / `checked` grades, in-out split |
| unregistered agent | `asserted` (no per-agent key), `resolved (self-asserted)` |
| revoked card | `capabilities: revoked`, `status: REVOKED — do not honor` |

## Built on what exists
Composes `core::capability` primitives, `registered_key_for_actor`, and the authorized-only `find_revocation`. No new cryptography. clippy clean.

## Next (slice 1b)
`GET /v1/agents/{agent}` on the Hub serves the same bundle; `treeship resolve` re-verifies the Hub's bytes offline. The assembly logic here is exactly what the endpoint reuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)