### PR TITLE
ci(release): read crates token from CARGO_REGISTRY_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,7 +465,7 @@ jobs:
           fi
           exit 1
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Verify treeship-core on crates.io
         run: .github/scripts/wait-for-crates-version.sh treeship-core "${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
The publish-crates job read secrets.CARGO_TOKEN, a nonstandard name
that cost us a 403 loop during the 0.16.0 release: the operator
rotated the expired token into the conventionally-named
CARGO_REGISTRY_TOKEN secret, which the workflow never read. Point the
workflow at CARGO_REGISTRY_TOKEN (already set, already valid) so the
secret name matches both cargo's own env-var convention and what any
operator would reach for. The stale CARGO_TOKEN secret is deleted
after this merges.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8
