### PR TITLE
feat(cli): treeship onboard — nothing to verifiable in one command (+ idempotent hub artifact insert)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- **`treeship onboard` — an agent goes from nothing to verifiable in one command.** Composes the existing lifecycle — `agent register --own-key`, `attest card` (`--from-harness` / `--tools-json` / `--from-a2a` / `--tools`), and with `--publish` the full `publish` + `merkle checkpoint` + `merkle publish` anchor — into one idempotent pass, and ends by printing the **trust bundle**: the exact `trust add` command(s) a counterparty runs (`agent_cert` for the agent key, `hub_checkpoint` for the ship key) plus the `resolve`/`audit` commands that verify the agent. One name in, one URI out: `onboard deployer` and `onboard agent://deployer` are the same call, closing the register-takes-a-name / everything-else-takes-a-URI trap. Adds no new attestation surface — every artifact is minted by the same code paths as the individual commands. Born directly from the 13-item friction ledger of a real end-to-end dogfood run.
+
+### Fixed
+- **Hub: re-pushing an already-published artifact no longer 500s.** `InsertArtifact` was a bare `INSERT`, so re-publishing an agent's resolvable set (exactly what an idempotent `onboard --publish` on every agent boot does) hit the `artifact_id` primary key and surfaced as a 500 to the pushing client, aborting the publish. Artifacts are content-addressed, signed envelopes — a re-push of the same id is the same bytes — so the insert is now `ON CONFLICT(artifact_id) DO NOTHING`: idempotent, and deliberately *never* an update, so a colliding id can never overwrite bytes the hub already serves. Regression-tested both ways (duplicate no-op + overwrite rejection).
+
 ## 0.16.0 (2026-07-06)
 
 ### Added

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod template;
 pub mod add;
 pub mod agent;
 pub mod agents;
+pub mod onboard;
 pub mod approval;
 pub mod cards;
 pub mod discovery;

--- a/packages/cli/src/commands/onboard.rs
+++ b/packages/cli/src/commands/onboard.rs
@@ -1,0 +1,197 @@
+//! `treeship onboard` — take an agent from nothing to verifiable in one
+//! command.
+//!
+//! The full TLS-for-agents lifecycle is ~ten commands with four traps
+//! (register takes `--name` while everything else takes an `agent://` URI; a
+//! mismatched URI silently downgrades signing; the card, publish, checkpoint
+//! and anchor steps each have their own invocation; and the trust material a
+//! counterparty needs was, until `keys export`, not printable at all). Every
+//! one of those was hit in a real end-to-end dogfood run. `onboard` composes
+//! the existing commands — register `--own-key`, `attest card`, `publish`,
+//! `merkle checkpoint` + `merkle publish` — into one idempotent pass and ends
+//! by printing exactly what a counterparty runs to resolve and verify the
+//! agent. It adds no new attestation surface of its own: every artifact it
+//! produces is minted by the same code paths as the individual commands.
+
+use crate::{ctx, printer::Printer};
+use treeship_core::statements::{payload_type, ReceiptStatement};
+
+pub struct OnboardArgs {
+    /// Agent name or `agent://` URI (normalized either way).
+    pub name:         String,
+    pub from_harness: Option<String>,
+    pub tools_json:   Option<String>,
+    pub from_a2a:     Option<String>,
+    pub tools:        Vec<String>,
+    pub models:       Vec<String>,
+    pub description:  Option<String>,
+    /// Also publish + checkpoint + anchor to the attached Hub.
+    pub publish:      bool,
+    pub config:       Option<String>,
+}
+
+pub fn onboard(args: OnboardArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    // One name in, one URI out — the register-takes-a-name /
+    // everything-else-takes-a-URI trap is normalized away here.
+    let name = args
+        .name
+        .strip_prefix("agent://")
+        .unwrap_or(&args.name)
+        .to_string();
+    if name.is_empty() || name.contains('/') {
+        return Err(format!(
+            "invalid agent name {:?} — use a bare name (deployer) or agent://<name>",
+            args.name
+        )
+        .into());
+    }
+    let actor = format!("agent://{name}");
+
+    // A card without a capability source is an empty declaration; require one
+    // up front rather than minting a vacuous card.
+    if args.from_harness.is_none()
+        && args.tools_json.is_none()
+        && args.from_a2a.is_none()
+        && args.tools.is_empty()
+    {
+        return Err("no capability source — pass at least one of --from-harness <settings.json>, --tools-json <file>, --from-a2a <AgentCard.json>, or --tools <list>".into());
+    }
+
+    let ctx = ctx::open(args.config.as_deref())?;
+
+    // ── 1/4 identity: per-agent key, certified + pinned ────────────────────
+    // register --own-key is idempotent: an existing key is reused, never
+    // duplicated, so onboard can run repeatedly (e.g. on every agent boot).
+    printer.info(&format!("[1/4] identity — registering {actor} with its own key"));
+    crate::commands::agent::register(
+        &name,
+        Vec::new(),
+        args.models.first().cloned(),
+        365,
+        args.description.clone(),
+        Vec::new(),
+        Vec::new(),
+        true, // --own-key
+        true, // --quiet (no .agent dir dropped into cwd)
+        args.config.as_deref(),
+        printer,
+    )?;
+    let agents_dir = crate::commands::cards::agents_dir_for(&ctx.config_path);
+    let key_id = crate::commands::cards::registered_key_for_actor(&agents_dir, &actor)
+        .ok_or("registration did not yield a per-agent key (registered without --own-key?)")?;
+    printer.info(&format!("      key: {key_id} (pinned under AgentCert)"));
+
+    // ── 2/4 capability card ────────────────────────────────────────────────
+    printer.info("[2/4] capability card");
+    crate::commands::attest::card(
+        crate::commands::attest::CardArgs {
+            agent: actor.clone(),
+            tools: args.tools.clone(),
+            models: args.models.clone(),
+            keyid: None,
+            owner: None,
+            version: "1".to_string(),
+            policy_ref: None,
+            from_harness: args.from_harness.clone(),
+            tools_json: args.tools_json.clone(),
+            from_a2a: args.from_a2a.clone(),
+            config: args.config.clone(),
+        },
+        printer,
+    )?;
+    let card_id = latest_card_for(&ctx, &actor, &key_id);
+
+    // ── 3/4 publish + anchor (opt-in) ──────────────────────────────────────
+    let mut hub_endpoint: Option<String> = None;
+    if args.publish {
+        printer.info("[3/4] publish + anchor to Hub");
+        // Fail loudly: --publish is an explicit request, and a silent local-only
+        // onboard would let the operator believe the agent is resolvable.
+        crate::commands::publish::publish(&actor, args.config.as_deref(), printer)?;
+        crate::commands::merkle::checkpoint(args.config.as_deref(), printer)?;
+        crate::commands::merkle::publish(args.config.as_deref(), printer)?;
+        hub_endpoint = ctx
+            .config
+            .resolve_hub(None)
+            .ok()
+            .map(|(_, h)| h.endpoint.clone());
+    } else {
+        printer.info("[3/4] publish — skipped (local only; re-run with --publish once a hub is attached)");
+    }
+
+    // ── 4/4 the trust bundle: what a counterparty runs ─────────────────────
+    // The out-of-band handshake, printed instead of implied. The agent key
+    // pins under agent_cert (verifies the card + receipts); the ship key pins
+    // under hub_checkpoint (verifies the transparency anchor).
+    printer.info("[4/4] trust bundle — hand these to a counterparty:");
+    printer.blank();
+    let agent_pub = pinnable(&ctx, &key_id)?;
+    printer.info(&format!(
+        "    treeship trust add {key_id} {agent_pub} --kind agent_cert --yes"
+    ));
+    if args.publish {
+        let ship_key = ctx.keys.default_key_id()?;
+        let ship_pub = pinnable(&ctx, &ship_key)?;
+        printer.info(&format!(
+            "    treeship trust add {ship_key} {ship_pub} --kind hub_checkpoint --yes"
+        ));
+    }
+    printer.blank();
+    printer.success("agent onboarded", &[
+        ("agent", actor.as_str()),
+        ("key",   key_id.as_str()),
+        ("card",  card_id.as_deref().unwrap_or("(see above)")),
+    ]);
+    if let Some(endpoint) = hub_endpoint {
+        printer.info("  a counterparty verifies with:");
+        printer.info(&format!("    treeship resolve --hub {endpoint} {actor}"));
+        printer.info(&format!("    treeship audit --hub {endpoint} {actor}"));
+    } else {
+        printer.hint(&format!("verify locally: treeship resolve {actor}"));
+    }
+    printer.blank();
+    Ok(())
+}
+
+/// The `ed25519:<base64url>` pinnable form of a key's public half.
+fn pinnable(ctx: &ctx::Ctx, key_id: &str) -> Result<String, Box<dyn std::error::Error>> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    let bytes = ctx.keys.public_key(key_id)?;
+    Ok(format!("ed25519:{}", URL_SAFE_NO_PAD.encode(bytes)))
+}
+
+/// The newest agent_card.v1 for this actor signed by its registered key —
+/// the same selection rule `resolve` applies, so onboard reports the card a
+/// resolver would serve.
+fn latest_card_for(ctx: &ctx::Ctx, actor: &str, key_id: &str) -> Option<String> {
+    let receipt_pt = payload_type("receipt");
+    let mut newest: Option<(String, String)> = None;
+    for entry in ctx.storage.list_by_type(&receipt_pt) {
+        let Ok(rec) = ctx.storage.read(&entry.id) else { continue };
+        let Ok(stmt) = rec.envelope.unmarshal_statement::<ReceiptStatement>() else { continue };
+        if stmt.kind != "agent_card.v1" {
+            continue;
+        }
+        let Some(payload) = stmt.payload else { continue };
+        if payload.get("agent").and_then(|v| v.as_str()) != Some(actor) {
+            continue;
+        }
+        let signer = rec
+            .envelope
+            .signatures
+            .first()
+            .map(|s| s.keyid.as_str())
+            .unwrap_or("");
+        if signer != key_id {
+            continue;
+        }
+        let is_newer = newest
+            .as_ref()
+            .map(|(_, t)| entry.signed_at > *t)
+            .unwrap_or(true);
+        if is_newer {
+            newest = Some((entry.id.clone(), entry.signed_at.clone()));
+        }
+    }
+    newest.map(|(id, _)| id)
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -285,6 +285,17 @@ enum Command {
     #[command(subcommand)]
     Agent(AgentCommand),
 
+    /// Onboard an agent end to end in one command: register it with its
+    /// own key, mint its capability card, optionally publish + anchor to
+    /// the attached Hub, and print the trust bundle a counterparty runs
+    /// to verify it. Idempotent -- safe to run on every agent boot.
+    ///
+    /// Examples:
+    ///   treeship onboard deployer --from-harness ~/.claude/settings.json
+    ///   treeship onboard agent://hermes --tools-json tools.json --publish
+    ///   treeship onboard scout --from-a2a AgentCard.json --models claude-fable-5
+    Onboard(OnboardCliArgs),
+
     /// Manage the local Agent Card store
     ///
     /// Cards are workspace trust objects -- who an agent is, where it
@@ -1746,6 +1757,42 @@ struct AuditArgs {
 
 // --- keys -------------------------------------------------------------------
 
+#[derive(clap::Args)]
+struct OnboardCliArgs {
+    /// Agent name or agent:// URI (normalized either way)
+    #[arg(value_name = "NAME")]
+    name: String,
+
+    /// Harness config (e.g. a Claude Code settings.json) whose
+    /// permissions.allow list is captured as the capability set
+    #[arg(long, value_name = "PATH")]
+    from_harness: Option<String>,
+
+    /// Operator-declared capability list (JSON array or { "tools": [...] })
+    #[arg(long, value_name = "PATH")]
+    tools_json: Option<String>,
+
+    /// A2A AgentCard JSON whose skills become `discovered` capabilities
+    #[arg(long, value_name = "PATH")]
+    from_a2a: Option<String>,
+
+    /// Capabilities: tool categories or family.* globs (comma-separated)
+    #[arg(long, value_name = "TOOLS", value_delimiter = ',')]
+    tools: Vec<String>,
+
+    /// Models the agent uses (comma-separated)
+    #[arg(long, value_name = "MODELS", value_delimiter = ',')]
+    models: Vec<String>,
+
+    /// Agent description
+    #[arg(long, value_name = "TEXT")]
+    description: Option<String>,
+
+    /// Also publish the agent + checkpoint + anchor to the attached Hub
+    #[arg(long)]
+    publish: bool,
+}
+
 #[derive(Subcommand)]
 enum KeysCommand {
     /// List all signing keys
@@ -2308,6 +2355,21 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 printer,
             ),
         },
+
+        Command::Onboard(a) => commands::onboard::onboard(
+            commands::onboard::OnboardArgs {
+                name: a.name.clone(),
+                from_harness: a.from_harness.clone(),
+                tools_json: a.tools_json.clone(),
+                from_a2a: a.from_a2a.clone(),
+                tools: a.tools.clone(),
+                models: a.models.clone(),
+                description: a.description.clone(),
+                publish: a.publish,
+                config: cli.config.clone(),
+            },
+            printer,
+        ),
 
         Command::Harness(sub) => match sub {
             HarnessCommand::List => commands::harness::list(

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -347,9 +347,16 @@ type Artifact struct {
 }
 
 func InsertArtifact(db *sql.DB, a *Artifact) error {
+	// Idempotent on artifact_id: artifacts are content-addressed, signed
+	// envelopes, so a re-push of the same id is by definition the same
+	// bytes — re-publishing an agent's resolvable set (e.g. `treeship
+	// onboard` running on every agent boot) must not 500 on the primary
+	// key. DO NOTHING rather than DO UPDATE so a colliding id can never
+	// overwrite previously served bytes (same rule as dock_challenges).
 	_, err := db.Exec(
 		`INSERT INTO artifacts (artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(artifact_id) DO NOTHING`,
 		a.ArtifactID, a.PayloadType, a.EnvelopeJSON, a.Digest, a.SignedAt, a.ParentID, a.HubURL, a.RekorIndex, a.DockID,
 	)
 	return err

--- a/packages/hub/internal/db/db_test.go
+++ b/packages/hub/internal/db/db_test.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// InsertArtifact must be idempotent on artifact_id: artifacts are
+// content-addressed, signed envelopes, so a re-push of the same id (an
+// agent re-publishing its resolvable set on every boot) is the same bytes
+// and must neither error nor overwrite what the hub already serves.
+func TestInsertArtifactIdempotent(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := Open()
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	defer database.Close()
+
+	a := &Artifact{
+		ArtifactID:   "art_test_dup",
+		PayloadType:  "application/vnd.treeship.receipt+json",
+		EnvelopeJSON: `{"payload":"original"}`,
+		Digest:       "sha256:aaaa",
+		SignedAt:     1,
+		HubURL:       "https://api.example.dev",
+	}
+	if err := InsertArtifact(database, a); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	// Same id again — must not error (this used to bubble up as a PK
+	// violation and a 500 to the pushing client).
+	if err := InsertArtifact(database, a); err != nil {
+		t.Fatalf("duplicate insert must be a no-op, got: %v", err)
+	}
+
+	// DO NOTHING, not DO UPDATE: a colliding id must never overwrite the
+	// previously served bytes.
+	mutated := *a
+	mutated.EnvelopeJSON = `{"payload":"attacker-swapped"}`
+	if err := InsertArtifact(database, &mutated); err != nil {
+		t.Fatalf("conflicting insert must be a no-op, got: %v", err)
+	}
+	got, err := GetArtifact(database, "art_test_dup")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.EnvelopeJSON != `{"payload":"original"}` {
+		t.Fatalf("stored envelope was overwritten: %q", got.EnvelopeJSON)
+	}
+}


### PR DESCRIPTION
## What

**`treeship onboard <name>`** — the 13-item friction ledger from the end-to-end dogfood run, folded into one command:

```
$ treeship onboard fable-scout --from-harness ~/.claude/settings.json --publish
[1/4] identity — registering agent://fable-scout with its own key
      key: key_d0a66f42446fd895 (pinned under AgentCert)
[2/4] capability card
      key-bound: yes (AgentCert) · 9 of 9 captured from harness
[3/4] publish + anchor to Hub
      checkpoint #2 sealed + anchored
[4/4] trust bundle — hand these to a counterparty:
      treeship trust add key_d0a6… ed25519:… --kind agent_cert --yes
      treeship trust add key_b4be… ed25519:… --kind hub_checkpoint --yes
      treeship resolve --hub https://api.treeship.dev agent://fable-scout
```

- Idempotent — safe to run on every agent boot (`register --own-key` reuses keys)
- One name in, one URI out: `onboard deployer` == `onboard agent://deployer` (closes the silent self-asserted downgrade trap)
- Requires a capability source — refuses to mint a vacuous card
- No new attestation surface: composes the exact same code paths as the individual commands

## Plus the hub bug the idempotency rerun immediately found

Re-publishing an already-pushed artifact hit `InsertArtifact`'s bare `INSERT` → PK violation → **500** → publish aborted. Artifacts are content-addressed signed envelopes, so duplicate pushes are now `ON CONFLICT(artifact_id) DO NOTHING` — idempotent, and deliberately never an UPDATE so a colliding id can never overwrite served bytes. `TestInsertArtifactIdempotent` covers both properties. (Hub needs a Railway redeploy after merge for this to take effect.)

## Tests

CLI suites green; hub `go test ./...` green incl. the new regression test. Live-tested against the production hub (first run clean end-to-end; rerun reproduced the 500 this PR fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8