### PR TITLE
docs: capture the plan — vision/roadmap + transparency-log spec

### DIFF
--- a/docs/specs/transparency-log.md
+++ b/docs/specs/transparency-log.md
@@ -1,0 +1,68 @@
+# Transparency Log Surface: Certificate Transparency for agents
+
+**Status:** draft, not implemented
+**Pairs with:** [agent-resolver](./agent-resolver.md), the Hub Merkle log, capability cards' `evidence_anchor`
+**Last updated:** 2026-06-24
+
+## The shift
+
+Treeship already anchors artifacts in a Merkle log and can verify that one card is *in* the log ([resolver slice 2](./agent-resolver.md)). What it cannot do yet is answer the question Certificate Transparency answers for web certs: **"show me everything this agent has done, and let me confirm nothing was hidden."**
+
+That is the transparency-log surface: an append-only, queryable, monitorable history of an agent's receipts, each provably in the log, with **omission detectable**. It turns "I can verify this one proof you handed me" into "I can audit the whole history myself."
+
+## The load-bearing invariant (unchanged)
+
+> The Hub serves metadata and Merkle anchors. It does not vouch for completeness or content. The client re-verifies every entry's inclusion proof against its own trust roots, and detects omission against the agent's own committed anchor. The Hub being wrong, lying, or gone does not change the client's verdict.
+
+## Honest constraints (state these or the surface over-promises)
+
+- **A log of digests and commitments, not contents.** Each entry is `{ artifact_id, kind, actor, action, timestamp, digest, merkle_anchor }`, never the payload. This is the memory-proof safe-default rule applied to the public surface: prompts, memories, and private content never enter it.
+- **Completeness is detectable for committed sets, not absolute.** Treeship cannot prove an agent recorded *everything it ever did*. It can prove that the receipts the agent **committed to** (via a card's `evidence_anchor`: a count, a tip, a Merkle root) are all present and unaltered, so post-hoc omission or backfill of a committed set is visible. Absolute completeness is a runtime-capture property, never a log property. The output says so.
+- **Append-only is the Merkle tree's property, not a promise the Hub makes.** A consistency check between two checkpoints (old root is a prefix of new root) is what proves no history was rewritten; that is slice 3.
+
+## The surface
+
+### Query (Hub)
+
+```
+GET /v1/agents/{agent}/log?since=<cursor>&limit=<n>
+→ {
+    "agent": "agent://deployer",
+    "entries": [
+      { "artifact_id": "art_…", "kind": "action", "actor": "agent://deployer",
+        "action": "file.write", "timestamp": "…", "digest": "sha256:…",
+        "merkle_anchor": { "checkpoint_index": 42, "leaf_index": 17 } | null },
+      …
+    ],
+    "next_cursor": "…",
+    "committed_anchor": { "receipt_count": 120, "merkle_root": "sha256:…" } | null
+  }
+```
+
+Read-only, unauthenticated (auditing an identity is public). Reuses the receipt scan and `db.GetProof`. `committed_anchor` is the latest `evidence_anchor` off the agent's current card, the number to check observed history against.
+
+### Audit (CLI)
+
+```
+treeship audit agent://deployer                       # local store
+treeship audit --hub https://api.treeship.dev agent://deployer   # over the network
+```
+
+Pulls the history, **re-verifies each anchored entry's Merkle inclusion offline**, prints the timeline, and runs the completeness check: does the observed, anchored receipt set match the agent's `committed_anchor`? Reports `complete (120/120 committed receipts present)` or `OMISSION: committed 120, observed 118`.
+
+## Slices
+
+1. **History query + `treeship audit` (local + remote).** `GET /v1/agents/{agent}/log` returns the metadata+anchor entries; `treeship audit` pulls and renders the timeline, re-verifying each anchored entry's inclusion. The minimum that makes an agent's history auditable by a third party. (Local half mirrors `resolve`'s offline path.)
+2. **Completeness check against `committed_anchor`.** Compare the observed anchored set to the agent's committed `evidence_anchor`; flag omission/backfill. This is the property that makes the log *worth* auditing.
+3. **Consistency proof (append-only).** Verify that a later checkpoint extends an earlier one (no history rewritten), the true CT property. Reuses the Merkle consistency primitive.
+4. **Monitor mode.** `treeship audit --watch` (or a scheduled check) that re-runs completeness/consistency and alerts on divergence, the "monitors catch anomalies" piece of the vision.
+
+## Open questions
+
+1. **Cursoring at scale.** A busy agent has thousands of receipts; the query needs a stable cursor (by `signed_at` + `artifact_id`) and the Hub needs the receipt scan indexed by actor (today it is a full scan, fine for slice 1, an index is the scale follow-up).
+2. **What "the agent's history" means across machines.** Receipts an agent signs on machine A vs B are distinct sets; the log is per-Hub. Cross-machine aggregation is a resolver-naming question, deferred with it.
+3. **Privacy of the actor graph.** Even metadata (who handed off to whom, when) is information. The surface should expose only what the operator published; nothing is in the log that was not explicitly pushed (`treeship publish` / `hub push`).
+
+## First slice to build
+
+Slice 1: `GET /v1/agents/{agent}/log` + `treeship audit`, returning the metadata+anchor timeline and re-verifying each anchored entry's inclusion client-side. It is additive, reuses the resolver's scan + the Merkle verify we already ship, and on day one turns "verify this one proof" into "audit the whole history," with the honest "digests not contents, committed-set not absolute" framing built into the output.

--- a/docs/specs/vision.md
+++ b/docs/specs/vision.md
@@ -1,0 +1,50 @@
+# Treeship Vision & Roadmap
+
+**Status:** living document, the source of truth for "what's next"
+**Last updated:** 2026-06-24
+
+This file exists so the plan is *captured*, not re-derived each session. The thesis, what is shipped, and what is next all live here. Per-feature design lives in the linked specs; this is the map above them.
+
+## The thesis: TLS for the agentic web
+
+TLS answered "how do I know this website is who it claims to be?" Treeship answers the same for agents: **how do I know this agent is who it claims to be, that it is authorized to do what it is doing, and that what it did actually happened?** Every action, approval, handoff, and capability claim becomes a cryptographically signed artifact that verifies offline, against no infrastructure.
+
+The discipline that makes this real, and distinguishes Treeship from a registry of claims, is one rule applied everywhere: **report provenance, never assume it.** Every fact carries how it is known, `captured` (the machine observed it), `checked` (a claim cross-verified against captured evidence), or `asserted` (a bare claim, labeled, never trusted silently). Identity, capability, behavior, and resolution all carry their grade.
+
+## Shipped (live in 0.13.0 and after)
+
+| Layer | TLS analogue | Status | Spec |
+|---|---|---|---|
+| Capability cards (`agent_card.v1`) | the certificate | ✅ | [agent-capability-cards](./agent-capability-cards.md) |
+| Per-actor signing (provable `actor`) | the key binding | ✅ | [per-actor-signing](./per-actor-signing.md) |
+| Revocation (`agent_card_revocation.v1`) | OCSP | ✅ | agent-capability-cards |
+| Capability provenance (captured/exercised/declared) | mis-issuance control | ✅ | [capability-provenance](./capability-provenance.md) |
+| Predicate registry (typed receipts) | — | ✅ | — |
+| Browser verification (WASM, same verdict as CLI) | the lock icon | ✅ | — |
+| Agent resolver (local + Hub + remote + transparency anchor + publish) | DNS + OCSP + CT lookup | ✅ | [agent-resolver](./agent-resolver.md) |
+
+The core "TLS for agents" stack is functionally complete: an agent has a provable identity, a capability card graded by real provenance, revocation, and resolves over the network with offline re-verification including a transparency anchor. The load-bearing invariant throughout: **the Hub creates nothing; the client re-verifies every byte against its own trust roots and decides.**
+
+## Frontiers (not yet built)
+
+These are the next big chunks, from the original TLS-for-agents vision. Each gets a spec before any code, the same rhythm that produced the shipped work.
+
+### 1. Transparency-log surface (Certificate Transparency for agents)
+
+We anchor cards in a Merkle log and verify inclusion. The missing piece is the *queryable* surface: "what has agent X done?", an append-only, monitorable history a third party can audit, with **completeness** detectable (the agent's `evidence_anchor` commits it to a receipt set, so omission is visible). Honest constraint: a log of **digests and commitments, not contents**, consistent with the memory-proof safe-default rule. Compounds everything already built. Spec: [transparency-log](./transparency-log.md).
+
+### 2. Protocol integration (the distribution flywheel)
+
+Wire per-actor signing into the protocols real agents already speak, the MCP plugin (exists, needs the per-actor-signing update) and an A2A integration, so agents emit provable, key-bound receipts *by default*. This is reach, not depth: the cryptographic core is done; this makes it used. Needs a spec before building.
+
+## What is explicitly out of scope (for now)
+
+- **Hosted registry / global naming**: the resolver works; global collision-free naming (ship-namespacing or DNS-delegation) is gated on a real buyer, not built speculatively.
+- **Runtime enforcement**: Treeship proves; it does not block at runtime. Confinement is a separate layer's job (Guard). Provenance grades, never gates.
+- **Standards / regulatory** (IETF, W3C, EU AI Act): pull, not push. Pursue once adoption creates demand, not before.
+
+## How we work
+
+1. A frontier becomes a **spec** in `docs/specs/` first; it lists slices and the load-bearing invariant.
+2. Slices ship one PR at a time, each with its own `CHANGELOG.md` entry and, for user-facing features, a docs page.
+3. The honest contract holds in every surface: report the strength of a claim, never overclaim.


### PR DESCRIPTION
Makes the plan **provenance-grade**. The roadmap lived only in conversation, so every "what's next" was re-derived instead of read from a source of truth. Now it's captured.

## `docs/specs/vision.md` — the living source of truth
The TLS-for-agents thesis, the `captured`/`checked`/`asserted` discipline, a table of **what's shipped** (cards, per-actor signing, revocation, capability provenance, predicate registry, browser verification, the full resolver) with links to each spec, the **two remaining frontiers**, what's explicitly out of scope, and how we work.

## `docs/specs/transparency-log.md` — the next frontier, specced
Certificate Transparency for agents: a queryable, append-only, monitorable history with **omission detectable** against a card's `evidence_anchor`. Honest constraints up front: digests not contents; committed-set not absolute completeness; append-only proven by a consistency check. Slices: history query + `treeship audit` → completeness check → consistency proof → monitor mode.

Per the rhythm that produced the shipped work: frontier → spec → sliced PRs. Next up is transparency-log slice 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)