### PR TITLE
feat(trust)!: split overloaded Ship trust kind into hub_org/cert_issuer/revoker (BREAKING)

### DIFF
--- a/docs/content/blog/verify-any-agent-in-five-minutes.mdx
+++ b/docs/content/blog/verify-any-agent-in-five-minutes.mdx
@@ -89,7 +89,7 @@ The `--publish` run ends by printing your **trust bundle**: the exact commands a
 
 ```
 [4/4] trust bundle — hand these to a counterparty:
-    treeship trust add key_… ed25519:… --kind ship --yes
+    treeship trust add key_… ed25519:… --kind cert_issuer --yes
     treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
 ```
 
@@ -100,7 +100,7 @@ Two lines. Note that they pin your **ship** key, not the deployer agent's key. T
 Now become the skeptic. On a clean machine (or a fresh config), holding nothing but those two `trust add` lines the deployer's operator sent you:
 
 ```bash
-treeship trust add key_… ed25519:… --kind ship --yes
+treeship trust add key_… ed25519:… --kind cert_issuer --yes
 treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
 
 treeship resolve --hub https://api.treeship.dev agent://deployer

--- a/docs/content/docs/capabilities.mdx
+++ b/docs/content/docs/capabilities.mdx
@@ -94,7 +94,7 @@ treeship merkle proof <artifact-id>   # generates an inclusion proof
 **Use / Test:**
 ```bash
 treeship trust list
-treeship trust add key_… ed25519:… --kind ship --yes
+treeship trust add key_… ed25519:… --kind cert_issuer --yes
 ```
 
 ### Connecting a hub

--- a/docs/content/docs/cli/keys.mdx
+++ b/docs/content/docs/cli/keys.mdx
@@ -26,7 +26,7 @@ treeship keys export
   pubkey:   ed25519:050j2M0Q…
 
   a counterparty pins it with:
-    treeship trust add key_b4be… ed25519:050j2M0Q… --kind ship --yes
+    treeship trust add key_b4be… ed25519:050j2M0Q… --kind cert_issuer --yes
     treeship trust add key_b4be… ed25519:050j2M0Q… --kind hub_checkpoint --yes
 ```
 

--- a/docs/content/docs/guides/what-to-expect.mdx
+++ b/docs/content/docs/guides/what-to-expect.mdx
@@ -148,7 +148,7 @@ The `--publish` run ends by printing a **trust bundle**: the exact two commands 
 
 ```bash
 # what your counterparty runs, once:
-treeship trust add key_… ed25519:… --kind ship --yes
+treeship trust add key_… ed25519:… --kind cert_issuer --yes
 treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
 
 # then they can verify, from anywhere:

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -351,20 +351,22 @@ pub fn revoke_capability(
         let signer_kid = signer.key_id();
         let self_revoke = !card_keyid.is_empty() && signer_kid == card_keyid;
         let trust = TrustRootStore::open_default_or_empty()?;
+        // Batch 5: issuer revocation is now scoped to the `Revoker` kind.
         let issuer_revoke = trust
             .roots()
             .iter()
-            .any(|r| r.key_id == signer_kid && r.kind == TrustRootKind::Ship);
+            .any(|r| r.key_id == signer_kid && r.kind == TrustRootKind::Revoker);
         self_revoke || issuer_revoke
     };
     if !will_be_honored {
         return Err(format!(
             "revocation would be IGNORED by verifiers: the resolved signer ({}) is \
-             neither the card's key ({}) nor a pinned Ship root.\n\n  This usually \
+             neither the card's key ({}) nor a pinned `revoker` root.\n\n  This usually \
              means the agent's per-agent key was rotated or removed after the card \
-             was minted. Re-register the agent's key, or pin a Ship trust root that \
-             is authorized to revoke, then retry — do not rely on a revocation that \
-             will not be honored.",
+             was minted. Re-register the agent's key, or pin a `revoker` trust root \
+             (treeship trust add <key_id> <pubkey> --kind revoker) that is authorized \
+             to revoke, then retry — do not rely on a revocation that will not be \
+             honored.",
             signer.key_id(),
             if card_keyid.is_empty() { "(none)" } else { card_keyid },
         )
@@ -397,7 +399,7 @@ pub fn revoke_capability(
     );
     if !self_revoke {
         printer.hint(
-            "signed with the ship's default key: verify-capability honors this only if that key is a Ship trust root; otherwise register the agent with --own-key and revoke as the agent.",
+            "signed with the ship's default key: verify-capability honors this only if that key is pinned as a `revoker` trust root; otherwise register the agent with --own-key and revoke as the agent.",
         );
     }
     printer.hint(&format!("treeship verify-capability {card_id}"));
@@ -439,11 +441,12 @@ pub(crate) fn find_revocation(
             .map(|r| r.verified_key_ids)
             .unwrap_or_default();
         let self_revoke = !card_keyid.is_empty() && verified.iter().any(|k| k == card_keyid);
+        // Batch 5: issuer revocation is now scoped to the `Revoker` kind.
         let issuer_revoke = verified.iter().any(|rk| {
             trust
                 .roots()
                 .iter()
-                .any(|r| &r.key_id == rk && r.kind == TrustRootKind::Ship)
+                .any(|r| &r.key_id == rk && r.kind == TrustRootKind::Revoker)
         });
         if self_revoke || issuer_revoke {
             let reason = payload

--- a/packages/cli/src/commands/keys.rs
+++ b/packages/cli/src/commands/keys.rs
@@ -60,14 +60,18 @@ pub fn export(
     let pinnable = format!("ed25519:{pub_b64}");
 
     // The trust kinds a counterparty pins this key under. A per-agent key
-    // backs cards and receipts (AgentCert); a ship key signs resolution
-    // bundles (Ship) and Merkle checkpoints (HubCheckpoint) — a remote
-    // verifier needs both to get `verified` on resolve AND
-    // `anchored & verified` on the transparency check.
+    // backs cards and receipts (AgentCert). A ship key signs several distinct
+    // things, and Batch 5 split those into separate kinds so a counterparty
+    // grants exactly the powers they intend: cert_issuer (vouch for this
+    // ship's agent certs → `verified` on resolve), revoker (honor this ship's
+    // capability revocations), hub_org (accept its hub-org single-use
+    // checkpoints), hub_checkpoint (Merkle checkpoints → `anchored & verified`
+    // on the transparency check). The deprecated `ship` kind is no longer
+    // emitted.
     let kinds: &[&str] = if is_agent_key {
         &["agent_cert"]
     } else {
-        &["ship", "hub_checkpoint"]
+        &["cert_issuer", "revoker", "hub_org", "hub_checkpoint"]
     };
 
     if printer.format == crate::printer::Format::Json {

--- a/packages/cli/src/commands/present.rs
+++ b/packages/cli/src/commands/present.rs
@@ -448,10 +448,11 @@ pub fn verify_presentation(
                 .map(|s| s.keyid.as_str())
                 .unwrap_or("");
             let self_revoke = !card_keyid.is_empty() && rev_signer == card_keyid;
+            // Batch 5: issuer revocation is now scoped to the `Revoker` kind.
             let issuer = trust
                 .roots()
                 .iter()
-                .any(|r| r.key_id == rev_signer && r.kind == TrustRootKind::Ship);
+                .any(|r| r.key_id == rev_signer && r.kind == TrustRootKind::Revoker);
             if self_revoke || issuer {
                 revoked = Some(
                     rev_stmt

--- a/packages/cli/src/commands/resolve.rs
+++ b/packages/cli/src/commands/resolve.rs
@@ -315,10 +315,12 @@ pub(crate) fn chain_verify_card(
             Some(s) => s.keyid.as_str(),
             None => continue,
         };
+        // Batch 5: certificate issuance is now scoped to the `CertIssuer`
+        // kind (was the overloaded `Ship` kind).
         let Some(ship_root) = trust
             .roots()
             .iter()
-            .find(|r| r.key_id == cert_signer && r.kind == TrustRootKind::Ship)
+            .find(|r| r.key_id == cert_signer && r.kind == TrustRootKind::CertIssuer)
         else {
             continue;
         };
@@ -492,10 +494,12 @@ fn resolve_remote(hub: &str, agent: &str, trust: &TrustRootStore, printer: &Prin
                 .map(|s| s.keyid.as_str())
                 .unwrap_or("");
             let self_revoke = !card_keyid.is_empty() && rev_signer == card_keyid;
+            // Batch 5: issuer revocation is now scoped to the `Revoker` kind
+            // (was the overloaded `Ship` kind).
             let issuer = trust
                 .roots()
                 .iter()
-                .any(|r| r.key_id == rev_signer && r.kind == TrustRootKind::Ship);
+                .any(|r| r.key_id == rev_signer && r.kind == TrustRootKind::Revoker);
             if self_revoke || issuer {
                 revocation = Some(
                     rev_stmt
@@ -722,7 +726,7 @@ mod chain_tests {
         let agent_key = Ed25519Signer::generate("key_agent").unwrap();
         let cert = signed_receipt("agent_cert.v1", cert_payload("agent://a", &agent_key), &ship);
         let card = signed_card("agent://a", "key_agent", &agent_key);
-        let trust = ship_pinned(&ship, TrustRootKind::Ship);
+        let trust = ship_pinned(&ship, TrustRootKind::CertIssuer);
 
         let verdict = chain_verify_card(
             &card, "key_agent", "agent://a",
@@ -756,7 +760,7 @@ mod chain_tests {
         let ship = Ed25519Signer::generate("key_ship").unwrap();
         let agent_key = Ed25519Signer::generate("key_agent").unwrap();
         let card = signed_card("agent://a", "key_agent", &agent_key);
-        let trust = ship_pinned(&ship, TrustRootKind::Ship);
+        let trust = ship_pinned(&ship, TrustRootKind::CertIssuer);
 
         let mut expired = cert_payload("agent://a", &agent_key);
         expired["valid_until"] = serde_json::json!("2026-01-02T00:00:00Z");
@@ -782,7 +786,7 @@ mod chain_tests {
         let ship = Ed25519Signer::generate("key_ship").unwrap();
         let agent_key = Ed25519Signer::generate("key_agent").unwrap();
         let other_key = Ed25519Signer::generate("key_other").unwrap();
-        let trust = ship_pinned(&ship, TrustRootKind::Ship);
+        let trust = ship_pinned(&ship, TrustRootKind::CertIssuer);
 
         // Cert certifies a DIFFERENT key than the card's signer.
         let cert = signed_receipt("agent_cert.v1", cert_payload("agent://a", &other_key), &ship);

--- a/packages/cli/src/commands/trust.rs
+++ b/packages/cli/src/commands/trust.rs
@@ -44,7 +44,7 @@ pub fn list(printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
                 "no trust roots configured (would be at {})",
                 path.display(),
             ));
-            printer.hint("treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|ship|agent_cert|session_host>");
+            printer.hint("treeship trust add <key_id> <pubkey> --kind <hub_checkpoint|hub_org|cert_issuer|revoker|agent_cert|session_host>");
             return Ok(());
         }
         Err(e) => return Err(e.into()),
@@ -96,8 +96,22 @@ pub fn add(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let kind = TrustRootKind::parse(kind)
         .ok_or_else(|| format!(
-            "unknown trust root kind '{kind}'. Expected one of: hub_checkpoint, ship, agent_cert, session_host",
+            "unknown trust root kind '{kind}'. Expected one of: \
+             hub_checkpoint, hub_org, cert_issuer, revoker, agent_cert, session_host",
         ))?;
+
+    // Batch 5: `ship` is a deprecated, inert kind retained only so legacy
+    // trust files still parse. It authorizes nothing, so refuse to mint a new
+    // one and point the operator at the specific power they meant to grant.
+    if kind.is_deprecated_ship() {
+        return Err(
+            "the `ship` trust kind is deprecated and no longer honored by any verifier. \
+             It used to grant three unrelated powers at once. Pin the specific power instead:\n  \
+             --kind hub_org      (trust this hub to promote local claims to global single-use)\n  \
+             --kind cert_issuer  (trust this ship to issue agent certificates)\n  \
+             --kind revoker      (trust this ship to revoke capabilities it issued)".into(),
+        );
+    }
 
     // Accept both `ed25519:<b64>` and bare base64url for ergonomics.
     // Normalize on write so the on-disk file is always prefixed.

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -193,7 +193,7 @@ enum Command {
     /// Examples:
     ///   treeship trust list
     ///   treeship trust add hub_zerker ed25519:<pubkey> --kind hub_checkpoint
-    ///   treeship trust add ship_acme  ed25519:<pubkey> --kind ship --label "ACME hub"
+    ///   treeship trust add ship_acme  ed25519:<pubkey> --kind cert_issuer --label "ACME ship"
     ///   treeship trust remove hub_zerker
     #[command(subcommand)]
     Trust(TrustCommand),
@@ -2016,7 +2016,7 @@ enum TrustCommand {
     ///
     /// Examples:
     ///   treeship trust add hub_zerker ed25519:<b64> --kind hub_checkpoint
-    ///   treeship trust add ship_acme  ed25519:<b64> --kind ship --label "ACME hub"
+    ///   treeship trust add ship_acme  ed25519:<b64> --kind cert_issuer --label "ACME ship"
     Add(TrustAddArgs),
 
     /// Remove a trust root by `key_id` (across all kinds).

--- a/packages/core/src/statements/approval_use.rs
+++ b/packages/core/src/statements/approval_use.rs
@@ -611,12 +611,14 @@ pub fn verify_hub_checkpoint_signature(
     };
 
     // Trust pin: the embedded hub_public_key MUST be in the operator's
-    // trust root store under kind `Ship` before we honor the signature.
+    // trust root store under kind `HubOrg` before we honor the signature.
     // Without this an attacker-minted keypair can self-sign a hub-org
-    // checkpoint and promote `replay-local-journal` to
-    // `replay-hub-org`. With it, the operator decides which hubs they
-    // trust to vouch for global single-use claims.
-    if !trust.contains(&vk, TrustRootKind::Ship) {
+    // checkpoint and promote `replay-local-journal` to `replay-hub-org`.
+    // With it, the operator decides which hubs they trust to vouch for
+    // global single-use claims. (Batch 5: this power used to ride on the
+    // overloaded `Ship` kind, which also granted cert issuance and
+    // revocation; it is now scoped to `HubOrg`.)
+    if !trust.contains(&vk, TrustRootKind::HubOrg) {
         return HubCheckpointVerification::UntrustedIssuer;
     }
 
@@ -910,15 +912,15 @@ mod tests {
         assert_eq!(v["checkpoint_kind"], "hub-org");
     }
 
-    /// Build a one-entry trust store that pins `pk` for kind `Ship`.
+    /// Build a one-entry trust store that pins `pk` for kind `HubOrg`.
     /// Used by every test below now that hub-checkpoint verification
-    /// requires a pin.
+    /// requires a pin (Batch 5: scoped to HubOrg, was the overloaded Ship).
     fn trust_with(pk: &ed25519_dalek::VerifyingKey) -> crate::trust::TrustRootStore {
         use crate::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
         TrustRootStore::with_roots(vec![TrustRoot {
             key_id:     "test_hub".into(),
             public_key: encode_ed25519_pubkey(pk),
-            kind:       TrustRootKind::Ship,
+            kind:       TrustRootKind::HubOrg,
             label:      "test pin".into(),
             added_at:   "2026-05-15T00:00:00Z".into(),
         }])
@@ -976,6 +978,49 @@ mod tests {
         assert_eq!(
             verify_hub_checkpoint_signature(&cp, &trust),
             HubCheckpointVerification::Valid,
+        );
+    }
+
+    // Batch 5: a deprecated `ship` pin must NOT authorize a hub-org checkpoint
+    // anymore; only a `hub_org` pin does. This is the security property of the
+    // trust-split — pinning a hub for one power no longer grants the others.
+    #[test]
+    fn deprecated_ship_pin_no_longer_authorizes_hub_checkpoint() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use ed25519_dalek::{Signer, SigningKey};
+        use crate::trust::{encode_ed25519_pubkey, TrustRoot, TrustRootKind, TrustRootStore};
+        let sk = SigningKey::from_bytes(&[9u8; 32]);
+        let pk = sk.verifying_key();
+        let mut cp = sample_checkpoint(CheckpointKind::HubOrg);
+        cp.hub_id          = "hub://zerker-org".into();
+        cp.hub_public_key  = URL_SAFE_NO_PAD.encode(pk.to_bytes());
+        cp.signed_at       = "2026-04-30T07:00:00Z".into();
+        cp.covered_use_ids = vec!["use_alpha".into()];
+        cp.hub_signature   = URL_SAFE_NO_PAD.encode(sk.sign(&cp.canonical_hub_signing_bytes()).to_bytes());
+
+        let pin = |kind| TrustRootStore::with_roots(vec![TrustRoot {
+            key_id: "h".into(),
+            public_key: encode_ed25519_pubkey(&pk),
+            kind,
+            label: String::new(),
+            added_at: "2026-05-15T00:00:00Z".into(),
+        }]);
+
+        // The exact same key, pinned as the deprecated `ship` kind: rejected.
+        assert_eq!(
+            verify_hub_checkpoint_signature(&cp, &pin(TrustRootKind::Ship)),
+            HubCheckpointVerification::UntrustedIssuer,
+            "a `ship` pin must no longer authorize hub-org checkpoints",
+        );
+        // Pinned as `hub_org`: honored.
+        assert_eq!(
+            verify_hub_checkpoint_signature(&cp, &pin(TrustRootKind::HubOrg)),
+            HubCheckpointVerification::Valid,
+        );
+        // Cross-power isolation: a `cert_issuer` pin does NOT grant hub-org.
+        assert_eq!(
+            verify_hub_checkpoint_signature(&cp, &pin(TrustRootKind::CertIssuer)),
+            HubCheckpointVerification::UntrustedIssuer,
         );
     }
 

--- a/packages/core/src/trust/mod.rs
+++ b/packages/core/src/trust/mod.rs
@@ -85,16 +85,33 @@ pub enum TrustRootKind {
     /// the ship-local journal checkpoint, distinct from the hub-org
     /// JournalCheckpoint kind below.
     HubCheckpoint,
-    /// `JournalCheckpoint` of kind `hub-org` -- signed by a remote Hub to
-    /// promote a local journal claim to a global single-use claim.
+    /// DEPRECATED, INERT (Batch 5 / trust-split). A single `ship` pin used to
+    /// authorize THREE unrelated powers at once: promoting a local journal
+    /// claim to a global single-use claim (hub checkpoints), issuing agent
+    /// certificates, and revoking capabilities. Pinning a hub for dedup thus
+    /// silently let it mint certs and kill capabilities. The powers are now
+    /// split across `HubOrg` / `CertIssuer` / `Revoker`, and NO verifier
+    /// accepts `ship` anymore. The variant is retained ONLY so an existing
+    /// `trust.json` that still contains `"kind":"ship"` parses (rather than
+    /// failing the whole file); such a pin is inert until re-pinned under the
+    /// specific kind. `treeship trust add --kind ship` is rejected.
     Ship,
+    /// `JournalCheckpoint` of kind `hub-org` -- signed by a remote Hub to
+    /// promote a local journal claim to a global single-use claim. Split out
+    /// of `Ship` so trusting a hub for single-use dedup does not also let it
+    /// issue certificates or revoke capabilities.
+    HubOrg,
+    /// A ship key trusted to ISSUE agent certificates. Split out of `Ship`.
+    CertIssuer,
+    /// A ship key trusted to REVOKE capabilities it issued. Split out of `Ship`.
+    Revoker,
     /// `AgentCertificate` issued by a ship to one of its agents.
     AgentCert,
     /// Phase 1 of agent invitations: the host's signing key that mints
     /// `InvitationStatement` envelopes. Verifiers (and the
     /// `treeship session join` flow) require the invitation's issuer
     /// pubkey to be present in the trust root store under this kind
-    /// before honoring the invitation. Separate from `Ship` so a
+    /// before honoring the invitation. Separate from the ship kinds so a
     /// machine can trust hub-org checkpoints without implicitly
     /// trusting that hub to host multi-agent rooms.
     SessionHost,
@@ -105,6 +122,9 @@ impl TrustRootKind {
         match self {
             Self::HubCheckpoint => "hub_checkpoint",
             Self::Ship          => "ship",
+            Self::HubOrg        => "hub_org",
+            Self::CertIssuer    => "cert_issuer",
+            Self::Revoker       => "revoker",
             Self::AgentCert     => "agent_cert",
             Self::SessionHost   => "session_host",
         }
@@ -114,10 +134,19 @@ impl TrustRootKind {
         match s {
             "hub_checkpoint" => Some(Self::HubCheckpoint),
             "ship"           => Some(Self::Ship),
+            "hub_org"        => Some(Self::HubOrg),
+            "cert_issuer"    => Some(Self::CertIssuer),
+            "revoker"        => Some(Self::Revoker),
             "agent_cert"     => Some(Self::AgentCert),
             "session_host"   => Some(Self::SessionHost),
             _                => None,
         }
+    }
+
+    /// True for the deprecated, inert `ship` kind that no verifier honors.
+    /// Kept parseable only so legacy trust files still load.
+    pub fn is_deprecated_ship(self) -> bool {
+        matches!(self, Self::Ship)
     }
 }
 
@@ -539,6 +568,21 @@ mod tests {
             added_at:   "2026-05-15T00:00:00Z".into(),
         };
         (sk, root)
+    }
+
+    // Batch 5: legacy `ship` must still PARSE (so an existing trust.json loads
+    // rather than failing the whole file), and round-trip through as_str, and
+    // report as the deprecated kind. The new kinds parse too.
+    #[test]
+    fn legacy_ship_kind_still_parses_but_is_deprecated() {
+        assert_eq!(TrustRootKind::parse("ship"), Some(TrustRootKind::Ship));
+        assert_eq!(TrustRootKind::Ship.as_str(), "ship");
+        assert!(TrustRootKind::Ship.is_deprecated_ship());
+        for k in ["hub_org", "cert_issuer", "revoker"] {
+            let parsed = TrustRootKind::parse(k).expect("new kind must parse");
+            assert_eq!(parsed.as_str(), k);
+            assert!(!parsed.is_deprecated_ship());
+        }
     }
 
     #[test]

--- a/packages/core/tests/hub_checkpoint_verify.rs
+++ b/packages/core/tests/hub_checkpoint_verify.rs
@@ -36,7 +36,8 @@ fn trust_for_hub(pk: &ed25519_dalek::VerifyingKey) -> TrustRootStore {
     TrustRootStore::with_roots(vec![TrustRoot {
         key_id:     "hub_test".into(),
         public_key: encode_ed25519_pubkey(pk),
-        kind:       TrustRootKind::Ship,
+        // Batch 5: hub-org checkpoint promotion is scoped to HubOrg.
+        kind:       TrustRootKind::HubOrg,
         label:      "test hub".into(),
         added_at:   "2026-05-15T00:00:00Z".into(),
     }])


### PR DESCRIPTION
**BREAKING (hard cutover, approved).** The trust-model split from the review: one `--kind ship` pin used to authorize three unrelated powers at once.

## The problem
A single `ship` trust root silently granted all of:
- promoting a local journal claim to a global single-use claim (hub-org checkpoints),
- issuing agent certificates,
- revoking capabilities.

So pinning a hub just for single-use dedup also let it mint certs and kill capabilities on your behalf — a confused-deputy over-grant.

## The fix
Split into three specific kinds, each verifier scoped to the one power it needs:

| Kind | Power | Verifier site |
|------|-------|---------------|
| `hub_org` | hub-org checkpoint promotion | `verify_hub_checkpoint_signature` |
| `cert_issuer` | agent certificate issuance | resolve chain verify |
| `revoker` | capability revocation | resolve / present / `capability revoke` |

## Hard cutover — what actually breaks
- **No `ship` fallback.** No verifier honors `ship` anymore. A legacy `ship` pin goes inert until re-pinned under the specific kind.
- **`ship` is retained as parseable-but-inert** so an existing `~/.treeship/trust.json` still loads. Removing the enum variant would make the whole file fail to deserialize and break *all* verification on that machine — this avoids that.
- **`treeship trust add --kind ship` is now rejected** with guidance to the three new kinds.
- **Nothing published breaks.** The trust kind is a local, verifier-side setting, not stored on the hub or embedded in any signed artifact. No re-publishing, no hub redeploy.

### Who is affected
Only operators who *manually* pinned a **remote** ship's key via `trust add --kind ship`. The default onboarding (`agent add --own-key`) pins `AgentCert`, not `ship`, so a normal single-operator setup is untouched.

### Migration (one command per power)
```
treeship trust add <key_id> <pubkey> --kind cert_issuer   # or hub_org / revoker
```

## Product output + docs updated
- `keys export` now emits `cert_issuer` / `revoker` / `hub_org` / `hub_checkpoint` for a ship key (it previously printed a `--kind ship` command that is now rejected).
- `trust add` hint, CLI help examples, and live docs (capabilities, cli/keys, what-to-expect, blog) point at the new kinds. Historical changelog entries left as accurate records of past releases.

## Tests (fail before the fix)
- `deprecated_ship_pin_no_longer_authorizes_hub_checkpoint` — ship rejected, hub_org honored, cert_issuer does not cross-grant
- `legacy_ship_kind_still_parses_but_is_deprecated`
- existing hub-checkpoint + cert-chain fixtures migrated to the new kinds

583 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)