### PR TITLE
feat: capability provenance — captured vs exercised vs declared (slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Hub agent resolver endpoint (`GET /v1/agents?agent=<uri>`).** Resolves an agent URI to its verifiable bundle, the current capability card and any revocations, returned as **raw signed envelopes**. The Hub performs no verification or authorization here; it serves bytes, and the client (`treeship resolve`) re-verifies and grades them offline, so the Hub and the CLI / WASM verifier cannot drift. Slice 1b of the agent resolver (the network half). See [`agent-resolver` spec](docs/specs/agent-resolver.md).
+- **Capability provenance: captured vs exercised vs declared.** `verify-capability` now grades each declared capability by its provenance — `captured` (read off the card's optional `capability_provenance` block, set from harness config at mint time), `exercised` (backed by captured action receipts, computed from the cross-check), or `declared-only` (asserted, never wired or used) — and reports the breakdown. A new optional `capability_provenance` field on `agent_card.v1` (additive; cards without it are treated as fully declared). The first step from a registry of claims to a registry of captured truth. See [`capability-provenance` spec](docs/specs/capability-provenance.md).
 
 ## 0.13.0 (2026-06-24)
 

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -15,6 +15,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 ### Added
 
 - **Hub agent resolver endpoint (`GET /v1/agents?agent=<uri>`).** Resolves an agent URI to its verifiable bundle, the current capability card and any revocations, returned as **raw signed envelopes**. The Hub performs no verification or authorization here; it serves bytes, and the client (`treeship resolve`) re-verifies and grades them offline, so the Hub and the CLI / WASM verifier cannot drift. Slice 1b of the agent resolver (the network half). See [`agent-resolver` spec](docs/specs/agent-resolver.md).
+- **Capability provenance: captured vs exercised vs declared.** `verify-capability` now grades each declared capability by its provenance — `captured` (read off the card's optional `capability_provenance` block, set from harness config at mint time), `exercised` (backed by captured action receipts, computed from the cross-check), or `declared-only` (asserted, never wired or used) — and reports the breakdown. A new optional `capability_provenance` field on `agent_card.v1` (additive; cards without it are treated as fully declared). The first step from a registry of claims to a registry of captured truth. See [`capability-provenance` spec](docs/specs/capability-provenance.md).
 
 ## 0.13.0 (2026-06-24)
 

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -11,8 +11,10 @@
 // completeness gap is Guard's runtime job, never a signature's. The output says
 // so.
 
+use std::collections::{HashMap, HashSet};
+
 use crate::{ctx, printer::Printer};
-use treeship_core::capability::action_in_scope;
+use treeship_core::capability::matched_capability;
 // Re-exported: attest.rs (attest card) resolves is_key_bound through this path.
 pub use treeship_core::capability::is_key_bound;
 use treeship_core::{
@@ -66,6 +68,8 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     let mut in_scope = 0usize;
     let mut total = 0usize;
     let mut violations: Vec<(String, String)> = Vec::new();
+    // Per-capability exercise counts: how many captured actions back each tool.
+    let mut exercised: HashMap<String, usize> = HashMap::new();
     for entry in ctx.storage.list_by_type(&action_pt) {
         let Ok(arec) = ctx.storage.read(&entry.id) else {
             continue;
@@ -86,8 +90,9 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
         // In scope if the action label OR meta.tool matches a declared
         // capability (exact or `family.*` glob). Shared with the WASM verifier
         // via treeship_core::capability so browser and CLI agree.
-        if action_in_scope(&action, &tools) {
+        if let Some(matched) = matched_capability(&action, &tools) {
             in_scope += 1;
+            *exercised.entry(matched).or_insert(0) += 1;
         } else {
             let mut label = action.action.clone();
             if let Some(tool) = action
@@ -121,6 +126,33 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     // cannot revoke your card.
     let revocation = find_revocation(&ctx, card_id, card_keyid, &trust);
 
+    // --- Capability provenance: captured vs exercised vs declared-only ------
+    // `captured` is read off the card (set at mint from harness config);
+    // `exercised` is computed here from captured receipts; everything else is
+    // `declared`. See docs/specs/capability-provenance.md.
+    let captured: HashSet<String> = card
+        .get("capability_provenance")
+        .and_then(|v| v.as_object())
+        .map(|m| {
+            m.iter()
+                .filter(|(_, v)| v.get("grade").and_then(|g| g.as_str()) == Some("captured"))
+                .map(|(k, _)| k.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    let (mut n_captured, mut n_exercised, mut n_declared) = (0usize, 0usize, 0usize);
+    for tool in &tools {
+        if captured.contains(tool) {
+            n_captured += 1;
+        } else if exercised.get(tool).copied().unwrap_or(0) > 0 {
+            n_exercised += 1;
+        } else {
+            n_declared += 1;
+        }
+    }
+    let provenance_str =
+        format!("{n_captured} captured, {n_exercised} exercised, {n_declared} declared-only");
+
     // --- Report ------------------------------------------------------------
     let status = if revocation.is_some() {
         "REVOKED"
@@ -150,6 +182,7 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
             ("agent", card_agent),
             ("key-bound", key_bound_str),
             ("declared tools", &tools_str),
+            ("provenance", &provenance_str),
             ("in-scope actions", &in_scope_str),
             ("out-of-scope", &oos_str),
             ("status", status),

--- a/packages/core/src/capability/mod.rs
+++ b/packages/core/src/capability/mod.rs
@@ -49,6 +49,25 @@ pub fn action_in_scope(action: &ActionStatement, declared_tools: &[String]) -> b
         .any(|c| declared_tools.iter().any(|d| tool_matches(d, c)))
 }
 
+/// The first declared capability an action matches, if any. Same matching as
+/// [`action_in_scope`], but returns *which* capability matched, so callers can
+/// grade each declared capability by whether captured receipts exercise it.
+pub fn matched_capability(action: &ActionStatement, declared_tools: &[String]) -> Option<String> {
+    let mut candidates: Vec<&str> = vec![action.action.as_str()];
+    if let Some(tool) = action
+        .meta
+        .as_ref()
+        .and_then(|m| m.get("tool"))
+        .and_then(|v| v.as_str())
+    {
+        candidates.push(tool);
+    }
+    declared_tools
+        .iter()
+        .find(|decl| candidates.iter().any(|c| tool_matches(decl, c)))
+        .cloned()
+}
+
 /// Extract the declared `capabilities.tools` from an agent_card.v1 payload.
 pub fn declared_tools(card_payload: &serde_json::Value) -> Vec<String> {
     card_payload
@@ -107,5 +126,14 @@ mod tests {
         a.action = "tool.call".into();
         a.meta = Some(serde_json::json!({ "tool": "db.query" }));
         assert!(action_in_scope(&a, &["db.query".to_string()]));
+    }
+
+    #[test]
+    fn matched_capability_returns_the_declared_glob() {
+        let a = ActionStatement::new("agent://x", "file.write");
+        let tools = vec!["db.query".to_string(), "file.*".to_string()];
+        assert_eq!(matched_capability(&a, &tools).as_deref(), Some("file.*"));
+        let b = ActionStatement::new("agent://x", "command.run");
+        assert_eq!(matched_capability(&b, &tools), None);
     }
 }

--- a/packages/core/src/predicates/schemas/agent_card.v1.json
+++ b/packages/core/src/predicates/schemas/agent_card.v1.json
@@ -49,6 +49,10 @@
     "policy_ref": {
       "description": "Optional policy this card operates under. Narrative reference; Guard consumes it at enforcement time.",
       "type": "string"
+    },
+    "capability_provenance": {
+      "description": "Optional per-capability provenance: a map from a capability (same string as in capabilities.tools) to { grade, source?, evidence? }. grade is 'captured' (the tool is wired into the agent's harness, read from config at mint time), 'exercised' (computed by verify-capability from captured receipts), or 'declared'. Cards without this block are treated as fully declared. See docs/specs/capability-provenance.md.",
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
Slice 1 of [capability provenance](../blob/main/docs/specs/capability-provenance.md) (#144): the first step from a **registry of claims to a registry of captured truth**. `verify-capability` now grades each declared capability by where the claim comes from.

## The grades
```
provenance:  0 captured, 2 exercised, 1 declared-only
```
- **captured** — read off the card's optional `capability_provenance` block (set from harness config at mint, slice 2)
- **exercised** — backed by captured action receipts (computed from the cross-check `verify-capability` already runs)
- **declared-only** — asserted, never wired or used

A card declaring `deploy.prod` that's never exercised is now visibly weaker than the tools backed by evidence.

## What's here
- New optional `capability_provenance` field on `agent_card.v1` (additive; cards without it are fully `declared`).
- `treeship_core::capability::matched_capability` — returns *which* capability an action exercises (shared logic, unit-tested).
- `verify-capability` reports the breakdown.

## Honest contract holds
Provenance **grades, never blocks**. `captured` proves *wired*, not *confined*. `exercised` proves *use*, not the capability ceiling.

## Verified e2e
| card | result |
|---|---|
| `[file.*, db.query, deploy.prod]`, file.write + db.query exercised | `2 exercised, 1 declared-only` |
| card carrying captured `file.*` | `1 captured` |

core + cli build; `matched_capability` unit test; clippy clean. Changelog entry included.

## Next
Slice 2: `attest card --from-harness` builds the tool list from discovered MCP/harness config and stamps `captured`. Slice 3: surface the ladder in `resolve` + the browser WASM path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)