### PR TITLE
fix(hub): hardening — body caps, indexes, enforced FKs, idempotent checkpoints, DPoP tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- **Hub hardening (audit Batch G).** Four fixes and a test wall for the network layer: **(1)** request bodies on `POST /v1/artifacts` and all `POST /v1/merkle/*` are now capped at 10 MB (the receipts handler always was; the other four buffered unbounded uploads into memory). **(2)** New indexes `artifacts(payload_type, signed_at)` and `artifacts(dock_id)` — the public, unauthenticated `GET /v1/agents` and `/v1/agents/log` endpoints were full-table scans that decode every receipt row per request and only get slower as the log grows. **(3)** `PRAGMA foreign_keys=ON`: every `REFERENCES` clause in the schema was decorative (SQLite ignores them unless enabled); a write claiming a dock the hub never registered is now refused by the database itself. **(4)** Re-POSTing a checkpoint no longer inserts a duplicate row forever — `InsertCheckpoint` is idempotent on its natural key (signer, root, tree_size) and returns the original row's id, matching the artifact/consistency insert discipline. **(5)** The public `GET /v1/verify/{id}` no longer echoes the verifier's stderr and internal error strings to anonymous callers (logged server-side; the response is a generic verdict — anyone wanting detail runs `treeship verify` themselves). And the **DPoP authentication boundary — through which every authenticated write funnels — now has a test suite** (it had zero): the accept path plus jti replay, foreign-key signature, unknown dock, htm/htu binding mismatches, clock skew, alg confusion, malformed JWTs, and payload tampering under a stale signature are all pinned.
+
 ## 0.17.1 (2026-07-06)
 
 ### Fixed

--- a/packages/hub/internal/artifacts/artifacts.go
+++ b/packages/hub/internal/artifacts/artifacts.go
@@ -51,6 +51,9 @@ func (h *Handlers) Push(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req pushRequest
+	// Cap request body at 10 MB (same rule as receipts): an authenticated
+	// dock must not be able to buffer arbitrary gigabytes into hub memory.
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -119,6 +119,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   receipt_json  TEXT,
   uploaded_at   INTEGER
 );
+CREATE INDEX IF NOT EXISTS idx_artifacts_payload_type ON artifacts(payload_type, signed_at);
+CREATE INDEX IF NOT EXISTS idx_artifacts_dock_id ON artifacts(dock_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_dock_id ON sessions(dock_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_uploaded_at ON sessions(uploaded_at);
 
@@ -160,6 +162,13 @@ func Open() (*sql.DB, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
+	}
+
+	// Enforce the schema's REFERENCES clauses — SQLite ignores them unless
+	// this pragma is on, so without it every foreign key is decorative.
+	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	// WAL mode for better concurrency.
@@ -516,6 +525,23 @@ type MerkleCheckpoint struct {
 }
 
 func InsertCheckpoint(database *sql.DB, cp *MerkleCheckpoint, dockID string) (int64, error) {
+	// Idempotent on the checkpoint's natural key (signer, root, tree_size):
+	// re-running `merkle publish` re-POSTs the same checkpoint, and before
+	// this guard every re-publish inserted a duplicate row forever (the
+	// autoincrement PK never collides). Same select-first shape as
+	// InsertConsistency; returns the existing row's id so callers behave
+	// identically on the repeat.
+	var existing int64
+	err := database.QueryRow(
+		`SELECT id FROM merkle_checkpoints
+		 WHERE signer_key_id = ? AND root_hex = ? AND tree_size = ?
+		 LIMIT 1`,
+		cp.SignerKeyID, cp.RootHex, cp.TreeSize,
+	).Scan(&existing)
+	if err == nil {
+		return existing, nil
+	}
+
 	res, err := database.Exec(
 		`INSERT INTO merkle_checkpoints (root_hex, tree_size, height, signed_at, signer_key_id, signature_b64, public_key_b64, rekor_index, dock_id)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,

--- a/packages/hub/internal/db/db_test.go
+++ b/packages/hub/internal/db/db_test.go
@@ -50,3 +50,61 @@ func TestInsertArtifactIdempotent(t *testing.T) {
 		t.Fatalf("stored envelope was overwritten: %q", got.EnvelopeJSON)
 	}
 }
+
+// InsertCheckpoint must be idempotent on its natural key: re-running
+// `merkle publish` re-POSTs the same checkpoint, and before the guard every
+// re-publish inserted a duplicate row forever (autoincrement PK never
+// collides). The repeat must return the ORIGINAL row's id.
+func TestInsertCheckpointIdempotent(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := Open()
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	defer database.Close()
+
+	// Checkpoints reference a real dock — and with foreign keys now
+	// actually enforced (PRAGMA foreign_keys=ON), a fabricated dock_id is
+	// refused at the database, which this test also pins below.
+	if err := InsertShip(database, "dck_cp", []byte("shippub"), []byte("dockpub"), 1); err != nil {
+		t.Fatalf("insert ship: %v", err)
+	}
+
+	cp := &MerkleCheckpoint{
+		RootHex: "ab12", TreeSize: 42, Height: 6,
+		SignedAt: "2026-07-06T12:00:00Z", SignerKeyID: "key_s",
+		SignatureB64: "sig", PublicKeyB64: "pub",
+	}
+	id1, err := InsertCheckpoint(database, cp, "dck_cp")
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	id2, err := InsertCheckpoint(database, cp, "dck_cp")
+	if err != nil {
+		t.Fatalf("repeat insert: %v", err)
+	}
+	if id1 != id2 {
+		t.Fatalf("repeat must return the original id: %d vs %d", id1, id2)
+	}
+
+	// A genuinely different checkpoint (same signer, new size) still inserts.
+	cp2 := *cp
+	cp2.TreeSize = 43
+	cp2.RootHex = "cd34"
+	id3, err := InsertCheckpoint(database, &cp2, "dck_cp")
+	if err != nil {
+		t.Fatalf("new checkpoint insert: %v", err)
+	}
+	if id3 == id1 {
+		t.Fatalf("distinct checkpoint must get a new row")
+	}
+
+	// Foreign keys are enforced: a checkpoint claiming a dock the hub has
+	// never registered must be refused by the database itself.
+	cp3 := *cp
+	cp3.TreeSize = 44
+	cp3.RootHex = "ef56"
+	if _, err := InsertCheckpoint(database, &cp3, "dck_ghost"); err == nil {
+		t.Fatalf("unknown dock_id must violate the foreign key")
+	}
+}

--- a/packages/hub/internal/dpop/dpop_test.go
+++ b/packages/hub/internal/dpop/dpop_test.go
@@ -1,0 +1,230 @@
+package dpop
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/treeship/hub/internal/db"
+)
+
+// The DPoP verifier is the hub's entire authentication boundary — every
+// authenticated write (artifacts, checkpoints, proofs, receipts) funnels
+// through Verify. These tests pin the accept path and every rejection
+// branch with real Ed25519 keys, so a regression here is a failing test,
+// not a silent auth bypass.
+
+type testDock struct {
+	dockID string
+	priv   ed25519.PrivateKey
+}
+
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	return database
+}
+
+func registerDock(t *testing.T, database *sql.DB, dockID string) testDock {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	if err := db.InsertShip(database, dockID, pub, pub, time.Now().Unix()); err != nil {
+		t.Fatalf("insert ship: %v", err)
+	}
+	return testDock{dockID: dockID, priv: priv}
+}
+
+type proofOpts struct {
+	alg    string
+	typ    string
+	iat    int64
+	jti    string
+	htm    string
+	htu    string
+	signer ed25519.PrivateKey // overrides the dock's key when set
+}
+
+func (d testDock) proof(t *testing.T, opts proofOpts) string {
+	t.Helper()
+	if opts.alg == "" {
+		opts.alg = "EdDSA"
+	}
+	if opts.typ == "" {
+		opts.typ = "dpop+jwt"
+	}
+	if opts.iat == 0 {
+		opts.iat = time.Now().Unix()
+	}
+	h, _ := json.Marshal(map[string]string{"alg": opts.alg, "typ": opts.typ})
+	p, _ := json.Marshal(map[string]any{
+		"iat": opts.iat, "jti": opts.jti, "htm": opts.htm, "htu": opts.htu,
+	})
+	enc := base64.RawURLEncoding.EncodeToString
+	msg := enc(h) + "." + enc(p)
+	key := d.priv
+	if opts.signer != nil {
+		key = opts.signer
+	}
+	sig := ed25519.Sign(key, []byte(msg))
+	return msg + "." + enc(sig)
+}
+
+// verifyWith runs Verify against a synthetic request and returns
+// (dock_id, http status). Status is 200 when Verify never wrote an error.
+func verifyWith(database *sql.DB, dockID, jwt, method, target string) (string, int) {
+	r := httptest.NewRequest(method, target, nil)
+	r.Header.Set("Authorization", "DPoP "+dockID)
+	r.Header.Set("DPoP", jwt)
+	w := httptest.NewRecorder()
+	got := Verify(database, w, r)
+	return got, w.Code
+}
+
+const testURL = "http://hub.test/v1/artifacts"
+
+func TestVerifyAcceptsValidProofAndBurnsJTI(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_ok")
+
+	jwt := d.proof(t, proofOpts{jti: "jti-1", htm: "POST", htu: testURL})
+	got, code := verifyWith(database, d.dockID, jwt, "POST", testURL)
+	if got != d.dockID || code != 200 {
+		t.Fatalf("valid proof must pass: got=%q code=%d", got, code)
+	}
+
+	// The SAME proof replayed must reject: jti is single-use.
+	got, code = verifyWith(database, d.dockID, jwt, "POST", testURL)
+	if got != "" || code != 401 {
+		t.Fatalf("replayed jti must reject: got=%q code=%d", got, code)
+	}
+}
+
+func TestVerifyRejectsWrongKeySignature(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_a")
+	_, otherPriv, _ := ed25519.GenerateKey(rand.Reader)
+
+	// Signed by a key that is NOT the dock's registered key.
+	jwt := d.proof(t, proofOpts{jti: "jti-forge", htm: "POST", htu: testURL, signer: otherPriv})
+	if got, code := verifyWith(database, d.dockID, jwt, "POST", testURL); got != "" || code != 401 {
+		t.Fatalf("foreign-key signature must reject: got=%q code=%d", got, code)
+	}
+}
+
+func TestVerifyRejectsUnknownDock(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_known")
+
+	jwt := d.proof(t, proofOpts{jti: "jti-ghost", htm: "POST", htu: testURL})
+	// Valid proof, but presented under a dock_id the hub has never seen —
+	// the exact post-database-wipe condition that motivated the attach probe.
+	if got, code := verifyWith(database, "dck_ghost", jwt, "POST", testURL); got != "" || code != 401 {
+		t.Fatalf("unknown dock must reject: got=%q code=%d", got, code)
+	}
+}
+
+func TestVerifyRejectsMethodAndURLBindingMismatches(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_bind")
+
+	// htm says POST, request is GET: a captured proof must not authorize a
+	// different operation.
+	jwt := d.proof(t, proofOpts{jti: "jti-htm", htm: "POST", htu: testURL})
+	if got, code := verifyWith(database, d.dockID, jwt, "GET", testURL); got != "" || code != 401 {
+		t.Fatalf("htm mismatch must reject: got=%q code=%d", got, code)
+	}
+
+	// htu bound to a different endpoint: a proof minted for one URL must
+	// not authorize another.
+	jwt = d.proof(t, proofOpts{jti: "jti-htu", htm: "POST", htu: "http://hub.test/v1/merkle/checkpoint"})
+	if got, code := verifyWith(database, d.dockID, jwt, "POST", testURL); got != "" || code != 401 {
+		t.Fatalf("htu mismatch must reject: got=%q code=%d", got, code)
+	}
+}
+
+func TestVerifyRejectsClockSkew(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_time")
+
+	for name, iat := range map[string]int64{
+		"stale":  time.Now().Unix() - 120,
+		"future": time.Now().Unix() + 120,
+	} {
+		jwt := d.proof(t, proofOpts{jti: "jti-" + name, iat: iat, htm: "POST", htu: testURL})
+		if got, code := verifyWith(database, d.dockID, jwt, "POST", testURL); got != "" || code != 401 {
+			t.Fatalf("%s iat must reject: got=%q code=%d", name, got, code)
+		}
+	}
+}
+
+func TestVerifyRejectsWrongAlgAndMalformedJWT(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_alg")
+
+	// alg confusion: only EdDSA/dpop+jwt is accepted.
+	jwt := d.proof(t, proofOpts{alg: "none", jti: "jti-alg", htm: "POST", htu: testURL})
+	if got, code := verifyWith(database, d.dockID, jwt, "POST", testURL); got != "" || code != 401 {
+		t.Fatalf("alg=none must reject: got=%q code=%d", got, code)
+	}
+
+	for name, raw := range map[string]string{
+		"two-part":   "aaaa.bbbb",
+		"not-base64": "!!.!!.!!",
+		"empty":      "",
+	} {
+		if got, code := verifyWith(database, d.dockID, raw, "POST", testURL); got != "" || code != 401 {
+			t.Fatalf("%s JWT must reject: got=%q code=%d", name, got, code)
+		}
+	}
+
+	// Missing/blank Authorization forms.
+	r := httptest.NewRequest("POST", testURL, nil)
+	r.Header.Set("DPoP", d.proof(t, proofOpts{jti: "jti-noauth", htm: "POST", htu: testURL}))
+	w := httptest.NewRecorder()
+	if got := Verify(database, w, r); got != "" || w.Code != 401 {
+		t.Fatalf("missing Authorization must reject: got=%q code=%d", got, w.Code)
+	}
+}
+
+func TestVerifyTamperedPayloadRejects(t *testing.T) {
+	database := openTestDB(t)
+	d := registerDock(t, database, "dck_tamper")
+
+	jwt := d.proof(t, proofOpts{jti: "jti-t", htm: "POST", htu: testURL})
+	// Swap in a fresh payload under the ORIGINAL signature.
+	h, _ := json.Marshal(map[string]string{"alg": "EdDSA", "typ": "dpop+jwt"})
+	p, _ := json.Marshal(map[string]any{
+		"iat": time.Now().Unix(), "jti": "jti-t2", "htm": "POST", "htu": testURL,
+	})
+	enc := base64.RawURLEncoding.EncodeToString
+	// Take the ORIGINAL signature but swap in a fresh payload.
+	origSig := jwt[len(jwt)-fmtLen(jwt):]
+	tampered := enc(h) + "." + enc(p) + "." + origSig
+	if got, code := verifyWith(database, d.dockID, tampered, "POST", testURL); got != "" || code != 401 {
+		t.Fatalf("tampered payload with stale signature must reject: got=%q code=%d", got, code)
+	}
+}
+
+// fmtLen returns the length of the final JWT segment (the signature).
+func fmtLen(jwt string) int {
+	for i := len(jwt) - 1; i >= 0; i-- {
+		if jwt[i] == '.' {
+			return len(jwt) - i - 1
+		}
+	}
+	return 0
+}

--- a/packages/hub/internal/merkle/handlers.go
+++ b/packages/hub/internal/merkle/handlers.go
@@ -38,6 +38,8 @@ func (h *Handlers) PublishCheckpoint(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req checkpointRequest
+	// Cap request body at 10 MB (same rule as receipts/artifacts).
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
@@ -90,6 +92,8 @@ func (h *Handlers) PublishProof(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req proofRequest
+	// Cap request body at 10 MB (same rule as receipts/artifacts).
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
@@ -204,6 +208,8 @@ func (h *Handlers) PublishConsistency(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req consistencyRequest
+	// Cap request body at 10 MB (same rule as receipts/artifacts).
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return

--- a/packages/hub/internal/verify/verify.go
+++ b/packages/hub/internal/verify/verify.go
@@ -3,6 +3,7 @@ package verify
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
 	"net/http"
 	"os/exec"
 
@@ -47,20 +48,21 @@ func (h *Handlers) Verify(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// treeship exited with error -- return the stderr or a generic message.
+		// treeship exited nonzero. This is a PUBLIC, unauthenticated
+		// endpoint: internal verifier stderr and Go error strings are
+		// implementation detail an anonymous caller has no business
+		// reading (paths, versions, panic text). Log server-side, return
+		// a generic verdict. The artifact is client-verifiable anyway --
+		// anyone who wants detail runs `treeship verify` themselves.
 		if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"outcome": "error",
-				"message": string(exitErr.Stderr),
-			})
-			return
+			log.Printf("verify %s: %s", id, string(exitErr.Stderr))
+		} else {
+			log.Printf("verify %s: %v", id, err)
 		}
-
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"outcome": "error",
-			"message": "verification failed: " + err.Error(),
+			"message": "verification failed",
 		})
 		return
 	}


### PR DESCRIPTION
Batch G of the full-codebase audit, closing the program.

- 10 MB MaxBytesReader on POST /v1/artifacts + all POST /v1/merkle/*
  (receipts already had it; the other four buffered unbounded bodies)
- Indexes artifacts(payload_type, signed_at) + artifacts(dock_id):
  the public unauthenticated /v1/agents endpoints were full scans
  decoding every receipt row per request, worsening monotonically
- PRAGMA foreign_keys=ON: every REFERENCES clause was decorative;
  writes claiming unregistered docks are now refused by the DB (all
  legitimate paths take dock_id from DPoP verification, which only
  returns registered ships — verified caller-by-caller)
- InsertCheckpoint idempotent on (signer_key_id, root_hex, tree_size),
  returning the original row id: re-running merkle publish inserted a
  duplicate checkpoint row forever
- GET /v1/verify/{id} no longer echoes verifier stderr / internal
  error strings to anonymous callers (logged server-side, generic
  verdict returned)
- dpop package: the auth boundary every authenticated write funnels
  through had ZERO tests. New suite pins the accept path + jti replay,
  foreign-key signature, unknown dock (the post-wipe condition), htm/
  htu binding mismatches, clock skew both directions, alg confusion,
  malformed JWTs, and payload tampering under a stale signature. The
  FK pragma immediately caught the first draft of the checkpoint test
  passing a fabricated dock id — enforcement demonstrably works, and
  the test now pins that too.

go test ./... green across the hub.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8
