### PR TITLE
fix: stop trust-ladder laundering of self-declared attestation_class (AUD-06)

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -15,6 +15,19 @@ use crate::commands::verify::{check_scope_violation, find_approval_by_nonce, now
 use crate::{ctx, printer::Printer};
 use treeship_core::session::event::EventType;
 
+/// Receipt kinds that are minted only by a dedicated command from sealed
+/// evidence and must never be hand-signed through the generic attest path
+/// (AUD-06). Returns the owning command for the error message, or None if the
+/// kind is freely attestable.
+pub(crate) fn close_only_kind_owner(kind: &str) -> Option<&'static str> {
+    match kind {
+        // session.v1 records carry a self-declared `attestation_class` that
+        // `session close` derives from consumed approvals / tool runtimes.
+        "session.v1" => Some("treeship session close"),
+        _ => None,
+    }
+}
+
 /// Resolve which key signs for a given actor URI. An `agent://<name>` whose
 /// agent card carries a registered per-agent key that is pinned under
 /// AgentCert signs with **that** key, so the actor is provable (the receipt's
@@ -389,6 +402,24 @@ pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::
         .map(serde_json::from_str)
         .transpose()
         .map_err(|e| format!("receipt payload is not valid JSON: {e}"))?;
+
+    // AUD-06: some receipt kinds are minted ONLY by a command that derives
+    // every field from sealed session evidence (e.g. `session close` computes
+    // `attestation_class` from consumed approvals / tool runtimes). Letting a
+    // caller hand-sign them through the generic attest path is a trust-ladder
+    // laundering vector: an attacker mints `session.v1` with
+    // `attestation_class:"countersigned"` and an inflated `action_count`, no
+    // countersignature or runtime evidence, and it aggregates into the highest
+    // trust classes. Refuse those kinds here.
+    if let Some(owner) = close_only_kind_owner(&args.kind) {
+        return Err(format!(
+            "kind '{}' is minted only by `{owner}` from sealed session evidence; \
+             it cannot be hand-signed via `attest receipt`. This prevents forging a \
+             work-history record with a self-declared attestation_class. \
+             See docs/specs/work-history.md.",
+            args.kind
+        ).into());
+    }
 
     // Typed-predicate validation: if `kind` is a registered predicate, the
     // payload must conform to its schema before we sign. Unregistered kinds
@@ -1276,5 +1307,25 @@ fn write_last(storage_dir: &str, artifact_id: &str) {
     {
         use std::os::unix::fs::PermissionsExt;
         let _ = std::fs::set_permissions(&last_path, std::fs::Permissions::from_mode(0o600));
+    }
+}
+
+#[cfg(test)]
+mod aud06_tests {
+    use super::close_only_kind_owner;
+
+    // AUD-06: session.v1 must be refused by the generic attest path so a
+    // work-history record with a self-declared attestation_class cannot be
+    // hand-signed.
+    #[test]
+    fn session_v1_is_close_only() {
+        assert_eq!(close_only_kind_owner("session.v1"), Some("treeship session close"));
+    }
+
+    #[test]
+    fn ordinary_kinds_are_freely_attestable() {
+        assert_eq!(close_only_kind_owner("note.v1"), None);
+        assert_eq!(close_only_kind_owner("deploy"), None);
+        assert_eq!(close_only_kind_owner(""), None);
     }
 }

--- a/packages/cli/src/commands/history.rs
+++ b/packages/cli/src/commands/history.rs
@@ -99,11 +99,13 @@ pub fn history(
         if p.get("actor").and_then(|v| v.as_str()) != Some(agent.as_str()) {
             continue;
         }
-        let class = p
-            .get("attestation_class")
-            .and_then(|v| v.as_str())
-            .unwrap_or("?")
-            .to_string();
+        // AUD-06: cap the displayed class to what the payload's own counts
+        // justify, so a forged `countersigned`/`runtime` label does not render
+        // as such. A record with no class at all still shows "?".
+        let class = match p.get("attestation_class").and_then(|v| v.as_str()) {
+            Some(declared) => super::profile::cap_class_to_evidence(declared, &p).to_string(),
+            None => "?".to_string(),
+        };
         if let Some(cf) = class_filter {
             if class != cf {
                 continue;

--- a/packages/cli/src/commands/profile.rs
+++ b/packages/cli/src/commands/profile.rs
@@ -27,6 +27,55 @@ type CmdResult = Result<(), Box<dyn std::error::Error>>;
 /// Pure — the entire recomputability guarantee rests on this function being
 /// a function of exactly these inputs. `computed_at` is deliberately NOT
 /// part of the comparable aggregate (verify-profile ignores it).
+/// Normalize a self-declared class to a known ladder value; anything outside
+/// the vocabulary folds to `self` so it can never be tallied as a trusted
+/// bucket or outrank a real class.
+fn normalize_class(class: &str) -> &'static str {
+    match class {
+        "countersigned" => "countersigned",
+        "runtime" => "runtime",
+        _ => "self",
+    }
+}
+
+/// Ladder rank: self < runtime < countersigned.
+fn class_rank(class: &str) -> u8 {
+    match class {
+        "countersigned" => 2,
+        "runtime" => 1,
+        _ => 0,
+    }
+}
+
+/// The strongest class a session.v1 payload's OWN counts substantiate, using
+/// the same rule `session close` mints by: countersigned requires a consumed
+/// approval; runtime requires a non-cli harness. A self-consistency floor,
+/// not a full evidence check (AUD-06).
+fn justified_class(p: &serde_json::Value) -> &'static str {
+    let approvals = p.get("approval_count").and_then(|v| v.as_u64()).unwrap_or(0);
+    let harness = p.get("harness").and_then(|v| v.as_str()).unwrap_or("cli");
+    if approvals > 0 {
+        "countersigned"
+    } else if !harness.is_empty() && harness != "cli" {
+        "runtime"
+    } else {
+        "self"
+    }
+}
+
+/// Cap a declared class to what the payload's own evidence justifies: the
+/// weaker of (normalized declared, justified). A record claiming
+/// `countersigned` with zero approvals is tallied as what its counts support.
+pub(crate) fn cap_class_to_evidence(declared: &str, p: &serde_json::Value) -> &'static str {
+    let declared = normalize_class(declared);
+    let justified = justified_class(p);
+    if class_rank(declared) <= class_rank(justified) {
+        declared
+    } else {
+        justified
+    }
+}
+
 pub(crate) fn aggregate_profile(
     agent: &str,
     checkpoint: &Checkpoint,
@@ -39,11 +88,20 @@ pub(crate) fn aggregate_profile(
     let mut span: Vec<String> = Vec::new();
 
     for p in session_payloads {
-        let class = p
+        let declared = p
             .get("attestation_class")
             .and_then(|v| v.as_str())
-            .unwrap_or("self")
-            .to_string();
+            .unwrap_or("self");
+        // AUD-06: do not tally a self-declared class higher than the payload's
+        // own evidence counts justify. `session close` derives `countersigned`
+        // only when approvals were consumed and `runtime` only under a real
+        // tool runtime; a record claiming a stronger class than its own
+        // approval_count / harness support is internally inconsistent, so we
+        // cap it to what it can substantiate rather than laundering it into
+        // the higher trust bucket. (Full cross-checking against the embedded
+        // signed grants requires the sealed packages, not just these payloads;
+        // that deeper dereference is tracked as a follow-up.)
+        let class = cap_class_to_evidence(declared, p).to_string();
         *by_class.entry(class).or_insert(0u64) += 1;
         actions += p.get("action_count").and_then(|v| v.as_u64()).unwrap_or(0);
         approvals += p.get("approval_count").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -341,6 +399,55 @@ mod tests {
             "tools_exercised": tools,
             "closed_at": closed,
         })
+    }
+
+    // AUD-06: a self-declared class must not be tallied higher than the
+    // payload's own counts justify.
+    #[test]
+    fn forged_countersigned_without_approvals_is_capped_to_self() {
+        let forged = serde_json::json!({
+            "attestation_class": "countersigned",
+            "action_count": 9999,
+            "approval_count": 0,   // no consumed approval backs the claim
+            "harness": "cli",      // no runtime either
+            "closed_at": "2026-07-06T00:00:00Z",
+        });
+        assert_eq!(cap_class_to_evidence("countersigned", &forged), "self");
+
+        let c = cp(1, 10, "sha256:aa");
+        let out = aggregate_profile("agent://x", &c, &[forged], "T");
+        assert_eq!(out["sessions_countersigned"], 0, "forge must not land in countersigned");
+        assert_eq!(out["sessions_self"], 1);
+    }
+
+    #[test]
+    fn forged_runtime_without_harness_is_capped_to_self() {
+        let forged = serde_json::json!({
+            "attestation_class": "runtime",
+            "approval_count": 0,
+            "harness": "cli",
+            "closed_at": "2026-07-06T00:00:00Z",
+        });
+        assert_eq!(cap_class_to_evidence("runtime", &forged), "self");
+    }
+
+    #[test]
+    fn honest_countersigned_with_approval_is_kept() {
+        let honest = serde_json::json!({
+            "attestation_class": "countersigned",
+            "approval_count": 2,
+            "harness": "claude-code",
+            "closed_at": "2026-07-06T00:00:00Z",
+        });
+        assert_eq!(cap_class_to_evidence("countersigned", &honest), "countersigned");
+    }
+
+    #[test]
+    fn unknown_class_folds_to_self() {
+        let p = serde_json::json!({ "approval_count": 5, "harness": "claude-code" });
+        // Even though evidence would justify countersigned, an unrecognized
+        // declared label never outranks; it normalizes to self.
+        assert_eq!(cap_class_to_evidence("super-trusted", &p), "self");
     }
 
     #[test]

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -80,6 +80,14 @@ pub enum PredicateError {
     },
     /// The payload was not a JSON object (registered predicates require one).
     NotAnObject { suffix: String },
+    /// A present field's value was not among the schema's `enum` (or did not
+    /// equal its `const`). This is what stops a self-declared field from
+    /// carrying an out-of-vocabulary value (AUD-06).
+    NotInEnum {
+        suffix: String,
+        field: String,
+        allowed: String,
+    },
     /// The embedded schema itself failed to parse (a build-time bug).
     SchemaParse { suffix: String, detail: String },
 }
@@ -101,6 +109,10 @@ impl fmt::Display for PredicateError {
             PredicateError::NotAnObject { suffix } => {
                 write!(f, "{suffix}: payload must be a JSON object")
             }
+            PredicateError::NotInEnum { suffix, field, allowed } => write!(
+                f,
+                "{suffix}: field `{field}` has a value outside its allowed set ({allowed})"
+            ),
             PredicateError::SchemaParse { suffix, detail } => {
                 write!(f, "{suffix}: registered schema is invalid JSON: {detail}")
             }
@@ -156,15 +168,40 @@ pub fn validate(suffix: &str, payload: Option<&Value>) -> Result<(), PredicateEr
             let Some(actual) = map.get(field) else {
                 continue; // optional-and-absent; `required` already enforced presence
             };
-            let Some(type_decl) = subschema.get("type") else {
-                continue; // no declared primitive type (e.g. const/enum/$ref) -> not structurally checked
-            };
-            if !type_matches(actual, type_decl) {
-                return Err(PredicateError::TypeMismatch {
-                    suffix: suffix.to_string(),
-                    field: field.to_string(),
-                    expected: type_decl.to_string(),
-                });
+
+            // Primitive type, when declared.
+            if let Some(type_decl) = subschema.get("type") {
+                if !type_matches(actual, type_decl) {
+                    return Err(PredicateError::TypeMismatch {
+                        suffix: suffix.to_string(),
+                        field: field.to_string(),
+                        expected: type_decl.to_string(),
+                    });
+                }
+            }
+
+            // AUD-06: enforce `enum` and `const`, independently of whether a
+            // `type` is also declared. Before this, a field with a declared
+            // enum (e.g. session.v1 `attestation_class`) passed on type alone,
+            // so an out-of-vocabulary value slipped through. A missing type is
+            // no longer a free pass either.
+            if let Some(allowed) = subschema.get("enum").and_then(Value::as_array) {
+                if !allowed.iter().any(|a| a == actual) {
+                    return Err(PredicateError::NotInEnum {
+                        suffix: suffix.to_string(),
+                        field: field.to_string(),
+                        allowed: Value::Array(allowed.clone()).to_string(),
+                    });
+                }
+            }
+            if let Some(constant) = subschema.get("const") {
+                if actual != constant {
+                    return Err(PredicateError::NotInEnum {
+                        suffix: suffix.to_string(),
+                        field: field.to_string(),
+                        allowed: constant.to_string(),
+                    });
+                }
             }
         }
     }
@@ -289,6 +326,45 @@ mod tests {
             "report_url": null
         });
         assert!(validate("session.v1", Some(&payload)).is_ok());
+    }
+
+    #[test]
+    fn session_record_out_of_enum_class_fails_closed() {
+        // AUD-06: before enum enforcement, an out-of-vocabulary
+        // attestation_class passed on type (string) alone. It must now be
+        // rejected against the schema's enum.
+        let payload = json!({
+            "session_id": "ssn_abc123",
+            "actor": "agent://hermes",
+            "outcome": "completed",
+            "started_at": "2026-07-06T14:00:00Z",
+            "closed_at": "2026-07-06T15:30:00Z",
+            "attestation_class": "super-trusted",
+            "receipt_digest": "sha256:deadbeef"
+        });
+        let err = validate("session.v1", Some(&payload)).unwrap_err();
+        assert!(
+            matches!(err, PredicateError::NotInEnum { ref field, .. } if field == "attestation_class"),
+            "expected NotInEnum for attestation_class, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn session_record_out_of_enum_outcome_fails_closed() {
+        // `outcome` also carries an enum; a bogus value must be rejected.
+        let payload = json!({
+            "session_id": "ssn_abc123",
+            "actor": "agent://hermes",
+            "outcome": "totally-shipped",
+            "started_at": "2026-07-06T14:00:00Z",
+            "closed_at": "2026-07-06T15:30:00Z",
+            "attestation_class": "self",
+            "receipt_digest": "sha256:deadbeef"
+        });
+        assert!(matches!(
+            validate("session.v1", Some(&payload)).unwrap_err(),
+            PredicateError::NotInEnum { .. }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
MEDIUM from the July 2026 internal audit. Shipped `profile`/`history` surface.

## The problem
A `session.v1` work-history record carries an `attestation_class` (`self` < `runtime` < `countersigned`) that `session close` derives from **sealed evidence**: `countersigned` only when approvals were consumed, `runtime` only under a real tool runtime. Three gaps let an attacker launder self-attested work into the highest trust classes:

1. **Mint vector** — `treeship attest receipt --kind session.v1 --payload '{... "attestation_class":"countersigned", "action_count":9999 ...}'` hand-signed a work-history record with no countersignature or runtime evidence.
2. **Schema bypass** — `predicates::validate` checked a field's `type` but never its `enum`, so an out-of-vocabulary class (or `outcome`) passed validation.
3. **Read side** — `aggregate_profile` and `history` tallied/displayed the declared class verbatim, so a forged `countersigned` landed in that trusted bucket and `verify_profile` re-derived the same forged number and certified it "checked".

## Fixes
- **attest**: refuse close-only kinds (`session.v1`) in the generic attest path (`close_only_kind_owner`) — they are minted only by `session close`.
- **predicates**: enforce `enum` and `const` in `validate`, independent of whether a `type` is also declared (new `PredicateError::NotInEnum`).
- **profile/history**: cap the declared class to what the payload's **own** counts justify (`cap_class_to_evidence`: countersigned needs `approval_count>0`, runtime needs a non-cli harness) and normalize unknown labels to `self`, so an internally-inconsistent record cannot outrank its evidence.

### Residual (follow-up)
Full cross-checking against the embedded signed approval grants / runtime logs needs the sealed packages, not just these payloads. The cap is a self-consistency floor that closes the naive forge and matches the mint rule; documented inline.

## Tests (fail before the fix)
- core: `session_record_out_of_enum_class_fails_closed`, `session_record_out_of_enum_outcome_fails_closed`
- cli: `forged_countersigned_without_approvals_is_capped_to_self`, `forged_runtime_without_harness_is_capped_to_self`, `honest_countersigned_with_approval_is_kept`, `unknown_class_folds_to_self`, `session_v1_is_close_only`

Full core + cli suites green.

Refs AUD-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)