### PR TITLE
feat: quarantine-gated approvals — memory-provenance-binding phases 2–3 (predicate + irreversibility gate)

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -121,6 +121,8 @@ treeship attest approval [OPTIONS] --approver <URI>
 | `--allowed-subject <URI>` | Scope: subject URI(s) permitted as the action's target. Repeatable. Matched against ActionStatement.subject.&#123;uri \| artifact_id \| digest&#125; |
 | `--max-uses <N>` | Scope: maximum number of actions this approval may authorise. Signed into the grant for future ledger enforcement; verify reports replay posture honestly and does NOT claim global single-use |
 | `--unscoped` | Explicit opt-in to an unscoped (bearer) approval. Required when no --allowed-* or --max-uses flag is set; without it the CLI refuses, since unscoped approvals are footguns |
+| `--irreversibility <CLASS>` | Irreversibility class of the actions this approval authorizes. one_way_consequential and one_way_terminal require a clean --quarantine-receipt; one_way_terminal additionally requires a human:// approver. Signed into the grant [possible values: two_way, one_way_recoverable, one_way_consequential, one_way_terminal] |
+| `--quarantine-receipt <ARTIFACT_ID>` | Artifact ID of a memory.quarantine-check.v1 receipt gating this grant. Must be locally stored, schema-valid, clean:true, and signed by a key pinned under agent_cert (the memory provider) |
 
 ### `treeship attest handoff`
 

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -3,12 +3,13 @@ use treeship_core::{
     attestation::{sign, Signer},
     journal::{self, Journal},
     statements::{
-        nonce_digest, payload_type, ActionStatement, ApprovalScope, ApprovalStatement, ApprovalUse,
-        DecisionStatement, EndorsementStatement, HandoffStatement, ReceiptStatement, SubjectRef,
-        TYPE_APPROVAL_USE,
+        irreversibility_requires_quarantine, is_irreversibility_class, nonce_digest, payload_type,
+        ActionStatement, ApprovalScope, ApprovalStatement, ApprovalUse, DecisionStatement,
+        EndorsementStatement, HandoffStatement, ReceiptStatement, SubjectRef,
+        IRREVERSIBILITY_CLASSES, TYPE_APPROVAL_USE,
     },
     storage::Record,
-    trust::{TrustRootKind, TrustRootStore},
+    trust::{decode_ed25519_pubkey, TrustRootKind, TrustRootStore},
 };
 
 use crate::commands::verify::{check_scope_violation, find_approval_by_nonce, now_rfc3339};
@@ -247,6 +248,13 @@ pub struct ApprovalArgs {
     /// scope axis is populated; without it the command refuses since
     /// unscoped approvals are footguns.
     pub unscoped: bool,
+    /// Declared irreversibility class (closed vocabulary; validated
+    /// again here even though clap constrains it, so SDK callers get
+    /// the same fail-closed behavior).
+    pub irreversibility: Option<String>,
+    /// Artifact id of the memory.quarantine-check.v1 receipt gating
+    /// this grant.
+    pub quarantine_receipt: Option<String>,
     pub config: Option<String>,
 }
 
@@ -278,6 +286,43 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
         Some(scope)
     };
 
+    // Irreversibility gate (memory-provenance-binding §2.4-2.5).
+    // A supplied quarantine receipt is validated whenever present -- we
+    // never sign a reference to evidence we did not check. Consequential
+    // and terminal classes REQUIRE that evidence; terminal additionally
+    // requires a human approver. Fail-closed: a dirty, missing, or
+    // unverifiable check refuses the grant.
+    if let Some(rid) = &args.quarantine_receipt {
+        validate_quarantine_receipt(&ctx, rid)?;
+    }
+    if let Some(class) = &args.irreversibility {
+        // Clap constrains the vocabulary for CLI callers; re-check here so
+        // programmatic callers get the same closed-vocabulary behavior.
+        if !is_irreversibility_class(class) {
+            return Err(format!(
+                "unknown irreversibility class `{class}`\n  valid: {}",
+                IRREVERSIBILITY_CLASSES.join(", ")
+            )
+            .into());
+        }
+        if class == "one_way_terminal" && !args.approver.starts_with("human://") {
+            return Err(format!(
+                "one_way_terminal grants require a human approver, got `{}`\n  \
+                 fix: --approver human://<name>",
+                args.approver
+            )
+            .into());
+        }
+        if irreversibility_requires_quarantine(class) && args.quarantine_receipt.is_none() {
+            return Err(format!(
+                "a `{class}` grant requires memory quarantine evidence\n  \
+                 the provider mints it, then pass: --quarantine-receipt <artifact-id>\n  \
+                 (a clean memory.quarantine-check.v1 receipt signed by a key pinned under agent_cert)"
+            )
+            .into());
+        }
+    }
+
     // Generate a cryptographically random nonce for approval binding.
     // AUD-24: OS CSPRNG, not thread_rng (policy §5).
     let nonce = {
@@ -294,6 +339,8 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
     stmt.description = args.description.clone();
     stmt.expires_at = args.expires.clone();
     stmt.scope = scope_for_stmt;
+    stmt.irreversibility = args.irreversibility.clone();
+    stmt.quarantine_receipt = args.quarantine_receipt.clone();
     if let Some(id) = &args.subject_id {
         stmt.subject.artifact_id = Some(id.clone());
     }
@@ -341,11 +388,92 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
         }
         printer.hint(&format!("scope: {}", parts.join(", ")));
     }
+    if let Some(class) = &stmt.irreversibility {
+        match &stmt.quarantine_receipt {
+            Some(rid) => printer.hint(&format!(
+                "irreversibility: {class}  (quarantine evidence: {rid})"
+            )),
+            None => printer.hint(&format!("irreversibility: {class}")),
+        }
+    }
     printer.hint(&format!(
         "nonce: {}  (echo this in --approval-nonce when you attest the action)",
         nonce
     ));
     printer.blank();
+    Ok(())
+}
+
+/// Validate a memory.quarantine-check.v1 receipt as gate evidence for an
+/// approval grant (memory-provenance-binding §2.4). Fail-closed on every
+/// axis: the receipt must exist locally, be the right kind, validate
+/// against the registered predicate schema, report `clean: true`, and be
+/// signed by a key pinned under `agent_cert` -- the memory provider's own
+/// key, never the ship key of whoever is minting the grant (a self-signed
+/// verdict is not a check).
+fn validate_quarantine_receipt(
+    ctx: &ctx::Ctx,
+    receipt_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let rec = ctx.storage.read(receipt_id).map_err(|_| {
+        format!(
+            "quarantine receipt {receipt_id} not found in local storage\n  \
+             the provider mints it: treeship attest receipt --system system://<provider> \
+             --kind memory.quarantine-check.v1 --payload-file <check.json>"
+        )
+    })?;
+    let stmt: ReceiptStatement = rec.envelope.unmarshal_statement().map_err(|e| {
+        format!("quarantine receipt {receipt_id} is not a receipt statement: {e}")
+    })?;
+    if stmt.kind != "memory.quarantine-check.v1" {
+        return Err(format!(
+            "{receipt_id} is a `{}` receipt, not memory.quarantine-check.v1",
+            stmt.kind
+        )
+        .into());
+    }
+    treeship_core::predicates::validate("memory.quarantine-check.v1", stmt.payload.as_ref())
+        .map_err(|e| format!("quarantine receipt payload is invalid: {e}"))?;
+
+    // The verdict must be the boolean `true`. The predicate schema already
+    // rejects non-boolean values; this rejects a well-formed DIRTY verdict.
+    let payload = stmt.payload.as_ref().expect("validated payload present");
+    if payload.get("clean").and_then(Value::as_bool) != Some(true) {
+        let triggers = payload
+            .get("quarantined_triggers")
+            .map(|t| t.to_string())
+            .unwrap_or_else(|| "[]".into());
+        return Err(format!(
+            "quarantine check {receipt_id} reports DIRTY (clean: false) -- grant refused\n  \
+             quarantined triggers: {triggers}\n  \
+             a high-privilege grant must not act on quarantined memory; \
+             re-check after the provider promotes or forgets the triggering entries"
+        )
+        .into());
+    }
+
+    // Key-bound signer check. Build a verifier from ONLY the agent_cert
+    // pins: the provider's own key (onboard pins it automatically). An
+    // unreadable trust store is an error, never silently empty (lane J).
+    let trust = TrustRootStore::open_default_or_empty()
+        .map_err(|e| format!("trust store unreadable: {e}"))?;
+    let mut provider_keys = std::collections::HashMap::new();
+    for r in trust.roots() {
+        if r.kind == TrustRootKind::AgentCert {
+            if let Ok(vk) = decode_ed25519_pubkey(&r.public_key) {
+                provider_keys.insert(r.key_id.clone(), vk);
+            }
+        }
+    }
+    let verifier = treeship_core::attestation::Verifier::new(provider_keys);
+    verifier.verify_any(&rec.envelope).map_err(|_| {
+        format!(
+            "quarantine receipt {receipt_id} is not signed by a key-bound memory provider\n  \
+             the signer's key must be pinned under agent_cert\n  \
+             fix: treeship onboard <provider>   (or)   \
+             treeship trust add <key_id> <pubkey> --kind agent_cert --yes"
+        )
+    })?;
     Ok(())
 }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1522,6 +1522,19 @@ struct AttestApprovalArgs {
     /// refuses, since unscoped approvals are footguns.
     #[arg(long)]
     unscoped: bool,
+
+    /// Irreversibility class of the actions this approval authorizes.
+    /// one_way_consequential and one_way_terminal require a clean
+    /// --quarantine-receipt; one_way_terminal additionally requires a
+    /// human:// approver. Signed into the grant.
+    #[arg(long, value_name = "CLASS", value_parser = ["two_way", "one_way_recoverable", "one_way_consequential", "one_way_terminal"])]
+    irreversibility: Option<String>,
+
+    /// Artifact ID of a memory.quarantine-check.v1 receipt gating this
+    /// grant. Must be locally stored, schema-valid, clean:true, and
+    /// signed by a key pinned under agent_cert (the memory provider).
+    #[arg(long, value_name = "ARTIFACT_ID")]
+    quarantine_receipt: Option<String>,
 }
 
 #[derive(Args)]
@@ -2778,6 +2791,8 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     allowed_subjects: a.allowed_subject.clone(),
                     max_uses: a.max_uses,
                     unscoped: a.unscoped,
+                    irreversibility: a.irreversibility.clone(),
+                    quarantine_receipt: a.quarantine_receipt.clone(),
                     config: cli.config.clone(),
                 },
                 printer,

--- a/packages/cli/tests/approval_gate_cli.rs
+++ b/packages/cli/tests/approval_gate_cli.rs
@@ -1,0 +1,247 @@
+//! End-to-end tests for the irreversibility gate on `treeship attest approval`
+//! (docs/specs/memory-provenance-binding.md §2.4-2.5).
+//!
+//! The gate's contract: a consequential-or-worse grant is refused without a
+//! clean, schema-valid, key-bound memory.quarantine-check.v1 receipt; a
+//! terminal grant additionally requires a human approver; a dirty verdict or
+//! an unpinned provider signer refuses fail-closed. Each refusal path is
+//! exercised against a real binary in an isolated workspace.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Workspace {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        Self { _tmp: tmp, root }
+    }
+
+    fn config(&self) -> String {
+        self.root
+            .join(".treeship/config.json")
+            .display()
+            .to_string()
+    }
+
+    fn cmd(&self) -> Command {
+        let mut c = Command::new(cli_path());
+        c.env("HOME", &self.root);
+        c.env(
+            "TREESHIP_TRUST_ROOTS",
+            self.root
+                .join(".treeship/trust_roots.json")
+                .display()
+                .to_string(),
+        );
+        c.env("TREESHIP_ALLOW_INSECURE_KEY_PERMS", "1");
+        c.current_dir(&self.root);
+        c
+    }
+
+    fn init(&self) {
+        let out = self
+            .cmd()
+            .args(["init", "--config"])
+            .arg(self.config())
+            .args(["--name", "gate-test"])
+            .output()
+            .expect("treeship init");
+        assert!(
+            out.status.success(),
+            "init failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    /// Default ship key id + base64url pubkey, read from the keystore.
+    fn default_key(&self) -> (String, String) {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let keys_dir = self.root.join(".treeship/keys");
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(keys_dir.join("manifest.json")).unwrap())
+                .unwrap();
+        let default_id = manifest["default_key_id"].as_str().unwrap().to_string();
+        let entry: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(keys_dir.join(format!("{default_id}.json"))).unwrap(),
+        )
+        .unwrap();
+        let pk: Vec<u8> = entry["public_key"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_u64().unwrap() as u8)
+            .collect();
+        (default_id, URL_SAFE_NO_PAD.encode(pk))
+    }
+
+    /// Pin the default (ship) key under agent_cert so receipts it signs
+    /// count as key-bound provider attestations for the gate.
+    fn pin_default_key_as_provider(&self) {
+        let (key_id, pk) = self.default_key();
+        let out = self
+            .cmd()
+            .args(["trust", "add", &key_id, &format!("ed25519:{pk}")])
+            .args(["--kind", "agent_cert", "--yes", "--config"])
+            .arg(self.config())
+            .output()
+            .expect("trust add");
+        assert!(
+            out.status.success(),
+            "trust add failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    /// Mint a memory.quarantine-check.v1 receipt and return its artifact id.
+    fn mint_check(&self, clean: bool) -> String {
+        let payload = format!(
+            r#"{{"action_id":"aac_test01","provider":"system://zmem","chain_root":"u3v9xJ2kQm4Zr8pW","decision_seq":7,"clean":{clean},"quarantined_triggers":{}}}"#,
+            if clean { "[]" } else { r#"["mem_poisoned1"]"# }
+        );
+        let out = self
+            .cmd()
+            .args(["attest", "receipt", "--system", "system://zmem"])
+            .args(["--kind", "memory.quarantine-check.v1"])
+            .args(["--payload", &payload])
+            .args(["--format", "json", "--config"])
+            .arg(self.config())
+            .output()
+            .expect("attest receipt");
+        assert!(
+            out.status.success(),
+            "attest receipt failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        // JSON mode may emit more than one object (warnings); take the one
+        // carrying the artifact id.
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                if let Some(id) = v.get("id").or_else(|| v.get("artifact_id")) {
+                    if let Some(s) = id.as_str() {
+                        return s.to_string();
+                    }
+                }
+            }
+        }
+        panic!(
+            "no artifact id in attest receipt output: {}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+
+    /// Attempt a consequential approval, returning (success, combined output).
+    fn approve_consequential(&self, receipt: Option<&str>, approver: &str, class: &str) -> (bool, String) {
+        let mut c = self.cmd();
+        c.args(["attest", "approval", "--approver", approver])
+            .args(["--description", "irreversible thing"])
+            .args(["--allowed-action", "deploy.production"])
+            .args(["--max-uses", "1"])
+            .args(["--irreversibility", class]);
+        if let Some(r) = receipt {
+            c.args(["--quarantine-receipt", r]);
+        }
+        c.args(["--config"]).arg(self.config());
+        let out = c.output().expect("attest approval");
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (out.status.success(), combined)
+    }
+}
+
+#[test]
+fn consequential_without_receipt_is_refused() {
+    let ws = Workspace::new();
+    ws.init();
+    let (ok, output) = ws.approve_consequential(None, "human://alice", "one_way_consequential");
+    assert!(!ok, "grant must be refused without quarantine evidence");
+    assert!(
+        output.contains("requires memory quarantine evidence"),
+        "refusal must say why: {output}"
+    );
+}
+
+#[test]
+fn terminal_requires_human_approver() {
+    let ws = Workspace::new();
+    ws.init();
+    // Fails on the approver check even before evidence is considered.
+    let (ok, output) = ws.approve_consequential(None, "agent://deployer", "one_way_terminal");
+    assert!(!ok, "terminal grant must require a human approver");
+    assert!(
+        output.contains("human approver"),
+        "refusal must name the fix: {output}"
+    );
+}
+
+#[test]
+fn recoverable_class_needs_no_evidence() {
+    let ws = Workspace::new();
+    ws.init();
+    let (ok, output) = ws.approve_consequential(None, "human://alice", "one_way_recoverable");
+    assert!(ok, "recoverable grant must mint without evidence: {output}");
+}
+
+#[test]
+fn unpinned_provider_signer_is_refused() {
+    let ws = Workspace::new();
+    ws.init();
+    // Receipt exists and is clean, but its signer is not pinned under
+    // agent_cert -- a self-asserted verdict must not pass as a check.
+    let receipt = ws.mint_check(true);
+    let (ok, output) =
+        ws.approve_consequential(Some(&receipt), "human://alice", "one_way_consequential");
+    assert!(!ok, "unpinned provider signer must refuse the grant");
+    assert!(
+        output.contains("key-bound memory provider"),
+        "refusal must name the trust gap: {output}"
+    );
+}
+
+#[test]
+fn dirty_verdict_is_refused() {
+    let ws = Workspace::new();
+    ws.init();
+    ws.pin_default_key_as_provider();
+    let receipt = ws.mint_check(false);
+    let (ok, output) =
+        ws.approve_consequential(Some(&receipt), "human://alice", "one_way_consequential");
+    assert!(!ok, "dirty quarantine verdict must refuse the grant");
+    assert!(output.contains("DIRTY"), "refusal must be explicit: {output}");
+    assert!(
+        output.contains("mem_poisoned1"),
+        "refusal must surface the quarantined triggers: {output}"
+    );
+}
+
+#[test]
+fn clean_keybound_check_mints_grant_with_evidence_signed_in() {
+    let ws = Workspace::new();
+    ws.init();
+    ws.pin_default_key_as_provider();
+    let receipt = ws.mint_check(true);
+    let (ok, output) =
+        ws.approve_consequential(Some(&receipt), "human://alice", "one_way_consequential");
+    assert!(ok, "clean key-bound check must mint the grant: {output}");
+    assert!(
+        output.contains(&receipt),
+        "the evidence link must be visible on the grant: {output}"
+    );
+}

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -42,6 +42,10 @@ const REGISTRY: &[(&str, &str)] = &[
         "memory.read.v1",
         include_str!("schemas/memory.read.v1.json"),
     ),
+    (
+        "memory.quarantine-check.v1",
+        include_str!("schemas/memory.quarantine-check.v1.json"),
+    ),
     ("boundary.v1", include_str!("schemas/boundary.v1.json")),
     ("agent_card.v1", include_str!("schemas/agent_card.v1.json")),
     (
@@ -262,6 +266,80 @@ mod tests {
             let raw = schema_json(s).unwrap();
             serde_json::from_str::<Value>(raw).expect("embedded schema must be valid JSON");
         }
+    }
+
+    #[test]
+    fn quarantine_check_valid_passes() {
+        let payload = json!({
+            "action_id": "aac_1f2e3d4c",
+            "provider": "system://zmem",
+            "chain_root": "u3v9xJ2kQm4Zr8pW1sTnA7bCdEfGhIjKlMnOpQrStUv",
+            "decision_seq": 1042,
+            "clean": true,
+            "quarantined_triggers": [],
+            "checked_at": "2026-07-17T19:00:00Z"
+        });
+        assert!(validate("memory.quarantine-check.v1", Some(&payload)).is_ok());
+    }
+
+    #[test]
+    fn quarantine_check_missing_verdict_fails_closed() {
+        let payload = json!({
+            "action_id": "aac_1f2e3d4c",
+            "chain_root": "u3v9xJ2kQm4Zr8pW1sTnA7bCdEfGhIjKlMnOpQrStUv",
+            "decision_seq": 1042
+        }); // `clean` missing — the field the whole gate hangs on
+        let err = validate("memory.quarantine-check.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::MissingField {
+                suffix: "memory.quarantine-check.v1".into(),
+                field: "clean".into()
+            }
+        );
+    }
+
+    #[test]
+    fn quarantine_check_stringly_typed_verdict_fails_closed() {
+        // A "true" string must not pass for a boolean verdict — a lenient
+        // parse here would let a provider bug (or an attacker) launder an
+        // ambiguous verdict into a clean one.
+        let payload = json!({
+            "action_id": "aac_1f2e3d4c",
+            "chain_root": "u3v9xJ2kQm4Zr8pW1sTnA7bCdEfGhIjKlMnOpQrStUv",
+            "decision_seq": 1042,
+            "clean": "true"
+        });
+        let err = validate("memory.quarantine-check.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::TypeMismatch {
+                suffix: "memory.quarantine-check.v1".into(),
+                field: "clean".into(),
+                expected: "\"boolean\"".into()
+            }
+        );
+    }
+
+    #[test]
+    fn quarantine_check_non_integer_seq_fails_closed() {
+        // decision_seq binds the verdict to a ledger state; a non-integer
+        // seq breaks chain-root rederivation for Class-2 verifiers.
+        let payload = json!({
+            "action_id": "aac_1f2e3d4c",
+            "chain_root": "u3v9xJ2kQm4Zr8pW1sTnA7bCdEfGhIjKlMnOpQrStUv",
+            "decision_seq": "1042",
+            "clean": true
+        });
+        let err = validate("memory.quarantine-check.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::TypeMismatch {
+                suffix: "memory.quarantine-check.v1".into(),
+                field: "decision_seq".into(),
+                expected: "\"integer\"".into()
+            }
+        );
     }
 
     #[test]

--- a/packages/core/src/predicates/schemas/memory.quarantine-check.v1.json
+++ b/packages/core/src/predicates/schemas/memory.quarantine-check.v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/memory.quarantine-check.v1.json",
+  "title": "memory.quarantine-check.v1",
+  "description": "Receipt payload recording a memory provider's quarantine verdict for one gated action: whether any of the beliefs that triggered the action came from quarantined (untrusted) memory. Minted by the provider (e.g. system://zmem) and signed with its own key; consumed at approval minting for actions in a consequential irreversibility class, per docs/specs/memory-provenance-binding.md. The verdict is about availability and trust state, never influence.",
+  "type": "object",
+  "required": ["action_id", "chain_root", "decision_seq", "clean"],
+  "properties": {
+    "action_id": {
+      "description": "The action (or approval grant) this check gates. The consuming artifact references this receipt; this field closes the loop back.",
+      "type": "string"
+    },
+    "provider": {
+      "description": "Optional provider system URI, e.g. 'system://zmem'. The authoritative provider identity is the receipt's signing key; this field is a convenience label.",
+      "type": "string"
+    },
+    "chain_root": {
+      "description": "The provider's memory chain root (base64url SHA-256 over its canonical ledger state) at decision time. A Class-2 verifier resolves this against the provider's provenance API to rederive the verdict.",
+      "type": "string"
+    },
+    "decision_seq": {
+      "description": "Ledger sequence number the chain root was computed at. Binding this into the grant lets a consumer detect belief drift between approval minting and consumption.",
+      "type": "integer"
+    },
+    "clean": {
+      "description": "True iff none of the triggering memory entries were in quarantine at decision_seq. A false verdict must refuse the grant; the refusal becomes a signed blocked artifact.",
+      "type": "boolean"
+    },
+    "quarantined_triggers": {
+      "description": "Entry ids of triggering memories found quarantined (empty or absent when clean).",
+      "type": "array"
+    },
+    "staleness_flags": {
+      "description": "Entry ids of triggering memories past the provider's freshness window. Advisory: staleness tolerance is the verifier's policy, not the provider's.",
+      "type": "array"
+    },
+    "checked_at": {
+      "description": "RFC 3339 UTC timestamp of the check. The check is fresh at minting; consumers of one_way_terminal grants should re-check at consumption (spec open question 5).",
+      "type": "string"
+    },
+    "scope": {
+      "description": "Tenant/workspace/session scope the check ran in.",
+      "type": "string"
+    }
+  }
+}

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -223,8 +223,48 @@ pub struct ApprovalStatement {
     #[serde(rename = "policyRef", skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<String>,
 
+    /// Irreversibility class of the actions this approval authorizes.
+    /// One of `IRREVERSIBILITY_CLASSES` (fail-closed: producers must
+    /// reject any other value; absent means undeclared, the pre-existing
+    /// behavior). Consequential-or-worse classes gate on memory
+    /// quarantine evidence at minting; see
+    /// docs/specs/memory-provenance-binding.md §2.4-2.5.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub irreversibility: Option<String>,
+
+    /// Artifact id of the `memory.quarantine-check.v1` receipt that
+    /// gated this grant. Signed into the approval so the evidence link
+    /// is tamper-evident: a verifier can walk grant -> check receipt ->
+    /// provider key -> chain root.
+    #[serde(rename = "quarantineReceipt", skip_serializing_if = "Option::is_none")]
+    pub quarantine_receipt: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<serde_json::Value>,
+}
+
+/// The irreversibility vocabulary, ordered from most to least recoverable.
+/// A grant's class is a claim about the worst-case effect of the actions it
+/// authorizes, not a property Treeship can observe -- but the vocabulary is
+/// closed so a self-declared class cannot smuggle an out-of-vocabulary value
+/// past a policy check (the AUD-06 rule, applied here).
+pub const IRREVERSIBILITY_CLASSES: &[&str] = &[
+    "two_way",
+    "one_way_recoverable",
+    "one_way_consequential",
+    "one_way_terminal",
+];
+
+/// True iff `class` is in the closed irreversibility vocabulary.
+pub fn is_irreversibility_class(class: &str) -> bool {
+    IRREVERSIBILITY_CLASSES.contains(&class)
+}
+
+/// True iff a grant of this class requires memory quarantine evidence at
+/// minting (consequential or worse). Unknown classes return true: an
+/// unrecognized claim gets the strictest treatment, never a bypass.
+pub fn irreversibility_requires_quarantine(class: &str) -> bool {
+    !matches!(class, "two_way" | "one_way_recoverable")
 }
 
 /// Records that work moved from one actor/domain to another.
@@ -483,6 +523,8 @@ impl ApprovalStatement {
             nonce: nonce.into(),
             scope: None,
             policy_ref: None,
+            irreversibility: None,
+            quarantine_receipt: None,
             meta: None,
         }
     }
@@ -666,6 +708,53 @@ mod tests {
         let decoded: ApprovalStatement = result.envelope.unmarshal_statement().unwrap();
         assert_eq!(decoded.nonce, "nonce_abc123");
         assert_eq!(decoded.scope.unwrap().max_actions, Some(1));
+    }
+
+    #[test]
+    fn approval_without_irreversibility_keeps_canonical_bytes() {
+        // The new optional fields must not appear in the serialized payload
+        // when absent -- content addressing means any accidental emission
+        // would change every existing approval's artifact id.
+        let approval = ApprovalStatement::new("human://alice", "nonce_abc123");
+        let bytes = serde_json::to_string(&approval).unwrap();
+        assert!(!bytes.contains("irreversibility"));
+        assert!(!bytes.contains("quarantineReceipt"));
+    }
+
+    #[test]
+    fn approval_irreversibility_fields_roundtrip_signed() {
+        let signer = Ed25519Signer::generate("key_human").unwrap();
+        let mut approval = ApprovalStatement::new("human://alice", "nonce_abc123");
+        approval.irreversibility = Some("one_way_consequential".into());
+        approval.quarantine_receipt = Some("art_deadbeef00112233".into());
+
+        let pt = payload_type("approval");
+        let result = sign(&pt, &approval, &signer).unwrap();
+        let decoded: ApprovalStatement = result.envelope.unmarshal_statement().unwrap();
+        assert_eq!(
+            decoded.irreversibility.as_deref(),
+            Some("one_way_consequential")
+        );
+        assert_eq!(
+            decoded.quarantine_receipt.as_deref(),
+            Some("art_deadbeef00112233")
+        );
+    }
+
+    #[test]
+    fn irreversibility_vocabulary_is_closed_and_fails_strict() {
+        for c in IRREVERSIBILITY_CLASSES {
+            assert!(is_irreversibility_class(c));
+        }
+        assert!(!is_irreversibility_class("reversible"));
+        assert!(!is_irreversibility_class(""));
+        // Recoverable classes do not gate; consequential and terminal do.
+        assert!(!irreversibility_requires_quarantine("two_way"));
+        assert!(!irreversibility_requires_quarantine("one_way_recoverable"));
+        assert!(irreversibility_requires_quarantine("one_way_consequential"));
+        assert!(irreversibility_requires_quarantine("one_way_terminal"));
+        // Unknown classes get the strictest treatment, never a bypass.
+        assert!(irreversibility_requires_quarantine("definitely_fine_trust_me"));
     }
 
     #[test]


### PR DESCRIPTION
Implements the treeship side of [docs/specs/memory-provenance-binding.md](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/memory-provenance-binding.md) §2.3–2.5, in two commits:

**1. `memory.quarantine-check.v1` predicate** — the typed receipt a memory provider (system://zmem) mints recording its quarantine verdict. Fail-closed schema validation; tests kill the laundering paths (missing verdict, stringly-typed `"true"`, non-integer seq).

**2. Irreversibility classes + the approval gate** — `ApprovalStatement` gains optional signed `irreversibility` + `quarantineReceipt` fields (absent ⇒ canonical bytes unchanged, test-pinned). `attest approval --irreversibility one_way_consequential|one_way_terminal` refuses to mint without a clean, schema-valid quarantine receipt **signed by a key pinned under `agent_cert`** — a self-signed verdict is not a check. Terminal grants additionally require a `human://` approver. Unknown classes are treated as strictest, never a bypass.

Six end-to-end tests exercise every refusal path against the real binary in isolated workspaces. Full CI surface: **625 passed, 0 failed**.

Follow-ups (separate): `blocked.v1` signed refusal artifacts (§2.6), effect-status ladder (§2.7), consume-time re-check for terminal grants (spec open question 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTXooUfeMhjFCc6MUkzEQG