### PR TITLE
fix: OS CSPRNG for CLI security nonces + A2A trust-field gating (AUD-24/27)

### DIFF
--- a/bridges/a2a/src/types.ts
+++ b/bridges/a2a/src/types.ts
@@ -120,13 +120,28 @@ export interface VerifiedReceipt {
   digest?: string;
   events: number;
   artifacts: number;
-  withinDeclaredBounds: boolean;
   /**
-   * True iff the receipt JSON passed cryptographic checks via WASM
-   * (Merkle root recomputation, inclusion proofs, leaf count parity,
-   * timeline ordering, chain linkage). False when WASM is unavailable
-   * in the runtime or when a check failed -- inspect `verifyChecks` for
-   * the per-step breakdown.
+   * Whether the session stayed within its declared boundaries. Present ONLY
+   * when the receipt passed STRUCTURAL verification AND carried a declaration.
+   * `undefined` means unknown -- no declaration, or the receipt did not verify.
+   * A consumer must treat `undefined` as "not asserted", never as "in bounds"
+   * (AUD-27: this field used to be computed from the raw, attacker-controlled
+   * JSON regardless of verification, and defaulted to `true` when no
+   * declaration was present).
+   */
+  withinDeclaredBounds?: boolean;
+  /**
+   * True iff the receipt JSON passed STRUCTURAL checks via WASM (recomputed
+   * Merkle root, inclusion proofs, leaf-count parity, timeline order). This is
+   * NOT signature or issuer verification -- a URL-fetched receipt carries no
+   * envelope bytes to check. False when WASM is unavailable or a check failed.
+   */
+  structurallyConsistent: boolean;
+  /**
+   * True iff individual envelope SIGNATURES were cryptographically verified.
+   * The URL / receipt-JSON path cannot do this (no envelope bytes), so it is
+   * always false here; use the local-storage CLI path for real signature
+   * verification. Kept so callers can gate on genuine cryptographic proof.
    */
   cryptographicallyVerified: boolean;
   /** Per-step verification results from WASM. Present when WASM ran. */

--- a/bridges/a2a/src/verify.ts
+++ b/bridges/a2a/src/verify.ts
@@ -56,11 +56,24 @@ export async function fetchReceipt(receiptUrl: string): Promise<unknown | null> 
  * means the receipt's JSON-level integrity was confirmed. `null` if the
  * URL is unreachable or the document is unparseable.
  */
-export async function verifyReceipt(receiptUrl: string): Promise<VerifiedReceipt | null> {
-  const raw = await fetchReceipt(receiptUrl);
-  if (!raw || typeof raw !== 'object') return null;
-  const r = raw as Record<string, unknown>;
+export type VerifyFlags = {
+  structurallyConsistent: boolean;
+  cryptographicallyVerified: boolean;
+  verifyChecks?: { step: string; status: 'pass' | 'fail' | 'warn'; detail: string }[];
+};
 
+/**
+ * Build the trust summary from a (hostile) raw receipt object and the
+ * verification flags. Pure and exported so the trust-gating logic is
+ * unit-testable without network or WASM. AUD-27: trust-bearing fields
+ * (`shipId`, `withinDeclaredBounds`) are derived from the raw JSON ONLY when
+ * the receipt structurally verified; otherwise they are `undefined`.
+ */
+export function summarizeVerifiedReceipt(
+  raw: Record<string, unknown>,
+  flags: VerifyFlags,
+): VerifiedReceipt {
+  const r = raw;
   const sessionId =
     (typeof r.session_id === 'string' && r.session_id) ||
     (typeof (r as { session?: { id?: unknown } }).session?.id === 'string' &&
@@ -81,10 +94,35 @@ export async function verifyReceipt(receiptUrl: string): Promise<VerifiedReceipt
   const declared = r.declaration as Record<string, unknown> | undefined;
   const violations = Array.isArray(r.violations) ? r.violations.length : 0;
 
-  let cryptographicallyVerified = false;
-  let verifyChecks:
-    | { step: string; status: 'pass' | 'fail' | 'warn'; detail: string }[]
-    | undefined;
+  const { structurallyConsistent, cryptographicallyVerified, verifyChecks } = flags;
+
+  // AUD-27: shipId and withinDeclaredBounds are reported ONLY when structurally
+  // consistent; withinDeclaredBounds additionally requires a declaration
+  // (absent => undefined/unknown, never a default "true"). sessionId / events /
+  // artifacts / digest stay as an informational summary (not trust claims).
+  return {
+    sessionId,
+    shipId: structurallyConsistent ? shipId : undefined,
+    digest: typeof r.digest === 'string' ? r.digest : undefined,
+    events,
+    artifacts,
+    withinDeclaredBounds:
+      structurallyConsistent && declared ? violations === 0 : undefined,
+    structurallyConsistent,
+    cryptographicallyVerified,
+    verifyChecks,
+    raw,
+  };
+}
+
+export async function verifyReceipt(receiptUrl: string): Promise<VerifiedReceipt | null> {
+  const raw = await fetchReceipt(receiptUrl);
+  if (!raw || typeof raw !== 'object') return null;
+
+  const flags: VerifyFlags = {
+    structurallyConsistent: false,
+    cryptographicallyVerified: false,
+  };
 
   const wasm = await loadWasm();
   if (wasm) {
@@ -92,26 +130,20 @@ export async function verifyReceipt(receiptUrl: string): Promise<VerifiedReceipt
       const resultJson = wasm.verify_receipt(JSON.stringify(raw));
       const parsed = JSON.parse(resultJson) as {
         outcome: string;
-        checks?: typeof verifyChecks;
+        signatures_verified?: boolean;
+        checks?: VerifyFlags['verifyChecks'];
       };
-      cryptographicallyVerified = parsed.outcome === 'pass';
-      verifyChecks = parsed.checks;
+      // AUD-01: verify_receipt is STRUCTURAL only. Its success outcome is
+      // "structural-pass" (never "pass"), and it verifies no signatures.
+      flags.structurallyConsistent = parsed.outcome === 'structural-pass';
+      flags.cryptographicallyVerified = parsed.signatures_verified === true;
+      flags.verifyChecks = parsed.checks;
     } catch {
-      // WASM available but verification threw. Leave cryptographicallyVerified=false.
+      // WASM available but verification threw. Leave both false.
     }
   }
 
-  return {
-    sessionId,
-    shipId,
-    digest: typeof r.digest === 'string' ? r.digest : undefined,
-    events,
-    artifacts,
-    withinDeclaredBounds: declared ? violations === 0 : true,
-    cryptographicallyVerified,
-    verifyChecks,
-    raw,
-  };
+  return summarizeVerifiedReceipt(raw as Record<string, unknown>, flags);
 }
 
 /**

--- a/bridges/a2a/test/verify.test.ts
+++ b/bridges/a2a/test/verify.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeVerifiedReceipt } from '../src/verify.js';
+
+describe('@treeship/a2a verifyReceipt trust gating (AUD-27)', () => {
+  // A hostile receipt: claims a ship, no declaration, zero violations.
+  const hostile = {
+    session_id: 'ssn_attacker',
+    ship_id: 'ship_VICTIM',
+    events: [1, 2],
+    artifacts: [1],
+    // no `declaration`, no `violations`
+  };
+
+  it('does NOT leak shipId / withinDeclaredBounds when unverified', () => {
+    const out = summarizeVerifiedReceipt(hostile, {
+      structurallyConsistent: false,
+      cryptographicallyVerified: false,
+    });
+    // The trust-bearing fields must not come from the raw JSON.
+    expect(out.shipId).toBeUndefined();
+    expect(out.withinDeclaredBounds).toBeUndefined();
+    expect(out.structurallyConsistent).toBe(false);
+    expect(out.cryptographicallyVerified).toBe(false);
+    // Informational summary is still available.
+    expect(out.sessionId).toBe('ssn_attacker');
+    expect(out.events).toBe(2);
+  });
+
+  it('does NOT default withinDeclaredBounds to true when there is no declaration', () => {
+    // Even when structurally consistent, no declaration means UNKNOWN, not "in bounds".
+    const out = summarizeVerifiedReceipt(hostile, {
+      structurallyConsistent: true,
+      cryptographicallyVerified: false,
+    });
+    expect(out.withinDeclaredBounds).toBeUndefined();
+    expect(out.shipId).toBe('ship_VICTIM'); // shipId is fine once structurally consistent
+  });
+
+  it('reports withinDeclaredBounds only with a declaration AND structural consistency', () => {
+    const declared = { ...hostile, declaration: { tools: ['x'] }, violations: [] };
+    const ok = summarizeVerifiedReceipt(declared, {
+      structurallyConsistent: true,
+      cryptographicallyVerified: false,
+    });
+    expect(ok.withinDeclaredBounds).toBe(true);
+
+    const withViolations = { ...declared, violations: ['tool.escape'] };
+    const bad = summarizeVerifiedReceipt(withViolations, {
+      structurallyConsistent: true,
+      cryptographicallyVerified: false,
+    });
+    expect(bad.withinDeclaredBounds).toBe(false);
+
+    // But if it did not structurally verify, still undefined regardless.
+    const unver = summarizeVerifiedReceipt(declared, {
+      structurallyConsistent: false,
+      cryptographicallyVerified: false,
+    });
+    expect(unver.withinDeclaredBounds).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/approve.rs
+++ b/packages/cli/src/commands/approve.rs
@@ -108,9 +108,11 @@ fn list_pending_files() -> Vec<(PathBuf, PendingApproval)> {
 }
 
 fn generate_nonce() -> String {
-    let mut buf = [0u8; 12];
+    // AUD-24: OS CSPRNG (policy §5 bans thread_rng for security nonces), and
+    // 16 bytes = 128 bits (was 96) for the approval binding nonce.
+    let mut buf = [0u8; 16];
     use rand::RngCore;
-    rand::thread_rng().fill_bytes(&mut buf);
+    rand::rngs::OsRng.fill_bytes(&mut buf);
     format!("nce_{}", hex::encode(buf))
 }
 

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -274,10 +274,11 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
     };
 
     // Generate a cryptographically random nonce for approval binding.
+    // AUD-24: OS CSPRNG, not thread_rng (policy §5).
     let nonce = {
         let mut b = [0u8; 16];
         use rand::RngCore;
-        rand::thread_rng().fill_bytes(&mut b);
+        rand::rngs::OsRng.fill_bytes(&mut b);
         b.iter().fold(String::new(), |mut s, byte| {
             s.push_str(&format!("{:02x}", byte));
             s
@@ -1211,10 +1212,11 @@ fn reserve_in_journal(
     let use_number = 0u32;
 
     // Use_id is a fresh UUID-style hex token. Same shape as nonces.
+    // AUD-24: OS CSPRNG, 16 bytes = 128 bits (was 12).
     let use_id = {
         use rand::RngCore;
-        let mut b = [0u8; 12];
-        rand::thread_rng().fill_bytes(&mut b);
+        let mut b = [0u8; 16];
+        rand::rngs::OsRng.fill_bytes(&mut b);
         let mut hex = String::with_capacity(2 * b.len() + 4);
         hex.push_str("use_");
         for byte in &b {

--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -93,7 +93,7 @@ pub fn attach(
         .to_string();
 
     // 2. Generate fresh Ed25519 hub keypair
-    let mut csprng = rand::thread_rng();
+    let mut csprng = rand::rngs::OsRng;
     let hub_signing_key = SigningKey::generate(&mut csprng);
     let hub_verifying_key: VerifyingKey = (&hub_signing_key).into();
 
@@ -850,7 +850,7 @@ pub(crate) fn build_dpop_jwt(
         .as_secs();
 
     let mut jti_bytes = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut jti_bytes);
+    rand::rngs::OsRng.fill_bytes(&mut jti_bytes);
     let jti = hex::encode(jti_bytes);
 
     let payload = serde_json::json!({

--- a/packages/cli/src/commands/invitation.rs
+++ b/packages/cli/src/commands/invitation.rs
@@ -559,9 +559,10 @@ pub fn join(
     let j_dir = journal_dir_for_ctx(&c);
     let j = Journal::new(&j_dir);
     let use_id = {
-        let mut buf = [0u8; 8];
+        // AUD-24: OS CSPRNG (policy §5), 16 bytes = 128 bits (was 64).
+        let mut buf = [0u8; 16];
         use rand::RngCore;
-        rand::thread_rng().fill_bytes(&mut buf);
+        rand::rngs::OsRng.fill_bytes(&mut buf);
         format!("use_inv_{}", hex::encode(buf))
     };
     let nonce_d = nonce_digest(&invitation.nonce);

--- a/packages/cli/src/commands/merkle.rs
+++ b/packages/cli/src/commands/merkle.rs
@@ -746,7 +746,7 @@ fn build_dpop_jwt(
         .as_secs();
 
     let mut jti_bytes = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut jti_bytes);
+    rand::rngs::OsRng.fill_bytes(&mut jti_bytes);
     let jti = hex::encode(jti_bytes);
 
     let payload = serde_json::json!({

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -108,6 +108,9 @@ impl Drop for CloseLock {
 }
 
 fn generate_session_id() -> String {
+    // AUD-24: thread_rng is deliberately retained here. A session id is a
+    // non-secret, non-security identifier (collision-avoidance only), not a
+    // key/nonce/token, so policy §5's OsRng requirement does not apply.
     let mut buf = [0u8; 8];
     use rand::RngCore;
     rand::thread_rng().fill_bytes(&mut buf);


### PR DESCRIPTION
Two contained mediums from the 2026-07-08 follow-up audit.

## AUD-24 — `thread_rng` for keys/nonces in CLI security paths
The code-quality policy (§5) bans `rand::thread_rng()` for key/nonce/token material (userland RNG that can degrade under `fork()`). Migrated every security-sensitive site to the OS CSPRNG (`rand::rngs::OsRng`) and widened the sub-128-bit nonces:
- `hub.rs`: hub Ed25519 keypair + two DPoP `jti`
- `approve.rs`: approval binding nonce (12 → 16 bytes)
- `invitation.rs`: invitation use-id (8 → 16)
- `attest.rs`: **approval-binding nonce the audit under-listed** (comment literally says "a cryptographically random nonce for approval binding") + a use-id (12 → 16)
- `merkle.rs`: DPoP `jti`

`session.rs`'s session-id **keeps** `thread_rng` and is annotated — it's a non-secret collision-avoidance id, not a key/nonce/token.

## AUD-27 — A2A `verifyReceipt` returned trust fields from unverified JSON
`shipId` and `withinDeclaredBounds` were derived from the raw, attacker-controlled JSON regardless of verification, and `withinDeclaredBounds` **defaulted to `true`** when no declaration was present. A consumer gating on it without checking verification trusted forged remote work. Also, since AUD-01 `verify_receipt` returns `"structural-pass"` (never `"pass"`) and verifies no signatures, so the old `outcome === 'pass'` check mislabeled structural consistency as cryptographic verification.

Fix:
- `structurallyConsistent` and honest `cryptographicallyVerified` (always false for a URL receipt — it verifies no signatures) are now distinct fields.
- `shipId` / `withinDeclaredBounds` are reported **only** when structurally consistent; `withinDeclaredBounds` additionally requires a declaration (absent → `undefined`, never a default `true`).
- Extracted the untrusted-JSON→summary mapping into a pure exported `summarizeVerifiedReceipt` so the trust-gating is unit-testable.

## Tests (fail before the fix)
- a2a `verify.test.ts`: unverified receipt leaks no `shipId`/`withinDeclaredBounds`; no default-true without a declaration; bounds only with declaration + structural consistency.
- Rust CLI suite green; a2a 18/18.

Refs AUD-24 / AUD-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)