### PR TITLE
docs: what-to-expect guide, states reference, and a 5-minute walkthrough blog

### DIFF
--- a/docs/content/blog/verify-any-agent-in-five-minutes.mdx
+++ b/docs/content/blog/verify-any-agent-in-five-minutes.mdx
@@ -1,0 +1,166 @@
+---
+title: "Verify any agent in five minutes: a Treeship walkthrough"
+description: "A complete worked example, from installing the CLI to a stranger verifying your agent over the network with nothing but one pinned key. Every command, every expected output, and what each one proves."
+date: 2026-07-07
+tags: ["tutorial", "getting-started", "verification", "handshake"]
+readTime: "8 min read"
+---
+
+Most tools ship with a "hello world." Treeship's is a handshake: by the end of this post, a person who has never met you will verify, on their own machine, that an agent you control is who it claims to be and did what it says it did. No shared server they have to trust, no account, one key.
+
+We will go the whole distance: install, create an agent, sign some work, publish it, and then switch hats and verify it as a skeptical third party. Every command shows the output you should see and, more importantly, what that output *proves*.
+
+## What Treeship actually is
+
+One sentence: Treeship is TLS for agents. TLS answered "how do I know this website is really my bank?" Treeship answers the same question for AI agents: how do I know this agent is who it claims, is allowed to do what it is doing, and actually did what it says?
+
+The mechanism is the same idea browsers use. Every action, approval, handoff, and capability claim becomes a small cryptographically signed document that anyone can verify offline, against no infrastructure. The discipline that makes it trustworthy is one rule applied everywhere: **report how you know something, never assume it.** A fact is labeled `captured` (the machine observed it), `checked` (recomputed from evidence), or `asserted` (a bare claim). Nothing is ever rounded up.
+
+## Step 1: Install
+
+```bash
+npm install -g treeship
+treeship init
+```
+
+```
+✓ ship initialized
+  ship:  ship_a1b2c3…
+  key:   key_… (ed25519, default)
+```
+
+You now have a **ship**: your local signing authority, the thing that issues and vouches for agents. Think of it as a small certificate authority that lives on your laptop. Its private key never leaves the machine.
+
+## Step 2: Create a verifiable agent
+
+The old way was ten commands with four ways to get it subtly wrong. The new way is one:
+
+```bash
+treeship onboard deployer --from-harness ~/.claude/settings.json
+```
+
+```
+[1/4] identity — registering agent://deployer with its own key
+      key: key_… (pinned under AgentCert)
+[2/4] capability card
+      key-bound: yes (AgentCert) · 9 of 9 captured from harness
+[3/4] publish — skipped (local only)
+[4/4] trust bundle — hand these to a counterparty:
+    treeship trust add key_… ed25519:… --kind agent_cert --yes
+✓ agent onboarded
+```
+
+Three things just happened that matter:
+
+1. **The agent got its own key** (`--own-key`, which `onboard` does by default). This is what lets the agent's later actions be *proven*, not merely asserted. The runtime holds the key; the agent itself cannot read it.
+2. **The capability card is key-bound** (`key-bound: yes`). A capability card is a signed document listing what the agent is allowed to do. "Key-bound" means it is cryptographically tied to that agent's key, so it cannot be forged or reattributed.
+3. **The tools were captured, not typed** (`9 of 9 captured from harness`). The list came from reading your real config file, not from someone hand-writing a wish list. That is the strongest kind of capability claim, and it is labeled as such.
+
+## Step 3: Do some work, and sign it
+
+Have the agent record an action:
+
+```bash
+treeship attest action --actor agent://deployer --action "Bash(git:commit)"
+treeship verify <the-artifact-id>
+```
+
+```
+✓ verified  (1 artifact · chain intact)
+  actor:        agent://deployer
+  actor proof:  proven (key-bound)
+  action:       Bash(git:commit)
+```
+
+`actor proof: proven (key-bound)` is the payoff. The receipt was signed by the deployer agent's own key, so "the deployer did this" is not a claim you have to take on faith. It is cryptographically established.
+
+In practice you rarely run `attest` by hand. If your agent runs under Claude Code, Cursor, Hermes, or an MCP or A2A bridge, Treeship captures actions automatically as the agent works. The manual command is here so you can see the primitive.
+
+## Step 4: Publish so others can find it
+
+Everything so far is local. To let someone else verify your agent, attach a hub and publish. A hub is a shared bulletin board that stores your signed documents. It is worth being precise about what a hub is *not*: it verifies nothing, it holds no secrets, and if it vanished tomorrow nothing you signed would become false. It only answers lookups.
+
+```bash
+treeship hub attach                 # one browser approval
+treeship onboard deployer --from-harness ~/.claude/settings.json --publish
+```
+
+The `--publish` run ends by printing your **trust bundle**: the exact commands a counterparty runs to trust you.
+
+```
+[4/4] trust bundle — hand these to a counterparty:
+    treeship trust add key_… ed25519:… --kind ship --yes
+    treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
+```
+
+Two lines. Note that they pin your **ship** key, not the deployer agent's key. This is the leverage: once someone trusts your ship, they can verify *every* agent your ship ever certifies, forever, without pinning anything else. Pin the certificate authority, trust the fleet. It is exactly how your browser trusts millions of websites by shipping a few hundred root certificates.
+
+## Step 5: Switch hats. Verify as a stranger.
+
+Now become the skeptic. On a clean machine (or a fresh config), holding nothing but those two `trust add` lines the deployer's operator sent you:
+
+```bash
+treeship trust add key_… ed25519:… --kind ship --yes
+treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
+
+treeship resolve --hub https://api.treeship.dev agent://deployer
+```
+
+```
+✓ agent resolved (remote)
+  agent:         agent://deployer
+  signature:     verified (chain to pinned ship root)
+  key-bound:     yes (AgentCert via ship chain)
+  declared tools: Bash(git:*), Read(*), …
+  transparency:  anchored & verified (checkpoint #42)
+  status:        resolved (key-bound)
+```
+
+Read those middle lines carefully, because this is the entire point of Treeship:
+
+- **`signature: verified (chain to pinned ship root)`** — you pinned one key (the ship's), and the deployer agent's card verified by following a certificate chain up to it. You never had to pin the agent's own key.
+- **`transparency: anchored & verified`** — the card is provably *in the public log*, not merely signed. This is the "Certificate Transparency" property: you can see that this exact card was published, and detect if it were ever quietly removed.
+
+Every byte of that verdict was recomputed on your machine, against your trust roots. The hub served bytes; you decided what to believe.
+
+## Step 6: The handshake, if you need it live
+
+Resolving a card proves the *record* is real. It does not prove the party you are talking to right now controls that agent, because a resolved card is a public document anyone could show you. For that, challenge them:
+
+```bash
+# you, the verifier, mint a random nonce:
+NONCE=$(openssl rand -hex 16)
+
+# they answer it, signing your nonce with the agent's key:
+treeship present agent://deployer --challenge $NONCE
+
+# you check the answer:
+treeship verify-presentation deployer.presentation.json --challenge $NONCE
+```
+
+```
+challenge:   verified — bearer controls key_… (response 2s old)
+status:      verified (key-bound, anchored, live)
+```
+
+That last line, `live`, is the mutual-TLS moment: not just "this record is real" but "the party across the wire controls this identity, right now." A captured presentation replayed against a new nonce fails with a replay warning. This is the piece a gateway or a payment counterparty demands before acting.
+
+## What you just proved
+
+In five minutes, with no shared trusted server, a stranger established that:
+
+1. Your agent has a real, key-bound identity (not a name anyone can claim).
+2. Its capabilities were captured from a real config (not a wish list).
+3. Its actions were signed by its own key (proven, not asserted).
+4. Its card is in a public, append-only log (anchored, and omission is detectable).
+5. The party presenting it controls the key right now (live).
+
+And the whole time, every verdict told you exactly *how* it knew each fact. That honesty is not a feature bolted on top. It is the product.
+
+## Where to go next
+
+- [What to expect](/docs/guides/what-to-expect) — the same path with a "you are on track when" line at every step, and a table of the outputs that actually mean trouble.
+- [States and grades](/docs/reference/agent-states) — every status word, decoded.
+- [The Agent Handshake](/docs/concepts/agent-handshake) — the chain, presentation, and challenge in depth.
+
+Install is one line. The stranger verifying you is five minutes away.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -1,4 +1,20 @@
 {
   "title": "Get started",
-  "pages": ["introduction", "quickstart", "install", "first-run", "coverage-levels", "replay-levels", "how-it-works", "templates", "approvals", "handoffs", "workflows", "merkle-proofs", "edge-runtime", "dogfood-checklist"]
+  "pages": [
+    "introduction",
+    "quickstart",
+    "install",
+    "first-run",
+    "what-to-expect",
+    "coverage-levels",
+    "replay-levels",
+    "how-it-works",
+    "templates",
+    "approvals",
+    "handoffs",
+    "workflows",
+    "merkle-proofs",
+    "edge-runtime",
+    "dogfood-checklist"
+  ]
 }

--- a/docs/content/docs/guides/what-to-expect.mdx
+++ b/docs/content/docs/guides/what-to-expect.mdx
@@ -1,0 +1,172 @@
+---
+title: What to expect
+description: A guided walk from install to a third party verifying your agent, with the exact output you should see at every step and how to tell it worked.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Steps, Step } from 'fumadocs-ui/components/steps';
+
+This page exists to answer one question: **when I run a Treeship command, is what I see correct, and what do I do next?**
+
+Every step below shows the command, the output you should expect, and a plain "you are on track when" line. If your output matches, it is working. If a status word looks alarming (like `needs-review`), this page tells you whether it is a problem (it usually is not) and what, if anything, to do about it.
+
+<Callout type="info">
+Everything runs locally. No account, no API key, nothing leaves your machine until you explicitly publish. You can run this entire page offline.
+</Callout>
+
+## The 60-second golden path
+
+<Steps>
+
+<Step>
+### Install and initialize
+
+```bash
+npm install -g treeship
+treeship init
+```
+
+Expected:
+
+```
+✓ ship initialized
+  ship:  ship_a1b2c3…
+  key:   key_… (ed25519, default)
+```
+
+**You are on track when** you see a `ship_` id and a `key_`. A "ship" is your local signing authority, the thing that vouches for your agents (the equivalent of a company that issues ID badges). The key is its private signing key and never leaves your machine.
+</Step>
+
+<Step>
+### Onboard an agent
+
+One command takes an agent from nothing to verifiable:
+
+```bash
+treeship onboard my-agent --from-harness ~/.claude/settings.json
+```
+
+Expected:
+
+```
+[1/4] identity — registering agent://my-agent with its own key
+      key: key_… (pinned under AgentCert)
+[2/4] capability card
+      key-bound: yes (AgentCert) · 9 of 9 captured from harness
+[3/4] publish — skipped (local only; re-run with --publish once a hub is attached)
+[4/4] trust bundle — hand these to a counterparty:
+    treeship trust add key_… ed25519:… --kind agent_cert --yes
+✓ agent onboarded
+```
+
+**You are on track when** step 2 says `key-bound: yes`. That means the agent's capability card (a signed document listing what the agent is allowed to do) is cryptographically tied to the agent's own key, not just asserted. `captured from harness` means the tool list was read from your real config, not typed by hand, which is the strongest kind of claim.
+</Step>
+
+<Step>
+### Verify it
+
+```bash
+treeship verify-capability <the-card-id-from-above>
+```
+
+Expected:
+
+```
+✓ capability card
+  key-bound:   yes (AgentCert)
+  provenance:  9 captured, 0 exercised, 0 declared-only
+  status:      verified
+```
+
+**You are on track when** `status: verified` and the command exits `0`. If the agent has actually done work, some capabilities move from `captured` to `exercised` (proven by real signed receipts of the agent using them).
+</Step>
+
+</Steps>
+
+## Reading `treeship agents list`
+
+This is the command most testers run first, and its output looks more alarming than it is. Here is a real listing:
+
+```
+Agent cards (/Users/you/.treeship/agents)
+
+  ? claude-code   (claude-code)
+    id:         agent_6be4c27314cce79f
+    status:     needs-review
+    coverage:   high
+    provenance: registered
+
+  ? tls-dogfood   (shell-wrap)
+    id:         agent_a413e220bbb6cfef
+    status:     needs-review
+    coverage:   basic
+    provenance: registered
+```
+
+Nothing here is broken. Decoding it:
+
+| Field | What you see | What it means |
+|---|---|---|
+| `?` marker | A grey question mark | The card is **awaiting your review**. It is not an error. It means "Treeship created this from what it observed; you have not confirmed it yet." |
+| `status` | `needs-review` | The normal state for a freshly registered agent. Promote it with `treeship agents review <id>` once you have looked at it. Nothing else requires this. |
+| `coverage` | `high` / `basic` | How much of the agent's behavior Treeship can observe through this harness. `high` (native hooks) sees more than `basic` (command wrapping). Neither is wrong; see [Coverage levels](/docs/guides/coverage-levels). |
+| `provenance` | `registered` | Where the card came from. `registered` means you created it with `treeship agent register` (or `onboard`). |
+
+<Callout type="info">
+**`needs-review` is the resting state, not a warning.** A card is only ever
+`active` or `verified` after you deliberately promote it. Most testing never
+needs to; the card is fully usable for signing and verification as-is. The
+status is about *your* review workflow, not the card's validity.
+</Callout>
+
+To clear the review flag on a card you have inspected:
+
+```bash
+treeship agents review agent_6be4c27314cce79f
+```
+
+## The status words, quickly
+
+You will meet a small vocabulary. None of it is jargon for its own sake; each word is a precise claim about how strongly something is known.
+
+- **`proven` vs `asserted`** (on an action) — `proven (key-bound)` means the action was signed by the agent's own key, so the "who did this" is cryptographically established. `asserted` means it is just a labeled claim, no key behind it. Onboarding with `--own-key` (which `onboard` does) gets you `proven`.
+- **`captured` vs `exercised` vs `declared`** (on a capability) — `captured` = read from a real config, `exercised` = backed by real signed receipts of the agent using it, `declared` = a bare claim someone typed. Stronger to weaker, always labeled, never mixed silently.
+- **`verified` vs `checked` vs `asserted`** (on a fact) — `verified`/`checked` mean Treeship recomputed the fact from evidence and it held; `asserted` means it is an unbacked claim. A verdict never rounds up.
+
+The one rule behind all of it: **Treeship reports how it knows something, and never claims to know more than it can prove.** That is the whole product.
+
+## Going over the network (optional)
+
+Everything above is local. To let someone else verify your agent, attach a hub (a shared bulletin board that stores signed artifacts; it verifies nothing itself) and publish:
+
+```bash
+treeship hub attach                 # one browser approval
+treeship onboard my-agent --from-harness ~/.claude/settings.json --publish
+```
+
+The `--publish` run ends by printing a **trust bundle**: the exact two commands a counterparty runs to trust your ship. They then verify any agent you ever register:
+
+```bash
+# what your counterparty runs, once:
+treeship trust add key_… ed25519:… --kind ship --yes
+treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
+
+# then they can verify, from anywhere:
+treeship resolve --hub https://api.treeship.dev agent://my-agent
+```
+
+**You are on track when** their `resolve` prints `signature: verified (chain to pinned ship root)` and `transparency: anchored & verified`. That is the full handshake: they pinned one key, and now trust your whole fleet. See [The Agent Handshake](/docs/concepts/agent-handshake).
+
+## When something is actually wrong
+
+These are the outputs that *do* mean a problem, and what they mean:
+
+| Output | Meaning | Fix |
+|---|---|---|
+| `MAC verification failed — wrong machine` | The keystore cannot be decrypted (rare; a hostname or username change on older versions). | Update to the latest CLI, which self-heals this. If it persists, the message prints a nondestructive recovery command. |
+| `signature: UNVERIFIED (key not in your trust roots)` | You have not pinned the signer's key. | Run the `trust add` line the other party gave you (or `keys export` to get yours). |
+| `status: REVOKED` on a card | The card was revoked by an authorized party. | Do not honor it. This is the system working. |
+| `append-only INVALID — possible history rewrite` on `audit` | A hub's log contradicts what you witnessed before. | The hub may have lost or rewritten data. Investigate before trusting further receipts from it. |
+| A command exits non-zero on a verification | The verdict was hostile (revoked, violation, omission, invalid proof). | The exit code is the point: gate your scripts on it. Read the printed reason. |
+
+Anything not in this table, and not a hostile verdict, is almost certainly the normal path. When in doubt, `treeship verify <id>` and read the top line.

--- a/docs/content/docs/reference/agent-states.mdx
+++ b/docs/content/docs/reference/agent-states.mdx
@@ -1,0 +1,89 @@
+---
+title: States and grades
+description: Every status word Treeship prints, what it claims, and what to do about it. Card lifecycle, coverage tiers, provenance grades, actor proof, and verification verdicts in one place.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Treeship's output is deliberately small in vocabulary and precise in meaning. Every word below is a claim about *how strongly something is known*. This page is the dictionary.
+
+<Callout type="info">
+The single rule underneath all of these: **report provenance, never assume
+it.** Nothing is ever rounded up to a stronger claim than the evidence
+supports. A grey `needs-review` or an `asserted` is not a failure; it is an
+honest label.
+</Callout>
+
+## Card lifecycle (`status`)
+
+A capability card moves through these states. Movement toward `verified` is always something you do deliberately; Treeship never auto-promotes.
+
+| Status | Meaning | Is it a problem? | Move it forward with |
+|---|---|---|---|
+| `draft` | Discovered automatically, not acknowledged. | No | `treeship agents review <id>` |
+| `needs-review` | Registered with a real certificate, awaiting your look. **The normal resting state.** | No | `treeship agents review <id>` |
+| `active` | You reviewed and approved it. | No | run a smoke session to reach `verified` |
+| `verified` | Active, and a session proved Treeship can capture this agent end to end. | No (this is the top) | — |
+
+The `?` marker in `treeship agents list` simply means the card is `draft` or `needs-review`, that is, you have not confirmed it yet. A card is fully usable for signing and verification in any state.
+
+## Coverage (`coverage`)
+
+How much of an agent's behavior Treeship can observe through the harness it is attached by. This is a promise about *completeness*, and it is honest about its own gaps.
+
+| Level | Sees | Does not see |
+|---|---|---|
+| `basic` | Commands you wrap explicitly, and MCP tool calls. | Anything the agent does outside those channels. |
+| `standard` | The above plus file and git reconciliation at session close. | Actions in un-instrumented tools. |
+| `high` | The above plus native harness hooks (e.g. Claude Code SessionStart / PostToolUse). | Very little; this is the most complete tier. |
+
+Full detail: [Coverage levels](/docs/guides/coverage-levels). A `basic` card is not wrong, it just claims less. A session report always states its own coverage so a reader is never surprised by a gap.
+
+## Provenance grades (on capabilities)
+
+When a capability card lists a tool, each entry carries *how that tool got onto the card*. Stronger to weaker:
+
+| Grade | Origin | Strength |
+|---|---|---|
+| `captured` | Read from the agent's real harness config. | Strongest. The machine observed it. |
+| `exercised` | Backed by real signed receipts of the agent using the tool. | Strong. Proven by use. |
+| `discovered` | Mapped from the agent's own published descriptor (e.g. an A2A AgentCard). | Medium. The agent's own claim about itself. |
+| `declared` | A bare list someone typed or supplied. | Weakest. An honest assertion, labeled as one. |
+
+`verify-capability` and `resolve` report the mix, e.g. `9 captured, 2 exercised, 0 declared-only`. A card built with `--from-harness` starts all-`captured`; capabilities move to `exercised` as the agent actually uses them.
+
+## Actor proof (on actions)
+
+When you `treeship verify` an action, the actor line answers "is the 'who' real?"
+
+| Verdict | Meaning |
+|---|---|
+| `proven (key-bound)` | The action was signed by the agent's **own** key, pinned under its certificate. The actor is cryptographically established. |
+| `asserted` | The `actor` field is a labeled claim with no dedicated key behind it (the action was signed by the shared ship key). |
+
+To get `proven`, the agent needs its own key: `treeship agent register --own-key` (or just use `treeship onboard`, which does this). Bridges (`@treeship/mcp`, `@treeship/a2a`) provision it automatically on startup.
+
+## Verification verdicts (on facts)
+
+Every verifier grades each fact it reports:
+
+| Grade | Meaning |
+|---|---|
+| `verified` / `checked` | Treeship recomputed the fact from evidence and it held. |
+| `asserted` | An unbacked claim, surfaced but not trusted. |
+| `REVOKED` | An authorized party revoked this. Do not honor it. |
+
+## Signature and transparency (on remote resolve / presentations)
+
+| Line | Meaning |
+|---|---|
+| `signature: verified (trusted key)` | The signer's key is directly in your trust roots. |
+| `signature: verified (chain to pinned ship root)` | The signer's key is vouched for by a certificate chain up to a ship key you pinned. You trust the fleet by pinning one key. |
+| `signature: UNVERIFIED (key not in your trust roots)` | You have not pinned this signer. Not a forgery claim, just "I cannot check this." Pin the key to resolve it. |
+| `transparency: anchored & verified (checkpoint #N)` | The card is provably in the transparency log, not merely signed. |
+| `transparency: anchored, but checkpoint signer not in your trust roots` | Pin the hub's checkpoint key with the printed command. |
+| `staple: … (9m old)` on a presentation | Freshness bound: the proof is current as of a checkpoint 9 minutes ago. Set your tolerance with `--max-staple-age`. |
+
+## Exit codes
+
+Verification commands (`verify`, `verify-capability`, `resolve`, `audit`, `verify-presentation`, `verify-profile`) exit **non-zero on a hostile verdict**: a revoked card, an out-of-scope violation, a detected omission or history rewrite, an invalid proof. Gate your scripts and CI on the exit code; the printed reason explains it. A monitor doing `treeship audit … && deploy` will correctly refuse to deploy if the log was rewritten.

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Reference",
   "pages": [
+    "agent-states",
     "feature-matrix",
     "schema",
     "predicates"


### PR DESCRIPTION
Closes the biggest documentation gap: a tester runs a command, gets
output, and cannot tell whether it means success or a problem. A user
sent a screenshot of `treeship agents list` showing four cards marked
`?` / needs-review and asked "what are our expectations and results?"
— exactly the confusion these fix.

- guides/what-to-expect: the golden path (install → onboard → verify →
  publish → third-party resolve) with the exact expected output and a
  "you are on track when" line at every step. Directly decodes the
  agents-list output (the `?` marker, needs-review, coverage), a table
  of the status vocabulary, and a table of the outputs that ACTUALLY
  mean trouble vs the normal path.
- reference/states-and-grades: the full dictionary — card lifecycle,
  coverage tiers, provenance grades, actor proof, verification
  verdicts, signature/transparency lines, exit codes. One page, every
  status word decoded, with "is it a problem?" and "what to do."
- blog/verify-any-agent-in-five-minutes: the narrative worked example,
  install to a stranger verifying over the network with one pinned
  key, then the live challenge handshake. Every command, every
  expected output, and what each proves.

No em dashes in the prose (CLI-output code blocks reproduce real
terminal output verbatim). Technical terms glossed in plain language
on first use. Docs build green, route health 10/10.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8
