### PR TITLE
fix: low-severity audit findings AUD-13/14/15/16

### DIFF
--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -879,10 +879,16 @@ pub(crate) fn build_dpop_jwt(
 /// Shows full code as XXXX-XXXX-XXXX-XXXX so the user can enter
 /// the complete code in the browser activation page.
 fn format_device_code(code: &str) -> String {
-    if code.len() >= 16 {
-        format!("{}-{}-{}-{}", &code[..4], &code[4..8], &code[8..12], &code[12..16])
-    } else if code.len() >= 8 {
-        format!("{}-{}", &code[..4], &code[4..8])
+    // AUD-14: group into 4-CHARACTER blocks, not 4-byte slices. A hub-supplied
+    // device code containing a multibyte character straddling a byte offset
+    // used to panic here (`&code[..4]` on a non-char-boundary), a server-driven
+    // DoS of the interactive attach flow. Operating on chars is panic-free.
+    let chars: Vec<char> = code.chars().collect();
+    let group = |range: std::ops::Range<usize>| -> String { chars[range].iter().collect() };
+    if chars.len() >= 16 {
+        format!("{}-{}-{}-{}", group(0..4), group(4..8), group(8..12), group(12..16))
+    } else if chars.len() >= 8 {
+        format!("{}-{}", group(0..4), group(4..8))
     } else {
         code.to_string()
     }
@@ -904,6 +910,20 @@ mod tests {
             hub_public_key: None,
             hub_secret_key: secret,
         }
+    }
+
+    // AUD-14: a hub-supplied device code with a multibyte char used to panic
+    // on a non-char-boundary slice. format_device_code must be panic-free.
+    #[test]
+    fn format_device_code_handles_multibyte() {
+        // 'é' is 2 bytes; the byte at offset 4 falls mid-character. The old
+        // `&code[..4]` panicked here (verified in the audit: exit 101).
+        let out = format_device_code("aaaé123456789012");
+        assert!(out.contains('-'), "long code should be grouped: {out}");
+        // Fully multibyte, short: must not panic, returns as-is.
+        assert_eq!(format_device_code("éé"), "éé");
+        // Exactly-8 chars with a multibyte in the split zone.
+        let _ = format_device_code("aaaéaaaé");
     }
 
     // AUD-02: the DPoP key must never sit in config.json as plaintext hex.

--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -152,10 +152,27 @@ pub fn run(
     let changed_files = diff_files(&files_before, &files_after);
     let files_changed_count = changed_files.len();
 
+    // AUD-15: when a changed file is unreadable at snapshot time (chmod-000 /
+    // TOCTOU delete), record the digest as JSON null, not "". An empty string
+    // is a specific-but-wrong value baked into the signed statement (a reader
+    // cannot tell it apart from a real digest); null is self-describing ("we
+    // saw the change but could not read the bytes").
+    let mut unreadable = 0usize;
     let files_modified: Vec<serde_json::Value> = changed_files.iter().map(|path| {
-        let digest = file_sha256(path).unwrap_or_default();
-        serde_json::json!({ "path": path, "digest": digest })
+        match file_sha256(path) {
+            Some(digest) => serde_json::json!({ "path": path, "digest": digest }),
+            None => {
+                unreadable += 1;
+                serde_json::json!({ "path": path, "digest": serde_json::Value::Null })
+            }
+        }
     }).collect();
+    if unreadable > 0 {
+        printer.warn(
+            "some changed files were unreadable at snapshot time; digest recorded as null",
+            &[("files", &unreadable.to_string())],
+        );
+    }
 
     // Short summary of changed dirs for display
     let files_summary = if changed_files.is_empty() {

--- a/packages/core/src/bundle/mod.rs
+++ b/packages/core/src/bundle/mod.rs
@@ -219,20 +219,26 @@ pub fn import(
     // signatures from a rotation/co-sign setup and the local trust root only
     // needs one to match. Index 0 = bundle envelope, 1..=N = artifact
     // envelopes (matches the order shown in error messages and CLI output).
-    verifier.verify_any(&export.bundle)
+    let bundle_vr = verifier.verify_any(&export.bundle)
         .map_err(|source| BundleError::UnverifiedEnvelope { index: 0, source })?;
+    let mut artifact_verified_keys: Vec<Option<String>> = Vec::with_capacity(export.artifacts.len());
     for (i, env) in export.artifacts.iter().enumerate() {
-        verifier.verify_any(env)
+        let vr = verifier.verify_any(env)
             .map_err(|source| BundleError::UnverifiedEnvelope { index: i + 1, source })?;
+        artifact_verified_keys.push(vr.verified_key_ids.first().cloned());
     }
 
-    // All signatures check out: now write.
-    for env in &export.artifacts {
-        let record = record_from_envelope(env)?;
+    // All signatures check out: now write, attributing each record to the key
+    // that actually verified (AUD-13), not to signatures.first().
+    for (env, vk) in export.artifacts.iter().zip(artifact_verified_keys.iter()) {
+        let record = record_from_envelope(env, vk.as_deref())?;
         storage.write(&record)?;
     }
 
-    let bundle_record = record_from_envelope(&export.bundle)?;
+    let bundle_record = record_from_envelope(
+        &export.bundle,
+        bundle_vr.verified_key_ids.first().map(|s| s.as_str()),
+    )?;
     let bundle_id = bundle_record.artifact_id.clone();
     storage.write(&bundle_record)?;
 
@@ -240,7 +246,16 @@ pub fn import(
 }
 
 /// Reconstruct a Record from a DSSE envelope by re-deriving the artifact ID.
-fn record_from_envelope(envelope: &Envelope) -> Result<Record, BundleError> {
+///
+/// `verified_key_id` is the key id whose signature ACTUALLY verified for this
+/// envelope (from the caller's `verify_any` result). It is used verbatim for
+/// the stored `key_id` so a decoy signature prepended ahead of the real one
+/// cannot misattribute the artifact's signer in local metadata (AUD-13). When
+/// None (no verification context), we fall back to the first signature's keyid.
+fn record_from_envelope(
+    envelope: &Envelope,
+    verified_key_id: Option<&str>,
+) -> Result<Record, BundleError> {
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
     let payload_bytes = URL_SAFE_NO_PAD.decode(&envelope.payload)
@@ -261,8 +276,11 @@ fn record_from_envelope(envelope: &Envelope) -> Result<Record, BundleError> {
         .ok()
         .and_then(|v| v.get("parentId").and_then(|t| t.as_str().map(|s| s.to_string())));
 
-    let key_id = envelope.signatures.first()
-        .map(|s| s.keyid.clone())
+    // AUD-13: attribute the record to the key that actually verified, not
+    // signatures.first() (which an attacker can prepend a decoy keyid to).
+    let key_id = verified_key_id
+        .map(|s| s.to_string())
+        .or_else(|| envelope.signatures.first().map(|s| s.keyid.clone()))
         .unwrap_or_default();
 
     Ok(Record {
@@ -484,6 +502,50 @@ mod tests {
         // record is persisted, so the destination store stays clean.
         assert!(!store2.exists(&a1));
         assert!(!store2.exists(&bundle.artifact_id));
+
+        rm(dir);
+        rm(dir2);
+    }
+
+    #[test]
+    fn import_attributes_record_to_verified_key_not_decoy() {
+        // AUD-13: a decoy signature prepended ahead of the real one must not
+        // misattribute the stored record's signer. verify_any skips the decoy
+        // and passes on the real sig; the stored key_id must be the key that
+        // actually verified, not signatures.first().
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+        let (store, dir) = tmp_store();
+        let signer   = Ed25519Signer::generate("key_real").unwrap();
+        let verifier = crate::attestation::Verifier::from_signer(&signer);
+
+        let a1 = sign_and_store(&store, &signer, &payload_type("action"),
+            &ActionStatement::new("agent://a", "tool.call"));
+        let bundle = create(&[&a1], Some("b"), None, &store, &signer).unwrap();
+        let export_path = dir.join("b.treeship");
+        export(&bundle.artifact_id, &export_path, &store).unwrap();
+
+        // Prepend a decoy signature (attacker keyid, garbage bytes) ahead of
+        // the real one on the first artifact envelope.
+        let raw = std::fs::read(&export_path).unwrap();
+        let mut ef: ExportFile = serde_json::from_slice(&raw).unwrap();
+        let real_sig = ef.artifacts[0].signatures[0].clone();
+        let decoy = crate::attestation::Signature {
+            keyid: "key_ceo".into(),
+            sig:   URL_SAFE_NO_PAD.encode([0u8; 64]),
+        };
+        ef.artifacts[0].signatures = vec![decoy, real_sig];
+        std::fs::write(&export_path, serde_json::to_vec(&ef).unwrap()).unwrap();
+
+        // Import into a fresh store: the real sig still verifies via verify_any.
+        let (store2, dir2) = tmp_store();
+        import(&export_path, &store2, &verifier).unwrap();
+
+        let rec = store2.read(&a1).unwrap();
+        assert_eq!(
+            rec.key_id, "key_real",
+            "record must be attributed to the VERIFIED key, not the prepended decoy"
+        );
 
         rm(dir);
         rm(dir2);

--- a/packages/sdk-ts/src/verify.ts
+++ b/packages/sdk-ts/src/verify.ts
@@ -16,9 +16,49 @@ const exec = promisify(execFile);
 // subsequent calls reuse the cached bindings.
 type WasmBindings = {
   verify_receipt: (json: string) => string;
-  verify_certificate: (json: string, now: string) => string;
-  cross_verify: (receipt: string, cert: string, now: string) => string;
+  // AUD-16: these must match the real core-wasm ABI. Both take a final
+  // trust_roots_json argument; omitting it (the stale 2/3-arg types) made the
+  // arg arrive as undefined -> empty trust store -> every certificate check
+  // failed closed, and the compiler could not catch the mismatch.
+  verify_certificate: (json: string, now: string, trustRoots: string) => string;
+  cross_verify: (
+    receipt: string,
+    cert: string,
+    now: string,
+    trustRoots: string
+  ) => string;
 };
+
+/** A pinned trust root for certificate verification (AUD-16). */
+export type TrustRootInput = {
+  /** Opaque key id / human label. */
+  keyId: string;
+  /** Public key as `ed25519:<base64url-no-pad>`. */
+  publicKey: string;
+  /** What this root may verify, e.g. `agent_cert`. */
+  kind: string;
+  label?: string;
+  addedAt?: string;
+};
+
+/**
+ * Serialize trust roots into the `{version, roots}` JSON the WASM verifier
+ * expects. Empty/absent roots serialize to "" so verification fails closed
+ * (an empty trust store trusts nothing) exactly as before.
+ */
+function serializeTrustRoots(roots?: TrustRootInput[]): string {
+  if (!roots || roots.length === 0) return "";
+  return JSON.stringify({
+    version: 1,
+    roots: roots.map((r) => ({
+      key_id: r.keyId,
+      public_key: r.publicKey,
+      kind: r.kind,
+      label: r.label ?? "",
+      added_at: r.addedAt ?? "",
+    })),
+  });
+}
 
 let wasmBindings: WasmBindings | null = null;
 
@@ -137,7 +177,8 @@ export class VerifyModule {
    */
   async verifyCertificate(
     target: VerifyTarget,
-    now?: Date | string
+    now?: Date | string,
+    trustRoots?: TrustRootInput[]
   ): Promise<VerifyCertificateResult> {
     const json = await normalizeToJson(target);
     const nowStr =
@@ -147,7 +188,9 @@ export class VerifyModule {
           ? now.toISOString()
           : now;
     const wasm = await loadWasm();
-    return JSON.parse(wasm.verify_certificate(json, nowStr));
+    return JSON.parse(
+      wasm.verify_certificate(json, nowStr, serializeTrustRoots(trustRoots))
+    );
   }
 
   /**
@@ -158,7 +201,8 @@ export class VerifyModule {
   async crossVerify(
     receipt: VerifyTarget,
     certificate: VerifyTarget,
-    now?: Date | string
+    now?: Date | string,
+    trustRoots?: TrustRootInput[]
   ): Promise<CrossVerifyResult> {
     const [receiptJson, certJson] = await Promise.all([
       normalizeToJson(receipt),
@@ -171,6 +215,13 @@ export class VerifyModule {
           ? now.toISOString()
           : now;
     const wasm = await loadWasm();
-    return JSON.parse(wasm.cross_verify(receiptJson, certJson, nowStr));
+    return JSON.parse(
+      wasm.cross_verify(
+        receiptJson,
+        certJson,
+        nowStr,
+        serializeTrustRoots(trustRoots)
+      )
+    );
   }
 }


### PR DESCRIPTION
Four low-severity findings from the July 2026 internal audit, batched.

## AUD-13 (bundle) — stored `key_id` from `signatures.first()`, not the verified sig
A decoy `{keyid:"key_ceo", sig:<garbage>}` prepended ahead of the real signature verifies fine (`verify_any` skips the decoy) but **misattributed** the stored artifact's signer in local metadata/proofs/OTel. Import now threads the `verify_any` result and attributes each record to the key that verified. No trust elevation (every real trust decision re-verifies per keyid), but the stored attribution is now correct.

## AUD-14 (hub) — `format_device_code` panics on a multibyte device code
`&code[..4]` was guarded only by a byte-length check, so a hub-supplied device code with a multibyte char straddling a byte offset panicked (exit 101) — a server-driven DoS of the interactive attach flow. Now groups by **characters**, panic-free.

## AUD-15 (wrap) — empty-digest fallback in a signed statement
An unreadable changed file (chmod-000 / TOCTOU delete) recorded `digest:""` via `file_sha256(..).unwrap_or_default()` — a specific-but-wrong value indistinguishable from a real digest. Now records JSON **null** (self-describing) and warns.

## AUD-16 (sdk-ts) — WasmBindings ABI drift dropped `trust_roots`
The stale 2/3-arg `verify_certificate`/`cross_verify` types meant the required `trust_roots_json` arrived as `undefined` → empty trust store → every cert check failed closed, and the compiler couldn't catch it. Updated the ABI types, added a `trustRoots` parameter + `serializeTrustRoots()` helper (empty → `""`, still fails closed). Fixes the contract break; not an exploitable bypass (already fail-closed).

## Tests (fail before the fix)
- `import_attributes_record_to_verified_key_not_decoy`
- `format_device_code_handles_multibyte`
- SDK typechecks against the real ABI

Full core + cli suites green; SDK `tsc --noEmit` clean.

Refs AUD-13 / AUD-14 / AUD-15 / AUD-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)