### PR TITLE
fix(capability): match harness-captured glob patterns (Bash(git:*))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **Capability matching now understands harness-captured glob patterns (`Bash(git:*)`).** `tool_matches` only expanded a *trailing* `*`, but the patterns `attest card --from-harness` captures from a Claude Code `settings.json` carry the wildcard *inside* the permission scope, `Bash(git:*)`, `Read(*)`, so every such pattern silently degraded to an exact string match that could never fire, and a card captured from a real config reported **every** real action out-of-scope. The wildcard may now sit anywhere in the pattern (one `*`, prefix and suffix must both hold), so `Bash(git:*)` matches `Bash(git:status)` and still rejects `Bash(gh:pr)`; the falsifiable cross-check keeps flagging genuinely off-card actions (`payments.charge`). Trailing-glob (`family.*`), bare-`*`, and exact matching are unchanged. Shared `treeship_core::capability` fix, so the CLI and the WASM browser verifier keep returning the same verdict. Found by dogfooding the full TLS-for-agents flow end to end.
+
 ## 0.15.0 (2026-06-26)
 
 ### Added

--- a/packages/core/src/capability/mod.rs
+++ b/packages/core/src/capability/mod.rs
@@ -12,11 +12,24 @@ use crate::trust::{TrustRootKind, TrustRootStore};
 
 /// `family.*` matches `family.write`; otherwise an exact match. A bare `*`
 /// matches anything.
+///
+/// The `*` may sit anywhere in the pattern, not only at the end: harness
+/// permission patterns captured by `attest card --from-harness` carry the
+/// glob *inside* a delimiter — `Bash(git:*)` — where a trailing-`*`-only
+/// matcher silently degrades to an exact match that can never fire, and a
+/// card captured from a real config then reports every real action
+/// out-of-scope. One wildcard is supported (the first, matching greedily);
+/// the text before it must prefix the action and the text after it must
+/// suffix the remainder, so `Bash(git:*)` matches `Bash(git:status)` but
+/// not `Bash(gh:pr)` or a `Bash(git:` with the closing paren missing.
 pub fn tool_matches(declared: &str, actual: &str) -> bool {
-    if let Some(prefix) = declared.strip_suffix('*') {
-        actual.starts_with(prefix)
-    } else {
-        declared == actual
+    match declared.split_once('*') {
+        Some((prefix, suffix)) => {
+            actual.len() >= prefix.len() + suffix.len()
+                && actual.starts_with(prefix)
+                && actual.ends_with(suffix)
+        }
+        None => declared == actual,
     }
 }
 
@@ -94,6 +107,26 @@ mod tests {
         assert!(tool_matches("file.*", "file.write"));
         assert!(!tool_matches("file.*", "db.query"));
         assert!(tool_matches("*", "anything.at.all"));
+    }
+
+    #[test]
+    fn harness_patterns_with_internal_glob_match() {
+        // The shape `attest card --from-harness` captures from a Claude Code
+        // settings.json permissions.allow list: the `*` sits inside the
+        // parenthesized scope, not at the end of the pattern.
+        assert!(tool_matches("Bash(git:*)", "Bash(git:status)"));
+        assert!(tool_matches("Bash(git:*)", "Bash(git:log --oneline)"));
+        assert!(tool_matches("Read(*)", "Read(/etc/hosts)"));
+        // prefix and suffix must both hold — no cross-family bleed, no
+        // matching a truncated action that drops the closing delimiter
+        assert!(!tool_matches("Bash(git:*)", "Bash(gh:pr)"));
+        assert!(!tool_matches("Bash(git:*)", "Bash(git:"));
+        assert!(!tool_matches("Bash(git:*)", "payments.charge"));
+        // the wildcard may match empty: the family root itself is in scope
+        assert!(tool_matches("Bash(git:*)", "Bash(git:)"));
+        // trailing-glob and exact behavior unchanged
+        assert!(tool_matches("file.*", "file.*"));
+        assert!(!tool_matches("Bash(git:status)", "Bash(git:log)"));
     }
 
     fn root(key_id: &str, kind: TrustRootKind) -> TrustRoot {


### PR DESCRIPTION
## What

`tool_matches` only expanded a **trailing** `*`. The patterns `attest card --from-harness` captures from a Claude Code `settings.json` carry the wildcard **inside** the permission scope — `Bash(git:*)`, `Read(*)` — so every harness-captured capability silently degraded to an exact string match that can never fire, and a card captured from a real config reported **every real action as an out-of-scope violation**.

## Fix

One wildcard may now sit anywhere in the pattern: the text before it must prefix the action, the text after must suffix the remainder, with a length guard so prefix and suffix cannot overlap.

- `Bash(git:*)` matches `Bash(git:status)`, `Bash(git:log --oneline)`
- still rejects `Bash(gh:pr)`, `Bash(git:` (truncated), `payments.charge`
- `family.*`, bare `*`, and exact matching unchanged

Fix is in shared `treeship_core::capability`, so the CLI and WASM browser verifier keep returning the same verdict.

## Found by

Dogfooding the full TLS-for-agents flow end to end (register → `--from-harness` card → attest → verify-capability): the card declared `Bash(git:*)` yet a real `Bash(git:status)` receipt graded out-of-scope. After the fix, re-verified against the same live artifacts: the receipt grades in-scope and the deliberate `payments.charge` violation is still caught.

## Tests

New `harness_patterns_with_internal_glob_match` unit test (9 assertions) + existing suites: 534 tests green across core + CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8