### PR TITLE
fix(verify): stop reporting fetched receipts as "authentic" (AUD-01, HIGH)

### DIFF
--- a/packages/cli/src/commands/verify_external.rs
+++ b/packages/cli/src/commands/verify_external.rs
@@ -47,6 +47,16 @@ impl ExternalExit {
     }
 }
 
+/// AUD-01: the honest machine outcome for the receipt/URL/package surface.
+/// This surface runs only keyless, self-referential checks (recomputed Merkle
+/// root, inclusion proofs, leaf count, timeline) and never verifies a
+/// signature, so it MUST NOT return "pass" (which a consumer could read as
+/// authenticity). A consistent receipt is "structural-pass"; a failed check
+/// or an empty receipt (nothing to prove) is "fail".
+fn structural_outcome(receipt_failed: bool, empty_receipt: bool) -> &'static str {
+    if receipt_failed || empty_receipt { "fail" } else { "structural-pass" }
+}
+
 /// Heuristic: does this look like a URL we should fetch?
 pub fn is_url(s: &str) -> bool {
     s.starts_with("http://") || s.starts_with("https://")
@@ -142,13 +152,35 @@ pub fn run(
     emit_step(printer, true, &load_label, None);
     emit_checks_as_steps(printer, &checks);
 
+    // AUD-01: this path performs only keyless, self-referential checks
+    // (recomputed Merkle root vs the receipt's own root, inclusion proofs
+    // against that same recomputed root, leaf-count parity, timeline order).
+    // It never opens the trust store and never verifies a signature, so a
+    // structurally-consistent forgery — or an empty receipt — passes. We must
+    // NOT call that "authentic". An empty receipt has nothing to check, so it
+    // is not even structurally meaningful.
+    let has_content = !receipt.artifacts.is_empty();
     let mut overall = if receipt_ok { ExternalExit::Ok } else { ExternalExit::VerifyFailed };
 
-    if receipt_ok {
+    if receipt_ok && has_content {
         printer.blank();
-        printer.info(&printer.green("Verified. This receipt is authentic."));
+        printer.info(&printer.green("Structurally consistent."));
+        printer.warn(
+            "signatures and issuer were NOT verified from this source",
+            &[("checked", "Merkle root, inclusion proofs, leaf count, timeline order"),
+              ("not checked", "who signed this receipt (no signature or trust-root check)")],
+        );
+        printer.hint("to verify signatures against your trust roots, use the local artifact form: treeship verify <artifact-id>");
         printer.blank();
         emit_summary(printer, &receipt);
+    } else if receipt_ok && !has_content {
+        printer.blank();
+        printer.warn(
+            "receipt is empty — nothing to verify",
+            &[("artifacts", "0"),
+              ("note", "an internally-consistent receipt with no artifacts proves nothing")],
+        );
+        overall = ExternalExit::VerifyFailed;
     } else {
         printer.blank();
         printer.failure("verification failed", &[("target", target)]);
@@ -156,8 +188,9 @@ pub fn run(
 
     // Cross-verify path.
     if let Some(cert_target) = certificate {
-        if !receipt_ok {
-            // Don't try to cross-verify against an unverified receipt.
+        if !receipt_ok || !has_content {
+            // Don't cross-verify against an unverified or empty receipt:
+            // an empty receipt has no tool calls to authorize.
             printer.blank();
             printer.warn("skipping cross-verification because receipt did not verify", &[]);
             return overall;
@@ -465,6 +498,9 @@ fn emit_json(
     certificate: Option<&str>,
 ) -> ExternalExit {
     let receipt_failed = checks.iter().any(|c| c.status == VerifyStatus::Fail);
+    // AUD-01: an internally-consistent receipt with no artifacts proves
+    // nothing; treat it as a failure rather than a pass.
+    let empty_receipt = receipt.artifacts.is_empty();
 
     let trust = treeship_core::trust::TrustRootStore::open_default_or_empty()
         .unwrap_or_else(|_| treeship_core::trust::TrustRootStore::empty());
@@ -478,10 +514,20 @@ fn emit_json(
         Err(_) => None,
     });
 
+    // Outcome is deliberately NOT "pass": this path never verifies a
+    // signature or consults the trust store, so the strongest honest claim
+    // is "structural-pass" (internally consistent, issuer unverified). A
+    // failed check is "fail"; an empty receipt is "fail" (nothing to prove).
+    let outcome = structural_outcome(receipt_failed, empty_receipt);
     let mut out = serde_json::json!({
         "target": target,
         "source": source_label,
-        "outcome": if receipt_failed { "fail" } else { "pass" },
+        "outcome": outcome,
+        // Explicit so no consumer mistakes structural consistency for an
+        // authenticity/signature result on this surface.
+        "signatures_verified": false,
+        "issuer_verified": false,
+        "note": "structural checks only (Merkle root, inclusion proofs, leaf count, timeline). Signatures and issuer are NOT verified from a fetched receipt; use the local artifact-ID verify path for signature verification.",
         "receipt": {
             "session_id": receipt.session.id,
             "ship_id": receipt.session.ship_id,
@@ -517,7 +563,7 @@ fn emit_json(
 
     printer.json(&out);
 
-    if receipt_failed {
+    if receipt_failed || empty_receipt {
         ExternalExit::VerifyFailed
     } else if let Some((cert_ok, ref result)) = cross {
         if !cert_ok || !result.ok() {
@@ -656,5 +702,23 @@ mod tests {
         assert_eq!(ExternalExit::VerifyFailed.code(), 1);
         assert_eq!(ExternalExit::CrossVerifyFailed.code(), 2);
         assert_eq!(ExternalExit::IoError.code(), 3);
+    }
+
+    // AUD-01: the JSON outcome must never be "pass" on this surface, because
+    // no signature is ever verified here.
+    #[test]
+    fn structural_outcome_never_claims_plain_pass() {
+        // Consistent, non-empty receipt: structural-pass, NOT pass.
+        assert_eq!(structural_outcome(false, false), "structural-pass");
+        // A failed check is a fail.
+        assert_eq!(structural_outcome(true, false), "fail");
+        // An empty (but internally consistent) receipt proves nothing.
+        assert_eq!(structural_outcome(false, true), "fail");
+        // Never, under any input, "pass".
+        for &f in &[true, false] {
+            for &e in &[true, false] {
+                assert_ne!(structural_outcome(f, e), "pass");
+            }
+        }
     }
 }

--- a/packages/core-wasm/src/lib.rs
+++ b/packages/core-wasm/src/lib.rs
@@ -369,6 +369,13 @@ pub fn verify_receipt(receipt_json: &str) -> String {
 
     let checks = verify_receipt_json_checks(&receipt);
     let any_fail = checks.iter().any(|c| c.status == VerifyStatus::Fail);
+    // AUD-01 / AUD-P10: these checks are keyless and self-referential — no
+    // signature or trust-root check runs here, and an empty receipt passes
+    // vacuously. The strongest honest outcome is "structural-pass", never
+    // "pass" (which a consumer could read as authenticity). An empty receipt
+    // proves nothing, so it is a "fail".
+    let empty_receipt = receipt.artifacts.is_empty();
+    let outcome = if any_fail || empty_receipt { "fail" } else { "structural-pass" };
 
     let agent_name = receipt
         .agent_graph
@@ -378,7 +385,10 @@ pub fn verify_receipt(receipt_json: &str) -> String {
         .unwrap_or_default();
 
     serde_json::json!({
-        "outcome": if any_fail { "fail" } else { "pass" },
+        "outcome": outcome,
+        "signatures_verified": false,
+        "issuer_verified": false,
+        "note": "structural checks only (Merkle root, inclusion proofs, leaf count, timeline). Signatures and issuer are NOT verified from a receipt JSON.",
         "checks": checks.iter().map(|c| serde_json::json!({
             "step": c.name,
             "status": status_label(&c.status),
@@ -851,14 +861,44 @@ mod tests {
     }
 
     #[test]
-    fn verify_receipt_passes_on_fresh_compose() {
+    fn verify_receipt_is_structural_pass_not_authentic() {
+        // AUD-01: a consistent receipt is "structural-pass", never "pass".
+        // This surface verifies no signature, so it must not imply authenticity.
         let json = sample_receipt_json();
         let out: serde_json::Value = serde_json::from_str(&verify_receipt(&json)).unwrap();
-        assert_eq!(out["outcome"], "pass", "got: {out}");
+        assert_eq!(out["outcome"], "structural-pass", "got: {out}");
+        assert_eq!(out["signatures_verified"], false);
+        assert_eq!(out["issuer_verified"], false);
         assert_eq!(out["session"]["id"], "ssn_wasm_test");
         assert_eq!(out["session"]["ship_id"], "ship_demo");
         assert_eq!(out["session"]["actions"], 2);
         assert_eq!(out["session"]["agent"], "root");
+    }
+
+    #[test]
+    fn verify_receipt_fabricated_but_consistent_is_not_pass() {
+        // The attack from AUD-01: fabricate a receipt for an arbitrary ship,
+        // fill merkle.root/inclusion_proofs with the PUBLIC algorithm so every
+        // self-referential check passes. The outcome must NOT be "pass" and
+        // must flag that no signature was verified.
+        let mut val: serde_json::Value = serde_json::from_str(&sample_receipt_json()).unwrap();
+        val["session"]["ship_id"] = serde_json::Value::String("ship_ATTACKER".into());
+        let forged = val.to_string();
+        let out: serde_json::Value = serde_json::from_str(&verify_receipt(&forged)).unwrap();
+        assert_ne!(out["outcome"], "pass", "must never claim a plain pass: {out}");
+        assert_eq!(out["outcome"], "structural-pass");
+        assert_eq!(out["signatures_verified"], false);
+    }
+
+    #[test]
+    fn verify_receipt_empty_is_fail() {
+        // An internally-consistent receipt with zero artifacts proves nothing.
+        let mut val: serde_json::Value = serde_json::from_str(&sample_receipt_json()).unwrap();
+        val["artifacts"] = serde_json::Value::Array(vec![]);
+        val["merkle"]["root"] = serde_json::Value::Null;
+        let empty = val.to_string();
+        let out: serde_json::Value = serde_json::from_str(&verify_receipt(&empty)).unwrap();
+        assert_eq!(out["outcome"], "fail", "empty receipt must fail: {out}");
     }
 
     #[test]

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -281,7 +281,13 @@ impl ReceiptComposer {
         // exist in the session directory.
         let proofs = ProofsSection {
             signature_count: artifact_entries.len() as u32,
-            signatures_valid: true, // Caller should verify
+            // AUD-01: compose does NOT run a signature-verification pass over
+            // the artifacts, so this must not claim signatures were verified.
+            // A `true` here was a self-asserted "valid" flag baked into the
+            // signed receipt that a consumer could mistake for an independent
+            // verification result. It stays false unless a real verify pass
+            // sets it.
+            signatures_valid: false,
             merkle_root_valid: merkle_tree.is_some(),
             inclusion_proofs_count: merkle_section.inclusion_proofs.len() as u32,
             zk_proofs_present: false,


### PR DESCRIPTION
Second HIGH from the July 2026 internal audit. Ships in the default binary; contradicts the repo's own "verifier must not return Ok for the wrong reason" policy.

## The problem
`treeship verify <url>` (and the WASM `verify_receipt` export, AUD-P10) ran only **keyless, self-referential** checks:
- recomputed Merkle root vs the receipt's *own* `merkle.root`
- inclusion proofs against that *same recomputed* root
- leaf-count parity, timeline order

No trust root is opened, no signature is verified. Then it printed **"Verified. This receipt is authentic."** (JSON `outcome: "pass"`). An attacker fabricates a receipt for any ship using the **public** Merkle algorithm, hosts it at any URL, and the victim's CLI calls it authentic. An **empty** receipt passed vacuously too.

Same root cause on the `.treeship` package path — `verify_package` runs **zero** per-artifact signature verification (grep confirms 0 `verify_strict`/`verify_any` calls).

## The fix — honest without overclaiming
- **CLI human path**: "authentic" → **"Structurally consistent."** + an explicit warning that *signatures and issuer were NOT verified from this source*, and a hint to use `treeship verify <artifact-id>` for signature verification against trust roots.
- **CLI + WASM JSON**: `outcome` is now **`structural-pass`** (never `pass`), with explicit `signatures_verified: false` / `issuer_verified: false` / `note`. Extracted `structural_outcome()` so the "never pass" invariant is unit-tested.
- **Empty receipt** (zero artifacts) is now a **`fail`** on every surface and is skipped for cross-verification.
- **core**: `ProofsSection.signatures_valid` was hard-coded `true` at compose. Compose runs no verification pass, so the flag baked into the signed receipt must not claim signatures were verified — it stays `false`.

## Tests (fail before the fix)
- wasm: `verify_receipt_is_structural_pass_not_authentic`, `verify_receipt_fabricated_but_consistent_is_not_pass`, `verify_receipt_empty_is_fail`
- cli: `structural_outcome_never_claims_plain_pass`

Full suites green (core + cli + core-wasm).

Refs AUD-01 / AUD-P10. Graduates to a `TS-2026-NNN` advisory once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)