### PR TITLE
feat(hub): GET /v1/agents resolver endpoint (agent resolver slice 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **Hub agent resolver endpoint (`GET /v1/agents?agent=<uri>`).** Resolves an agent URI to its verifiable bundle, the current capability card and any revocations, returned as **raw signed envelopes**. The Hub performs no verification or authorization here; it serves bytes, and the client (`treeship resolve`) re-verifies and grades them offline, so the Hub and the CLI / WASM verifier cannot drift. Slice 1b of the agent resolver (the network half). See [`agent-resolver` spec](docs/specs/agent-resolver.md).
+
 ## 0.13.0 (2026-06-24)
 
 ### Added

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -12,6 +12,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+### Added
+
+- **Hub agent resolver endpoint (`GET /v1/agents?agent=<uri>`).** Resolves an agent URI to its verifiable bundle, the current capability card and any revocations, returned as **raw signed envelopes**. The Hub performs no verification or authorization here; it serves bytes, and the client (`treeship resolve`) re-verifies and grades them offline, so the Hub and the CLI / WASM verifier cannot drift. Slice 1b of the agent resolver (the network half). See [`agent-resolver` spec](docs/specs/agent-resolver.md).
+
 ## 0.13.0 (2026-06-24)
 
 ### Added

--- a/packages/hub/internal/agents/agents.go
+++ b/packages/hub/internal/agents/agents.go
@@ -1,0 +1,137 @@
+// Package agents implements the agent resolver: GET /v1/agents?agent=<uri>.
+//
+// It turns an agent URI into a verifiable bundle by scanning stored receipts
+// for the agent's capability cards and revocations and returning the raw
+// signed envelopes. The Hub does NO verification or grading here -- it serves
+// bytes; the client re-verifies and grades them offline (`treeship resolve`).
+// This keeps the trust decision on the client and avoids reimplementing the
+// capability logic in Go, so the Hub and the CLI / WASM verifier cannot drift.
+package agents
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+
+	"github.com/treeship/hub/internal/db"
+)
+
+// receiptPayloadType is the MIME type of treeship receipt envelopes.
+const receiptPayloadType = "application/vnd.treeship.receipt.v1+json"
+
+type Handlers struct {
+	DB *sql.DB
+}
+
+// dsseEnvelope is the minimal shape needed to read the statement + signer.
+type dsseEnvelope struct {
+	Payload    string `json:"payload"`
+	Signatures []struct {
+		KeyID string `json:"keyid"`
+	} `json:"signatures"`
+}
+
+type receiptStatement struct {
+	Kind    string          `json:"kind"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// envelopeEntry is one raw signed artifact returned in the bundle. The client
+// re-verifies it; the Hub asserts nothing about it beyond "this is what we hold".
+type envelopeEntry struct {
+	ArtifactID   string `json:"artifact_id"`
+	EnvelopeJSON string `json:"envelope_json"`
+	SignerKeyID  string `json:"signer_keyid"`
+	SignedAt     int64  `json:"signed_at"`
+}
+
+// Resolve serves the verifiable bundle for an agent URI. Read-only and
+// unauthenticated: resolving an identity is a public act, like a DNS query.
+// The agent URI is taken as a query parameter (`?agent=agent://deployer`) so
+// the `//` in the URI does not collide with path routing.
+func (h *Handlers) Resolve(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	agent := r.URL.Query().Get("agent")
+	if agent == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing agent query parameter"})
+		return
+	}
+
+	receipts, err := db.ListArtifactsByPayloadType(h.DB, receiptPayloadType)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query failed"})
+		return
+	}
+
+	var cards []envelopeEntry
+	revByCard := map[string]envelopeEntry{} // revoked card_id -> revocation entry
+	cardIDs := map[string]bool{}            // this agent's card ids
+	for _, a := range receipts {
+		var env dsseEnvelope
+		if json.Unmarshal([]byte(a.EnvelopeJSON), &env) != nil {
+			continue
+		}
+		payloadBytes, decErr := base64.RawURLEncoding.DecodeString(env.Payload)
+		if decErr != nil {
+			continue
+		}
+		var stmt receiptStatement
+		if json.Unmarshal(payloadBytes, &stmt) != nil {
+			continue
+		}
+		signer := ""
+		if len(env.Signatures) > 0 {
+			signer = env.Signatures[0].KeyID
+		}
+		entry := envelopeEntry{a.ArtifactID, a.EnvelopeJSON, signer, a.SignedAt}
+
+		switch stmt.Kind {
+		case "agent_card.v1":
+			var p struct {
+				Agent string `json:"agent"`
+			}
+			if json.Unmarshal(stmt.Payload, &p) != nil || p.Agent != agent {
+				continue
+			}
+			cards = append(cards, entry)
+			cardIDs[a.ArtifactID] = true
+		case "agent_card_revocation.v1":
+			var p struct {
+				Card string `json:"card"`
+			}
+			if json.Unmarshal(stmt.Payload, &p) != nil || p.Card == "" {
+				continue
+			}
+			revByCard[p.Card] = entry
+		}
+	}
+
+	// receipts come newest-first, so the first matching card is the current one.
+	var current *envelopeEntry
+	if len(cards) > 0 {
+		current = &cards[0]
+	}
+
+	// Include only revocations that reference one of this agent's cards. The
+	// client decides whether each revocation is authorized; the Hub does not.
+	var revocations []envelopeEntry
+	for id := range cardIDs {
+		if rev, ok := revByCard[id]; ok {
+			revocations = append(revocations, rev)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"agent":        agent,
+		"current_card": current,
+		"cards":        cards,
+		"revocations":  revocations,
+		"note":         "raw signed envelopes; the client re-verifies and grades them offline. the Hub performs no verification or authorization here.",
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/packages/hub/internal/agents/agents_test.go
+++ b/packages/hub/internal/agents/agents_test.go
@@ -1,0 +1,112 @@
+package agents
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/treeship/hub/internal/db"
+)
+
+// makeEnvelope builds an envelope_json wrapping a receipt statement, the way
+// the CLI would: a base64url-no-pad payload over {kind, payload}, plus a signer.
+func makeEnvelope(t *testing.T, kind string, payload map[string]any, signer string) string {
+	t.Helper()
+	stmtBytes, _ := json.Marshal(map[string]any{"kind": kind, "payload": payload})
+	env := map[string]any{
+		"payload":     base64.RawURLEncoding.EncodeToString(stmtBytes),
+		"payloadType": receiptPayloadType,
+		"signatures":  []map[string]string{{"keyid": signer, "sig": "AAAA"}},
+	}
+	envBytes, _ := json.Marshal(env)
+	return string(envBytes)
+}
+
+func insertReceipt(t *testing.T, database *sql.DB, id, envJSON string, signedAt int64) {
+	t.Helper()
+	if err := db.InsertArtifact(database, &db.Artifact{
+		ArtifactID:   id,
+		PayloadType:  receiptPayloadType,
+		EnvelopeJSON: envJSON,
+		Digest:       "sha256:00",
+		SignedAt:     signedAt,
+		HubURL:       "https://hub.test",
+	}); err != nil {
+		t.Fatalf("insert %s: %v", id, err)
+	}
+}
+
+func TestResolve_BundlesAgentCardsAndRevocations(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// agent://deployer: an older card, a newer (current) card, a revocation of the new one.
+	insertReceipt(t, database, "art_card_old",
+		makeEnvelope(t, "agent_card.v1", map[string]any{"agent": "agent://deployer", "keyid": "key_d"}, "key_d"), 100)
+	insertReceipt(t, database, "art_card_new",
+		makeEnvelope(t, "agent_card.v1", map[string]any{"agent": "agent://deployer", "keyid": "key_d"}, "key_d"), 200)
+	insertReceipt(t, database, "art_rev",
+		makeEnvelope(t, "agent_card_revocation.v1", map[string]any{"card": "art_card_new"}, "key_d"), 300)
+	// A different agent's card and a non-card receipt -> must be excluded.
+	insertReceipt(t, database, "art_other",
+		makeEnvelope(t, "agent_card.v1", map[string]any{"agent": "agent://ghost", "keyid": "key_g"}, "key_g"), 150)
+	insertReceipt(t, database, "art_memproof",
+		makeEnvelope(t, "memory.proof", map[string]any{"foo": "bar"}, "key_d"), 160)
+
+	h := &Handlers{DB: database}
+	rec := httptest.NewRecorder()
+	h.Resolve(rec, httptest.NewRequest(http.MethodGet, "/v1/agents?agent=agent://deployer", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Agent       string          `json:"agent"`
+		CurrentCard *envelopeEntry  `json:"current_card"`
+		Cards       []envelopeEntry `json:"cards"`
+		Revocations []envelopeEntry `json:"revocations"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Agent != "agent://deployer" {
+		t.Errorf("agent = %q", body.Agent)
+	}
+	// Newest deployer card is current.
+	if body.CurrentCard == nil || body.CurrentCard.ArtifactID != "art_card_new" {
+		t.Errorf("current_card = %+v, want art_card_new (newest)", body.CurrentCard)
+	}
+	// Only deployer's two cards; ghost's card and the memory.proof are excluded.
+	if len(body.Cards) != 2 {
+		t.Errorf("cards = %d, want 2", len(body.Cards))
+	}
+	// The revocation referencing a deployer card is included.
+	if len(body.Revocations) != 1 || body.Revocations[0].ArtifactID != "art_rev" {
+		t.Errorf("revocations = %+v, want [art_rev]", body.Revocations)
+	}
+}
+
+func TestResolve_MissingAgentParam(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	h := &Handlers{DB: database}
+	rec := httptest.NewRecorder()
+	h.Resolve(rec, httptest.NewRequest(http.MethodGet, "/v1/agents", nil))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -393,6 +393,29 @@ func ListArtifactsByDock(db *sql.DB, dockID string) ([]Artifact, error) {
 	return out, rows.Err()
 }
 
+// ListArtifactsByPayloadType returns every artifact of a given payload type,
+// newest first. Used by the agent resolver to scan receipts. Bounded scans are
+// acceptable for now; an agent-indexed lookup is a later optimization.
+func ListArtifactsByPayloadType(db *sql.DB, payloadType string) ([]Artifact, error) {
+	rows, err := db.Query(
+		`SELECT artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id
+		 FROM artifacts WHERE payload_type = ? ORDER BY signed_at DESC`, payloadType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Artifact
+	for rows.Next() {
+		var a Artifact
+		if err := rows.Scan(&a.ArtifactID, &a.PayloadType, &a.EnvelopeJSON, &a.Digest, &a.SignedAt, &a.ParentID, &a.HubURL, &a.RekorIndex, &a.DockID); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
 func SetRekorIndex(db *sql.DB, artifactID string, logIndex int64) error {
 	_, err := db.Exec(`UPDATE artifacts SET rekor_index = ? WHERE artifact_id = ?`, logIndex, artifactID)
 	return err

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/treeship/hub/internal/agents"
 	"github.com/treeship/hub/internal/artifacts"
 	"github.com/treeship/hub/internal/db"
 	"github.com/treeship/hub/internal/dock"
@@ -33,6 +34,7 @@ func main() {
 	merkleHandlers := &merkle.Handlers{DB: database}
 	receiptHandlers := &receipts.Handlers{DB: database}
 	shipHandlers := &ship.Handlers{DB: database}
+	agentHandlers := &agents.Handlers{DB: database}
 
 	r := chi.NewRouter()
 
@@ -81,6 +83,10 @@ func main() {
 	// Per-ship registry endpoints (DPoP-authenticated).
 	r.Get("/v1/ship/agents", shipHandlers.ListAgents)
 	r.Get("/v1/ship/sessions", shipHandlers.ListSessions)
+
+	// Agent resolver: resolve an agent URI to its verifiable bundle (cards +
+	// revocations as raw signed envelopes; the client re-verifies). Public.
+	r.Get("/v1/agents", agentHandlers.Resolve)
 
 	// Well-known revocation list.
 	r.Get("/.well-known/treeship/revoked.json", revokedHandler)


### PR DESCRIPTION
The network half of the [agent resolver](../blob/main/docs/specs/agent-resolver.md): resolve an agent URI to its verifiable bundle over HTTP. The literal "DNS for agents" lookup.

## `GET /v1/agents?agent=<uri>`
Scans stored receipts for the agent's capability cards (`agent_card.v1`) and revocations (`agent_card_revocation.v1`) and returns them as **raw signed envelopes**: the current card (newest), all cards, and any revocations referencing them.

## The load-bearing design choice
**The Hub performs no verification, grading, or authorization here.** It serves bytes; the client (`treeship resolve`) re-verifies and grades them offline. This keeps the trust decision on the client and means the capability logic lives in exactly one place (the shared Rust module), so **the Hub and the CLI / WASM verifier cannot drift**. Read-only and unauthenticated, resolving an identity is a public act, like a DNS query. The agent URI is a query param so its `//` doesn't collide with path routing.

## What's here
- `db.ListArtifactsByPayloadType` — scan receipts by payload type (bounded scan for now; agent-indexed lookup is a later optimization).
- `internal/agents` — the `Resolve` handler + bundle shape.
- **Test** proving: agent filtering (another agent's card excluded), kind filtering (a `memory.proof` excluded), newest-card-is-current, revocation linkage; missing param → 400.

`go build ./...` + `go test ./internal/agents/...` pass.

## Next (slice 1c)
`treeship resolve --remote --hub <url> <agent>` pulls this bundle and runs the **existing** local grading on it, the client side of the network resolver. Then transparency anchor (slice 2) and `capability_provenance` (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)