### PR TITLE
Release v0.19.1 — portable verification (receipt export) + verify-status + npm pin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.19.0"
+    "version": "0.19.1"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## Unreleased
 
+## 0.19.1 (2026-07-11)
+
+The portable-verification release. The headline is a small command that closes a
+real gap: a Treeship signature is over the DSSE PAE (`DSSEv1 <len> <payloadType>
+<len> <payload>`), not the payload JSON, and nothing exported those exact bytes —
+so a counterparty verifying a receipt with a third-party Ed25519 library had to
+guess the PAE construction and failed. The "portable, offline, don't-trust-us"
+promise was true in the bytes but unusable without reading the source.
+
+### Added
+- **`treeship receipt export <id>` — the offline-verifiable triple.** Emits the
+  exact `{message (the PAE), signature, public_key, algorithm}` in copy-safe
+  base64, so a counterparty confirms a receipt with any Ed25519 library and zero
+  Treeship code. `--format json` pipes the triple straight to a partner. The
+  message is reconstructed from the same `payload_type`+`payload` the verifier
+  sees, so what is exported is provably what the signature covers; the public key
+  comes from the local keystore (export is for a receipt you produced — a
+  received receipt is checked with `treeship verify`).
+- **`scripts/verify-receipt.py` — the reference verifier.** Dependency-light,
+  independent Ed25519, offline: `treeship receipt export <id> --format json |
+  python3 scripts/verify-receipt.py` → `VALID`. The canonical thing a partner
+  copies.
+- **[Receipt format](docs/content/docs/reference/receipt-format.mdx) reference.**
+  The stable, partner-facing description of the byte format — envelope, PAE,
+  id derivation, a language-agnostic verification recipe — so anyone can
+  implement a verifier without reading the Rust. The format is frozen; this
+  documents it.
+
+### Fixed
+- **A clean session reports `verification_status: "pass"`, not `"warn"` (#231).**
+  The always-on `receipt_body_binding` scope caveat added in 0.19.0 is
+  informational (every package carries it), but it was flipping every
+  cryptographically-clean session's top-line verdict to `warn`, making `pass`
+  unreachable and breaking any caller that gates on `status == "pass"`. It is now
+  surfaced in `warnings` for transparency but no longer downgrades the verdict;
+  real warnings (git-degraded, event-log skips, determinism drift) still do.
+  Caught by the post-publish smoke test; regression-tested.
+- **Release tooling: npm pinned to 11.5.1 (#230).** The 0.19.0 publish failed on
+  npm because `npm@latest` on the runner's Node 24 shipped a build whose bundled
+  `sigstore` module was unresolvable, crashing trusted-publishing provenance
+  (crates.io and PyPI published fine). npm is now pinned to the trusted-publishing
+  floor instead of tracking `@latest`.
+- **Dead verify URL in the lobster-cash demo.** It printed the non-resolving
+  `hub.treeship.dev/verify/`; the public verify URL is `https://treeship.dev/verify/<id>`
+  (the hub's own `hub_url`).
+
 ## 0.19.0 (2026-07-09)
 
 The security-hardening release. Two independent AI-assisted adversarial audits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "base64",
  "clap",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.19.0"
+    "@treeship/core-wasm": "0.19.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@treeship/core-wasm": "0.19.0",
+    "@treeship/core-wasm": "0.19.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.19.0",
-    "@treeship/cli-darwin-arm64": "0.19.0",
-    "@treeship/cli-darwin-x64": "0.19.0"
+    "@treeship/cli-linux-x64": "0.19.1",
+    "@treeship/cli-darwin-arm64": "0.19.1",
+    "@treeship/cli-darwin-x64": "0.19.1"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.19.0", path = "../core" }
+treeship-core = { version = "0.19.1", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.19.0"
+version = "0.19.1"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.10.2"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.19.0"
+    "@treeship/core-wasm": "0.19.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.9.2"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.19.0"
+    "@treeship/core-wasm": "0.19.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Version bump to **0.19.1** across all 30 sites + changelog.

The patch cut on top of 0.19.0: the portable-verification feature (`treeship
receipt export` + reference verifier + Receipt Format doc, already merged in
#232), plus the two fixes that landed after the 0.19.0 tag — the verify-status
regression (#231, "every clean session = warn") and the npm-pin release-tooling
fix (#230, so npm publishes cleanly this time).

Prepared with `scripts/release.sh prepare 0.19.1` — version sites stamped and
verified (30/30), changelog written. No product code here beyond the bump; the
features/fixes are already on main.

After merge + green CI, the tag (`scripts/release.sh tag 0.19.1 --sha <sha>`) is
the publish trigger — held for explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)