### PR TITLE
fix(hub): verify checkpoint signatures + bind signer to pubkey (AUD-18, HIGH)

### DIFF
--- a/packages/cli/src/commands/merkle.rs
+++ b/packages/cli/src/commands/merkle.rs
@@ -519,6 +519,11 @@ pub fn publish(
         "signature":  checkpoint.signature,
         "public_key": checkpoint.public_key,
         "index":      checkpoint.index,
+        // AUD-18: the exact bytes the signature is over, so the hub can
+        // ed25519-verify the checkpoint without re-implementing the versioned
+        // canonical in Go. The hub cross-checks the structured fields above
+        // against the values embedded in this string.
+        "canonical":  checkpoint.canonical_signing_string(),
     });
 
     let cp_resp: serde_json::Value = ureq::post(&checkpoint_url)

--- a/packages/core/src/merkle/checkpoint.rs
+++ b/packages/core/src/merkle/checkpoint.rs
@@ -276,6 +276,29 @@ impl Checkpoint {
         })
     }
 
+    /// The exact canonical string this checkpoint's signature is computed
+    /// over, as bytes. Reproduces what `verify` reconstructs internally, so a
+    /// remote party (e.g. the hub, AUD-18) can be handed these bytes and run
+    /// `ed25519.Verify(public_key, canonical_signing_bytes, signature)` without
+    /// re-implementing the versioned canonical dispatch in another language.
+    /// The structured fields (root / tree_size / signer / signed_at) are all
+    /// present inside the returned string, pipe-delimited, so a verifier can
+    /// cross-check that the values it stores match the values that were signed.
+    pub fn canonical_signing_string(&self) -> String {
+        Self::canonical_for_signing(
+            self.canonical_version,
+            self.merkle_version,
+            self.algorithm.as_deref(),
+            self.zk_proof.as_ref(),
+            self.index,
+            &self.root,
+            self.tree_size,
+            self.height,
+            &self.signer,
+            &self.signed_at,
+        )
+    }
+
     /// Verify the checkpoint signature AND require the embedded public key
     /// to be present in `trust` under kind `HubCheckpoint`. Returns `false`
     /// on any failure (bad encoding, wrong key size, invalid signature,

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -581,6 +581,27 @@ func DockOwnsCheckpointSigner(database *sql.DB, dockID, signerKeyID string) (boo
 	return n > 0, nil
 }
 
+// GetSignerPublicKey returns the public key the FIRST checkpoint published
+// under signerKeyID bound it to, if any (AUD-18). This is the trust-on-first-
+// use binding: once a signer id has been seen with a public key, a later
+// checkpoint claiming the same signer with a DIFFERENT public key is rejected,
+// so an attacker cannot re-claim a victim's signer id to shadow its
+// consistency chain. `found` is false when the signer has never been seen.
+func GetSignerPublicKey(database *sql.DB, signerKeyID string) (pubKeyB64 string, found bool, err error) {
+	err = database.QueryRow(
+		`SELECT public_key_b64 FROM merkle_checkpoints
+		 WHERE signer_key_id = ? ORDER BY id ASC LIMIT 1`,
+		signerKeyID,
+	).Scan(&pubKeyB64)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return pubKeyB64, true, nil
+}
+
 func GetLatestCheckpoint(database *sql.DB, dockID string) (*MerkleCheckpoint, error) {
 	var row *sql.Row
 	if dockID != "" {

--- a/packages/hub/internal/db/db_test.go
+++ b/packages/hub/internal/db/db_test.go
@@ -203,3 +203,53 @@ func TestCheckpointAndArtifactOwnershipIsPerDock(t *testing.T) {
 		t.Fatalf("cross-tenant artifact must not read as dck_b's")
 	}
 }
+
+// AUD-18: a signer id is bound to the public key its first checkpoint used.
+// GetSignerPublicKey is the trust-on-first-use lookup the checkpoint handler
+// gates on so a second dock cannot re-claim a victim's signer id with a
+// different key.
+func TestGetSignerPublicKeyFirstWriterBinding(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := Open()
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	defer database.Close()
+
+	if err := InsertShip(database, "dck_victim", []byte("s"), []byte("d"), 1); err != nil {
+		t.Fatalf("insert ship: %v", err)
+	}
+
+	// Unknown signer: not found.
+	_, found, err := GetSignerPublicKey(database, "key_sig")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if found {
+		t.Fatal("an unseen signer must not be bound")
+	}
+
+	// Victim publishes first, binding key_sig -> PUBKEY_VICTIM.
+	cp := &MerkleCheckpoint{
+		RootHex: "ab12", TreeSize: 10, Height: 4,
+		SignedAt: "2026-07-08T00:00:00Z", SignerKeyID: "key_sig",
+		SignatureB64: "sig", PublicKeyB64: "PUBKEY_VICTIM",
+	}
+	if _, err := InsertCheckpoint(database, cp, "dck_victim"); err != nil {
+		t.Fatalf("insert checkpoint: %v", err)
+	}
+
+	pub, found, err := GetSignerPublicKey(database, "key_sig")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if !found || pub != "PUBKEY_VICTIM" {
+		t.Fatalf("signer must be bound to the first pubkey, got found=%v pub=%q", found, pub)
+	}
+	// The handler compares this against a later request's public_key: an
+	// attacker presenting "PUBKEY_ATTACKER" for the same signer would mismatch
+	// and be rejected.
+	if pub == "PUBKEY_ATTACKER" {
+		t.Fatal("binding must not resolve to an attacker key")
+	}
+}

--- a/packages/hub/internal/merkle/handlers.go
+++ b/packages/hub/internal/merkle/handlers.go
@@ -1,11 +1,14 @@
 package merkle
 
 import (
+	"crypto/ed25519"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -29,6 +32,11 @@ type checkpointRequest struct {
 	PublicKey  string `json:"public_key"`
 	RekorIndex *int64 `json:"rekor_index"`
 	Index      int64  `json:"index"`
+	// AUD-18: the exact bytes the CLI's signature is computed over. The hub
+	// ed25519-verifies against these rather than re-implementing the versioned
+	// canonical in Go, then cross-checks that the structured fields above are
+	// the ones actually signed.
+	Canonical string `json:"canonical"`
 }
 
 func (h *Handlers) PublishCheckpoint(w http.ResponseWriter, r *http.Request) {
@@ -45,8 +53,32 @@ func (h *Handlers) PublishCheckpoint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Root == "" || req.TreeSize == 0 || req.SignedAt == "" || req.Signer == "" || req.Signature == "" || req.PublicKey == "" {
+	if req.Root == "" || req.TreeSize == 0 || req.SignedAt == "" || req.Signer == "" || req.Signature == "" || req.PublicKey == "" || req.Canonical == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing required checkpoint fields"})
+		return
+	}
+
+	// AUD-18: verify the checkpoint signature. Before this, the hub stored
+	// signer/signature/public_key with NO verification, so anyone could POST a
+	// checkpoint naming a victim's signer, which made DockOwnsCheckpointSigner
+	// (the AUD-11 gate) return true for free and let the attacker shadow the
+	// victim's consistency chain.
+	if err := verifyCheckpointSignature(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	// Trust-on-first-use: a signer id is bound to the public key its first
+	// checkpoint used. A later checkpoint claiming that signer with a different
+	// key is rejected, so an attacker cannot re-claim a victim's signer id
+	// (which is what would otherwise make the AUD-11 gate meaningless).
+	boundPub, found, err := db.GetSignerPublicKey(h.DB, req.Signer)
+	if err != nil {
+		log.Printf("signer binding lookup error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to check signer binding"})
+		return
+	}
+	if found && boundPub != req.PublicKey {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "signer is already bound to a different public key"})
 		return
 	}
 
@@ -331,3 +363,52 @@ func writeJSON(w http.ResponseWriter, status int, v interface{}) {
 	w.WriteHeader(status)
 	json.NewEncoder(w).Encode(v)
 }
+
+// containsField reports whether want is an exact element of fields. Used to
+// confirm a structured checkpoint field was one of the pipe-delimited values
+// actually signed in the canonical string (AUD-18).
+func containsField(fields []string, want string) bool {
+	for _, f := range fields {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyCheckpointSignature ed25519-verifies a checkpoint publish request
+// against its canonical bytes and cross-checks that the structured fields the
+// hub will store were the ones actually signed (AUD-18). Returns nil on
+// success or a client-safe error describing the first failure. It does NOT
+// establish trust in the signer key — that is the signer→pubkey binding the
+// caller enforces separately; this only proves the request is internally
+// consistent and validly self-signed.
+func verifyCheckpointSignature(req *checkpointRequest) error {
+	pubKey, err := base64.RawURLEncoding.DecodeString(req.PublicKey)
+	if err != nil || len(pubKey) != ed25519.PublicKeySize {
+		return errCheckpoint("invalid public_key")
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(req.Signature)
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return errCheckpoint("invalid signature")
+	}
+	if !ed25519.Verify(pubKey, []byte(req.Canonical), sig) {
+		return errCheckpoint("checkpoint signature does not verify over the canonical bytes")
+	}
+	// The signature proves SOME key signed the canonical, but the canonical is
+	// attacker-authored. Bind the stored structured fields to the SIGNED bytes:
+	// each must appear as a pipe-delimited element of the canonical string, so
+	// the hub cannot serve a signer/root/tree_size/signed_at that was not signed.
+	canonFields := strings.Split(req.Canonical, "|")
+	for _, want := range []string{req.Signer, req.Root, req.SignedAt, strconv.FormatInt(req.TreeSize, 10)} {
+		if !containsField(canonFields, want) {
+			return errCheckpoint("structured field not present in the signed canonical")
+		}
+	}
+	return nil
+}
+
+type checkpointError string
+
+func (e checkpointError) Error() string { return string(e) }
+func errCheckpoint(msg string) error    { return checkpointError(msg) }

--- a/packages/hub/internal/merkle/handlers_test.go
+++ b/packages/hub/internal/merkle/handlers_test.go
@@ -1,0 +1,75 @@
+package merkle
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// AUD-18: PublishCheckpoint used to store signer/signature/public_key with no
+// verification at all. verifyCheckpointSignature is the gate that fixes it:
+// the signature must verify over the canonical bytes, and every structured
+// field the hub stores must be one that was actually signed.
+func TestVerifyCheckpointSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	root := "sha256:abcd1234"
+	signer := "key_hub"
+	signedAt := "2026-07-08T00:00:00Z"
+	var treeSize int64 = 10
+	// v3 canonical layout: v3|cv|mv|algo|zk|index|root|tree_size|height|signer|signed_at
+	canonical := strings.Join([]string{
+		"v3", "3", "2", "", "", "6",
+		root, strconv.FormatInt(treeSize, 10), "4", signer, signedAt,
+	}, "|")
+	sig := ed25519.Sign(priv, []byte(canonical))
+
+	valid := checkpointRequest{
+		Root:      root,
+		TreeSize:  treeSize,
+		SignedAt:  signedAt,
+		Signer:    signer,
+		Signature: base64.RawURLEncoding.EncodeToString(sig),
+		PublicKey: base64.RawURLEncoding.EncodeToString(pub),
+		Canonical: canonical,
+	}
+	if err := verifyCheckpointSignature(&valid); err != nil {
+		t.Fatalf("a validly-signed checkpoint must verify: %v", err)
+	}
+
+	// Tampered canonical: the signature no longer applies.
+	tampered := valid
+	tampered.Canonical = strings.Replace(canonical, root, "sha256:evil", 1)
+	if verifyCheckpointSignature(&tampered) == nil {
+		t.Fatal("a tampered canonical must fail signature verification")
+	}
+
+	// The AUD-18/AUD-11 shadow move: the signature is valid, but the attacker
+	// sets the stored `signer` to a victim's id that is NOT the one inside the
+	// signed canonical. Must be rejected so the hub cannot serve an unsigned
+	// signer.
+	spoofedSigner := valid
+	spoofedSigner.Signer = "key_victim"
+	if verifyCheckpointSignature(&spoofedSigner) == nil {
+		t.Fatal("a signer not present in the signed canonical must be rejected")
+	}
+
+	// A stored root that was not the one signed is likewise rejected.
+	spoofedRoot := valid
+	spoofedRoot.Root = "sha256:unsigned"
+	if verifyCheckpointSignature(&spoofedRoot) == nil {
+		t.Fatal("a root not present in the signed canonical must be rejected")
+	}
+
+	// Wrong-length / malformed key and signature fail closed.
+	badKey := valid
+	badKey.PublicKey = "not-base64!!"
+	if verifyCheckpointSignature(&badKey) == nil {
+		t.Fatal("malformed public_key must be rejected")
+	}
+}


### PR DESCRIPTION
Second finding from the **2026-07-08 follow-up audit**. HIGH, ships in the hub. Reproduced by the auditor.

## The problem
`PublishCheckpoint` authenticated the dock via DPoP, then stored `signer` / `signature` / `public_key` with **no Ed25519 verification**. Because `DockOwnsCheckpointSigner` (the AUD-11 gate against cross-tenant consistency shadowing) establishes "ownership" of a signer **by having published a checkpoint naming it**, this unverified endpoint let an attacker mint that ownership for free: POST a checkpoint with `signer=<victim's signer id>` and a bogus root, then pre-publish a first-writer-wins consistency row that silently drops the victim's real transition. **AUD-11's mitigation was not actually effective.**

## The fix — audit's option A (verify, don't re-implement the canonical in Go)
- **core:** `Checkpoint::canonical_signing_string()` exposes the exact bytes the signature is over.
- **cli:** `merkle publish` sends that `canonical` string with the checkpoint.
- **hub:** `verifyCheckpointSignature` ed25519-verifies over the canonical bytes, then cross-checks that each structured field the hub stores (`signer` / `root` / `tree_size` / `signed_at`) is a pipe-delimited element of the **signed** canonical, so the hub cannot serve a value that was not signed.
- **hub:** trust-on-first-use `signer→pubkey` binding (`db.GetSignerPublicKey`). Ed25519 verification **alone does not stop the shadow** (the attacker signs `signer=victim` with their *own* key); binding the signer id to the first public key it used, and 403-ing a later different key, is what makes the AUD-11 gate meaningful again. Residual (inherent to TOFU, noted in the audit): an attacker can still pre-claim a signer id the victim has never used.

## ⚠️ Coordinated deploy (please read)
The new hub **requires** the `canonical` field, so:
- New CLI → old hub: fine (old hub ignores the extra field).
- **Old CLI → new hub: rejected** ("missing required checkpoint fields"). An old CLI's `merkle publish` breaks against the upgraded hub until it updates.

Given the current user count this matches the Batch 5 "hard cutover" posture, but the hub deploy should be **paired with the CLI release**. If you'd rather have a transition window, I can make `canonical` optional-with-deprecation-warning instead (accept but skip verification for one release) — say the word.

## Tests (fail before the fix)
- Go `TestVerifyCheckpointSignature`: valid verifies; tampered canonical, spoofed signer, spoofed root, malformed key all rejected.
- Go `TestGetSignerPublicKeyFirstWriterBinding`: first pubkey binds; an attacker key for the same signer would mismatch.

Rust core/cli + hub `merkle`/`db` suites green.

Refs AUD-18. Graduates to a `TS-2026-NNN` advisory once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)