### PR TITLE
docs(capabilities): add the foundational layers (0.1 → 0.12)

### DIFF
--- a/docs/content/docs/capabilities.mdx
+++ b/docs/content/docs/capabilities.mdx
@@ -1,6 +1,6 @@
 ---
 title: Capabilities
-description: Everything Treeship can do, grouped by what it is for, with the command to use each capability and the command to test it. Covers all releases from 0.13 through 0.18.
+description: Everything Treeship can do, grouped by what it is for, with the command to use each capability and the command to test it. From the foundational signing model through the latest release.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -19,21 +19,94 @@ touches the network is marked. Nothing leaves your machine until you run a
 
 | Layer | What it gives you | Key commands |
 |---|---|---|
+| 0. The signing model | The primitives everything rests on: sign, verify, record | `init`, `attest action`, `verify`, `wrap`, `session` |
 | 1. Identity | A provable "who" for every agent | `agent register --own-key`, `attest action` |
 | 2. Capability cards | A signed, graded list of what an agent may do | `attest card`, `verify-capability`, `revoke-capability` |
 | 3. Typed receipts | Schema-checked, signed records of anything | `attest receipt`, predicate registry |
-| 4. Transparency log | An append-only history you can audit for tampering | `publish`, `merkle`, `audit` |
-| 5. Resolution | Look up and re-verify any agent over the network | `resolve`, `resolve --hub` |
-| 6. The handshake | Verify an agent with no registry, prove liveness | `onboard`, `present`, `verify-presentation`, `keys export` |
-| 7. Work history | A verifiable track record; find agents by evidence | `history`, `profile`, `match` |
-| 8. Protocol bridges | Provable receipts inside MCP and A2A automatically | `@treeship/mcp`, `@treeship/a2a` |
-| 9. Reliability | Honest verdicts, self-healing keys, a hardened hub | exit codes, `status`, keystore |
+| 4. Authorization | Scoped, single-use approvals; handoffs; multi-agent rooms | `attest approval`, `attest handoff`, `session invite` |
+| 5. Transparency log | An append-only history you can audit for tampering | `publish`, `merkle`, `audit` |
+| 6. Resolution | Look up and re-verify any agent over the network | `resolve`, `resolve --hub` |
+| 7. The handshake | Verify an agent with no registry, prove liveness | `onboard`, `present`, `verify-presentation`, `keys export` |
+| 8. Work history | A verifiable track record; find agents by evidence | `history`, `profile`, `match` |
+| 9. Protocol bridges | Provable receipts inside MCP and A2A automatically | `@treeship/mcp`, `@treeship/a2a` |
+| 10. Reliability | Honest verdicts, self-healing keys, a hardened hub | exit codes, `status`, keystore |
+
+---
+
+## Layer 0: The signing model
+
+Everything above the line is built on a handful of primitives that predate the agent stack. This is the "hello world" of Treeship: sign something, verify it, record a session. All of it runs locally, against no server.
+
+### Sign, verify, and the artifact
+`Since 0.1.0`
+
+**What:** Every artifact is a DSSE envelope (a standard signed-message format) over a canonical JSON payload (RFC 8785, so the exact bytes are reproducible), signed with Ed25519. `treeship init` creates your ship and key; `attest action` signs a record that an agent did something; `verify` re-checks the signature and the parent chain. These three are the atoms; every card, receipt, and session is built from them.
+
+**Use / Test:**
+```bash
+treeship init --name me
+treeship attest action --actor agent://me --action "tool.call"
+treeship verify <artifact-id>
+# expect: ✓ verified (1 artifact · chain intact)
+```
+
+### Wrap any command
+`Since 0.1.0`
+
+**What:** `treeship wrap -- <cmd>` runs any command and attests its execution (the command, exit code, and optional output digest) as a signed artifact. The zero-integration way to get a receipt for something.
+
+**Use / Test:**
+```bash
+treeship wrap -- git commit -m "ship it"
+treeship log   # the wrapped command appears as a signed artifact
+```
+
+### Session recording and the `.treeship` package
+`Since 0.5.0`, hardened through `0.11.x`
+
+**What:** `session start` / `session close` bracket a unit of work; everything the agent does in between is captured into a sealed, portable `.treeship` package containing a session receipt, the artifact chain, and a Merkle root. `session report` uploads it and returns a shareable URL. `session abandon` quarantines a wedged session without losing evidence. At close, Treeship reconciles file and git changes so edits made outside captured tool channels still land in the receipt.
+
+**Use / Test:**
+```bash
+treeship session start --name "my task"
+# ... agent does work ...
+treeship session close --headline "done"
+# expect: "session receipt composed" with a package path and a merkle root
+treeship package verify .treeship/sessions/<id>.treeship
+```
+
+### The Merkle log and checkpoints
+`Since 0.5.0`
+
+**What:** Every artifact hash is appended to a local Merkle tree (a tamper-evident structure where any change breaks the root). `treeship checkpoint` seals and signs a root over your artifacts; inclusion proofs let anyone confirm a specific artifact is in that root. This is the substrate the whole transparency layer (Layer 5) is built on.
+
+**Use / Test:**
+```bash
+treeship checkpoint
+treeship merkle proof <artifact-id>   # generates an inclusion proof
+```
+
+### Trust roots and the trust model
+`Since 0.9.x`
+
+**What:** Verification is always against *your* pinned trust roots, never a server's say-so. `treeship trust add` pins a key under a kind (`ship`, `hub_checkpoint`, `agent_cert`, `session_host`). A self-signed forgery does not verify, because its key is not pinned. This is the client-decides invariant that makes every other layer trustworthy.
+
+**Use / Test:**
+```bash
+treeship trust list
+treeship trust add key_… ed25519:… --kind ship --yes
+```
+
+### Connecting a hub
+`Since 0.9.x`  ·  network
+
+**What:** `treeship hub attach` connects your machine to a hub over a device flow (approve in a browser, like signing into a TV app). The hub stores signed artifacts and answers lookups; it holds no secrets and verifies nothing.
 
 ---
 
 ## Layer 1: Identity
 
-The foundation: give an agent a cryptographic identity so its actions are provably its own, not just labeled.
+Give an agent a cryptographic identity so its actions are provably its own, not just labeled.
 
 ### Per-actor signing (a provable `actor`)
 `Since 0.13.0`
@@ -182,7 +255,60 @@ treeship attest receipt --system system://x --kind session.v1 --payload '{}'
 
 ---
 
-## Layer 4: Transparency log
+## Layer 4: Authorization
+
+Beyond "who did what": who is *allowed* to, single-use permission grants, delegation between agents, and multiple agents in one accountable session.
+
+### Scoped approvals with replay protection
+`Since 0.9.6`–`0.9.9`
+
+**What:** `attest approval` mints a signed permission grant scoped to a specific actor, action, and subject, with a `--max-uses` limit. `attest action` consumes a grant *before* signing, via a local **Approval Use Journal** that is append-only, so a grant with `--max-uses 1` cannot be replayed even across separate runs. `verify` reports the replay posture: package-local, journal-local, or hub-verified.
+
+**Use:**
+```bash
+treeship attest approval --approver human://alice \
+  --allowed-action "stripe.charge.create" --allowed-actor agent://deployer --max-uses 1
+treeship attest action --actor agent://deployer --action "stripe.charge.create" --approval-nonce <nonce>
+```
+
+**Test:**
+```bash
+# a second consume of a max-uses=1 grant must fail
+treeship attest action --actor agent://deployer --action "stripe.charge.create" --approval-nonce <same-nonce>
+# expect: refused (max uses exceeded)
+```
+
+### Handoffs (delegation between agents)
+`Since 0.9.x`, A2A-wired `0.15.0`
+
+**What:** `attest handoff` records one agent transferring artifacts (and optionally inherited approvals and obligations) to another, as a signed delegation boundary. The A2A bridge emits these automatically when agents delegate tasks.
+
+**Use / Test:**
+```bash
+treeship attest handoff --from agent://planner --to agent://executor --artifacts <id>
+treeship verify <handoff-id>   # a signed, verifiable delegation record
+```
+
+### Agent invitations and multi-agent rooms
+`Since 0.11.0`
+
+**What:** `session invite` mints a signed, single-use, expiring grant that lets a second agent join an existing session; `session join` and `session countersign` complete a two-signature handshake (the joiner asserts "I'm joining," the host countersigns "I observed this join"). Backed by a `SessionHost` trust root so a forged invitation is quarantined. This is how multiple agents share one accountable session.
+
+**Use / Test:**
+```bash
+treeship session invite <session-id> --invitee-pubkey ed25519:…
+# the invitee runs: treeship session join --invite <blob> --actor agent://helper
+# the host runs:    treeship session countersign <participant-id>
+```
+
+### Trust templates
+`Since 0.11.0`
+
+**What:** Ready-made trust configurations for common patterns (for example the Robinhood agentic-trading template) so a new user starts from a worked setup rather than a blank config.
+
+---
+
+## Layer 5: Transparency log
 
 An append-only, monitorable history of an agent's receipts, with tampering detectable. This is Certificate Transparency, for agents.
 
@@ -232,7 +358,7 @@ treeship audit --hub https://api.treeship.dev agent://deployer
 
 ---
 
-## Layer 5: Resolution
+## Layer 6: Resolution
 
 Look up any agent by its URI and re-verify it against your own trust roots. DNS, OCSP, and Certificate Transparency, for agents.
 
@@ -250,7 +376,7 @@ treeship resolve --hub https://api.treeship.dev agent://deployer    # network
 
 ---
 
-## Layer 6: The handshake
+## Layer 7: The handshake
 
 Verify an agent with the agent handing you its proof, no registry in the loop, then prove it controls its key right now. See [The Agent Handshake](/docs/concepts/agent-handshake).
 
@@ -303,7 +429,7 @@ treeship verify-presentation deployer.presentation.json --challenge $NONCE
 
 ---
 
-## Layer 7: Work history
+## Layer 8: Work history
 
 Every session becomes a signed record; the records form a track record you can query, aggregate, and match against. See the [work-history spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/work-history.md).
 
@@ -354,7 +480,7 @@ treeship match --hub https://api.treeship.dev --exercised "Bash(git:*)"
 
 ---
 
-## Layer 8: Protocol bridges
+## Layer 9: Protocol bridges
 
 Provable receipts inside the protocols agents already speak, by default.
 
@@ -374,7 +500,7 @@ Provable receipts inside the protocols agents already speak, by default.
 
 ---
 
-## Layer 9: Reliability
+## Layer 10: Reliability
 
 The properties that make the above trustworthy in practice, not just in theory.
 


### PR DESCRIPTION
A capabilities map that started at 0.13 skipped the signing model
everything else rests on. Added:

- Layer 0: The signing model — init / attest action / verify (DSSE +
  Ed25519 + RFC 8785 canonical JSON), wrap, session recording and the
  .treeship package, the Merkle log and checkpoints, trust roots and
  the client-decides model, connecting a hub. The primitives from
  0.1–0.9 that every later layer is built on.
- Layer 4: Authorization — scoped single-use approvals with the
  append-only Approval Use Journal (replay protection), handoffs
  (delegation between agents), agent invitations and multi-agent rooms
  (the two-signature join handshake, SessionHost trust root), and
  trust templates. The 0.9.6–0.11 authorization primitives.

Existing layers renumbered (Transparency 4→5 … Reliability 9→10) and
the at-a-glance table updated. Every new entry keeps the What / Use /
Test / Since shape. Docs build green, routes 10/10.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4McuL4eo1HQjBg6SAMjN8
