### PR TITLE
spec: protocol integration (provable agents by default, MCP/A2A)

### DIFF
--- a/docs/specs/protocol-integration.md
+++ b/docs/specs/protocol-integration.md
@@ -1,0 +1,51 @@
+# Protocol Integration: provable agents by default (MCP, A2A)
+
+**Status:** draft, not implemented
+**Pairs with:** [per-actor-signing](./per-actor-signing.md), [agent-capability-cards](./agent-capability-cards.md), [capability-provenance](./capability-provenance.md), [agent-resolver](./agent-resolver.md), `bridges/mcp`, `bridges/a2a`
+**Last updated:** 2026-06-25
+
+## The shift
+
+Everything in the [vision](./vision.md) is built: provable identity, capability cards graded by real provenance, revocation, a resolver, a transparency log. It is all reachable from the CLI. The last gap is **reach**: making the agents that already exist, the ones speaking MCP and A2A, emit provable, key-bound receipts and become resolvable **by default**, without their operator hand-running `treeship` commands.
+
+This is distribution, not new cryptography. The cryptographic core is done.
+
+## The good news: the wiring already exists
+
+The bridges already shell out to the CLI and already pass an actor:
+
+- `bridges/mcp/src/attest.ts` calls `treeship attest action --actor <agent>` (and `attest receipt`) for tool calls.
+- `bridges/a2a/src/attest.ts` does the same for A2A tasks and handoffs, and `agent-card.ts` already builds an A2A `AgentCard`.
+
+So **per-actor signing flows through them the moment the agent has a registered key.** `attest action --actor agent://x` already signs with the agent's own `AgentCert` key *if that key exists* (we shipped that). Today it does not exist, so the bridge's receipts are signed by the shared ship key and the `actor` is asserted. The integration is therefore not "rewire attestation", it is **provision the agent's identity** so the existing wiring produces provable output.
+
+## What "provable by default" requires
+
+When a bridge starts representing an agent, three things should happen once, automatically:
+
+1. **Register a per-agent key** (`agent register --own-key`) so the agent's receipts are key-bound and its `actor` is `proven`, not asserted. (Per-actor signing, already shipped, does the rest.)
+2. **Mint a capability card from the harness** (`attest card --from-harness`) so the agent's declared capabilities are *captured* from its real wired tools (the MCP server's tool list / the A2A AgentCard skills), not hand-typed.
+3. **Publish** (`treeship publish`) so the agent is resolvable: anyone can `resolve --hub` it and `audit` its history.
+
+After that, every receipt the bridge emits is provably the agent's, its capabilities are evidence-checkable, and it is resolvable, with zero extra operator action.
+
+## Honest framing
+
+The bridge makes an agent's receipts *provable*; it does not change *what Treeship proves*. Per-actor signing closes intra-workspace actor forgery, not host compromise (a compromised bridge holds the key). Capability cards are consistency over captured evidence, not completeness. The bridge inherits these contracts unchanged and must not imply more, the same discipline carried into every surface.
+
+## Slices
+
+1. **MCP: provision a per-agent key.** On bridge setup, `agent register --own-key` for the agent it represents (idempotent: skip if already registered). Result: the bridge's existing `attest action --actor` calls become key-bound and `actor`-provable with no change to the attest path. The highest-leverage, smallest slice, it flips every MCP-bridge receipt from asserted to proven.
+2. **MCP: mint + publish a capability card from the wired tools.** Build the card from the MCP server's actual tool list via `--from-harness` (captured provenance), then `publish` so the agent resolves. Now an MCP agent is identity + capability + resolvable, automatically.
+3. **A2A: the AgentCard bridge.** Map the A2A `AgentCard` (skills, capabilities) to a Treeship `agent_card.v1`, register the per-agent key, and stamp provenance. A2A already has a card concept; this makes it *verifiable* (key-bound + evidence-checked) rather than a descriptor.
+4. **ACP / others.** The same three-step pattern (register key → capture card → publish) generalizes to any protocol whose bridge shells to the CLI.
+
+## Open questions
+
+1. **Key lifecycle in the bridge.** Where does the per-agent key live, in the operator's keystore (so it persists), and how is it rotated? Reuse the existing keystore; rotation reuses card `supersedes`.
+2. **Capturing tools per protocol.** MCP exposes a tool list at handshake; A2A exposes skills in the AgentCard. `--from-harness` currently reads a Claude Code `settings.json`; it needs a path (or a small adapter) for "tools the bridge already knows at runtime" rather than a config file. Likely a `--tools-json` companion to `--from-harness`.
+3. **Where publish points.** Default Hub vs operator-configured. Reuse the existing `hub attach` connection; publish is a no-op (with a clear hint) when no hub is attached.
+
+## First slice to build
+
+Slice 1: the MCP bridge registers a per-agent key (`--own-key`) for its agent on setup, idempotently. It is the smallest change with the largest effect, it turns every receipt the MCP bridge already emits from `actor: asserted` into `actor: proven (key-bound)`, with no change to the attestation path, because per-actor signing already does the work once the key exists. It is the cleanest possible demonstration that the whole stack we built reaches real agents.

--- a/docs/specs/vision.md
+++ b/docs/specs/vision.md
@@ -25,17 +25,17 @@ The discipline that makes this real, and distinguishes Treeship from a registry 
 
 The core "TLS for agents" stack is functionally complete: an agent has a provable identity, a capability card graded by real provenance, revocation, and resolves over the network with offline re-verification including a transparency anchor. The load-bearing invariant throughout: **the Hub creates nothing; the client re-verifies every byte against its own trust roots and decides.**
 
-## Frontiers (not yet built)
+## Frontiers
 
 These are the next big chunks, from the original TLS-for-agents vision. Each gets a spec before any code, the same rhythm that produced the shipped work.
 
-### 1. Transparency-log surface (Certificate Transparency for agents)
+### 1. Transparency-log surface (Certificate Transparency for agents) — mostly shipped (0.14.0)
 
-We anchor cards in a Merkle log and verify inclusion. The missing piece is the *queryable* surface: "what has agent X done?", an append-only, monitorable history a third party can audit, with **completeness** detectable (the agent's `evidence_anchor` commits it to a receipt set, so omission is visible). Honest constraint: a log of **digests and commitments, not contents**, consistent with the memory-proof safe-default rule. Compounds everything already built. Spec: [transparency-log](./transparency-log.md).
+The queryable surface is live: `GET /v1/agents/log` + `treeship audit` give an append-only, monitorable history a third party can audit, with **omission detectable** against the agent's `evidence_anchor`, and `audit --watch` for continuous monitoring. The Merkle **consistency-proof primitive** (append-only, no-rewrite guarantee) is built and test-gated in `core`. Remaining: the slice-3 *plumbing* (Hub consistency endpoint + `audit` checkpoint-witnessing) on top of the primitive. Specs: [transparency-log](./transparency-log.md), [merkle-consistency](./merkle-consistency.md).
 
-### 2. Protocol integration (the distribution flywheel)
+### 2. Protocol integration (the distribution flywheel) — specced, next to build
 
-Wire per-actor signing into the protocols real agents already speak, the MCP plugin (exists, needs the per-actor-signing update) and an A2A integration, so agents emit provable, key-bound receipts *by default*. This is reach, not depth: the cryptographic core is done; this makes it used. Needs a spec before building.
+Provision a per-agent identity inside the protocols real agents already speak (MCP, A2A) so they emit provable, key-bound receipts and become resolvable **by default**. The bridges already shell to the CLI and pass `--actor`, so per-actor signing flows through the moment the agent has a key, this is provisioning (register key → capture card → publish), not rewiring. Reach, not depth: the cryptographic core is done; this makes it used. Spec: [protocol-integration](./protocol-integration.md).
 
 ## What is explicitly out of scope (for now)
 


### PR DESCRIPTION
The **last frontier**, specced: make the agents that already speak MCP and A2A emit provable, key-bound receipts and become resolvable **by default**.

## The finding that makes this clean
The bridges (`bridges/mcp`, `bridges/a2a`) **already shell to the CLI** and already pass `treeship attest action --actor <agent>`. So **per-actor signing (already shipped) flows through them the moment the agent has a registered key.** The integration is *not* rewiring attestation, it's **provisioning the agent's identity**:
1. `agent register --own-key` → receipts become key-bound, `actor` becomes `proven`.
2. `attest card --from-harness` → capabilities captured from the agent's real wired tools.
3. `publish` → the agent is resolvable + auditable.

After that, every receipt the bridge emits is provably the agent's, with zero extra operator action.

## Slices
1. **MCP: register a per-agent key on setup** (idempotent). Smallest change, largest effect, flips every MCP-bridge receipt from `actor: asserted` to `actor: proven`, no change to the attest path.
2. **MCP: mint + publish a capability card** from the wired tool list (captured provenance).
3. **A2A: AgentCard ↔ `agent_card.v1` bridge** (makes the A2A descriptor *verifiable*).
4. Generalize the three-step pattern to ACP / others.

## Honest framing
The bridge makes receipts *provable*; it doesn't change *what Treeship proves* (per-actor signing closes intra-workspace forgery not host compromise; cards are consistency not completeness). Inherited unchanged.

Also refreshes `vision.md`: transparency-log surface mostly shipped in 0.14.0; protocol integration now specced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)