### PR TITLE
Portable receipt verification: receipt export + reference verifier + format spec

### DIFF
--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "agent-states",
     "feature-matrix",
+    "receipt-format",
     "schema",
     "predicates"
   ]

--- a/docs/content/docs/reference/receipt-format.mdx
+++ b/docs/content/docs/reference/receipt-format.mdx
@@ -1,0 +1,138 @@
+---
+title: Receipt format
+description: The byte-level format of a Treeship receipt and how to verify one in any language, with no Treeship code.
+---
+
+A Treeship receipt is a self-contained JSON object that anyone can verify
+offline, in any language, without trusting Treeship or contacting any endpoint.
+This page documents the exact bytes so you can implement a verifier yourself.
+
+The format is **stable**: the structure and the signed-bytes construction below
+are frozen. New statement types may be added, but the envelope shape, the
+pre-authentication encoding, and the id derivation do not change without a new
+major version in the type strings themselves.
+
+## The envelope
+
+A receipt is a [DSSE](https://github.com/secure-systems-lab/dsse) envelope —
+the same signing envelope Sigstore and in-toto use — with camelCase fields:
+
+```json
+{
+  "payload": "<base64url(statement_json_bytes)>",
+  "payloadType": "application/vnd.treeship.action.v1+json",
+  "signatures": [
+    { "keyid": "key_...", "sig": "<base64url(ed25519_signature)>" }
+  ]
+}
+```
+
+- `payload` — the statement, as JSON, base64url-encoded **without padding**.
+- `payloadType` — a media type identifying the statement kind and version.
+- `signatures` — one or more Ed25519 signatures. `keyid` is a label, **not** a
+  secret and **not** trusted on its own; the public key is supplied by the
+  verifier out of band.
+
+## What is signed: the PAE
+
+The signature is **not** over the payload JSON. It is over the DSSE
+**pre-authentication encoding** (PAE) of the payload — this is the single fact
+external verifiers most often miss:
+
+```
+PAE = "DSSEv1" SP LEN(payloadType) SP payloadType SP LEN(payload) SP payload
+```
+
+where `SP` is a single ASCII space, `LEN(x)` is the byte length of `x` as an
+ASCII decimal string, and `payload` is the **raw statement bytes** (the
+base64url-decoded `payload` field — *not* re-serialized JSON).
+
+Concretely, for an action receipt:
+
+```
+DSSEv1 39 application/vnd.treeship.action.v1+json 112 {"type":"treeship/action/v1","timestamp":"2026-07-11T06:48:53Z","actor":"agent://deployer","action":"tool.call"}
+```
+
+> **Do not re-serialize the payload to build the PAE.** Decode the `payload`
+> field's base64url to get the exact signed bytes and use them verbatim. Sorting
+> keys, adding whitespace, or re-encoding will change the bytes and the
+> signature will not verify. This is the number-one cause of failed third-party
+> verification.
+
+## The artifact id
+
+The content-addressed id is derived from the PAE bytes, never stored inside the
+statement:
+
+```
+artifact_id = "art_" + hex( sha256(PAE_bytes) )[..16]
+```
+
+Same content always yields the same id.
+
+## Verifying a receipt (any language)
+
+1. Read `payloadType` and base64url-decode `payload` to raw bytes.
+2. Build the PAE string exactly as above.
+3. Obtain the signer's Ed25519 **public key** out of band (see below). The
+   `keyid` in the envelope is only a hint.
+4. Verify each `signatures[i].sig` (base64url-decoded, 64 bytes) against the PAE
+   with the public key, using strict Ed25519 (reject small-order keys and
+   non-canonical signatures).
+5. Optionally recompute `artifact_id` from the PAE and confirm it matches.
+
+That is the whole verification. No network, no Treeship library.
+
+### The verifiable triple
+
+To hand a counterparty everything they need in one step, export the triple:
+
+```bash
+treeship receipt export <artifact_id> --format json
+```
+
+emits `{ message_b64, signature_b64, public_key_b64, algorithm }`, where
+`message_b64` is the base64 of the PAE (the exact signed bytes), so the
+counterparty runs a plain Ed25519 verify with no reconstruction. The reference
+verifier `scripts/verify-receipt.py` in the repo does exactly this:
+
+```bash
+treeship receipt export <id> --format json | python3 scripts/verify-receipt.py
+# VALID: art_... verified offline (ed25519 over the DSSE PAE)
+```
+
+### Getting the public key
+
+The signature only proves possession of the signing key. To decide whether to
+*trust* that key, the verifier pins it out of band. `treeship keys export`
+prints a key's public half in pinnable form (`ed25519:<base64url>`) with the
+`treeship trust add` command a counterparty runs. Trust is always the verifier's
+decision; a receipt never carries a key you are told to trust.
+
+## Statement types
+
+The `payloadType` names the statement kind. Each payload also carries a `type`
+field with the same version string. Current media types:
+
+```
+application/vnd.treeship.action.v1+json
+application/vnd.treeship.approval.v1+json
+application/vnd.treeship.handoff.v1+json
+application/vnd.treeship.endorsement.v1+json
+application/vnd.treeship.receipt.v1+json
+application/vnd.treeship.bundle.v1+json
+```
+
+Typed payloads carried inside a `receipt` (capability cards, session records,
+certificates, and other predicates) are validated against a registered JSON
+Schema before signing; see [predicates](./predicates). The envelope and PAE
+construction above are identical regardless of the statement kind — a verifier
+that checks the signature over the PAE works for every receipt type.
+
+## What Treeship does not put in a receipt
+
+- **No raw content by default.** Payloads carry digests and signed metadata,
+  never the agent's outputs, tool results, or user data.
+- **No key you must trust.** The verifier pins public keys itself.
+- **No dependency on Treeship being online.** Verification is a signature check
+  over bytes you already hold.

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub mod declare;
 pub mod package;
 pub mod prove;
 pub mod quickstart;
+pub mod receipt;
 pub mod trust;
 pub mod zk;
 pub mod invitation;

--- a/packages/cli/src/commands/receipt.rs
+++ b/packages/cli/src/commands/receipt.rs
@@ -1,0 +1,89 @@
+//! `treeship receipt export` — emit the exact offline-verifiable triple.
+//!
+//! A Treeship signature is over the DSSE PAE (`DSSEv1 <len> <payloadType>
+//! <len> <payload>`), not the payload JSON, and no command previously exported
+//! those exact bytes. So a counterparty trying to verify a receipt with a
+//! third-party Ed25519 library had to guess the PAE construction and always
+//! failed — the signature is valid, but nothing outside Treeship knew what
+//! message it covers. This command emits `{message (the PAE), signature,
+//! public_key}` in copy-safe base64 so any Ed25519 verifier confirms the
+//! receipt with no Treeship code in the loop. That is the whole "portable,
+//! offline, don't-trust-us" promise, made runnable in one command.
+
+use crate::{ctx, printer::Printer};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine,
+};
+use treeship_core::attestation::pae;
+
+type CmdResult = Result<(), Box<dyn std::error::Error>>;
+
+pub fn export(id: &str, config: Option<&str>, printer: &Printer) -> CmdResult {
+    let ctx = ctx::open(config)?;
+    let rec = ctx
+        .storage
+        .read(id)
+        .map_err(|e| format!("no artifact {id} in the local store: {e}"))?;
+    let env = &rec.envelope;
+    let sig = env.signatures.first().ok_or(
+        "artifact has no signature — nothing to export (an unsigned envelope should never have been stored)",
+    )?;
+
+    // The message is the PAE: the exact bytes that were signed. Reconstruct it
+    // from the same payload_type + payload the verifier sees, so what we export
+    // is provably what the signature covers.
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(&env.payload)
+        .map_err(|e| format!("envelope payload is not valid base64url: {e}"))?;
+    let pae_bytes = pae(&env.payload_type, &payload_bytes);
+
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(&sig.sig)
+        .map_err(|e| format!("signature is not valid base64url: {e}"))?;
+    // The public key comes from THIS machine's keystore (the signer's own key).
+    // Export is for handing a counterparty a receipt you produced; a receipt
+    // you received from elsewhere is verified with `treeship verify`.
+    let pub_bytes = ctx.keys.public_key(&sig.keyid).map_err(|e| {
+        format!(
+            "no public key for signer {} in this keystore: {e}\n  receipt export works on receipts THIS machine signed",
+            sig.keyid
+        )
+    })?;
+
+    let message_b64 = STANDARD.encode(&pae_bytes);
+    let signature_b64 = STANDARD.encode(&sig_bytes);
+    let public_key_b64 = STANDARD.encode(&pub_bytes);
+
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "artifact_id": id,
+            "algorithm": "ed25519",
+            "encoding": "base64",
+            "message_b64": message_b64,
+            "signature_b64": signature_b64,
+            "public_key_b64": public_key_b64,
+            "key_id": sig.keyid,
+        }));
+        return Ok(());
+    }
+
+    printer.success(
+        "verifiable triple",
+        &[
+            ("artifact", id),
+            ("algorithm", "ed25519 over the DSSE PAE"),
+            ("key_id", sig.keyid.as_str()),
+        ],
+    );
+    printer.blank();
+    printer.info(&format!("  message     (base64)  {message_b64}"));
+    printer.info(&format!("  signature   (base64)  {signature_b64}"));
+    printer.info(&format!("  public_key  (base64)  {public_key_b64}"));
+    printer.blank();
+    printer.hint(
+        "any Ed25519 library confirms this offline, no Treeship code needed: base64-decode all three, then verify(public_key, message, signature). Use --format json to pipe the triple to a partner.",
+    );
+    printer.blank();
+    Ok(())
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -138,6 +138,19 @@ enum Command {
     ///   treeship verify-capability art_<agent_card_id>
     VerifyCapability(VerifyCapabilityArgs),
 
+    /// Export a receipt's offline-verifiable triple: message, signature, key
+    ///
+    /// Emits the exact {message (the DSSE PAE), signature, public_key} in
+    /// copy-safe base64, so a counterparty confirms the receipt with any
+    /// Ed25519 library and no Treeship code. The signature is over the PAE,
+    /// not the payload JSON — this is the command that makes that fact usable.
+    ///
+    /// Examples:
+    ///   treeship receipt export art_a1b2c3d4e5f6a1b2
+    ///   treeship receipt export art_a1b2c3d4e5f6a1b2 --format json
+    #[command(subcommand, display_order = 8)]
+    Receipt(ReceiptCommand),
+
     /// Revoke a capability card (agent_card_revocation.v1)
     ///
     /// Mints a signed revocation of an agent_card.v1. Signed with the agent's
@@ -1700,6 +1713,25 @@ struct AttestEndorsementArgs {
     out: Option<String>,
 }
 
+// --- receipt ----------------------------------------------------------------
+
+#[derive(Subcommand)]
+enum ReceiptCommand {
+    /// Export a receipt's offline-verifiable triple (message, signature, key)
+    ///
+    /// Examples:
+    ///   treeship receipt export art_a1b2c3d4e5f6a1b2
+    ///   treeship receipt export art_a1b2c3d4e5f6a1b2 --format json
+    Export(ReceiptExportArgs),
+}
+
+#[derive(clap::Args)]
+struct ReceiptExportArgs {
+    /// Artifact id of the receipt to export
+    #[arg(value_name = "ARTIFACT_ID")]
+    id: String,
+}
+
 // --- bundle -----------------------------------------------------------------
 
 #[derive(Subcommand)]
@@ -2847,6 +2879,12 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
         Command::VerifyCapability(a) => {
             commands::capability::verify_capability(&a.card_id, cli.config.as_deref(), printer)
         }
+
+        Command::Receipt(sub) => match sub {
+            ReceiptCommand::Export(a) => {
+                commands::receipt::export(&a.id, cli.config.as_deref(), printer)
+            }
+        },
 
         Command::RevokeCapability(a) => commands::capability::revoke_capability(
             &a.card_id,

--- a/packages/skills/lobster-cash/demo.sh
+++ b/packages/skills/lobster-cash/demo.sh
@@ -81,6 +81,6 @@ echo ""
 # Verification URL
 # -----------------------------------------------
 echo "[verify] Attestation verification URL:"
-echo "  https://hub.treeship.dev/verify/${SESSION_ID:-demo-session}"
+echo "  https://treeship.dev/verify/${SESSION_ID:-demo-session}"
 echo ""
 echo "=== Demo complete ==="

--- a/scripts/verify-receipt.py
+++ b/scripts/verify-receipt.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Reference verifier for a Treeship receipt triple — no Treeship code.
+
+A Treeship signature is over the DSSE PAE (the exact bytes in the `message`
+field), not the payload JSON. `treeship receipt export <id> --format json`
+emits the {message, signature, public_key} triple in base64; this script
+verifies it with an independent Ed25519 implementation, offline, so a
+counterparty can confirm a receipt without trusting Treeship or any endpoint.
+
+    treeship receipt export art_xxx --format json | python3 verify-receipt.py
+    python3 verify-receipt.py triple.json
+
+Exit 0 = valid, 1 = invalid, 2 = malformed input. Requires `cryptography`
+(pip install cryptography). Copy this file freely — it is the reference a
+partner runs.
+"""
+import base64
+import json
+import sys
+
+
+def main() -> int:
+    src = open(sys.argv[1]) if len(sys.argv) > 1 else sys.stdin
+    try:
+        t = json.load(src)
+    except json.JSONDecodeError as e:
+        print(f"input is not valid JSON: {e}", file=sys.stderr)
+        return 2
+
+    if t.get("algorithm") != "ed25519":
+        print(f"unsupported algorithm: {t.get('algorithm')!r} (expected ed25519)", file=sys.stderr)
+        return 2
+
+    try:
+        d = base64.b64decode
+        message = d(t["message_b64"])       # the DSSE PAE — what was signed
+        signature = d(t["signature_b64"])   # 64 bytes
+        public_key = d(t["public_key_b64"]) # 32 bytes
+    except (KeyError, ValueError) as e:
+        print(f"triple is missing or malformed: {e}", file=sys.stderr)
+        return 2
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    from cryptography.exceptions import InvalidSignature
+
+    artifact = t.get("artifact_id", "<unknown>")
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(signature, message)
+    except InvalidSignature:
+        print(f"INVALID: signature does not verify for {artifact}", file=sys.stderr)
+        return 1
+
+    print(f"VALID: {artifact} verified offline (ed25519 over the DSSE PAE)")
+    preview = message[:64].decode("utf-8", errors="replace")
+    print(f"  signed message begins: {preview}...")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The fix for the cross-verification failure a partner hit in public: a Treeship
signature is over the DSSE **PAE**, not the payload JSON, and nothing exported
those exact bytes or documented the format — so a partner ran 14 verification
attempts (all over the payload) and every one failed. This bundles the fix.

### `treeship receipt export <id>`
Emits the exact `{message (the PAE), signature, public_key, algorithm}` triple
in copy-safe base64, so a counterparty verifies a receipt with any Ed25519
library and zero Treeship code. `--format json` pipes it straight to a partner.
New command, touches nothing existing.

### `scripts/verify-receipt.py`
The canonical, dependency-light reference verifier. A partner runs:
```
treeship receipt export <id> --format json | python3 scripts/verify-receipt.py
# VALID: art_... verified offline (ed25519 over the DSSE PAE)
```

### Receipt Format reference doc
The stable, partner-facing description of the byte format — envelope, PAE,
id derivation, a language-agnostic verification recipe. The doc whose absence
caused the failure. States the format is frozen: something to build on
independently of the CLI version.

### Dead URL fix
`lobster-cash/demo.sh` printed the non-resolving `hub.treeship.dev/verify/`;
now the real `treeship.dev/verify/` (the hub's own `hub_url`).

### Verification
Verified end to end: exported a real receipt, ran it through the reference
verifier → VALID, tampered-message negative control → rejected. Builds clean;
cherry-picked cleanly onto current main.

Suggested as the **0.19.1** cut (pairs with the verify-status regression fix
already on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)