### PR TITLE
feat(sdk-ts): add SessionModule — session timeline events via ship.session.event()

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -8,4 +8,5 @@ export { Ship } from "./ship.js";
 export { AttestModule } from "./attest.js";
 export { VerifyModule } from "./verify.js";
 export { HubModule } from "./hub.js";
+export { SessionModule } from "./session.js";
 export * from "./types.js";

--- a/packages/sdk-ts/src/session.ts
+++ b/packages/sdk-ts/src/session.ts
@@ -1,0 +1,32 @@
+import { runTreeship } from "./exec.js";
+import type { SessionEventParams, SessionEventResult } from "./types.js";
+
+/**
+ * Session module: append structured events to the active session's event log.
+ *
+ * Where `attest.*` signs a tamper-evident artifact (the proof chain), a session
+ * event is what populates the receipt's **timeline**, **side-effect ledger**,
+ * and **activity-density chart**. Wraps `treeship session event`, so it requires
+ * an active session (`treeship session start`). Pass `artifactId` to link the
+ * timeline entry to the signed artifact it references.
+ */
+export class SessionModule {
+  async event(params: SessionEventParams): Promise<SessionEventResult> {
+    const args = ["session", "event", "--type", params.type, "--format", "json"];
+    if (params.tool) args.push("--tool", params.tool);
+    if (params.file) args.push("--file", params.file);
+    if (params.destination) args.push("--destination", params.destination);
+    if (params.actor) args.push("--actor", params.actor);
+    if (params.agentName) args.push("--agent-name", params.agentName);
+    if (params.durationMs !== undefined) args.push("--duration-ms", String(params.durationMs));
+    if (params.exitCode !== undefined) args.push("--exit-code", String(params.exitCode));
+    if (params.artifactId) args.push("--artifact-id", params.artifactId);
+    if (params.model) args.push("--model", params.model);
+    if (params.provider) args.push("--provider", params.provider);
+    if (params.tokensIn !== undefined) args.push("--tokens-in", String(params.tokensIn));
+    if (params.tokensOut !== undefined) args.push("--tokens-out", String(params.tokensOut));
+    if (params.meta) args.push("--meta", JSON.stringify(params.meta));
+    const result = await runTreeship(args);
+    return { eventId: (result.event_id || result.id) as string };
+  }
+}

--- a/packages/sdk-ts/src/ship.ts
+++ b/packages/sdk-ts/src/ship.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { AttestModule } from "./attest.js";
 import { VerifyModule } from "./verify.js";
 import { HubModule } from "./hub.js";
+import { SessionModule } from "./session.js";
 
 const exec = promisify(execFile);
 
@@ -17,6 +18,7 @@ export class Ship {
   readonly attest = new AttestModule();
   readonly verify = new VerifyModule();
   readonly hub = new HubModule();
+  readonly session = new SessionModule();
 
   /**
    * Checks that the `treeship` CLI binary is available and returns its

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -44,6 +44,41 @@ export interface ApprovalResult {
   nonce: string;
 }
 
+export interface SessionEventParams {
+  /** Event type, e.g. "agent.called_tool", "agent.wrote_file", "agent.read_file", "agent.connected_network", "agent.decision". */
+  type: string;
+  /** Tool name (for agent.called_tool events). */
+  tool?: string;
+  /** File path (for agent.wrote_file / agent.read_file events). */
+  file?: string;
+  /** Network destination host (for agent.connected_network events). */
+  destination?: string;
+  /** Actor URI. Defaults to the actor recorded in the active session manifest. */
+  actor?: string;
+  /** Agent name attached to the event. */
+  agentName?: string;
+  /** Duration of the action, in milliseconds. */
+  durationMs?: number;
+  /** Exit code / error indicator (0 = success). */
+  exitCode?: number;
+  /** Attestation artifact id this event references — links the timeline entry to its signed artifact. */
+  artifactId?: string;
+  /** Model identifier (for agent.decision events). */
+  model?: string;
+  /** Provider name (for agent.decision events). */
+  provider?: string;
+  /** Input tokens consumed by the inference (for agent.decision events). */
+  tokensIn?: number;
+  /** Output tokens produced by the inference (for agent.decision events). */
+  tokensOut?: number;
+  /** Arbitrary JSON metadata. */
+  meta?: Record<string, unknown>;
+}
+
+export interface SessionEventResult {
+  eventId: string;
+}
+
 export interface VerifyCheck {
   step: string;
   status: "pass" | "fail" | "warn";

--- a/packages/sdk-ts/test/sdk.test.ts
+++ b/packages/sdk-ts/test/sdk.test.ts
@@ -7,11 +7,12 @@ describe("@treeship/sdk", () => {
     expect(typeof ship).toBe("function");
   });
 
-  it("ship has attest, verify, hub modules", () => {
+  it("ship has attest, verify, hub, session modules", () => {
     const s = ship();
     expect(s.attest).toBeDefined();
     expect(s.verify).toBeDefined();
     expect(s.hub).toBeDefined();
+    expect(s.session).toBeDefined();
   });
 
   it("attest module has action, approval, handoff, decision", () => {
@@ -39,5 +40,10 @@ describe("@treeship/sdk", () => {
     expect(typeof s.hub.push).toBe("function");
     expect(typeof s.hub.pull).toBe("function");
     expect(typeof s.hub.status).toBe("function");
+  });
+
+  it("session module has an event method", () => {
+    const s = ship();
+    expect(typeof s.session.event).toBe("function");
   });
 });


### PR DESCRIPTION
## What

Adds a `SessionModule` to `@treeship/sdk`, exposed as `ship.session.event()`, that wraps the existing `treeship session event` CLI command.

## Why

`ship.attest.*` signs the tamper-evident artifacts (the proof chain), but only the CLI's `session event` populates the receipt's **timeline**, **side-effect ledger**, and **activity-density chart**. Without an SDK method, consumers have to shell out to the `treeship` binary by hand (via `child_process`) to record those timeline entries. This closes the gap so the full receipt can be built through the SDK.

## Changes

- **`src/session.ts`** — new `SessionModule.event(params)`, mirroring the `AttestModule` arg-building pattern; covers all `session event` flags (`--type/--tool/--file/--destination/--actor/--agent-name/--duration-ms/--exit-code/--artifact-id/--model/--provider/--tokens-in/--tokens-out/--meta`), returns `{ eventId }`.
- **`src/ship.ts`** — `readonly session = new SessionModule()`.
- **`src/index.ts`** — export `SessionModule`.
- **`src/types.ts`** — `SessionEventParams` + `SessionEventResult`.
- **`test/sdk.test.ts`** — surface tests for the new module.

## Notes

- No CLI/Rust changes — wraps the existing `session event` command, so behaviour is unchanged.
- `session.event()` requires an active session (`treeship session start`), same as the CLI.
- `npm run build` (tsc) and `vitest run` pass (7 passed).
- Happy to add a Python-SDK counterpart or a docs snippet for parity if you'd like.
