### PR TITLE
release: 0.13.0 — agent identity, capability cards, per-actor signing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.13.0 (2026-06-24)
+
 ### Added
 
 - **Predicate registry: typed, schema-validated receipt payloads.** Registered `kind` suffixes are bound to a JSON Schema and validated at attest time, **before** the receipt is signed; unregistered kinds attest sign-on-submit exactly as before (additive, backward compatible). Registered predicates: `memory.write.v1`, `memory.read.v1`, `boundary.v1`, `agent_card.v1`, `agent_card_revocation.v1`. The validator is dependency-free on purpose so the signing path and the WASM verifier stay lean. See [`reference/predicates`](docs/content/docs/reference/predicates.mdx).
@@ -9,6 +11,7 @@
 - **Per-actor signing: a provable `actor`.** `treeship agent register --own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it under `AgentCert`. `treeship attest action` / `attest card` / `attest decision` / `attest handoff` then sign with the **agent's own key** when the actor has one, so the `actor` is cryptographically provable rather than an asserted label. `treeship verify` reports `actor proof: proven (key-bound) | asserted`. Strictly additive: agents without a per-agent key sign with the ship key exactly as before. (#134, #135, #136)
 - **Capability-card revocation (`agent_card_revocation.v1`).** `treeship revoke-capability <card> --reason …` mints a signed revocation. `verify-capability` honors it **only when its signer is authorized** (the card's own key, or a `Ship` trust root) and then reports `status: REVOKED`; an unauthorized revocation is ignored (fail-closed). (#137)
 - **Browser verification of capability cards.** A new `verify_capability(card, actions, trust_roots)` WASM export and a typed `verifyCapability()` in `@treeship/verify-js` let a browser receipt viewer show key-bound status and the in/out-of-scope cross-check, returning the **same verdict the CLI does**. The matching logic lives in a shared `treeship_core::capability` module so the browser and CLI verifiers cannot drift. (#138)
+- **`treeship resolve <agent>`.** Resolves an agent URI to a verifiable bundle, re-derived from local artifacts: its per-agent key, current capability card, revocation status, and a provenance grade on every fact (`captured` = the machine observed it, `checked` = a claim cross-verified against captured evidence, `asserted` = a bare claim). The local, offline half of the agent resolver; the Hub serves the same bundle next. See [`agent-resolver` spec](docs/specs/agent-resolver.md). (#141)
 
 ## 0.12.0 (2026-06-06)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "base64",
  "clap",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.12.0"
+    "@treeship/core-wasm": "0.13.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.12.0",
+    "@treeship/core-wasm": "0.13.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -12,6 +12,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+## 0.13.0 (2026-06-24)
+
 ### Added
 
 - **Predicate registry: typed, schema-validated receipt payloads.** Registered `kind` suffixes are bound to a JSON Schema and validated at attest time, **before** the receipt is signed; unregistered kinds attest sign-on-submit exactly as before (additive, backward compatible). Registered predicates: `memory.write.v1`, `memory.read.v1`, `boundary.v1`, `agent_card.v1`, `agent_card_revocation.v1`. The validator is dependency-free on purpose so the signing path and the WASM verifier stay lean. See [`reference/predicates`](docs/content/docs/reference/predicates.mdx).
@@ -19,6 +21,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 - **Per-actor signing: a provable `actor`.** `treeship agent register --own-key` mints a dedicated per-agent key, certifies it (the ship signs as issuer), and pins it under `AgentCert`. `treeship attest action` / `attest card` / `attest decision` / `attest handoff` then sign with the **agent's own key** when the actor has one, so the `actor` is cryptographically provable rather than an asserted label. `treeship verify` reports `actor proof: proven (key-bound) | asserted`. Strictly additive: agents without a per-agent key sign with the ship key exactly as before. (#134, #135, #136)
 - **Capability-card revocation (`agent_card_revocation.v1`).** `treeship revoke-capability <card> --reason …` mints a signed revocation. `verify-capability` honors it **only when its signer is authorized** (the card's own key, or a `Ship` trust root) and then reports `status: REVOKED`; an unauthorized revocation is ignored (fail-closed). (#137)
 - **Browser verification of capability cards.** A new `verify_capability(card, actions, trust_roots)` WASM export and a typed `verifyCapability()` in `@treeship/verify-js` let a browser receipt viewer show key-bound status and the in/out-of-scope cross-check, returning the **same verdict the CLI does**. The matching logic lives in a shared `treeship_core::capability` module so the browser and CLI verifiers cannot drift. (#138)
+- **`treeship resolve <agent>`.** Resolves an agent URI to a verifiable bundle, re-derived from local artifacts: its per-agent key, current capability card, revocation status, and a provenance grade on every fact (`captured` = the machine observed it, `checked` = a claim cross-verified against captured evidence, `asserted` = a bare claim). The local, offline half of the agent resolver; the Hub serves the same bundle next. See [`agent-resolver` spec](docs/specs/agent-resolver.md). (#141)
 
 ## 0.12.0 (2026-06-06)
 

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.12.0",
-    "@treeship/cli-darwin-arm64": "0.12.0",
-    "@treeship/cli-darwin-x64": "0.12.0"
+    "@treeship/cli-linux-x64": "0.13.0",
+    "@treeship/cli-darwin-arm64": "0.13.0",
+    "@treeship/cli-darwin-x64": "0.13.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.12.0", path = "../core" }
+treeship-core = { version = "0.13.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.12.0"
+version = "0.13.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.12.0"
+    "@treeship/core-wasm": "0.13.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.12.0"
+    "@treeship/core-wasm": "0.13.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Cuts **0.13.0**: the full agent-identity arc moves from `Unreleased` to a versioned line and ships to users.

## What's in it
- **Predicate registry** — typed, schema-validated receipt payloads
- **Agent capability cards** (`agent_card.v1`) — `attest card` + `verify-capability`
- **Per-actor signing** — `agent register --own-key`, attest signs as the agent, `verify` reports `actor proof: proven | asserted`
- **Capability-card revocation** (`agent_card_revocation.v1`) + `revoke-capability` (authorized-only, fail-closed)
- **Browser verification** — `verify_capability` WASM export + `verifyCapability()`, same verdict as the CLI
- **`treeship resolve <agent>`** — agent resolver slice 1 (local, offline, provenance-graded)

## Release hygiene
- Every release-version site bumped to 0.13.0 (Rust crates, npm packages, Python SDK, npm cli shims, claude-plugin marketplace).
- Verified with the **same guard the release preflight runs**: `scripts/check-release-versions.py 0.13.0` → **23/23 aligned, 0 wrong**.
- `CHANGELOG.md` rolled (`Unreleased` → `## 0.13.0 (2026-06-24)`); docs changelog page regenerated.
- CLI builds; `Cargo.lock` refreshed to 0.13.0.

Merging this and tagging `v0.13.0` triggers the Release workflow (preflight + build + publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)