### PR TITLE
fix(session): mark git reconcile fail-open as degraded, not clean (AUD-07)

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1197,6 +1197,14 @@ pub fn close(
         receipt.proofs.reconcile_untracked_cap =
             reconcile_summary.untracked_cap.min(u32::MAX as usize) as u32;
     }
+    // AUD-07: git worked at session start (we captured a HEAD) but the reconcile
+    // backstop found no git repo at close — it was disabled mid-session
+    // (`.git` removed, corrupt index, PATH-poisoned git). A file changed via a
+    // non-AgentWroteFile channel could be missing from the ledger with no other
+    // signal, so stamp the receipt degraded and let `package verify` WARN.
+    if manifest.start_commit_sha.is_some() && !reconcile_summary.git_repo_present {
+        receipt.proofs.reconcile_degraded = true;
+    }
 
     // Override narrative with explicit --headline/--review if provided
     if headline.is_some() || review.is_some() {

--- a/packages/core/src/session/git.rs
+++ b/packages/core/src/session/git.rs
@@ -55,6 +55,16 @@ pub struct ReconcileSummary {
     pub untracked_seen: usize,
     pub untracked_cap: usize,
     pub untracked_truncated: bool,
+    /// Whether a git work tree was actually present when reconcile ran
+    /// (AUD-07). `false` means `is_git_repo` returned false — not in a repo,
+    /// git binary missing/PATH-poisoned, or `.git` removed/corrupted — so the
+    /// git-diff backstop produced NO changes for a reason other than "clean
+    /// tree". The close path cross-checks this against the session's
+    /// start-of-session HEAD: if git worked at start but not at close, the
+    /// backstop was disabled mid-session and the receipt is stamped degraded.
+    /// Defaults to false so a `ReconcileSummary::default()` (reconcile never
+    /// ran) is treated as "git not confirmed present", not a clean tree.
+    pub git_repo_present: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -258,8 +268,11 @@ pub fn reconcile_changes_with_options(
     };
 
     if !is_git_repo(repo_dir) {
+        // git_repo_present stays false: the caller can distinguish "clean tree
+        // in a real repo" from "no repo / git unavailable" (AUD-07).
         return result;
     }
+    result.summary.git_repo_present = true;
 
     use std::collections::BTreeMap;
     // path -> change. BTreeMap so output is deterministic across runs,
@@ -398,6 +411,33 @@ mod tests {
         std::fs::create_dir_all(&tmp).unwrap();
         let result = reconcile_changes(&tmp, None);
         assert!(result.is_empty());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // AUD-07: git_repo_present distinguishes "clean tree in a real repo" from
+    // "no repo / git unavailable" so the close path can detect a backstop that
+    // was disabled mid-session.
+    #[test]
+    fn git_repo_present_false_outside_repo() {
+        let tmp = std::env::temp_dir().join(format!("treeship-nogit-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let r = reconcile_changes_with_options(&tmp, None, &ReconcileOptions::default());
+        assert!(!r.summary.git_repo_present, "no git repo -> git_repo_present must be false");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_repo_present_true_in_real_repo() {
+        let tmp = std::env::temp_dir().join(format!("treeship-git-{}", rand::random::<u32>()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let inited = Command::new("git")
+            .arg("-C").arg(&tmp).arg("init")
+            .stdout(Stdio::null()).stderr(Stdio::null())
+            .status().map(|s| s.success()).unwrap_or(false);
+        if inited {
+            let r = reconcile_changes_with_options(&tmp, None, &ReconcileOptions::default());
+            assert!(r.summary.git_repo_present, "real git repo -> git_repo_present must be true");
+        }
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/packages/core/src/session/package.rs
+++ b/packages/core/src/session/package.rs
@@ -639,6 +639,21 @@ pub fn verify_package_with_trust(
         ));
     }
 
+    // AUD-07: the git-diff backstop was disabled between session start and
+    // close (git worked at start — a HEAD was captured — but not at close).
+    // A file changed via a non-AgentWroteFile channel could be missing from
+    // the "Files changed" ledger with no other signal, so this must not read
+    // as a clean, complete audit trail.
+    if receipt.proofs.reconcile_degraded {
+        checks.push(VerifyCheck::warn(
+            "reconcile_degraded",
+            "the git reconcile backstop was UNAVAILABLE at session close although git worked at start \
+             (.git removed, corrupt index, or git not on PATH). Files changed outside a captured \
+             AgentWroteFile event may be MISSING from this receipt's file ledger — treat the \
+             \"Files changed\" list as incomplete.",
+        ));
+    }
+
     // 8. Approval evidence -- v0.9.9 PR 4. Three independent replay
     // checks, each emitted as its own VerifyCheck row so the printer
     // (and downstream tooling) can render them separately.
@@ -1465,6 +1480,41 @@ mod tests {
         let passes: Vec<_> = checks.iter().filter(|c| c.status == VerifyStatus::Pass).collect();
         assert!(passes.len() >= 5, "expected at least 5 pass checks, got {}", passes.len());
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // AUD-07: a receipt stamped reconcile_degraded must surface a WARN on
+    // verify, so a consumer is told the file ledger may be incomplete rather
+    // than reading the package as a clean, complete audit trail.
+    #[test]
+    fn verify_warns_when_reconcile_degraded() {
+        let mut receipt = make_receipt();
+        receipt.proofs.reconcile_degraded = true;
+        let tmp = std::env::temp_dir().join(format!("treeship-pkg-degraded-{}", rand::random::<u32>()));
+
+        let output = build_package(&receipt, &tmp).unwrap();
+        let checks = verify_package(&output.path).unwrap();
+
+        let warned = checks.iter().any(|c| c.name == "reconcile_degraded" && c.status == VerifyStatus::Warn);
+        assert!(warned, "expected a reconcile_degraded WARN, got {checks:?}");
+        // It is a WARN, not a hard fail (the signatures/Merkle are still valid).
+        let fails: Vec<_> = checks.iter().filter(|c| c.status == VerifyStatus::Fail).collect();
+        assert!(fails.is_empty(), "must not hard-fail: {fails:?}");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn verify_no_degraded_warn_when_clean() {
+        // The default receipt has reconcile_degraded=false: no such WARN.
+        let receipt = make_receipt();
+        let tmp = std::env::temp_dir().join(format!("treeship-pkg-clean-{}", rand::random::<u32>()));
+        let output = build_package(&receipt, &tmp).unwrap();
+        let checks = verify_package(&output.path).unwrap();
+        assert!(
+            !checks.iter().any(|c| c.name == "reconcile_degraded"),
+            "clean receipt must not emit a reconcile_degraded check"
+        );
         let _ = std::fs::remove_dir_all(&tmp);
     }
 

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -173,9 +173,19 @@ pub struct ProofsSection {
     pub reconcile_untracked_truncated: u32,
     #[serde(default, skip_serializing_if = "is_zero_u32")]
     pub reconcile_untracked_cap: u32,
+    /// AUD-07: the git-diff backstop was unavailable at close even though git
+    /// worked at session start (start_commit_sha was captured). A file could
+    /// have changed via a non-AgentWroteFile channel and the only backstop
+    /// that would have caught it was disabled (`.git` removed, corrupt index,
+    /// PATH-poisoned git), so the "Files changed" ledger may be incomplete.
+    /// `package verify` WARNs on this. Absent on receipts sealed before this
+    /// field so they stay byte-identical.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub reconcile_degraded: bool,
 }
 
 fn is_zero_u32(n: &u32) -> bool { *n == 0 }
+fn is_false(b: &bool) -> bool { !*b }
 
 /// Merkle section of the receipt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -294,6 +304,7 @@ impl ReceiptComposer {
             event_log_skipped: 0, // Set by caller after compose (Codex #8)
             reconcile_untracked_truncated: 0,
             reconcile_untracked_cap: 0,
+            reconcile_degraded: false, // Set by caller after compose (AUD-07)
         };
 
         // Compute cost/token totals from agent graph


### PR DESCRIPTION
MEDIUM from the July 2026 internal audit. Ships in the default binary.

## The problem
The git-diff reconcile is the **sole backstop** for file changes made through a non-`AgentWroteFile` channel (e.g. `sed -i src/x.rs` under a Bash tool call, which emits `AgentCompletedProcess`). It is fail-open by contract: `is_git_repo() == false` returns an empty `ReconcileResult` and close proceeds.

So an adversarial agent could edit a tracked file off-channel, then **disable git for the close** — `rm -rf .git`, corrupt the index, or PATH-poison `git` — and the receipt was composed and signed with the edit **absent and no degraded signal**. `package verify` passed offline: valid signatures, valid Merkle, no warning. A verifier returning Ok for the wrong reason, defeating "if a file changed during the session it appears in the receipt."

## The fix — an in-band degraded signal (mirrors `event_log_skipped`)
- **git**: `ReconcileSummary` gains `git_repo_present`, set true only when a git work tree actually answered at reconcile time (false on the early return).
- **session close**: git worked at **start** (`start_commit_sha` was captured) but the work tree is absent at **close** → stamp `ProofsSection.reconcile_degraded`. This start-vs-close cross-check catches `.git` removal / corruption / PATH poisoning (all make `is_git_repo` fail) with **no false positives** on genuinely non-git sessions (those never capture a start SHA).
- **ProofsSection.reconcile_degraded**: new bool, serde `default` + skip-when-false so pre-existing receipts stay **byte-identical**.
- **package verify**: WARN on `reconcile_degraded` so the "Files changed" ledger is flagged as possibly incomplete instead of reading as a clean audit trail.

## Tests (fail before the fix)
- `git_repo_present_false_outside_repo`, `git_repo_present_true_in_real_repo`
- `verify_warns_when_reconcile_degraded` (WARN, not a hard fail), `verify_no_degraded_warn_when_clean`

Full core + cli suites green.

Refs AUD-07.

🤖 Generated with [Claude Code](https://claude.com/claude-code)