### PR TITLE
feat(match): find agents by exercised evidence (work-history slice 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- **`treeship match --exercised <glob>` + `GET /v1/agents/match` — find agents by exercised evidence (work-history slice 4, completing the spec).** Declared capability gets an agent *found*; exercised history gets it *chosen*. The Hub indexes `tools_exercised` from the signed `session.v1` records it already holds and proposes candidates (filterable by `--class` and `--min-sessions`, ranked by matched session count); it grades nothing. The client **re-verifies every candidate's records on this machine** — each envelope signature against your own trust roots, and the glob match recomputed locally with the shared `tool_matches` (never trusting the Hub's own match) — then re-ranks by *verified* sessions, showing a Hub-proposed candidate whose records don't verify honestly as `unverified` rather than silently trusting it. The honest version of an agent marketplace: the search is a lead, the verdict is always recomputed locally. Gated on record density by design — it is only as good as the published history under it. Hub handler covered by tests (glob match, class filter, min-sessions, ranking, missing-param 400). See the [work-history spec](docs/specs/work-history.md).
+
+
 ## 0.18.0 (2026-07-07)
 
 ### Added

--- a/packages/cli/src/commands/match.rs
+++ b/packages/cli/src/commands/match.rs
@@ -1,0 +1,166 @@
+//! `treeship match --hub <url> --exercised <glob>` — find agents by their
+//! EXERCISED evidence (docs/specs/work-history.md slice 4).
+//!
+//! Declared capability gets an agent *found*; exercised history gets it
+//! *chosen*. The Hub indexes `tools_exercised` from the typed session.v1
+//! records it already holds and proposes candidates; it grades nothing. The
+//! client re-verifies every candidate's records on this machine — each
+//! record's envelope signature against YOUR trust roots, each claimed anchor
+//! re-proved offline — and ranks by *verified* evidence, so a candidate the
+//! Hub proposes but whose records don't verify is shown honestly as
+//! unverified, never silently trusted. This is the honest version of an
+//! agent marketplace: the search is only ever a lead, the verdict is always
+//! recomputed locally.
+
+use crate::commands::resolve::verifier_from_trust;
+use crate::printer::Printer;
+use treeship_core::attestation::Envelope;
+use treeship_core::capability::tool_matches;
+use treeship_core::statements::ReceiptStatement;
+use treeship_core::trust::TrustRootStore;
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+pub fn match_agents(
+    hub: &str,
+    exercised: &str,
+    class: Option<&str>,
+    min_sessions: usize,
+    printer: &Printer,
+) -> CmdResult {
+    let trust = TrustRootStore::open_default_or_empty()?;
+    let base = hub.trim_end_matches('/');
+
+    let mut req = ureq::get(&format!("{base}/v1/agents/match")).query("exercised", exercised);
+    if let Some(c) = class {
+        req = req.query("class", c);
+    }
+    if min_sessions > 1 {
+        req = req.query("min_sessions", &min_sessions.to_string());
+    }
+    let resp: serde_json::Value = req
+        .call()
+        .map_err(|e| format!("could not reach hub {base}: {e}"))?
+        .into_json()
+        .map_err(|e| format!("hub returned invalid JSON: {e}"))?;
+
+    let verifier = verifier_from_trust(&trust);
+
+    struct Candidate {
+        agent: String,
+        matched_tools: Vec<String>,
+        proposed_sessions: usize,
+        verified_sessions: usize,
+        verified_matches: bool,
+    }
+    let mut candidates: Vec<Candidate> = Vec::new();
+
+    for c in resp
+        .get("candidates")
+        .and_then(|v| v.as_array())
+        .unwrap_or(&Vec::new())
+    {
+        let agent = c
+            .get("agent")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let matched_tools: Vec<String> = c
+            .get("matched_tools")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|t| t.as_str().map(String::from)).collect())
+            .unwrap_or_default();
+        let proposed = c
+            .get("matched_sessions")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+
+        // Re-verify each record the Hub returned: the envelope must verify
+        // against our roots, be a session.v1 for THIS agent, and actually
+        // exercise a tool matching the glob (never trust the Hub's own
+        // match — recompute it here with the shared matcher).
+        let mut verified = 0usize;
+        if let Some(records) = c.get("records").and_then(|v| v.as_array()) {
+            for rec in records {
+                let Some(ej) = rec.get("envelope_json").and_then(|v| v.as_str()) else { continue };
+                let Ok(env) = serde_json::from_str::<Envelope>(ej) else { continue };
+                if verifier.verify_any(&env).is_err() {
+                    continue;
+                }
+                let Ok(stmt) = env.unmarshal_statement::<ReceiptStatement>() else { continue };
+                if stmt.kind != "session.v1" {
+                    continue;
+                }
+                let Some(p) = stmt.payload else { continue };
+                if p.get("actor").and_then(|v| v.as_str()) != Some(agent.as_str()) {
+                    continue;
+                }
+                let exercises_match = p
+                    .get("tools_exercised")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .filter_map(|t| t.as_str())
+                            .any(|t| tool_matches(exercised, t))
+                    })
+                    .unwrap_or(false);
+                if exercises_match {
+                    verified += 1;
+                }
+            }
+        }
+        candidates.push(Candidate {
+            agent,
+            matched_tools,
+            proposed_sessions: proposed,
+            verified_sessions: verified,
+            verified_matches: verified > 0,
+        });
+    }
+
+    // Rank by VERIFIED sessions (locally recomputed), not the Hub's count.
+    candidates.sort_by(|a, b| b.verified_sessions.cmp(&a.verified_sessions));
+
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "exercised": exercised,
+            "count": candidates.len(),
+            "candidates": candidates.iter().map(|c| serde_json::json!({
+                "agent": c.agent,
+                "matched_tools": c.matched_tools,
+                "proposed_sessions": c.proposed_sessions,
+                "verified_sessions": c.verified_sessions,
+                "verified": c.verified_matches,
+            })).collect::<Vec<_>>(),
+        }));
+        return Ok(());
+    }
+
+    if candidates.is_empty() {
+        printer.warn("no agents match", &[("exercised", exercised)]);
+        printer.hint("no published session.v1 records exercise a tool matching this glob. matching is only as good as the density of published history.");
+        printer.blank();
+        return Ok(());
+    }
+
+    printer.success("evidence match", &[
+        ("exercised", exercised),
+        ("candidates", &candidates.len().to_string()),
+    ]);
+    printer.blank();
+    for c in &candidates {
+        let mark = if c.verified_matches {
+            format!("{} verified", c.verified_sessions)
+        } else {
+            "unverified (records did not verify against your trust roots)".to_string()
+        };
+        printer.info(&format!("  {}  {}/{} sessions {mark}", c.agent, c.verified_sessions, c.proposed_sessions));
+        printer.dim_info(&format!("    exercised: {}", c.matched_tools.join(", ")));
+    }
+    printer.blank();
+    printer.hint(
+        "the hub proposed candidates from its index; each record was re-verified on this machine against YOUR trust roots. ranked by verified sessions. pin an agent's key (treeship trust add) to move it from unverified to verified.",
+    );
+    printer.blank();
+    Ok(())
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -29,6 +29,8 @@ pub mod onboard;
 pub mod present;
 pub mod history;
 pub mod profile;
+#[path = "match.rs"]
+pub mod match_cmd;
 pub mod approval;
 pub mod cards;
 pub mod discovery;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -348,6 +348,16 @@ enum Command {
     ///   treeship verify-profile art_a1b2c3
     VerifyProfile(VerifyProfileCliArgs),
 
+    /// Find agents by their EXERCISED evidence: which agents actually ran
+    /// tools matching a glob, ranked by verified session count. The hub
+    /// proposes candidates from its index; every record is re-verified on
+    /// this machine against your trust roots.
+    ///
+    /// Examples:
+    ///   treeship match --hub https://api.treeship.dev --exercised "payments.*"
+    ///   treeship match --hub <url> --exercised "Bash(git:*)" --class countersigned --min-sessions 2
+    Match(MatchCliArgs),
+
     /// Manage the local Agent Card store
     ///
     /// Cards are workspace trust objects -- who an agent is, where it
@@ -1843,6 +1853,25 @@ struct VerifyPresentationCliArgs {
 }
 
 #[derive(clap::Args)]
+struct MatchCliArgs {
+    /// Hub to query
+    #[arg(long, required = true, value_name = "URL")]
+    hub: String,
+
+    /// Tool glob the agent must have exercised (e.g. "payments.*")
+    #[arg(long, required = true, value_name = "GLOB")]
+    exercised: String,
+
+    /// Only sessions with this attestation class (self | runtime | countersigned)
+    #[arg(long, value_name = "CLASS")]
+    class: Option<String>,
+
+    /// Minimum matching sessions a candidate must have
+    #[arg(long, default_value = "1", value_name = "N")]
+    min_sessions: usize,
+}
+
+#[derive(clap::Args)]
 struct ProfileCliArgs {
     /// Agent name or agent:// URI
     #[arg(value_name = "AGENT")]
@@ -2494,6 +2523,14 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             &a.file,
             a.max_staple_age.as_deref(),
             a.challenge.as_deref(),
+            printer,
+        ),
+
+        Command::Match(a) => commands::match_cmd::match_agents(
+            &a.hub,
+            &a.exercised,
+            a.class.as_deref(),
+            a.min_sessions,
             printer,
         ),
 

--- a/packages/hub/internal/agents/agents.go
+++ b/packages/hub/internal/agents/agents.go
@@ -14,6 +14,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/treeship/hub/internal/db"
 )
@@ -369,5 +371,135 @@ func (h *Handlers) History(w http.ResponseWriter, r *http.Request) {
 		"entries": entries,
 		"count":   len(entries),
 		"note":    "raw signed session.v1 envelopes + Merkle anchors. the client re-verifies signatures and inclusion against its own trust roots; the Hub filters and serves, never interprets.",
+	})
+}
+
+// toolGlobMatches mirrors treeship_core::capability::tool_matches: a single
+// '*' anywhere in the pattern (prefix before it must prefix the value, suffix
+// after must suffix it); otherwise exact. Kept byte-identical in behavior so
+// the Hub's index filter cannot disagree with the client's verification.
+func toolGlobMatches(pattern, value string) bool {
+	star := strings.IndexByte(pattern, '*')
+	if star < 0 {
+		return pattern == value
+	}
+	prefix, suffix := pattern[:star], pattern[star+1:]
+	return len(value) >= len(prefix)+len(suffix) &&
+		strings.HasPrefix(value, prefix) &&
+		strings.HasSuffix(value, suffix)
+}
+
+// Match handles GET /v1/agents/match?exercised=<glob>&class=<c>&min_sessions=<n>
+// — the evidence-matching query (docs/specs/work-history.md slice 4). It scans
+// session.v1 records, groups by actor, and returns agents whose EXERCISED
+// evidence (tools actually recorded in their sessions) matches the glob, with
+// each candidate's matching records as raw signed envelopes so the client
+// re-verifies them itself. This is a metadata index over data the Hub already
+// holds; it grades nothing. "Declared capability gets you found; exercised
+// history gets you chosen" — and the Hub only proposes candidates, the client
+// decides.
+func (h *Handlers) Match(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	exercised := r.URL.Query().Get("exercised")
+	if exercised == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing exercised query parameter (a tool glob, e.g. payments.*)"})
+		return
+	}
+	classFilter := r.URL.Query().Get("class")
+	minSessions := 1
+	if v := r.URL.Query().Get("min_sessions"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			minSessions = n
+		}
+	}
+
+	receipts, err := db.ListArtifactsByPayloadType(h.DB, receiptPayloadType)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query failed"})
+		return
+	}
+
+	type record struct {
+		ArtifactID   string      `json:"artifact_id"`
+		EnvelopeJSON string      `json:"envelope_json"`
+		MerkleAnchor interface{} `json:"merkle_anchor"`
+	}
+	type candidate struct {
+		Agent          string   `json:"agent"`
+		MatchedTools   []string `json:"matched_tools"`
+		MatchedSessions int     `json:"matched_sessions"`
+		Records        []record `json:"records"`
+		toolSet        map[string]bool
+	}
+	cands := map[string]*candidate{}
+
+	for _, a := range receipts {
+		payload, _ := decodeStatementPayload(a.EnvelopeJSON)
+		if payload == nil {
+			continue
+		}
+		var stmt receiptStatement
+		if json.Unmarshal(payload, &stmt) != nil || stmt.Kind != "session.v1" {
+			continue
+		}
+		var p struct {
+			Actor            string   `json:"actor"`
+			AttestationClass string   `json:"attestation_class"`
+			ToolsExercised   []string `json:"tools_exercised"`
+		}
+		if json.Unmarshal(stmt.Payload, &p) != nil || p.Actor == "" {
+			continue
+		}
+		if classFilter != "" && p.AttestationClass != classFilter {
+			continue
+		}
+		var hit []string
+		for _, tool := range p.ToolsExercised {
+			if toolGlobMatches(exercised, tool) {
+				hit = append(hit, tool)
+			}
+		}
+		if len(hit) == 0 {
+			continue
+		}
+		c := cands[p.Actor]
+		if c == nil {
+			c = &candidate{Agent: p.Actor, toolSet: map[string]bool{}}
+			cands[p.Actor] = c
+		}
+		c.MatchedSessions++
+		for _, t := range hit {
+			if !c.toolSet[t] {
+				c.toolSet[t] = true
+				c.MatchedTools = append(c.MatchedTools, t)
+			}
+		}
+		c.Records = append(c.Records, record{
+			ArtifactID:   a.ArtifactID,
+			EnvelopeJSON: a.EnvelopeJSON,
+			MerkleAnchor: h.anchorFor(a.ArtifactID),
+		})
+	}
+
+	out := []*candidate{}
+	for _, c := range cands {
+		if c.MatchedSessions >= minSessions {
+			sort.Strings(c.MatchedTools)
+			out = append(out, c)
+		}
+	}
+	// Rank by matched session count (most exercised first), then agent URI.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].MatchedSessions != out[j].MatchedSessions {
+			return out[i].MatchedSessions > out[j].MatchedSessions
+		}
+		return out[i].Agent < out[j].Agent
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"exercised":  exercised,
+		"candidates": out,
+		"count":      len(out),
+		"note":       "candidates whose exercised evidence matches, ranked by matched session count. raw signed envelopes included; the client re-verifies every record. the Hub indexes metadata it holds and grades nothing.",
 	})
 }

--- a/packages/hub/internal/agents/agents_test.go
+++ b/packages/hub/internal/agents/agents_test.go
@@ -252,3 +252,79 @@ func TestHistory_FiltersToAgentSessionRecords(t *testing.T) {
 		t.Fatalf("missing agent must 400, got %d", w2.Code)
 	}
 }
+
+func TestMatch_ByExercisedEvidence(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	// hermes: two sessions exercising payment-ish tools (one countersigned).
+	insertReceipt(t, database, "m1", makeEnvelope(t, "session.v1", map[string]any{
+		"actor": "agent://hermes", "attestation_class": "runtime",
+		"tools_exercised": []string{"payments.charge", "Read(*)"},
+	}, "key_h"), 100)
+	insertReceipt(t, database, "m2", makeEnvelope(t, "session.v1", map[string]any{
+		"actor": "agent://hermes", "attestation_class": "countersigned",
+		"tools_exercised": []string{"payments.refund"},
+	}, "key_h"), 200)
+	// scout: one payment session.
+	insertReceipt(t, database, "m3", makeEnvelope(t, "session.v1", map[string]any{
+		"actor": "agent://scout", "attestation_class": "self",
+		"tools_exercised": []string{"payments.charge"},
+	}, "key_s"), 150)
+	// ghost: exercises something else entirely -> must not match payments.*
+	insertReceipt(t, database, "m4", makeEnvelope(t, "session.v1", map[string]any{
+		"actor": "agent://ghost", "attestation_class": "runtime",
+		"tools_exercised": []string{"Bash(git:status)"},
+	}, "key_g"), 160)
+
+	h := &Handlers{DB: database}
+	get := func(q string) map[string]any {
+		r := httptest.NewRequest("GET", "/v1/agents/match?"+q, nil)
+		w := httptest.NewRecorder()
+		h.Match(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status %d for %q", w.Code, q)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return resp
+	}
+
+	// payments.* -> hermes (2 sessions) ranked above scout (1); ghost absent.
+	resp := get("exercised=payments.*")
+	cands := resp["candidates"].([]any)
+	if len(cands) != 2 {
+		t.Fatalf("want 2 candidates, got %d", len(cands))
+	}
+	first := cands[0].(map[string]any)
+	if first["agent"] != "agent://hermes" || int(first["matched_sessions"].(float64)) != 2 {
+		t.Fatalf("hermes must rank first with 2 sessions, got %v", first["agent"])
+	}
+
+	// class filter narrows hermes to its one countersigned session.
+	resp = get("exercised=payments.*&class=countersigned")
+	cands = resp["candidates"].([]any)
+	if len(cands) != 1 || cands[0].(map[string]any)["agent"] != "agent://hermes" {
+		t.Fatalf("countersigned filter must yield only hermes, got %d", len(cands))
+	}
+
+	// min_sessions=2 drops scout.
+	resp = get("exercised=payments.*&min_sessions=2")
+	if int(resp["count"].(float64)) != 1 {
+		t.Fatalf("min_sessions=2 must yield 1 candidate, got %v", resp["count"])
+	}
+
+	// missing exercised -> 400.
+	r := httptest.NewRequest("GET", "/v1/agents/match", nil)
+	w := httptest.NewRecorder()
+	h.Match(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing exercised must 400, got %d", w.Code)
+	}
+}

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -96,6 +96,7 @@ func main() {
 	// + Merkle anchors only, never payloads). Public; the client re-verifies.
 	r.Get("/v1/agents/log", agentHandlers.Log)
 	r.Get("/v1/agents/history", agentHandlers.History)
+	r.Get("/v1/agents/match", agentHandlers.Match)
 
 	// Well-known revocation list.
 	r.Get("/.well-known/treeship/revoked.json", revokedHandler)


### PR DESCRIPTION
Completes the work-history spec. Declared capability gets an agent
found; exercised history gets it chosen.

Hub: GET /v1/agents/match?exercised=<glob>&class=<c>&min_sessions=<n>
scans session.v1 records, groups by actor, and returns agents whose
tools_exercised match the glob, ranked by matched session count, with
each candidate's matching records as raw signed envelopes. toolGlobMatches
mirrors treeship_core::capability::tool_matches byte-for-byte so the
Hub's index filter cannot disagree with the client's verification. The
Hub indexes metadata it already holds and grades nothing.

CLI: treeship match --hub <url> --exercised <glob> [--class]
[--min-sessions]. Re-verifies EVERY candidate record on this machine —
envelope signature against the client's trust roots, session.v1 for the
claimed actor, and the glob match recomputed locally (never trusting
the Hub's match) — then re-ranks by VERIFIED sessions. A Hub-proposed
candidate whose records don't verify is shown as unverified, never
silently trusted. The honest agent marketplace: search is a lead, the
verdict is recomputed locally.

Deliberately last and density-gated per the spec. Hub handler tested
(glob match, class filter, min-sessions threshold, ranking order,
missing-param 400). Remote live proof follows the hub deploy, as
slice 2 did. Hub + 7 Rust suites green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8
