### PR TITLE
fix(cli): honest verdicts — nonzero exits + real JSON on all verification surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **Verification commands no longer exit 0 on hostile verdicts, and emit real JSON.** `resolve`, `audit`, and `verify-capability` computed hostile verdicts — a REVOKED card, out-of-scope violations, an OMISSION against the committed anchor, an invalid inclusion proof, an equivocating checkpoint, a failed append-only proof — printed a warning, and **returned success**, so any script, CI gate, or monitor keying off the exit code treated a detected history rewrite as green. All four verification surfaces (including `verify-presentation`) now exit nonzero on a hostile verdict. `audit --watch` deliberately keeps looping and alerting instead of exiting — a monitor's job is to keep watching. In JSON mode (`--format json`) each of the four now emits **one structured verdict object** carrying every field the text output shows; previously `resolve`/`verify-capability` returned a bare success envelope, `verify-presentation` returned essentially nothing (its verdict lines went through info, which JSON mode suppresses), and `audit` streamed multiple concatenated JSON objects no parser could consume. Programmatic callers — the bridges, the gateway, CI — can finally gate on these commands.
+
 ## 0.17.0 (2026-07-06)
 
 ### Added

--- a/packages/cli/src/commands/audit.rs
+++ b/packages/cli/src/commands/audit.rs
@@ -78,7 +78,11 @@ pub fn audit(
     // One-shot, or monitor mode: re-run on an interval and keep alerting on
     // omission. "Monitors catch anomalies." Ctrl-C to stop.
     if !watch {
-        return audit_once(base, agent, &trust, printer);
+        let hostile = audit_once(base, agent, &trust, printer)?;
+        if hostile {
+            std::process::exit(1);
+        }
+        return Ok(());
     }
     printer.hint(&format!(
         "watching {agent} on {base} every {interval}s (Ctrl-C to stop)"
@@ -88,13 +92,18 @@ pub fn audit(
         if let Err(e) = audit_once(base, agent, &trust, printer) {
             printer.warn("audit cycle failed", &[("error", &e.to_string())]);
         }
+        // watch mode never exits on anomalies -- its job is to keep alerting.
         std::thread::sleep(std::time::Duration::from_secs(interval.max(1)));
     }
 }
 
 /// A single audit pass: pull the history, re-verify anchored inclusions, check
-/// completeness against the agent's committed anchor.
-fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer) -> CmdResult {
+/// completeness against the agent's committed anchor. Returns whether the
+/// verdict was HOSTILE (omission / invalid inclusion / equivocation /
+/// append-only failure) so the one-shot caller can exit nonzero — a monitor
+/// that detects a history rewrite and exits 0 is lying to whatever gates on
+/// it. Watch mode keeps looping and alerting instead.
+fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer) -> Result<bool, Box<dyn std::error::Error>> {
     let log: serde_json::Value = ureq::get(&format!("{base}/v1/agents/log"))
         .query("agent", agent)
         .call()
@@ -111,6 +120,7 @@ fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer
     // Walk the history; re-verify each anchored entry's inclusion offline, and
     // track the highest fully-verified checkpoint so we can witness it.
     let (mut anchored, mut verified) = (0usize, 0usize);
+    let mut invalid = 0usize;
     let mut current_cp: Option<Checkpoint> = None;
     let mut lines: Vec<String> = Vec::new();
     for e in &entries {
@@ -137,7 +147,10 @@ fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer
                     }
                     "anchored ✓"
                 }
-                Ok((false, _)) => "anchored ✗ INVALID",
+                Ok((false, _)) => {
+                    invalid += 1;
+                    "anchored ✗ INVALID"
+                }
                 Err(_) => "anchored (proof unavailable)",
             }
         } else {
@@ -181,6 +194,37 @@ fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer
         (Some(_), None) => ("append-only: first witness, nothing to extend from yet".to_string(), false),
         _ => ("append-only: no checkpoint to prove".to_string(), false),
     };
+
+    let omission = committed_count.is_some_and(|c| observed < c);
+    let hostile = omission || invalid > 0 || anomaly || append_anomaly;
+
+    // JSON mode: ONE structured verdict object (the text path streams
+    // success + N warn objects, which is unparseable as a JSON document).
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "verdict": if hostile { "ANOMALY" } else { "clean" },
+            "ok": !hostile,
+            "agent": agent,
+            "hub": base,
+            "receipts": observed,
+            "anchored": anchored,
+            "anchored_verified": verified,
+            "anchored_invalid": invalid,
+            "completeness": completeness,
+            "omission": omission,
+            "consistency": consistency,
+            "equivocation_or_regression": anomaly,
+            "append_only": append_only,
+            "append_only_failed": append_anomaly,
+            "entries": entries.iter().map(|e| serde_json::json!({
+                "artifact_id": e.get("artifact_id"),
+                "kind": e.get("kind"),
+                "action": e.get("action"),
+                "anchored": e.get("merkle_anchor").map(|v| !v.is_null()).unwrap_or(false),
+            })).collect::<Vec<_>>(),
+        }));
+        return Ok(hostile);
+    }
 
     let receipts_str = observed.to_string();
     let anchored_str = format!("{verified}/{anchored} verified");
@@ -228,7 +272,7 @@ fn audit_once(base: &str, agent: &str, trust: &TrustRootStore, printer: &Printer
         "metadata + anchors only, never payloads. each anchored entry's inclusion is re-verified offline against your trust roots; completeness is checked against the agent's committed evidence_anchor (omission detectable for committed sets, not absolute). consistency witnesses the checkpoint across audits to catch a forking/regressing hub; append-only re-verifies the hub's Merkle consistency chain offline to prove the log only appended since you last witnessed it (no rewrite).",
     );
     printer.blank();
-    Ok(())
+    Ok(hostile)
 }
 
 /// Fetch one artifact's Merkle proof from the Hub and re-verify it offline:

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -192,6 +192,37 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     };
     let in_scope_str = in_scope.to_string();
     let oos_str = violations.len().to_string();
+
+    // A hostile verdict must be machine-visible: nonzero exit and, in JSON
+    // mode, one structured object carrying the full verdict (printer.info /
+    // warn are suppressed or stream separate objects in JSON — useless to a
+    // programmatic caller). A verifier that detects a revoked card or
+    // out-of-scope actions and exits 0 is lying to every script gating on it.
+    let hostile = revocation.is_some() || !violations.is_empty();
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "verdict": status,
+            "ok": !hostile,
+            "card": card_id,
+            "agent": card_agent,
+            "key_bound": key_bound,
+            "declared_tools": tools,
+            "provenance": provenance_str,
+            "in_scope": in_scope,
+            "out_of_scope": violations.len(),
+            "violations": violations
+                .iter()
+                .map(|(id, tool)| serde_json::json!({ "artifact": id, "action": tool }))
+                .collect::<Vec<_>>(),
+            "revocation": revocation
+                .as_ref()
+                .map(|(reason, who)| serde_json::json!({ "by": who, "reason": reason })),
+        }));
+        if hostile {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
     printer.success(
         "capability card",
         &[
@@ -234,6 +265,9 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
         "consistency over captured evidence: proves in/out-of-scope for actions Treeship recorded, not that no off-card action occurred (that is Guard's runtime job).",
     );
     printer.blank();
+    if hostile {
+        std::process::exit(1);
+    }
     Ok(())
 }
 

--- a/packages/cli/src/commands/present.rs
+++ b/packages/cli/src/commands/present.rs
@@ -570,6 +570,38 @@ pub fn verify_presentation(
     };
 
     let ok = revoked.is_none() && key_bound && !stale && challenge_ok;
+
+    // JSON mode: one structured object with the complete verdict. The text
+    // path below reports via printer.info, which JSON mode suppresses — a
+    // programmatic caller (the gateway) must never receive an empty success
+    // envelope in place of a verdict.
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "verdict": status,
+            "ok": ok,
+            "agent": agent,
+            "card": card_id,
+            "signature": sig_str,
+            "key_bound": key_bound,
+            "via_chain": via_chain,
+            "staple": {
+                "detail": staple_str,
+                "verified": staple_ok,
+                "age_secs": staple_age_secs,
+                "stale": stale,
+            },
+            "challenge": challenge_str,
+            "challenge_checked": challenge.is_some(),
+            "challenge_ok": if challenge.is_some() { Some(challenge_ok) } else { None },
+            "revocation": revocation_str,
+            "revoked": revoked,
+        }));
+        if !ok {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     let headline = "presentation";
     if ok {
         printer.success(headline, &[]);
@@ -594,7 +626,7 @@ pub fn verify_presentation(
         printer.blank();
     }
     if !ok {
-        return Err("presentation did not verify".into());
+        return Err(format!("presentation did not verify — status: {status}").into());
     }
     Ok(())
 }

--- a/packages/cli/src/commands/resolve.rs
+++ b/packages/cli/src/commands/resolve.rs
@@ -197,6 +197,35 @@ pub fn resolve(
     };
     let behavior_str =
         format!("{total} captured actions ({in_scope} in scope, {out_of_scope} out)");
+
+    // Hostile verdicts are machine-visible: nonzero exit, and in JSON mode a
+    // single structured verdict object (the text path's info/warn lines are
+    // suppressed or stream separately in JSON). A resolver that detects a
+    // revoked card or violations and exits 0 lies to every script gating on it.
+    let hostile = revocation.is_some() || (card_key_bound && out_of_scope > 0);
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "verdict": status,
+            "ok": !hostile,
+            "agent": agent,
+            "key": key_id,
+            "key_provenance": key_grade,
+            "current_card": card_id,
+            "declared_tools": tools,
+            "capabilities": cap_grade,
+            "capability_mix": provenance_str,
+            "captured_actions": total,
+            "in_scope": in_scope,
+            "out_of_scope": out_of_scope,
+            "revocation": revocation
+                .as_ref()
+                .map(|(reason, who)| serde_json::json!({ "by": who, "reason": reason })),
+        }));
+        if hostile {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
     printer.success(
         "agent resolved",
         &[
@@ -222,6 +251,9 @@ pub fn resolve(
         "every field is re-derived from local artifacts, not a stored verdict. captured = the machine observed it; checked = a claim cross-verified against captured evidence; asserted = a bare claim.",
     );
     printer.blank();
+    if hostile {
+        std::process::exit(1);
+    }
     Ok(())
 }
 
@@ -587,6 +619,33 @@ fn resolve_remote(hub: &str, agent: &str, trust: &TrustRootStore, printer: &Prin
         "resolved (UNVERIFIED)"
     };
 
+    // Remote hostile verdicts: a revoked card, OR a signature that failed
+    // against the verifier's roots (UNVERIFIED means verification FAILED —
+    // matching verify-presentation's semantics — not merely "ungraded").
+    // Machine-visible: nonzero exit + one structured JSON verdict object.
+    let hostile = revocation.is_some() || !sig_ok;
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "verdict": status,
+            "ok": !hostile,
+            "agent": agent,
+            "hub": base,
+            "current_card": card_id,
+            "signature": sig_str,
+            "key_bound": key_bound,
+            "via_chain": chain_cert_id.is_some(),
+            "chain_cert": chain_cert_id,
+            "declared_tools": tools,
+            "capability_mix": mix_str,
+            "transparency": transparency_str,
+            "revocation": revocation,
+        }));
+        if hostile {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
     printer.success(
         "agent resolved (remote)",
         &[
@@ -609,6 +668,9 @@ fn resolve_remote(hub: &str, agent: &str, trust: &TrustRootStore, printer: &Prin
         "re-verified client-side against YOUR trust roots; the hub's word is not trusted. the exercised grade needs the agent's receipts (run `treeship resolve` locally).",
     );
     printer.blank();
+    if hostile {
+        std::process::exit(1);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What (audit Batch A — the P0)

`resolve`, `audit`, and `verify-capability` computed hostile verdicts — **REVOKED cards, violations, OMISSION, invalid inclusions, equivocation, failed append-only proofs** — printed a ⚠, and **exited 0**. A monitor gating on exit code treated a detected history rewrite as success. The single worst brand contradiction found by the full-codebase audit.

### Changes
- **Nonzero exits** on hostile verdicts across all four verification surfaces (`resolve` local+remote, `audit` one-shot, `verify-capability`, `verify-presentation`). `audit --watch` deliberately keeps looping and alerting — a monitor's job is to keep watching.
- **Real `--format json`**: one structured verdict object per command with every field the text path shows. Previously: bare success envelopes (`resolve`, `verify-capability`), essentially-empty output (`verify-presentation` — its verdict went through `printer.info`, suppressed in JSON), and concatenated multi-object streams (`audit`). This unblocks every programmatic caller — bridges, CI, and the gateway.
- `audit` distinguishes invalid inclusions from proof-unavailable fetch errors; JSON verdict carries `anchored` / `anchored_verified` / `anchored_invalid`.
- `verify-presentation`'s bare failure error now names the status.

### Verified live
- `verify-capability` (card with violations): exit 1 in text and JSON, violations array populated
- `audit --format json`: **single parseable object** (was an unparseable stream)
- `verify-presentation --format json`: full verdict (signature/key_bound/staple/challenge/revocation)

### Follow-up noted (not this PR)
Witnessing advances its stored checkpoint even when the append-only proof FAILED — the rewrite alarm fires once, then auto-forgives. Filed for the hardening batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8