### PR TITLE
fix(plugin): redact secrets from captured Bash commands (AUD-26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
       - name: Trust-fabric acceptance suite
         run: bash tests/acceptance/trust-fabric.sh
 
+      # Plugin hook parity: runs each plugin's PostToolUse/PreToolUse hooks
+      # against fixtures with a mock treeship and diffs the recorded events.
+      # Gates the AUD-26 secret-redaction fixtures (and the per-plugin event
+      # mapping) so a change to a hook script that leaks or drops events fails
+      # on push. Self-contained: mock binary, no cargo build needed.
+      - name: Plugin hook parity suite
+        run: sh integrations/tests/parity.sh
+
   hub:
     runs-on: ubuntu-latest
     steps:

--- a/integrations/claude-code-plugin/scripts/post-tool-use.sh
+++ b/integrations/claude-code-plugin/scripts/post-tool-use.sh
@@ -32,7 +32,12 @@ if ! command -v treeship >/dev/null 2>&1; then
   exit 0
 fi
 
-if [ ! -d "./.treeship" ]; then
+# Locate the project. Honor TREESHIP_PROJECT_ROOT when it points at a real
+# .treeship dir (matches the kimi plugin, and lets the hook work when invoked
+# from a different cwd), otherwise require a .treeship in the cwd or $HOME.
+if [ -n "${TREESHIP_PROJECT_ROOT:-}" ] && [ -d "${TREESHIP_PROJECT_ROOT}/.treeship" ]; then
+  cd "${TREESHIP_PROJECT_ROOT}"
+elif [ ! -d "./.treeship" ] && [ ! -d "${HOME}/.treeship" ]; then
   exit 0
 fi
 
@@ -114,6 +119,20 @@ emit_called_tool() {
     >/dev/null 2>&1 || true
 }
 
+# AUD-26: redact secret-bearing tokens from a command string before it is
+# recorded in the session timeline, which can be PUBLISHED to a no-auth URL via
+# `session report`. Removes the values of env-assignment secrets (FOO_KEY=,
+# TOKEN=, ...), secret CLI flags (--token=, --password, --api-key=), and HTTP
+# bearer tokens, keeping the rest of the command readable. Best-effort and
+# pattern-based, NOT a guarantee — real secrets belong in env vars, not inline.
+# Portable POSIX `sed -E` only (no GNU-only \b or case-insensitive flag).
+redact_secrets() {
+  printf '%s' "$1" | sed -E \
+    -e 's/([A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD|CREDENTIAL|AUTH|APIKEY)[A-Z0-9_]*=)[^[:space:]]*/\1[REDACTED]/g' \
+    -e 's/(--?(token|secret|password|passwd|api[-_]?key|apikey|auth|bearer)[=[:space:]])[^[:space:]]*/\1[REDACTED]/g' \
+    -e 's/([Bb]earer[[:space:]]+)[A-Za-z0-9._~+/=-]+/\1[REDACTED]/g'
+}
+
 # ----------------------------------------------------------------------------
 # Dispatch on tool name.
 # ----------------------------------------------------------------------------
@@ -156,9 +175,9 @@ case "$TOOL_NAME" in
     ;;
   Bash)
     CMD=$(extract tool_input.command)
-    # Trim long commands to a sensible process_name. The full command is
-    # available in the meta if a downstream consumer wants it.
-    PROC_NAME=$(printf '%s' "${CMD:-bash}" | cut -c1-120)
+    # Redact secrets BEFORE truncating (AUD-26), then trim to a sensible
+    # process_name. This string can end up in a published, no-auth receipt.
+    PROC_NAME=$(redact_secrets "${CMD:-bash}" | cut -c1-120)
     # PostToolUse fires AFTER the command exits. The exit code is in the
     # tool_response payload (Claude Code uses tool_response.exit_code OR
     # the tool_response.is_error boolean depending on Bash variant).

--- a/integrations/kimi-code-plugin/scripts/post-tool-use.sh
+++ b/integrations/kimi-code-plugin/scripts/post-tool-use.sh
@@ -68,6 +68,19 @@ emit_called_tool() {
     >/dev/null 2>&1 || true
 }
 
+# AUD-26: redact secret-bearing tokens from a command string before it is
+# recorded in the session timeline, which can be PUBLISHED to a no-auth URL via
+# `session report`. Removes env-assignment secrets (FOO_KEY=, TOKEN=, ...),
+# secret CLI flags (--token=, --password, --api-key=), and HTTP bearer tokens,
+# keeping the rest readable. Best-effort, pattern-based — real secrets belong in
+# env vars, not inline. Portable POSIX `sed -E` only.
+redact_secrets() {
+  printf '%s' "$1" | sed -E \
+    -e 's/([A-Z0-9_]*(KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD|CREDENTIAL|AUTH|APIKEY)[A-Z0-9_]*=)[^[:space:]]*/\1[REDACTED]/g' \
+    -e 's/(--?(token|secret|password|passwd|api[-_]?key|apikey|auth|bearer)[=[:space:]])[^[:space:]]*/\1[REDACTED]/g' \
+    -e 's/([Bb]earer[[:space:]]+)[A-Za-z0-9._~+/=-]+/\1[REDACTED]/g'
+}
+
 TOOL_LOWER=$(printf '%s' "$TOOL_NAME" | tr 'A-Z' 'a-z')
 
 case "$TOOL_LOWER" in
@@ -109,7 +122,9 @@ case "$TOOL_LOWER" in
     ;;
   bash|exec|shell|run|run_command|terminal)
     CMD=$(pick params.command params.cmd params.shell tool_input.command input.command)
-    PROC_NAME=$(printf '%s' "${CMD:-bash}" | cut -c1-120)
+    # Redact secrets BEFORE truncating (AUD-26): this string can be published
+    # to a no-auth receipt URL.
+    PROC_NAME=$(redact_secrets "${CMD:-bash}" | cut -c1-120)
     EXIT_CODE=$(pick params.exit_code result.exit_code tool_response.exit_code exit_code)
     if [ -z "$EXIT_CODE" ]; then
       IS_ERROR=$(pick params.is_error result.is_error tool_response.is_error error)

--- a/integrations/tests/expectations/claude-code-plugin/post-tool-use-Bash-secret.txt
+++ b/integrations/tests/expectations/claude-code-plugin/post-tool-use-Bash-secret.txt
@@ -1,0 +1,2 @@
+session status --check
+session event --type agent.completed_process --tool AWS_SECRET_ACCESS_KEY=[REDACTED] aws s3 ls --exit-code 0 --agent-name claude-code

--- a/integrations/tests/expectations/kimi-code-plugin/post-tool-use-Bash-secret.txt
+++ b/integrations/tests/expectations/kimi-code-plugin/post-tool-use-Bash-secret.txt
@@ -1,0 +1,2 @@
+session status --check
+session event --type agent.completed_process --tool AWS_SECRET_ACCESS_KEY=[REDACTED] aws s3 ls --exit-code 0 --agent-name kimi-code

--- a/integrations/tests/fixtures/claude-code-plugin/post-tool-use-Bash-secret.json
+++ b/integrations/tests/fixtures/claude-code-plugin/post-tool-use-Bash-secret.json
@@ -1,0 +1,1 @@
+{"tool_name":"Bash","tool_input":{"command":"AWS_SECRET_ACCESS_KEY=hunter2 aws s3 ls"},"tool_response":{"exit_code":0}}

--- a/integrations/tests/fixtures/kimi-code-plugin/post-tool-use-Bash-secret.json
+++ b/integrations/tests/fixtures/kimi-code-plugin/post-tool-use-Bash-secret.json
@@ -1,0 +1,1 @@
+{"toolName":"bash","params":{"command":"AWS_SECRET_ACCESS_KEY=hunter2 aws s3 ls"},"runId":"r-9","toolCallId":"t-9","result":{"exit_code":0},"durationMs":8}


### PR DESCRIPTION
Privacy finding from the **2026-07-08 follow-up audit**. Ships in the Claude Code / Kimi plugins.

## The problem
Both plugins recorded the first 120 chars of **every Bash command** verbatim as the tool name in the session timeline (`PROC_NAME=$(… cut -c1-120)`). That timeline is **publishable to a no-auth public URL** via `session report`. So secret-bearing prefixes landed in shareable receipts:
- `AWS_SECRET_ACCESS_KEY=… aws s3 …`
- `curl -H "Authorization: Bearer …"`
- `deploy --token=…`

The MCP `meta` fields are labeled "no secrets" but nothing enforced it.

## The fix
A portable POSIX `redact_secrets` sed helper (both plugins) runs **before** truncation and strips the **values** of:
- env-assignment secrets: `FOO_KEY=` / `TOKEN=` / `SECRET=` / `PASSWORD=` / `PWD=` / …
- secret CLI flags: `--token=` / `--password` / `--api-key=` / bearer
- HTTP `Bearer <token>` header values

The rest of the command stays readable. Verified that common non-secret flags are **not** mangled: `docker run -p8080:80` and `mkdir -pv` pass through untouched. Best-effort and pattern-based (real secrets still belong in env vars); inline single-letter password flags (`mysql -pXXX`) are a documented residual, since redacting `-p*` would break `docker -p`.

## Bonus: fixed a pre-existing claude-plugin bug
The parity suite exposed that the claude hook only detected the project via `./.treeship` in cwd and **ignored `TREESHIP_PROJECT_ROOT`**, so it silently no-op'd when invoked from another cwd. Now mirrors the kimi guard.

## Tests (fail before the fix)
- New `Bash-secret` parity fixtures for **both** plugins assert the recorded `--tool` value is redacted.
- **Wired the parity suite into CI** (`integrations/tests/parity.sh` ran nowhere before) so hook regressions gate on push.
- Full parity: **11/11** (was 6/11 — the 4 claude tests were failing on `main` from the cwd bug).

Refs AUD-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)