### PR TITLE
feat: blocked.v1 — refused grants become signed evidence (memory-provenance-binding §2.6)

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -286,18 +286,19 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
         Some(scope)
     };
 
-    // Irreversibility gate (memory-provenance-binding §2.4-2.5).
+    // Irreversibility gate (memory-provenance-binding §2.4-2.6).
     // A supplied quarantine receipt is validated whenever present -- we
     // never sign a reference to evidence we did not check. Consequential
     // and terminal classes REQUIRE that evidence; terminal additionally
     // requires a human approver. Fail-closed: a dirty, missing, or
-    // unverifiable check refuses the grant.
-    if let Some(rid) = &args.quarantine_receipt {
-        validate_quarantine_receipt(&ctx, rid)?;
-    }
+    // unverifiable check refuses the grant -- and the refusal itself is
+    // recorded as a signed blocked.v1 artifact (§2.6), so "the guardrail
+    // fired" is evidence rather than a narrative.
+    //
+    // The vocabulary check stays a plain usage error (no blocked
+    // artifact): clap already prevents it for CLI callers, and a typo is
+    // not a policy refusal.
     if let Some(class) = &args.irreversibility {
-        // Clap constrains the vocabulary for CLI callers; re-check here so
-        // programmatic callers get the same closed-vocabulary behavior.
         if !is_irreversibility_class(class) {
             return Err(format!(
                 "unknown irreversibility class `{class}`\n  valid: {}",
@@ -305,22 +306,51 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
             )
             .into());
         }
-        if class == "one_way_terminal" && !args.approver.starts_with("human://") {
-            return Err(format!(
-                "one_way_terminal grants require a human approver, got `{}`\n  \
-                 fix: --approver human://<name>",
-                args.approver
-            )
-            .into());
+    }
+    let gate: Result<(), (&'static str, String)> = (|| {
+        if let Some(rid) = &args.quarantine_receipt {
+            validate_quarantine_receipt(&ctx, rid)
+                .map_err(|e| ("quarantine_triggered", e.to_string()))?;
         }
-        if irreversibility_requires_quarantine(class) && args.quarantine_receipt.is_none() {
-            return Err(format!(
-                "a `{class}` grant requires memory quarantine evidence\n  \
-                 the provider mints it, then pass: --quarantine-receipt <artifact-id>\n  \
-                 (a clean memory.quarantine-check.v1 receipt signed by a key pinned under agent_cert)"
-            )
-            .into());
+        if let Some(class) = &args.irreversibility {
+            if class == "one_way_terminal" && !args.approver.starts_with("human://") {
+                return Err((
+                    "human_escalation_pending",
+                    format!(
+                        "one_way_terminal grants require a human approver, got `{}`\n  \
+                         fix: --approver human://<name>",
+                        args.approver
+                    ),
+                ));
+            }
+            if irreversibility_requires_quarantine(class) && args.quarantine_receipt.is_none() {
+                return Err((
+                    "quarantine_triggered",
+                    format!(
+                        "a `{class}` grant requires memory quarantine evidence\n  \
+                         the provider mints it, then pass: --quarantine-receipt <artifact-id>\n  \
+                         (a clean memory.quarantine-check.v1 receipt signed by a key pinned under agent_cert)"
+                    ),
+                ));
+            }
         }
+        Ok(())
+    })();
+    if let Err((reason_class, msg)) = gate {
+        // Best-effort: a failure to record the refusal must never mask
+        // the refusal itself.
+        let blocked = record_approval_refusal(
+            &ctx,
+            reason_class,
+            msg.lines().next().unwrap_or(reason_class),
+            &args.approver,
+            args.irreversibility.as_deref(),
+            args.quarantine_receipt.as_deref(),
+        );
+        return Err(match blocked {
+            Some(id) => format!("{msg}\n  refusal recorded: {id}").into(),
+            None => msg.into(),
+        });
     }
 
     // Generate a cryptographically random nonce for approval binding.
@@ -402,6 +432,57 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
     ));
     printer.blank();
     Ok(())
+}
+
+/// Record a refused approval mint as a signed blocked.v1 receipt
+/// (memory-provenance-binding §2.6). Best-effort by contract: every
+/// failure path returns None so the caller's refusal error is never
+/// masked by a recording problem. The artifact is written to storage
+/// and chained like any receipt, but deliberately does NOT move the
+/// `last` pointer -- `verify last` must keep meaning "the artifact you
+/// just minted on purpose", not a refusal tombstone.
+fn record_approval_refusal(
+    ctx: &ctx::Ctx,
+    reason_class: &str,
+    description: &str,
+    approver: &str,
+    irreversibility: Option<&str>,
+    quarantine_receipt: Option<&str>,
+) -> Option<String> {
+    let mut payload = serde_json::json!({
+        "reason_class": reason_class,
+        "refused_kind": "approval",
+        "approver": approver,
+        "description": description,
+    });
+    if let Some(c) = irreversibility {
+        payload["irreversibility"] = c.into();
+    }
+    if let Some(r) = quarantine_receipt {
+        payload["quarantine_receipt"] = r.into();
+    }
+    // Never mint an invalid refusal record: if it does not satisfy its
+    // own predicate, recording is skipped rather than degraded.
+    treeship_core::predicates::validate("blocked.v1", Some(&payload)).ok()?;
+
+    let mut stmt = ReceiptStatement::new(&format!("ship://{}", ctx.config.ship_id), "blocked.v1");
+    stmt.payload = Some(payload);
+    let signer = ctx.keys.default_signer().ok()?;
+    let pt = payload_type("receipt");
+    let result = sign(&pt, &stmt, signer.as_ref()).ok()?;
+    ctx.storage
+        .write(&Record {
+            artifact_id: result.artifact_id.clone(),
+            digest: result.digest.clone(),
+            payload_type: pt,
+            key_id: signer.key_id().to_string(),
+            signed_at: stmt.timestamp.clone(),
+            parent_id: None,
+            envelope: result.envelope,
+            hub_url: None,
+        })
+        .ok()?;
+    Some(result.artifact_id)
 }
 
 /// Validate a memory.quarantine-check.v1 receipt as gate evidence for an

--- a/packages/cli/tests/approval_gate_cli.rs
+++ b/packages/cli/tests/approval_gate_cli.rs
@@ -166,8 +166,35 @@ impl Workspace {
     }
 }
 
+impl Workspace {
+    /// Extract the blocked.v1 artifact id from a refusal output and
+    /// assert it verifies as a signed local artifact (§2.6: the refusal
+    /// is evidence, not just an error message).
+    fn assert_refusal_recorded(&self, output: &str) -> String {
+        let id = output
+            .split("refusal recorded: ")
+            .nth(1)
+            .and_then(|s| s.split_whitespace().next())
+            .unwrap_or_else(|| panic!("no `refusal recorded:` in refusal output: {output}"))
+            .to_string();
+        let out = self
+            .cmd()
+            .args(["verify", &id, "--no-chain", "--config"])
+            .arg(self.config())
+            .output()
+            .expect("verify blocked artifact");
+        assert!(
+            out.status.success(),
+            "blocked artifact {id} must verify: stdout={} stderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+        id
+    }
+}
+
 #[test]
-fn consequential_without_receipt_is_refused() {
+fn consequential_without_receipt_is_refused_and_recorded() {
     let ws = Workspace::new();
     ws.init();
     let (ok, output) = ws.approve_consequential(None, "human://alice", "one_way_consequential");
@@ -176,6 +203,7 @@ fn consequential_without_receipt_is_refused() {
         output.contains("requires memory quarantine evidence"),
         "refusal must say why: {output}"
     );
+    ws.assert_refusal_recorded(&output);
 }
 
 #[test]
@@ -189,6 +217,7 @@ fn terminal_requires_human_approver() {
         output.contains("human approver"),
         "refusal must name the fix: {output}"
     );
+    ws.assert_refusal_recorded(&output);
 }
 
 #[test]
@@ -229,6 +258,9 @@ fn dirty_verdict_is_refused() {
         output.contains("mem_poisoned1"),
         "refusal must surface the quarantined triggers: {output}"
     );
+    // The refusal record links back to the dirty check receipt.
+    let blocked = ws.assert_refusal_recorded(&output);
+    assert_ne!(blocked, receipt, "blocked artifact is distinct from the check receipt");
 }
 
 #[test]

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -46,6 +46,7 @@ const REGISTRY: &[(&str, &str)] = &[
         "memory.quarantine-check.v1",
         include_str!("schemas/memory.quarantine-check.v1.json"),
     ),
+    ("blocked.v1", include_str!("schemas/blocked.v1.json")),
     ("boundary.v1", include_str!("schemas/boundary.v1.json")),
     ("agent_card.v1", include_str!("schemas/agent_card.v1.json")),
     (
@@ -338,6 +339,48 @@ mod tests {
                 suffix: "memory.quarantine-check.v1".into(),
                 field: "decision_seq".into(),
                 expected: "\"integer\"".into()
+            }
+        );
+    }
+
+    #[test]
+    fn blocked_valid_passes() {
+        let payload = json!({
+            "reason_class": "quarantine_triggered",
+            "refused_kind": "approval",
+            "approver": "human://alice",
+            "irreversibility": "one_way_consequential",
+            "description": "quarantine check reports DIRTY",
+            "quarantine_receipt": "art_deadbeef00112233"
+        });
+        assert!(validate("blocked.v1", Some(&payload)).is_ok());
+    }
+
+    #[test]
+    fn blocked_out_of_vocabulary_reason_fails_closed() {
+        // A refusal record whose reason is not in the closed vocabulary
+        // must not validate -- otherwise "blocked" becomes a freeform
+        // label that policy checks cannot rely on (AUD-06).
+        let payload = json!({
+            "reason_class": "just_felt_like_it",
+            "refused_kind": "approval"
+        });
+        let err = validate("blocked.v1", Some(&payload)).unwrap_err();
+        assert!(
+            matches!(err, PredicateError::NotInEnum { ref field, .. } if field == "reason_class"),
+            "expected NotInEnum on reason_class, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn blocked_missing_reason_fails_closed() {
+        let payload = json!({ "refused_kind": "approval" });
+        let err = validate("blocked.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::MissingField {
+                suffix: "blocked.v1".into(),
+                field: "reason_class".into()
             }
         );
     }

--- a/packages/core/src/predicates/schemas/blocked.v1.json
+++ b/packages/core/src/predicates/schemas/blocked.v1.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/blocked.v1.json",
+  "title": "blocked.v1",
+  "description": "Receipt payload recording a REFUSED action or grant: the guardrail fired and this is the signed evidence. Negative space made verifiable -- without it, 'the safety constraint was evaluated' is a narrative. Minted best-effort by the refusing gate (e.g. the approval irreversibility gate) and chained like any artifact; see docs/specs/memory-provenance-binding.md §2.6. Metadata only: evidence travels by reference or digest, never inline.",
+  "type": "object",
+  "required": ["reason_class", "refused_kind"],
+  "properties": {
+    "reason_class": {
+      "description": "Why the refusal fired. Closed vocabulary (AUD-06): an out-of-vocabulary reason must not pass validation.",
+      "type": "string",
+      "enum": [
+        "policy_threshold_exceeded",
+        "quarantine_triggered",
+        "scope_violation",
+        "operator_revocation",
+        "human_escalation_pending"
+      ]
+    },
+    "refused_kind": {
+      "description": "What was refused.",
+      "type": "string",
+      "enum": ["approval", "action"]
+    },
+    "approver": {
+      "description": "Approver URI of the refused grant, when the refusal was an approval mint.",
+      "type": "string"
+    },
+    "actor": {
+      "description": "Actor URI of the refused action, when the refusal was an action.",
+      "type": "string"
+    },
+    "irreversibility": {
+      "description": "Declared irreversibility class of the refused grant/action, when one was declared.",
+      "type": "string"
+    },
+    "description": {
+      "description": "One-line human-readable refusal reason. Keep it short; detailed evidence travels by reference, not inline.",
+      "type": "string"
+    },
+    "quarantine_receipt": {
+      "description": "Artifact id of the memory.quarantine-check.v1 receipt involved in the refusal (e.g. the DIRTY verdict), when one exists.",
+      "type": "string"
+    },
+    "evidence_digest": {
+      "description": "sha256:<hex> digest of a private evidence object backing the refusal, when the producer keeps one.",
+      "type": "string"
+    },
+    "reevaluate_when": {
+      "description": "Condition or RFC 3339 time after which the refused request may be re-attempted, when the block is conditional.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
When the irreversibility gate refuses an approval, the refusal is now recorded as a signed `blocked.v1` receipt (best-effort, never masking the refusal) and surfaced as `refusal recorded: art_…`. Closed `reason_class` vocabulary, enum-enforced; evidence by reference, never inline; the `last` pointer is deliberately not moved. Tests assert every refusal path produces a verifiable artifact. Suite: 628 passed, 0 failed.

Remaining from the spec: effect-status ladder (§2.7), epoch identity (§2.8), consume-time re-check (open q5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTXooUfeMhjFCc6MUkzEQG