### PR TITLE
fix(hub): encrypt DPoP signing key at rest (AUD-02, HIGH)

### DIFF
--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -39,10 +39,13 @@ pub fn attach(
     // difference between reporting a fact and reporting a hope. On probe
     // failure we fall through to the full device flow rather than lying.
     if let Some(existing) = ctx.config.hub_connections.get(hub_name) {
-        if let Some(secret_hex) = existing.hub_secret_key.as_deref() {
+        // A sealed key that cannot be decrypted here (different machine)
+        // resolves to Err and falls through to a fresh device flow, exactly
+        // as a missing key did before.
+        if let Ok(secret_hex) = resolve_dpop_secret_hex(existing, &ctx.keys) {
             let probe_endpoint = existing.endpoint.trim_end_matches('/');
             let probe_url = format!("{probe_endpoint}/v1/ship/agents");
-            let probe_ok = build_dpop_jwt(secret_hex, "GET", &probe_url)
+            let probe_ok = build_dpop_jwt(&secret_hex, "GET", &probe_url)
                 .ok()
                 .and_then(|jwt| {
                     ureq::get(&probe_url)
@@ -195,7 +198,8 @@ pub fn attach(
             created_at,
             last_push:       None,
             hub_public_key: Some(hub_public_hex),
-            hub_secret_key: Some(hub_secret_hex),
+            // Sealed at rest under the machine key (AUD-02), not plaintext hex.
+            hub_secret_key: Some(seal_dpop_secret(&hub_secret_hex, &final_hub_id, &ctx.keys)?),
         },
     );
     cfg.active_hub = Some(hub_name.to_string());
@@ -570,14 +574,13 @@ pub fn open(
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
     // We need the dock's private key to DPoP-sign the session mint request.
-    let hub_secret_hex = entry.hub_secret_key.as_deref()
-        .ok_or("this hub connection has no private key on disk; re-run `treeship hub attach`")?;
+    let hub_secret_hex = resolve_dpop_secret_hex(entry, &ctx.keys)?;
 
     // 1. Mint a short-lived share token from the Hub. This is the only call
     //    that needs the dock's private key — the browser then uses the opaque
     //    token (no private key involved).
     let session_url = format!("{}/v1/session", entry.endpoint.trim_end_matches('/'));
-    let dpop_jwt = build_dpop_jwt(hub_secret_hex, "POST", &session_url)?;
+    let dpop_jwt = build_dpop_jwt(&hub_secret_hex, "POST", &session_url)?;
 
     let resp: serde_json::Value = ureq::post(&session_url)
         .set("Authorization", &format!("DPoP {}", entry.hub_id))
@@ -681,17 +684,14 @@ fn push_artifact_to_hub(
     id:    &str,
     entry: &HubConnection,
 ) -> Result<PushResult, Box<dyn std::error::Error>> {
-    let hub_secret_hex = entry
-        .hub_secret_key
-        .as_deref()
-        .ok_or("no hub_secret_key -- run: treeship hub attach")?;
+    let hub_secret_hex = resolve_dpop_secret_hex(entry, &ctx.keys)?;
 
     // 1. Load artifact from local storage
     let record = ctx.storage.read(id)?;
 
     // 2. Build DPoP proof JWT
     let artifacts_url = format!("{}/v1/artifacts", entry.endpoint);
-    let dpop_jwt = build_dpop_jwt(hub_secret_hex, "POST", &artifacts_url)?;
+    let dpop_jwt = build_dpop_jwt(&hub_secret_hex, "POST", &artifacts_url)?;
 
     // 3. POST to Hub
     let envelope_json = serde_json::to_string(&record.envelope)?;
@@ -755,6 +755,68 @@ fn resolve_artifact_id(
         Ok(resolved)
     } else {
         Ok(id.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DPoP secret at-rest sealing (AUD-02)
+//
+// The hub DPoP signing key used to be written to config.json as plaintext
+// hex. A passive read of config.json (backup, dotfile sync, container layer,
+// a committed `.treeship` dir, a co-tenant) then handed an attacker full
+// impersonation of the ship to the hub. We now seal it under the machine key
+// with the same AES-256-GCM path the ship key already uses, so a stolen
+// config.json is useless on another machine -- restoring the AGENTS.md §7
+// guarantee for the one key that was the outlier.
+// ---------------------------------------------------------------------------
+
+/// Marker prefix for a machine-sealed DPoP secret. A stored value without it
+/// is treated as legacy plaintext hex: still honored so existing configs keep
+/// working, and re-sealed on the next `attach`.
+const DPOP_SEALED_PREFIX: &str = "enc.v1:";
+
+/// AEAD context binding a sealed DPoP key to its hub connection, so a local
+/// attacker cannot swap one connection's ciphertext into another entry.
+fn dpop_seal_context(hub_id: &str) -> String {
+    format!("hub-dpop:v1:{hub_id}")
+}
+
+/// Seal a 64-char hex DPoP secret for at-rest storage in config.json.
+/// Returns `enc.v1:<base64url>`.
+fn seal_dpop_secret(
+    secret_hex: &str,
+    hub_id:     &str,
+    keys:       &treeship_core::keys::Store,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let raw = hex::decode(secret_hex)
+        .map_err(|e| format!("hub secret is not valid hex: {e}"))?;
+    let blob = keys.encrypt_secret(&dpop_seal_context(hub_id), &raw)?;
+    Ok(format!("{DPOP_SEALED_PREFIX}{}", URL_SAFE_NO_PAD.encode(blob)))
+}
+
+/// Resolve the stored DPoP secret (sealed or legacy plaintext) to hex,
+/// ready for `build_dpop_jwt`. A sealed value that cannot be decrypted on
+/// this machine is an error (fail closed); a legacy plaintext hex value is
+/// returned as-is for backward compatibility.
+pub(crate) fn resolve_dpop_secret_hex(
+    entry: &HubConnection,
+    keys:  &treeship_core::keys::Store,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let stored = entry.hub_secret_key.as_deref()
+        .ok_or("this hub connection has no private key on disk; re-run `treeship hub attach`")?;
+    match stored.strip_prefix(DPOP_SEALED_PREFIX) {
+        Some(b64) => {
+            let blob = URL_SAFE_NO_PAD.decode(b64)
+                .map_err(|e| format!("stored hub key is corrupt (bad base64): {e}"))?;
+            let raw = keys.decrypt_secret(&dpop_seal_context(&entry.hub_id), &blob)
+                .map_err(|e| format!(
+                    "cannot decrypt the hub key on this machine \
+                     (it was sealed on a different machine, or the keystore moved): {e}"
+                ))?;
+            Ok(hex::encode(raw))
+        }
+        // Legacy plaintext hex. Honored for back-compat; `attach` re-seals.
+        None => Ok(stored.to_string()),
     }
 }
 
@@ -823,5 +885,67 @@ fn format_device_code(code: &str) -> String {
         format!("{}-{}", &code[..4], &code[4..8])
     } else {
         code.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::HubConnection;
+    use tempfile::tempdir;
+
+    fn conn(hub_id: &str, secret: Option<String>) -> HubConnection {
+        HubConnection {
+            hub_id:         hub_id.to_string(),
+            key_id:         String::new(),
+            endpoint:       "https://hub.example".to_string(),
+            created_at:     "0Z".to_string(),
+            last_push:      None,
+            hub_public_key: None,
+            hub_secret_key: secret,
+        }
+    }
+
+    // AUD-02: the DPoP key must never sit in config.json as plaintext hex.
+    #[test]
+    fn sealed_dpop_secret_hides_plaintext_and_roundtrips() {
+        let dir = tempdir().unwrap();
+        let keys = treeship_core::keys::Store::open(dir.path()).unwrap();
+        // 32-byte secret -> 64 hex chars, the real DPoP signing key shape.
+        let secret_hex = "ab".repeat(32);
+
+        let sealed = seal_dpop_secret(&secret_hex, "hub_xyz", &keys).unwrap();
+        // Fail-before-fix invariant: the stored string is the sealed marker,
+        // and the raw hex must NOT appear anywhere in it.
+        assert!(sealed.starts_with(DPOP_SEALED_PREFIX));
+        assert!(!sealed.contains(&secret_hex), "sealed value must not embed the plaintext hex");
+
+        // Resolving the stored (sealed) value returns the original hex.
+        let entry = conn("hub_xyz", Some(sealed));
+        let recovered = resolve_dpop_secret_hex(&entry, &keys).unwrap();
+        assert_eq!(recovered, secret_hex);
+    }
+
+    #[test]
+    fn sealed_dpop_secret_bound_to_hub_id() {
+        let dir = tempdir().unwrap();
+        let keys = treeship_core::keys::Store::open(dir.path()).unwrap();
+        let secret_hex = "cd".repeat(32);
+        let sealed = seal_dpop_secret(&secret_hex, "hub_A", &keys).unwrap();
+        // Same sealed blob, but stored under a different hub_id: the AEAD
+        // context no longer matches, so it must fail closed rather than
+        // hand back the key for the wrong connection.
+        let wrong = conn("hub_B", Some(sealed));
+        assert!(resolve_dpop_secret_hex(&wrong, &keys).is_err());
+    }
+
+    #[test]
+    fn legacy_plaintext_hex_still_resolves() {
+        let dir = tempdir().unwrap();
+        let keys = treeship_core::keys::Store::open(dir.path()).unwrap();
+        // A pre-AUD-02 config with a bare hex key must keep working.
+        let secret_hex = "ef".repeat(32);
+        let entry = conn("hub_legacy", Some(secret_hex.clone()));
+        assert_eq!(resolve_dpop_secret_hex(&entry, &keys).unwrap(), secret_hex);
     }
 }

--- a/packages/cli/src/commands/merkle.rs
+++ b/packages/cli/src/commands/merkle.rs
@@ -496,8 +496,7 @@ pub fn publish(
 
     let endpoint = &hub_entry.endpoint;
     let hub_id = &hub_entry.hub_id;
-    let hub_secret_hex = hub_entry.hub_secret_key.as_deref()
-        .ok_or("no hub_secret_key in config -- run: treeship hub attach")?;
+    let hub_secret_hex = super::hub::resolve_dpop_secret_hex(hub_entry, &ctx.keys)?;
 
     // 1. Load latest checkpoint
     let checkpoint = load_latest_checkpoint()?
@@ -509,7 +508,7 @@ pub fn publish(
 
     // 2. POST checkpoint to Hub
     let checkpoint_url = format!("{}/v1/merkle/checkpoint", endpoint);
-    let dpop_jwt = build_dpop_jwt(hub_secret_hex, "POST", &checkpoint_url)?;
+    let dpop_jwt = build_dpop_jwt(&hub_secret_hex, "POST", &checkpoint_url)?;
 
     let cp_body = serde_json::json!({
         "root":       checkpoint.root,
@@ -580,7 +579,7 @@ pub fn publish(
 
         let proof_json_str = serde_json::to_string(&proof_file)?;
 
-        let dpop_jwt = build_dpop_jwt(hub_secret_hex, "POST", &proof_url)?;
+        let dpop_jwt = build_dpop_jwt(&hub_secret_hex, "POST", &proof_url)?;
 
         let proof_body = serde_json::json!({
             "artifact_id":   artifact_id,
@@ -608,7 +607,7 @@ pub fn publish(
         &artifact_ids,
         endpoint,
         hub_id,
-        hub_secret_hex,
+        &hub_secret_hex,
         printer,
     ) {
         printer.hint(&format!("consistency proof not published: {e}"));

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1887,9 +1887,11 @@ pub fn report(
         }
     };
 
-    let hub_secret_hex = match hub_entry.hub_secret_key.as_deref() {
-        Some(s) => s,
-        None => {
+    // Resolve the DPoP key (sealed at rest under the machine key, AUD-02).
+    // A missing key or one sealed on a different machine both surface here.
+    let hub_secret_hex = match super::hub::resolve_dpop_secret_hex(hub_entry, &ctx.keys) {
+        Ok(s) => s,
+        Err(e) => {
             if format == "json" {
                 return emit_report_output(
                     format,
@@ -1901,15 +1903,13 @@ pub fn report(
                     package_digest.as_deref(),
                     &verification_status,
                     &warnings,
-                    Some(&format!(
-                        "hub connection '{hub_name}' has no hub_secret_key -- run `treeship hub attach`"
-                    )),
+                    Some(&format!("hub connection '{hub_name}': {e}")),
                     None,
                     printer,
                 );
             }
             return Err(format!(
-                "no hub_secret_key for connection '{hub_name}' -- run: treeship hub attach\n\n  \
+                "{e} (connection '{hub_name}')\n\n  \
                  Or verify the sealed receipt locally without publishing:\n    \
                  treeship package verify {}",
                 pkg_dir.display(),
@@ -1919,7 +1919,7 @@ pub fn report(
 
     // 4. Build the PUT URL and DPoP proof.
     let put_url = format!("{}/v1/receipt/{}", hub_entry.endpoint, resolved_id);
-    let dpop_jwt = super::hub::build_dpop_jwt(hub_secret_hex, "PUT", &put_url)?;
+    let dpop_jwt = super::hub::build_dpop_jwt(&hub_secret_hex, "PUT", &put_url)?;
 
     // 5. Send the receipt body verbatim with content-type application/json.
     let resp = ureq::put(&put_url)

--- a/packages/core/src/keys/mod.rs
+++ b/packages/core/src/keys/mod.rs
@@ -832,6 +832,46 @@ impl Store {
         Ok(self.load_entry(id)?.public_key)
     }
 
+    /// Encrypt an arbitrary secret for at-rest storage OUTSIDE the keystore
+    /// (for example, the hub DPoP signing key that lives in `config.json`).
+    ///
+    /// The secret is sealed under this machine's key with the same
+    /// AES-256-GCM v2 framing the keystore uses for private keys, so a
+    /// stolen `config.json` is useless on another machine — the same
+    /// guarantee AGENTS.md §7 already makes for the ship key. `context` is
+    /// bound as AEAD associated data: a blob sealed for one context (e.g.
+    /// `"hub-dpop:v1:<hub_id>"`) will not decrypt under another, so a local
+    /// attacker cannot swap a ciphertext between two hub connections in the
+    /// same file. Store the returned bytes base64-encoded; recover the
+    /// plaintext with [`KeyStore::decrypt_secret`] using the same `context`.
+    pub fn encrypt_secret(&self, context: &str, plaintext: &[u8]) -> Result<Vec<u8>, KeyError> {
+        // public_key is empty: for a non-keystore secret there is no
+        // associated pubkey to bind, but `context` (carried as the AAD
+        // entry_id) plus the framing prefix still bind machine + purpose.
+        encrypt_for_disk_v2(&self.machine_key, context, &[], plaintext)
+            .map_err(KeyError::Crypto)
+    }
+
+    /// Decrypt a blob produced by [`KeyStore::encrypt_secret`] with the same
+    /// `context`. Tries the primary machine key first, then the same
+    /// migration fallbacks used for keystore entries, so a machine whose
+    /// hostname/username drifted still recovers the secret. A wrong
+    /// `context`, a tampered blob, or a different machine each fail closed
+    /// with a MAC error rather than returning wrong bytes.
+    pub fn decrypt_secret(&self, context: &str, blob: &[u8]) -> Result<Vec<u8>, KeyError> {
+        match decrypt_v2(&self.machine_key, context, &[], blob) {
+            Ok(pt) => Ok(pt),
+            Err(primary_err) => {
+                for candidate in &self.fallback_machine_keys {
+                    if let Ok(pt) = decrypt_v2(candidate, context, &[], blob) {
+                        return Ok(pt);
+                    }
+                }
+                Err(KeyError::Crypto(primary_err))
+            }
+        }
+    }
+
     // --- private ---
 
     fn load_entry(&self, id: &str) -> Result<EncryptedEntry, KeyError> {
@@ -2141,6 +2181,43 @@ mod tests {
         let dec =
             decrypt_from_disk(&key, TEST_ENTRY_ID, TEST_PUBLIC_KEY, &blob, &[]).unwrap();
         assert_eq!(&*dec, plaintext);
+    }
+
+    // ── KeyStore::encrypt_secret / decrypt_secret (AUD-02) ─────────────
+    // The hub DPoP key used to be written to config.json as plaintext hex.
+    // These lock the machine-bound, context-bound at-rest sealing that
+    // replaces it.
+
+    #[test]
+    fn encrypt_secret_roundtrips_and_hides_plaintext() {
+        let (store, dir) = make_store();
+        // A 32-byte Ed25519 secret, the actual thing we are protecting.
+        let secret = [0x42u8; 32];
+        let ctx = "hub-dpop:v1:hub_abc";
+        let blob = store.encrypt_secret(ctx, &secret).unwrap();
+
+        // Fail-before-fix invariant: the sealed blob must NOT contain the
+        // raw secret bytes. (The old code stored them verbatim.)
+        assert!(
+            !blob.windows(secret.len()).any(|w| w == secret),
+            "sealed blob must not contain the raw secret"
+        );
+
+        let recovered = store.decrypt_secret(ctx, &blob).unwrap();
+        assert_eq!(recovered.as_slice(), &secret, "roundtrip must recover the secret");
+        cleanup(dir);
+    }
+
+    #[test]
+    fn decrypt_secret_wrong_context_fails_closed() {
+        let (store, dir) = make_store();
+        let secret = [0x11u8; 32];
+        let blob = store.encrypt_secret("hub-dpop:v1:hub_A", &secret).unwrap();
+        // A blob sealed for hub A must not open under hub B's context —
+        // this is what prevents an intra-file ciphertext swap.
+        let r = store.decrypt_secret("hub-dpop:v1:hub_B", &blob);
+        assert!(r.is_err(), "wrong context must fail closed, not return wrong bytes");
+        cleanup(dir);
     }
 
     #[test]


### PR DESCRIPTION
First fix from the July 2026 internal security audit. **AUD-02 (HIGH), ships in the default binary, contradicts a written AGENTS.md guarantee.**

## The problem
`treeship hub attach` wrote the hub DPoP private key to `config.json` as plaintext hex (`hub_secret_key = hex(...)`), protected only by file mode `0o600`. A **passive** read of that file (backup, dotfile/cloud sync, container image layer, a committed `.treeship` dir, a co-tenant) is enough to:
- push forged artifacts under the victim's ship identity (`POST /v1/artifacts`), and
- mint interactive workspace session tokens.

The ship signing key is AES-256-GCM encrypted at rest; the DPoP key was the one outlier, defeating AGENTS.md §7 ("stolen `config.json` is useless without the encrypted key").

## The fix
Seal the DPoP key under the machine key with the same v2 AES-256-GCM framing the keystore already uses for private keys.

- **core** — `KeyStore::encrypt_secret` / `decrypt_secret`: seal an arbitrary secret under the machine key, bound to a caller `context` string as AEAD associated data, reusing the same primary+fallback machine-key resolution keystore entries use. A stolen blob is useless on another machine and cannot be swapped between contexts.
- **cli** — `config.json` now stores `enc.v1:<base64>` sealed with context `hub-dpop:v1:<hub_id>`. Every read site (attach reconnect probe, `hub open`, artifact push, `merkle publish`/proof/consistency, `session report`) goes through `resolve_dpop_secret_hex`, which decrypts sealed values and passes **legacy plaintext hex through unchanged** for back-compat (re-sealed on the next `attach`).

Fail-closed: a sealed key that won't decrypt on this machine is an error, not a silent fallthrough. The one intentional exception is the attach reconnect probe, which falls through to a fresh device flow exactly as it did for a missing key.

### Back-compat residual
`migrate_legacy_hub` (pre-`hub_connections` configs) carries an already-plaintext key forward as legacy plaintext until the next `attach` re-seals it. It runs at config-load with no keystore handle, so sealing there is out of scope for this PR.

## Tests (fail before the fix)
- core: `encrypt_secret_roundtrips_and_hides_plaintext`, `decrypt_secret_wrong_context_fails_closed`
- cli: `sealed_dpop_secret_hides_plaintext_and_roundtrips`, `sealed_dpop_secret_bound_to_hub_id`, `legacy_plaintext_hex_still_resolves`

Full suites green.

Refs AUD-02. Graduates to a `TS-2026-NNN` advisory once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)