### PR TITLE
fix(hermes): ship skill and provable setup docs

### DIFF
--- a/docs/content/docs/integrations/hermes.mdx
+++ b/docs/content/docs/integrations/hermes.mdx
@@ -1,12 +1,16 @@
 ---
 title: Hermes
-description: Integrate Treeship with Hermes agents via skill file or MCP server.
+description: Integrate Treeship with Hermes agents via skill file and MCP server.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Steps, Step } from 'fumadocs-ui/components/steps';
 
-Hermes agents support two integration methods: a skill file (instruction-based) and an MCP server (tool-call interception).
+Hermes agents support two integration methods: a skill file for session discipline and the Treeship MCP server for MCP-routed tool-call receipts. The best setup uses both.
+
+<Callout type="warn">
+Hermes does not currently have a Treeship-native in-process hook. Coverage is skill-driven plus MCP-routed, so use `treeship wrap` for important shell commands and session reports as a backstop.
+</Callout>
 
 ## Method 1: Skill file
 
@@ -15,7 +19,7 @@ Hermes agents support two integration methods: a skill file (instruction-based) 
 ### Install Treeship CLI
 
 ```bash
-curl -fsSL treeship.dev/install | sh
+curl -fsSL https://treeship.dev/install | sh
 treeship init
 ```
 </Step>
@@ -23,17 +27,26 @@ treeship init
 ### Install the Treeship skill
 
 ```bash
-curl -sL https://raw.githubusercontent.com/zerkerlabs/treeship/main/integrations/hermes/treeship.skill/SKILL.md \
-  -o ~/.hermes/skills/treeship.skill/SKILL.md --create-dirs
+mkdir -p ~/.hermes/skills/treeship
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/integrations/hermes/treeship.skill/SKILL.md \
+  -o ~/.hermes/skills/treeship/SKILL.md
 ```
 
-The Hermes agent reads the skill and follows the instructions to wrap commands, set env vars, and manage session lifecycle.
+The Hermes agent reads the skill and follows the instructions to start/close sessions, wrap side-effectful shell commands, record approvals and handoffs, and avoid publishing secrets.
 </Step>
 </Steps>
 
 ## Method 2: MCP server
 
-Add Treeship as an MCP server in your Hermes config:
+Add Treeship as an MCP server in Hermes:
+
+```bash
+hermes mcp add treeship --command npx \
+  --env TREESHIP_ACTOR=agent://hermes TREESHIP_HUB_ENDPOINT=https://api.treeship.dev \
+  --args -y @treeship/mcp
+```
+
+Then make sure the configured server has the Hermes actor in its environment:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -42,21 +55,30 @@ mcp_servers:
     command: npx
     args: ["-y", "@treeship/mcp"]
     env:
+      TREESHIP_ACTOR: "agent://hermes"
       TREESHIP_HUB_ENDPOINT: "https://api.treeship.dev"
 ```
 
-This intercepts every MCP tool call and creates signed artifacts + session events automatically.
+`TREESHIP_ACTOR=agent://hermes` is required. Without it, receipts may fall back to a generic MCP identity.
+
+## Recommended setup
+
+```bash
+treeship agent register --name hermes --own-key --tools mcp,terminal,file,git --description "Hermes Agent"
+treeship session start --name "hermes: first verified session"
+```
 
 ## What appears in the receipt
 
 | Section | Skill file | MCP server |
 |---------|-----------|------------|
-| Commands | Via `treeship wrap` `[AUTO]` | Not applicable |
-| Tool calls | Not applicable | Every MCP tool call `[AUTO]` |
-| Model/cost | Via env vars `[EXPLICIT]` | Via env vars `[EXPLICIT]` |
-| File operations | File snapshot diff `[AUTO]` | Not applicable |
-| Handoffs | Via `treeship session event` `[EXPLICIT]` | Via `treeship session event` `[EXPLICIT]` |
+| Commands | Via `treeship wrap` `[EXPLICIT]` | Not applicable |
+| Tool calls | Not applicable | MCP-routed tool calls `[AUTO]` |
+| Agent identity | `agent://hermes` in events `[EXPLICIT]` | `TREESHIP_ACTOR=agent://hermes` `[AUTO]` |
+| File operations | Session report / git reconcile backstop `[AUTO]` | Routed file-tool metadata when available `[AUTO]` |
+| Approvals | `treeship approve` + approval nonce `[EXPLICIT]` | Not applicable |
+| Handoffs | `treeship attest handoff` or session event `[EXPLICIT]` | Not applicable |
 
 <Callout type="info">
-**Integration status**: Skill file and MCP server packages are ready. Full end-to-end testing with a live Hermes server is pending. If you test it, please report results at github.com/zerkerlabs/treeship/issues.
+**Expected outcome**: a Hermes session can produce a local-verifiable Treeship receipt and optional Hub report. MCP-routed tool calls can verify as Hermes-owned when the bridge signs with a registered `agent://hermes` key.
 </Callout>

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,29 +1,47 @@
 # Treeship + Hermes Integration
 
-Hermes integrates via the universal MCP bridge and a declarative skill file — there is **no Hermes-native plugin** (no in-process hooks, no compiled extension). Coverage is skill-driven + MCP-routed; if you need hook-based bypass-proof capture, that lives in the Claude Code, Kimi Code, or OpenClaw plugins.
+Hermes integrates via the universal MCP bridge and a declarative skill file — there is **no Hermes-native in-process plugin** today. Coverage is skill-driven + MCP-routed; if you need hook-based bypass-proof capture, that lives in the Claude Code, Kimi Code, or OpenClaw plugins.
 
-Two integration methods for Hermes agents:
+The target outcome is a **provable Hermes session**: Hermes has its own Treeship agent identity, MCP-routed tool calls are signed as `agent://hermes`, important shell commands are wrapped, and the final session report verifies offline.
+
+## Prerequisites
+
+```bash
+curl -fsSL https://treeship.dev/install | sh
+treeship init
+npm install -g @treeship/mcp
+```
 
 ## Method 1: Skill file (instruction-based)
 
-Copy the skill file to your Hermes skills directory:
+Copy this integration skill into Hermes:
 
 ```bash
-cp -r treeship.skill ~/.hermes/skills/
+mkdir -p ~/.hermes/skills/treeship
+cp integrations/hermes/treeship.skill/SKILL.md ~/.hermes/skills/treeship/SKILL.md
 ```
 
-Or install from the repo:
+Or install from GitHub:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/zerkerlabs/treeship/main/integrations/hermes/treeship.skill/SKILL.md \
-  -o ~/.hermes/skills/treeship.skill/SKILL.md --create-dirs
+mkdir -p ~/.hermes/skills/treeship
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/integrations/hermes/treeship.skill/SKILL.md \
+  -o ~/.hermes/skills/treeship/SKILL.md
 ```
 
-The Hermes agent reads the skill and follows the instructions to wrap commands, set env vars, and manage session lifecycle automatically.
+The Hermes agent reads the skill and follows the instructions to start/close sessions, wrap side-effectful shell commands, record approvals and handoffs, and avoid publishing secrets.
 
 ## Method 2: MCP server (tool-call interception)
 
-Add Treeship as an MCP server in your Hermes config:
+Add Treeship as an MCP server in Hermes:
+
+```bash
+hermes mcp add treeship --command npx \
+  --env TREESHIP_ACTOR=agent://hermes TREESHIP_HUB_ENDPOINT=https://api.treeship.dev \
+  --args -y @treeship/mcp
+```
+
+Then ensure the MCP server env contains the Hermes actor:
 
 ```yaml
 # ~/.hermes/config.yaml
@@ -36,34 +54,38 @@ mcp_servers:
       TREESHIP_HUB_ENDPOINT: "https://api.treeship.dev"
 ```
 
-This intercepts every MCP tool call and creates signed artifacts + session events automatically. The `TREESHIP_ACTOR` env is required — without it, Hermes events fall back to the generic `agent_name=mcp` in receipts instead of `hermes`.
+`TREESHIP_ACTOR=agent://hermes` is required — without it, MCP receipts may fall back to a generic MCP identity instead of Hermes.
 
-## Prerequisites
+## Recommended setup
 
 ```bash
-curl -fsSL treeship.dev/install | sh
-treeship init
-npm install -g @treeship/mcp  # for Method 2
+# Give Hermes its own key-bound identity for provable receipts.
+treeship agent register --name hermes --own-key --tools mcp,terminal,file,git --description "Hermes Agent"
+
+# Start a session before meaningful work.
+treeship session start --name "hermes-test"
 ```
 
 ## Testing
 
 ```bash
-# Start a session
-treeship session start --name "hermes-test"
+# Run Hermes with the skill active and MCP configured.
+hermes chat -q "Use Treeship to record a short non-secret test note, then stop."
 
-# Run Hermes with the skill active
-hermes run "research the latest AI safety papers"
-
-# Close and verify
+# Close, verify, and optionally publish a report.
 treeship session close --summary "Tested Hermes integration"
-treeship package verify .treeship/sessions/ssn_*.treeship
+treeship verify last
 treeship session report
 ```
 
 ## Expected receipt contents
 
-- Agent: hermes (or hermes-2 if TREESHIP_MODEL is set)
-- Timeline: every wrapped command or MCP tool call
-- Commands: full command strings with exit codes
-- Provider: populated if TREESHIP_PROVIDER is set
+- Agent: `agent://hermes`.
+- Actor proof: key-bound/proven when Hermes has an `--own-key` identity and the MCP path signs with that actor.
+- Timeline: MCP-routed tool calls plus explicit session events.
+- Commands: side-effectful shell commands when run through `treeship wrap`.
+- Approvals/handoffs: explicit artifacts when sensitive work or agent transitions happen.
+
+## Honest coverage
+
+Hermes skill coverage is not bypass-proof because it depends on the agent following instructions. Pair it with MCP for automatic MCP tool-call receipts and `treeship wrap` for shell commands. Use session reports and git reconcile as backstops for file-level evidence.

--- a/integrations/hermes/treeship.skill/SKILL.md
+++ b/integrations/hermes/treeship.skill/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: treeship
+description: Use when operating Hermes Agent in a repo or organization where AI work should produce Treeship-verifiable receipts. Captures Hermes sessions, MCP-routed tool calls, wrapped shell commands, approvals, handoffs, and publishable session reports while avoiding raw secrets in receipts.
+version: 1.0.0
+author: Treeship
+license: MIT
+metadata:
+  hermes:
+    tags: [treeship, receipts, provenance, hermes, mcp, agent-trust]
+    related_skills: []
+---
+
+# Treeship for Hermes — Verifiable Agent Work
+
+## Overview
+
+Treeship creates local-first, cryptographically signed receipts for agent work. In Hermes, use Treeship to answer:
+
+- Who asked for the work?
+- Which Hermes actor did it?
+- Which commands, MCP tool calls, files, approvals, and handoffs were involved?
+- Can someone verify the receipt offline without trusting Treeship Hub?
+
+Hermes currently integrates through **skill instructions + the universal Treeship MCP bridge**. There is no Hermes-native in-process hook yet, so be honest about coverage: MCP-routed tool calls can be captured automatically; built-in Hermes tool calls and direct shell work should be wrapped or summarized as explicit session events.
+
+## Quick Start
+
+```bash
+# Install and initialize Treeship
+curl -fsSL https://treeship.dev/install | sh
+treeship init
+
+# Register Hermes as a distinct agent identity.
+# --own-key makes Hermes receipts verify as key-bound when the MCP path signs as agent://hermes.
+treeship agent register --name hermes --own-key --tools mcp,terminal,file,git --description "Hermes Agent"
+
+# Start a named session before important work
+treeship session start --name "hermes: <task>"
+```
+
+If the workspace already has Treeship initialized, do not reinitialize or rotate keys unless the user asks.
+
+## Hermes MCP Configuration
+
+Add the Treeship MCP server to Hermes so MCP-routed tool calls create intent/result receipts and session events:
+
+```bash
+hermes mcp add treeship --command npx \
+  --env TREESHIP_ACTOR=agent://hermes TREESHIP_HUB_ENDPOINT=https://api.treeship.dev \
+  --args -y @treeship/mcp
+```
+
+Then ensure the server environment includes the Hermes actor:
+
+```yaml
+# ~/.hermes/config.yaml
+mcp_servers:
+  treeship:
+    command: npx
+    args: ["-y", "@treeship/mcp"]
+    env:
+      TREESHIP_ACTOR: "agent://hermes"
+      TREESHIP_HUB_ENDPOINT: "https://api.treeship.dev"
+```
+
+`TREESHIP_ACTOR=agent://hermes` is required. Without it, receipts may fall back to a generic MCP actor and lose useful identity.
+
+After changing Hermes MCP config, start a fresh Hermes session or run `/reload-mcp` if available.
+
+## Operating Loop
+
+1. **Start or inspect the session**
+   ```bash
+   treeship session status --format json || treeship session start --name "hermes: <task>"
+   ```
+   Completion criterion: there is an active session ID.
+
+2. **Record intent for significant work**
+   ```bash
+   treeship session event \
+     --type agent.decision \
+     --actor agent://hermes \
+     --agent-name hermes \
+     --meta '{"decision":"approach chosen","reason":"brief non-secret reason"}'
+   ```
+   Completion criterion: the receipt timeline explains why the agent took meaningful actions.
+
+3. **Wrap shell commands with side effects**
+   ```bash
+   treeship wrap --actor agent://hermes -- <command>
+   ```
+   Use wrapping for builds, tests, git operations, deploy commands, migrations, scripts, package publishing, or any command whose result should be auditable. Avoid putting secrets or bearer tokens in command-line args; prefer env vars or config files that Treeship does not print.
+   Completion criterion: important command boundaries are signed or represented by a session event.
+
+4. **Use approvals for sensitive actions**
+   ```bash
+   treeship approve --approver human://<slack-or-github-id> --description "Approve deploy to production"
+   treeship wrap --approval-nonce <nonce> --actor agent://hermes -- <deploy-command>
+   ```
+   Completion criterion: the receipt links the sensitive action to a human approval artifact.
+
+5. **Record handoffs and collaboration**
+   ```bash
+   treeship attest handoff \
+     --from agent://hermes \
+     --to agent://claude-code \
+     --task "continue implementation" \
+     --format json
+   ```
+   Completion criterion: multi-agent transitions are explicit rather than hidden in chat text.
+
+6. **Close, verify, and publish when useful**
+   ```bash
+   treeship session close --summary "<non-secret summary>"
+   treeship session report
+   treeship verify last
+   ```
+   Completion criterion: local verification passes and, if published, the user gets a shareable receipt URL.
+
+## What Treeship Should Capture
+
+| Evidence | Preferred Hermes capture path | Notes |
+|---|---|---|
+| MCP tool call intent/result | `@treeship/mcp` | Automatic when tools route through MCP. |
+| Shell command boundary | `treeship wrap -- ...` | Captures command boundary and exit status; avoid raw secrets in args. |
+| File changes | MCP event when routed, otherwise git reconcile/session report | Do not paste file contents into metadata. |
+| Human approval | `treeship approve` + `--approval-nonce` | Use stable human URIs such as `human://slack/T123/U456`. |
+| Agent handoff | `treeship attest handoff` or `treeship session event` | Use `agent://hermes`, `agent://claude-code`, etc. |
+| Model/provider/cost | Session metadata/event | Only include values the user is comfortable sharing. |
+| Final deliverable | `treeship session report` | Produces a portable report and optional Hub URL. |
+
+## Identity Conventions
+
+Use stable actor URIs:
+
+- `agent://hermes` — this Hermes instance or profile.
+- `agent://claude-code` — Claude Code.
+- `agent://claude-tag/<workspace>/<channel>` — a channel-scoped Claude Tag identity when known.
+- `agent://perplexity/<surface>` — Perplexity/Comet-style agent surfaces when known.
+- `human://slack/<team_id>/<user_id>` — Slack human identity.
+- `room://slack/<team_id>/<channel_id>` — Slack channel / trusted room.
+
+Do not use mutable display names as the only identity. Put display names in metadata if needed.
+
+## Trusted Room Pattern
+
+When Hermes is working in a Slack/channel-style room, treat the room as a policy boundary:
+
+1. Record the room identity: `room://slack/<team>/<channel>`.
+2. Record the requester as a human identity: `human://slack/<team>/<user>`.
+3. Record the agent identity: `agent://hermes` or the channel-scoped agent URI.
+4. Keep room memories, tool permissions, approvals, spend limits, and reports scoped to that room.
+5. Never let private-room memory or evidence leak into another room’s receipt unless an explicit approved handoff exists.
+
+This aligns with Claude Tag-style team agents: channel-scoped agent identity, controlled tools, scoped memory, task log, requester log, and channel-level spend limits.
+
+## Privacy Rules
+
+- Do not include API keys, OAuth tokens, bearer tokens, private URLs, raw prompts with secrets, or database connection strings in Treeship metadata.
+- Prefer hashes, artifact IDs, paths, command names, exit codes, and short non-secret summaries.
+- For commands that require secrets, pass secrets through environment/config and record only the command boundary.
+- If a receipt must mention sensitive context, ask the user before publishing it to Hub.
+
+## Common Pitfalls
+
+1. **No `TREESHIP_ACTOR`.** MCP receipts become generic and harder to trust. Set `TREESHIP_ACTOR=agent://hermes`.
+2. **Assuming Hermes skill coverage is bypass-proof.** It is instruction-based. Use MCP and `treeship wrap` for stronger evidence.
+3. **Leaking command-line secrets.** Treeship can record command boundaries; do not put secrets in args.
+4. **Using display names as identities.** Slack names change; use workspace/user/channel IDs.
+5. **Publishing before checking.** Run `treeship verify last` before sharing a Hub URL.
+6. **Mixing room memory.** Keep channel-scoped agent memories and receipts separate unless there is an explicit handoff/approval.
+
+## Verification Checklist
+
+Before saying a Hermes task is Treeship-verifiable:
+
+- [ ] `treeship init` has been run for the workspace or user.
+- [ ] Hermes has an agent identity, preferably from `treeship agent register --name hermes --own-key`.
+- [ ] Hermes MCP config includes `TREESHIP_ACTOR=agent://hermes`.
+- [ ] Important shell commands were run via `treeship wrap` or recorded as session events.
+- [ ] Sensitive actions have approval artifacts.
+- [ ] Handoffs identify both agents.
+- [ ] `treeship verify last` passes.
+- [ ] Published reports contain no secrets.


### PR DESCRIPTION
## Summary
- Populate the previously empty Hermes Treeship skill file.
- Update Hermes integration docs to install the skill at `~/.hermes/skills/treeship/SKILL.md`.
- Document provable Hermes setup with `agent://hermes`, `TREESHIP_ACTOR=agent://hermes`, per-agent key registration, and the current `hermes mcp add --env ... --args ...` syntax.
- Clarify honest coverage: Hermes is currently skill + MCP, not a native in-process hook.

## Test Plan
- [x] `git diff --check -- integrations/hermes/treeship.skill/SKILL.md integrations/hermes/README.md docs/content/docs/integrations/hermes.mdx`
- [x] `python3 scripts/check-docs-routes.py`
- [x] `hermes mcp add --help | grep -E -- '--command|--env|--args'`
- [x] `cd docs && npm install --no-package-lock && npm run build`

## Notes
- Kept this PR limited to the Hermes bug/docs update. Trusted Rooms product-spec work remains local for a separate PR.
