### PR TITLE
ci: run the full shipped-binary test surface, not just treeship-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,16 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
 
+      # Run the full shipped-binary test surface, not just core. Before this,
+      # CI ran only `cargo test -p treeship-core`, so every regression test in
+      # treeship-cli (capability / verify / hub / wrap / resolve / profile) and
+      # treeship-core-wasm (the browser verifier) passed on a contributor's
+      # machine but never gated a merge. That is the gap the 2026-07 audits
+      # flagged: a fix's fail-before-fix test must actually run on push.
+      # (treeship-zk-risc0 needs the RISC0 guest toolchain and is added
+      # separately; the `zk` feature is pre-release.)
       - name: Run tests
-        run: cargo test -p treeship-core
+        run: cargo test -p treeship-core -p treeship-cli -p treeship-core-wasm
 
       - name: Build CLI
         run: cargo build -p treeship-cli
@@ -72,6 +80,13 @@ jobs:
       - name: Build Hub
         working-directory: packages/hub
         run: go build ./...
+
+      # Run the hub's Go tests too. The object-authz regression tests from the
+      # 2026-07 audit (DockOwnsCheckpointSigner, per-dock ownership) live here
+      # and previously did not gate merges — CI only built the hub.
+      - name: Test Hub
+        working-directory: packages/hub
+        run: go test ./...
 
   cross-sdk:
     name: Cross-SDK contract (${{ matrix.os }} / Node ${{ matrix.node }} / Python ${{ matrix.python }})


### PR DESCRIPTION
## The gap
CI ran only `cargo test -p treeship-core` and `go build ./...` for the hub. So every regression test in **treeship-cli** (capability / verify / hub / wrap / resolve / profile), **treeship-core-wasm** (the browser verifier), and the hub's **Go tests** (the AUD-04/11 object-authz suite) passed on a contributor's machine but **never gated a merge**. A fix's fail-before-fix test could regress in CI silently.

Both 2026-07 audits flagged this directly ("a fix must be verified as it's pushed"). This is the highest-leverage, lowest-risk close.

## Change
- **test job:** `cargo test -p treeship-core -p treeship-cli -p treeship-core-wasm` (was core-only).
- **hub job:** add `go test ./...` after the build.

`treeship-zk-risc0` needs the RISC0 guest toolchain and the `zk` feature is pre-release, so it's a tracked follow-up rather than part of this PR.

## Safety
No product code changes — this only makes existing tests enforce. Verified green on clean `main` before widening: 9 Rust test groups pass; hub `db` / `dpop` / `dock` / `agents` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)