### PR TITLE
fix(hub): server timeouts + Rekor timeout + dock body cap (AUD-20/23/30)

### DIFF
--- a/packages/hub/internal/dock/dock.go
+++ b/packages/hub/internal/dock/dock.go
@@ -162,6 +162,11 @@ type authorizeRequest struct {
 
 // Authorize handles POST /v1/dock/authorize
 func (h *Handlers) Authorize(w http.ResponseWriter, r *http.Request) {
+	// AUD-30: cap the body before decoding. Every authenticated endpoint wraps
+	// the body in MaxBytesReader; this UNauthenticated dock-finalize did not, so
+	// a huge JSON string value buffered straight into memory (OOM, no auth
+	// required). 64 KiB is ample for the device-code + two 32-byte pubkeys.
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
 	var req authorizeRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		jsonError(w, "invalid JSON body", http.StatusBadRequest)

--- a/packages/hub/internal/dock/dock_test.go
+++ b/packages/hub/internal/dock/dock_test.go
@@ -260,3 +260,27 @@ func toStrings(in []interface{}) []string {
 	}
 	return out
 }
+
+// AUD-30: /dock/authorize is unauthenticated and used to decode r.Body with no
+// size cap, so a huge JSON value could OOM the hub. The MaxBytesReader must
+// reject an oversized body instead of buffering it.
+func TestAuthorizeRejectsOversizedBody(t *testing.T) {
+	h := newTestHandlers(t)
+	// A JSON body well over the 64 KiB cap.
+	huge := `{"device_code":"` + strings.Repeat("A", 200*1024) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/dock/authorize", bytes.NewReader([]byte(huge)))
+	rec := httptest.NewRecorder()
+	h.Authorize(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("oversized body must be rejected with 400, got %d", rec.Code)
+	}
+	// Fail-before-fix: with the MaxBytesReader cap the body is rejected at
+	// DECODE ("invalid JSON body"). Without the cap the giant value decodes
+	// fine and only fails later validation ("missing or invalid device_code")
+	// — asserting the decode-path message proves the cap actually fired.
+	var body map[string]string
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body["error"] != "invalid JSON body" {
+		t.Fatalf("expected rejection at decode (cap fired), got error=%q", body["error"])
+	}
+}

--- a/packages/hub/internal/rekor/rekor.go
+++ b/packages/hub/internal/rekor/rekor.go
@@ -2,6 +2,7 @@ package rekor
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -10,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/treeship/hub/internal/db"
 )
@@ -75,14 +77,31 @@ func Anchor(database *sql.DB, artifactID, digest, envelopeJSON, shipPubKeyHex st
 		return nil
 	}
 
-	resp, err := http.Post(rekorURL, "application/json", bytes.NewReader(bodyBytes))
+	// AUD-23: the default http.Post has NO timeout. A slow or hung
+	// rekor.sigstore.dev (outage, or an on-path attacker holding the socket)
+	// blocked artifacts.Push indefinitely, each blocked call pinning a
+	// Throttle(100) slot -> full-hub DoS during a Rekor outage. Bound the whole
+	// round-trip with a context + client timeout, and LimitReader the response
+	// so a hostile server cannot stream unbounded data into memory. (Moving
+	// anchoring fully off the request path into an async worker is the deeper
+	// fix, tracked as a follow-up.)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, rekorURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		log.Printf("rekor: build request failed: %v", err)
+		return nil
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(httpReq)
 	if err != nil {
 		log.Printf("rekor: POST failed: %v", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
 		log.Printf("rekor: failed to read response: %v", err)
 		return nil

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -106,8 +106,23 @@ func main() {
 		port = "8080"
 	}
 
+	// AUD-20: an explicit server with timeouts. `http.ListenAndServe` sets
+	// none, so a handful of connections that dribble request headers a byte at
+	// a time (Slowloris) each held a Throttle(100) slot forever and froze the
+	// service. ReadHeaderTimeout is the direct fix; the others bound slow
+	// bodies, slow responses, and idle keep-alives. (Per-IP rate limiting to
+	// complement the global Throttle is a follow-up — it needs the httprate
+	// module.)
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 	log.Printf("treeship hub listening on :%s", port)
-	if err := http.ListenAndServe(":"+port, r); err != nil {
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
 }


### PR DESCRIPTION
Three hub availability findings from the **2026-07-08 follow-up audit**.

## AUD-20 (HIGH) — no server timeouts → Slowloris
`http.ListenAndServe` sets no timeouts, and the only backpressure is a global `middleware.Throttle(100)`. ~100 connections from one host that dribble request headers a byte at a time each hold a throttle slot forever and freeze the service. Replaced with an explicit `&http.Server{ReadHeaderTimeout:10s, ReadTimeout:30s, WriteTimeout:60s, IdleTimeout:120s}`. `ReadHeaderTimeout` is the direct fix. (Per-IP rate limiting to complement the global throttle is a follow-up — needs the `httprate` module.)

## AUD-23 (MEDIUM) — timeout-less synchronous Rekor POST
The default `http.Post` has no timeout, so a slow/hung `rekor.sigstore.dev` (outage or on-path attacker) blocked `artifacts.Push` indefinitely, each blocked call pinning a throttle slot → full-hub DoS during a Rekor outage. Now uses a context + client timeout (5s) and `LimitReader(1 MiB)` on the response. (Async off-request-path anchoring is the deeper fix, tracked separately.)

## AUD-30 (LOW) — `/dock/authorize` had no body cap
Every authenticated endpoint wraps the body in `MaxBytesReader`; this **unauthenticated** dock-finalize decoded `r.Body` with no cap, so a huge JSON value buffered into memory (OOM, no auth). Now `MaxBytesReader(64 KiB)` before decode.

## Tests (fail before the fix)
- Go `TestAuthorizeRejectsOversizedBody` — asserts the oversized body is rejected at **decode** (`"invalid JSON body"`), which distinguishes the cap firing from later field validation.
- AUD-20/23 are `http.Server` / `http.Client` config; hub build/vet/test green.

Refs AUD-20 / AUD-23 / AUD-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)