### PR TITLE
fix(release): pin npm to 11.5.1 (npm@latest broke the 0.19.0 npm publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,8 +248,14 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Ensure npm >= 11.5.1
-        run: npm install -g npm@latest
+      # Pin npm rather than tracking @latest. The 0.19.0 release failed here
+      # because `npm@latest` on Node 24 shipped a build whose bundled `sigstore`
+      # module was unresolvable, so trusted-publishing provenance generation
+      # crashed with "Cannot find module 'sigstore'" and unwound the npm
+      # publish (crates.io and PyPI succeeded). 11.5.1 is the trusted-publishing
+      # floor and a known-good build; bump this pin deliberately after testing.
+      - name: Ensure npm >= 11.5.1 (pinned)
+        run: npm install -g npm@11.5.1
 
       # Pre-flight: every package we intend to publish must already exist on
       # the @treeship scope with the OIDC trusted publisher configured. npm


### PR DESCRIPTION
## What happened
The `v0.19.0` tag triggered the release workflow. **crates.io ✓ and PyPI ✓ published 0.19.0**, but **`publish-npm` failed** — none of the five `@treeship` npm packages (core-wasm, sdk, mcp, a2a, verify) published.

Root cause: `npm install -g npm@latest` on Node 24 installed an npm build whose **bundled `sigstore` module was unresolvable**, so trusted-publishing provenance generation crashed:
```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
npm error - .../libnpmpublish/lib/provenance.js
```
Not a code issue — a floating-`@latest` tooling regression.

## Fix
Pin `npm@11.5.1` (the trusted-publishing floor, known-good) instead of `@latest`. Bump deliberately after testing in future.

## Re-publishing npm 0.19.0 (after this merges)
crates.io and PyPI are already at 0.19.0, and all three publish jobs are **idempotent** (they check the registry and skip if the version is live). So re-running the release with the fixed workflow re-publishes only npm; crates/pypi skip cleanly. Path TBD with maintainer (re-tag vs manual publish) — see the release thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)