### PR TITLE
fix(zk): fail-closed guest verify, real base64, honest Groth16 binding (AUD-03/08/09)

### DIFF
--- a/packages/core-wasm/src/zk.rs
+++ b/packages/core-wasm/src/zk.rs
@@ -55,16 +55,34 @@ pub fn verify_circom_proof(proof_json: &serde_json::Value) -> Result<String, Str
     let valid = Groth16::<Bn254>::verify_proof(&pvk, &ark_proof, &public_signals)
         .unwrap_or(false);
 
-    let artifact_id = proof_json.get("artifact_id")
+    // AUD-09: the pairing check proves the proof is valid FOR THE SUPPLIED
+    // PUBLIC SIGNALS — it says nothing about which artifact those signals
+    // describe. The `artifact_id` field in the proof JSON is caller-controlled
+    // and is NOT compared against any public signal here, so echoing it beside
+    // `valid:true` would let anyone rebind a genuine proof about their own
+    // statement onto `art_VICTIM`. We therefore report `bound:false` and
+    // surface the actual public-signal field elements (as decimal strings) so
+    // a caller holding the trusted artifact_id can bind it themselves. The
+    // in-WASM binding (recompute artifact_id_hash and match the circuit's
+    // public input) is tracked as a follow-up; until then this path must not
+    // claim the proof is about the JSON's artifact_id.
+    let claimed_artifact_id = proof_json.get("artifact_id")
         .and_then(|a| a.as_str())
         .unwrap_or("unknown");
+    let public_signal_values: Vec<String> =
+        public_signals.iter().map(|f| f.into_bigint().to_string()).collect();
 
     Ok(serde_json::json!({
         "valid": valid,
         "system": "circom-groth16",
         "circuit": circuit,
-        "artifact_id": artifact_id,
+        // The artifact id is what the proof CLAIMS to be about; it is NOT
+        // verified against the public signals on this path.
+        "claimed_artifact_id": claimed_artifact_id,
+        "bound": false,
+        "note": "pairing verified for the supplied public signals only; the proof is NOT bound to claimed_artifact_id on this path. Match a trusted artifact_id's field hash against public_signal_values to bind it.",
         "public_signals": public_signals.len(),
+        "public_signal_values": public_signal_values,
         "proved_at": proof_json.get("proved_at")
             .and_then(|p| p.as_str())
             .unwrap_or("unknown"),

--- a/packages/zk-risc0/Cargo.toml
+++ b/packages/zk-risc0/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"
+base64 = "0.22"
 treeship-zk-risc0-methods = { path = "methods" }
 risc0-zkvm = { version = "^3.0.5" }
 bincode = "1"

--- a/packages/zk-risc0/methods/guest/src/main.rs
+++ b/packages/zk-risc0/methods/guest/src/main.rs
@@ -65,8 +65,13 @@ fn main() {
             }
         }
 
-        // 2. Verify content-addressed digest
-        if !artifacts[i].content.is_empty() {
+        // 2. Verify content-addressed digest. AUD-03: empty content cannot be
+        // digest-valid — it must FAIL closed, not skip the check. Before this,
+        // an artifact with empty content left all_digests_valid = true, so a
+        // chain of empty artifacts scored digest-valid with no real content.
+        if artifacts[i].content.is_empty() {
+            all_digests_valid = false;
+        } else {
             let computed_hash = hex::encode(Sha256::digest(&artifacts[i].content));
             let expected = artifacts[i].digest
                 .strip_prefix("sha256:")
@@ -76,18 +81,27 @@ fn main() {
             }
         }
 
-        // 3. Verify Ed25519 signature
-        if let Some(ref vk) = verifying_key {
-            if artifacts[i].signature_bytes.len() == 64 && !artifacts[i].signed_message.is_empty() {
+        // 3. Verify Ed25519 signature. AUD-03: every artifact MUST carry a
+        // verifying key, a 64-byte signature, and a NON-EMPTY signed message
+        // that verifies. Any missing piece fails closed. Before this, an empty
+        // signed_message (or a missing key) skipped verification entirely and
+        // left all_signatures_valid = true — a validly-signed chain forged
+        // with no private key, using only the victim's public key.
+        match &verifying_key {
+            Some(vk)
+                if artifacts[i].signature_bytes.len() == 64
+                    && !artifacts[i].signed_message.is_empty() =>
+            {
                 let mut sig_arr = [0u8; 64];
                 sig_arr.copy_from_slice(&artifacts[i].signature_bytes);
                 let signature = Signature::from_bytes(&sig_arr);
-
                 if vk.verify(&artifacts[i].signed_message, &signature).is_err() {
                     all_signatures_valid = false;
                 }
-            } else if !artifacts[i].signed_message.is_empty() {
-                // Signature bytes wrong length
+            }
+            // No key, wrong signature length, or empty signed message: the
+            // artifact is NOT validly signed.
+            _ => {
                 all_signatures_valid = false;
             }
         }

--- a/packages/zk-risc0/src/prover.rs
+++ b/packages/zk-risc0/src/prover.rs
@@ -103,19 +103,21 @@ impl RiscZeroProver {
             artifacts.len()
         );
 
-        // Build guest-compatible artifacts with full content + signatures
+        // Build guest-compatible artifacts with full content + signatures.
+        // A malformed signature encoding is now a hard error (AUD-08), not a
+        // silently-corrupted byte string.
         let guest_artifacts: Vec<GuestArtifact> = artifacts.iter().map(|a| {
-            // Decode base64url signature to raw bytes
-            let sig_bytes = base64_decode_sig(&a.signature);
-            GuestArtifact {
+            let sig_bytes = base64_decode_sig(&a.signature)
+                .map_err(|e| format!("artifact {}: {e}", a.artifact_id))?;
+            Ok(GuestArtifact {
                 artifact_id: a.artifact_id.clone(),
                 digest: a.digest.clone(),
                 parent_id: a.parent_id.clone(),
                 content: a.pae_message.clone(), // PAE bytes used for digest
                 signature_bytes: sig_bytes,
                 signed_message: a.pae_message.clone(), // PAE is the signed message
-            }
-        }).collect();
+            })
+        }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
         // Write both inputs matching the guest's two env::read() calls
         let env = risc0_zkvm::ExecutorEnv::builder()
@@ -190,42 +192,45 @@ impl RiscZeroProver {
     }
 }
 
-/// Decode a base64url signature string to raw bytes.
-fn base64_decode_sig(input: &str) -> Vec<u8> {
-    // Simple base64url decode
-    let standard: String = input.chars().map(|c| match c {
-        '-' => '+',
-        '_' => '/',
-        other => other,
-    }).collect();
-
-    let padded = match standard.len() % 4 {
-        2 => format!("{}==", standard),
-        3 => format!("{}=", standard),
-        _ => standard,
-    };
-
-    base64_simple_decode(&padded)
+/// Decode a base64url-no-pad signature string to raw bytes.
+///
+/// AUD-08: the previous hand-rolled decoder mapped every non-alphabet byte
+/// (INCLUDING `=` padding) to a zero sextet and emitted 3 bytes per 4-char
+/// chunk with no padding accounting. A 64-byte Ed25519 signature therefore
+/// decoded to 66 bytes, so `signature_bytes.len() == 64` failed and EVERY
+/// genuine signature was rejected — leaving the empty-`signed_message` forgery
+/// (AUD-03) as the only reachable "signatures valid" path. It also silently
+/// corrupted tampered inputs (`_ => 0`) instead of erroring. Use a real
+/// error-returning decoder: a valid signature decodes to exactly 64 bytes and
+/// malformed input is an explicit error.
+fn base64_decode_sig(input: &str) -> Result<Vec<u8>, String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    URL_SAFE_NO_PAD
+        .decode(input)
+        .map_err(|e| format!("bad signature base64: {e}"))
 }
 
-fn base64_simple_decode(input: &str) -> Vec<u8> {
-    let chars: Vec<u8> = input.bytes().map(|b| match b {
-        b'A'..=b'Z' => b - b'A',
-        b'a'..=b'z' => b - b'a' + 26,
-        b'0'..=b'9' => b - b'0' + 52,
-        b'+' => 62,
-        b'/' => 63,
-        _ => 0,
-    }).collect();
+#[cfg(test)]
+mod aud08_tests {
+    use super::base64_decode_sig;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
-    let mut output = Vec::new();
-    for chunk in chars.chunks(4) {
-        if chunk.len() < 4 { break; }
-        let n = ((chunk[0] as u32) << 18) | ((chunk[1] as u32) << 12)
-            | ((chunk[2] as u32) << 6) | (chunk[3] as u32);
-        output.push((n >> 16) as u8);
-        output.push((n >> 8) as u8);
-        output.push(n as u8);
+    // AUD-08: a 64-byte Ed25519 signature must decode to EXACTLY 64 bytes.
+    // The old hand-rolled decoder produced 66 (padding mapped to zero sextets
+    // + no padding accounting), so signature_bytes.len() == 64 always failed
+    // and every genuine signature was rejected.
+    #[test]
+    fn sig_decodes_to_exactly_64_bytes() {
+        let sig = [0x5au8; 64];
+        let encoded = URL_SAFE_NO_PAD.encode(sig);
+        let decoded = base64_decode_sig(&encoded).expect("valid base64url must decode");
+        assert_eq!(decoded.len(), 64, "64-byte signature must decode to 64 bytes, got {}", decoded.len());
+        assert_eq!(decoded, sig);
     }
-    output
+
+    // Malformed input is now an explicit error, not silently zero-substituted.
+    #[test]
+    fn malformed_base64_errors() {
+        assert!(base64_decode_sig("not valid base64 !!!").is_err());
+    }
 }


### PR DESCRIPTION
`zk`-feature-gated, pre-release soundness fixes. Per the audit, these must land **before the `zk` feature is enabled in any release**.

## AUD-03 (HIGH) — RISC0 chain guest scores empty artifacts as valid → signed-chain forgery with no private key
The digest check was gated on `!content.is_empty()` and **both** signature arms on `!signed_message.is_empty()`. An attacker builds N artifacts with empty `content` + empty `signed_message`, chains them under the victim's **public** key, and `env::commit`s `chain_intact/all_digests_valid/all_signatures_valid` all `true` — a cryptographically valid RISC Zero receipt attesting a digest-correct, validly-Ed25519-signed chain, fabricated with **no private key**.

Now fails closed: empty content → `all_digests_valid = false`; the signature arm requires a verifying key **and** a 64-byte signature **and** a non-empty signed message that verifies, else `all_signatures_valid = false`.

## AUD-08 (MEDIUM) — hand-rolled base64 in the signature path silently zero-substitutes
`base64_simple_decode` mapped every non-alphabet byte (including `=`) to a zero sextet and emitted 3 bytes per 4-char chunk with no padding accounting, so a 64-byte signature decoded to **66** bytes — `len() == 64` always failed and **every genuine signature was rejected**, leaving the AUD-03 empty-message forgery as the only reachable "signatures valid" path. Replaced with `base64` 0.22 `URL_SAFE_NO_PAD` (exactly 64 bytes for a valid sig; malformed input is an explicit error, no more silent `_ => 0`). The prove path propagates the decode error.

## AUD-09 (MEDIUM) — Groth16 proof not bound to the artifact it claims
`verify_circom_proof` ran the pairing against caller-supplied public signals then echoed the caller's `artifact_id` beside `valid:true`, never comparing any signal to the claimed artifact — so a genuine proof about the attacker's own statement rebinds onto `art_VICTIM`. The output no longer implies binding: `bound:false`, `claimed_artifact_id` (explicitly unverified), and the actual `public_signal_values` so a caller holding a trusted artifact_id can bind it themselves. Full in-WASM binding (recompute `artifact_id_hash`, match the circuit's public input) needs the circuit hashing spec and is tracked as a follow-up.

## Tests
- `sig_decodes_to_exactly_64_bytes`, `malformed_base64_errors` (AUD-08)
- AUD-03 (guest) and AUD-09 output shape need the zkVM prover / proof fixtures to exercise end-to-end; all three crates build.

Refs AUD-03 / AUD-08 / AUD-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)