### PR TITLE
verify: surface the delegation chain on the authority axis

### DIFF
--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -7,7 +7,8 @@ use treeship_core::{
         invitation::InvitationStatement,
         payload_type, payload_type_v2,
         session_participant::{verify_participant_envelope, SessionParticipantStatement},
-        verify_effect, verify_mandate, ActionStatement, ActionStatementV2, ApprovalScope,
+        resolve_grant_chain, verify_effect, verify_grant_chain, verify_mandate, ActionStatement,
+        ActionStatementV2, ApprovalScope,
         ApprovalStatement, DecisionStatement, EffectConfidence, EffectVerdict, HandoffStatement,
         MandateVerdict, NoRevocationSource, NoWitnessAuthority,
         ReceiptStatement,
@@ -77,8 +78,27 @@ struct StepInfo {
     // "was it allowed". A receipt can be impeccably signed and still record an
     // action outside its grant.
     mandate_verdict: Option<MandateSummary>,
+    // action/v2 delegation chain outcome, when the mandate carries ancestors.
+    chain_summary: Option<ChainSummary>,
     // action/v2 runtime identity (who/what executed the action).
     runtime_model: Option<String>,
+}
+
+/// Delegation-chain outcome for display. Distinct from the mandate verdict:
+/// the mandate asks whether THIS hop was inside its grant, the chain asks
+/// whether the grant itself descends legitimately from a root.
+#[derive(Clone)]
+enum ChainSummary {
+    /// No ancestors carried. A single-hop mandate makes no lineage claim, so
+    /// there is nothing to check -- reported as absent, not as a pass.
+    NotClaimed,
+    /// Links resolved and every hop attenuates.
+    Holds { hops: usize },
+    /// Links resolved but a hop widens scope, extends expiry, jumps depth, or
+    /// changes audience.
+    Widened(String),
+    /// The carried set could not be assembled into a chain at all.
+    Unresolvable(String),
 }
 
 /// Flattened mandate outcome for display. `Unverified` carries the layers we
@@ -130,6 +150,29 @@ fn v2_mandate_summary(env: &Envelope) -> Option<MandateSummary> {
         MandateVerdict::Pass => MandateSummary::Pass,
         MandateVerdict::Unverified(r) => MandateSummary::Unverified(r),
         MandateVerdict::Fail(r) => MandateSummary::Fail(r),
+    })
+}
+
+/// Resolve and judge the delegation chain behind a v2 action's mandate.
+///
+/// Two steps that only mean something together: `resolve_grant_chain` derives
+/// the order from signed parent links (so the carrier cannot choose which
+/// pairs get compared), then `verify_grant_chain` checks attenuation across
+/// those pairs. Order first, then invariants.
+fn v2_chain_summary(env: &Envelope) -> Option<ChainSummary> {
+    if env.payload_type != payload_type_v2("action") {
+        return None;
+    }
+    let stmt = env.unmarshal_statement::<ActionStatementV2>().ok()?;
+    if stmt.mandate.chain.is_empty() {
+        return Some(ChainSummary::NotClaimed);
+    }
+    Some(match resolve_grant_chain(&stmt.mandate) {
+        Err(e) => ChainSummary::Unresolvable(format!("{e:?}")),
+        Ok(chain) => match verify_grant_chain(chain.as_slice()) {
+            Ok(()) => ChainSummary::Holds { hops: chain.len() },
+            Err(e) => ChainSummary::Widened(format!("{e:?}")),
+        },
     })
 }
 
@@ -779,6 +822,26 @@ fn print_step_card(step: &StepInfo, printer: &Printer) {
         None => {}
     }
 
+    // Delegation chain (action/v2). Printed under authority: a mandate can be
+    // perfectly in scope for a grant that was never legitimately delegated.
+    match &step.chain_summary {
+        Some(ChainSummary::Holds { hops }) => {
+            print_box_line(
+                &format!("chain:     {hops} hop(s), attenuation holds"),
+                printer,
+            );
+        }
+        Some(ChainSummary::Widened(why)) => {
+            print_box_line(&format!("chain:     WIDENED ({why})"), printer);
+        }
+        Some(ChainSummary::Unresolvable(why)) => {
+            print_box_line(&format!("chain:     unresolvable ({why})"), printer);
+        }
+        // No ancestors carried: say nothing rather than imply a single-hop
+        // mandate passed a check that never ran.
+        Some(ChainSummary::NotClaimed) | None => {}
+    }
+
     // Effect verdict (action/v2): operational confidence, reconciled against
     // evidence. Distinct from the signature check -- a valid signature over a
     // Verified claim still reads not-verified here when nothing backs it.
@@ -940,6 +1003,7 @@ fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) ->
         effect_claimed: None,
         effect_downgraded: false,
         mandate_verdict: None,
+        chain_summary: None,
         effect_trusted_witnesses: 0,
         runtime_model: None,
     };
@@ -958,6 +1022,7 @@ fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) ->
             }
             // Surface the effect line only when there is an effect to judge.
             info.mandate_verdict = v2_mandate_summary(env);
+            info.chain_summary = v2_chain_summary(env);
             if let Some(verdict) = v2_effect_verdict(env) {
                 info.effect_effective = Some(verdict.effective_confidence);
                 info.effect_claimed = verdict.claimed_confidence;
@@ -1636,6 +1701,7 @@ mod tests {
                 path: "hub://acme/revocations".into(),
                 revoked_at: None,
             },
+            chain: Vec::new(),
         };
         let mut stmt = ActionStatementV2::new("agent://worker", "payments.charge", mandate);
         // Verified claim with NO independent evidence: must downgrade.
@@ -1917,6 +1983,7 @@ mod tests {
                 path: "hub://acme/revocations".into(),
                 revoked_at: None,
             },
+            chain: Vec::new(),
         };
         let signer = Ed25519Signer::generate("agent_worker").unwrap();
         let dir = std::env::temp_dir().join("ts_verify_v2_mandate_test");
@@ -1959,5 +2026,120 @@ mod tests {
             v2_mandate_summary(&v1_env).is_none(),
             "v1 receipts must not claim anything about authority"
         );
+    }
+
+    // ── action/v2 delegation chain wiring ──────────────────────────────
+    #[test]
+    fn v2_chain_summary_reports_holds_widened_and_absent() {
+        use treeship_core::attestation::{sign, Ed25519Signer, Signer as _};
+        use treeship_core::statements::{
+            payload_type_v2, ActionStatementV2, Grant, Mandate, Revocation,
+        };
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+        let signer = Ed25519Signer::generate("issuer").unwrap();
+        let pk = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+
+        let mk = |scope: Vec<&str>, depth: u32, parent: Option<&str>| -> Grant {
+            let mut g = Grant {
+                grant_id: String::new(),
+                grantor: pk.clone(),
+                issuer_sig: None,
+                scope: scope.into_iter().map(String::from).collect(),
+                audience: "acme".into(),
+                parent_request_id: None,
+                parent_grant_id: parent.map(String::from),
+                delegation_depth: depth,
+                issued_at: "2026-07-20T10:00:00Z".into(),
+                expiry: "2026-07-20T11:00:00Z".into(),
+                max_delegation: 3,
+                objective_hash: None,
+            };
+            g.grant_id = g.derive_grant_id();
+            g.issuer_sig = Some(g.sign_canonical(&signer).unwrap());
+            g
+        };
+
+        let mandate_for = |leaf: &Grant, chain: Vec<Grant>| Mandate {
+            grant_id: leaf.grant_id.clone(),
+            grantor: pk.clone(),
+            issuer_sig: leaf.issuer_sig.clone(),
+            objective_hash: None,
+            scope: leaf.scope.clone(),
+            audience: "acme".into(),
+            parent_request_id: None,
+            delegation_depth: leaf.delegation_depth,
+            issued_at: "2026-07-20T10:00:00Z".into(),
+            expiry: "2026-07-20T11:00:00Z".into(),
+            max_delegation: 3,
+            revocation: Revocation {
+                path: "hub://acme/revocations".into(),
+                revoked_at: None,
+            },
+            chain,
+        };
+
+        let envelope_for = |m: Mandate, action: &str| {
+            let mut st = ActionStatementV2::new("agent://worker", action, m);
+            st.timestamp = "2026-07-20T10:30:00Z".into();
+            st.audience = Some("acme".into());
+            sign(&payload_type_v2("action"), &st, &signer).unwrap().envelope
+        };
+
+        // Holds: child narrows the parent's scope at depth+1.
+        let root = mk(vec!["payments.*"], 0, None);
+        let leaf = mk(vec!["payments.charge"], 1, Some(&root.grant_id));
+        let env = envelope_for(
+            mandate_for(&leaf, vec![leaf.clone(), root.clone()]), // carrier order: leaf first
+            "payments.charge",
+        );
+        match v2_chain_summary(&env) {
+            Some(ChainSummary::Holds { hops }) => assert_eq!(hops, 2),
+            other => panic!("expected Holds, got {}", chain_label(&other)),
+        }
+
+        // Widened: child claims scope the parent never had. Must not pass
+        // just because every individual grant is validly signed.
+        let wroot = mk(vec!["payments.charge"], 0, None);
+        let wleaf = mk(vec!["payments.*"], 1, Some(&wroot.grant_id));
+        let wenv = envelope_for(
+            mandate_for(&wleaf, vec![wroot.clone(), wleaf.clone()]),
+            "payments.charge",
+        );
+        assert!(
+            matches!(v2_chain_summary(&wenv), Some(ChainSummary::Widened(_))),
+            "a scope-widening hop must be reported"
+        );
+
+        // Truncated: the leaf points at a parent that was not carried.
+        let tenv = envelope_for(mandate_for(&leaf, vec![leaf.clone()]), "payments.charge");
+        assert!(
+            matches!(v2_chain_summary(&tenv), Some(ChainSummary::Unresolvable(_))),
+            "a missing ancestor must be unresolvable, not silently rooted"
+        );
+
+        // No ancestors carried: no claim, so no line.
+        let nenv = envelope_for(mandate_for(&leaf, vec![]), "payments.charge");
+        assert!(matches!(
+            v2_chain_summary(&nenv),
+            Some(ChainSummary::NotClaimed)
+        ));
+
+        // v1 artifacts have no chain concept at all.
+        let v1 = act("agent://x", "tool.call", None);
+        let v1_env = sign(&treeship_core::statements::payload_type("action"), &v1, &signer)
+            .unwrap()
+            .envelope;
+        assert!(v2_chain_summary(&v1_env).is_none());
+    }
+
+    fn chain_label(c: &Option<ChainSummary>) -> String {
+        match c {
+            Some(ChainSummary::Holds { hops }) => format!("Holds({hops})"),
+            Some(ChainSummary::Widened(w)) => format!("Widened({w})"),
+            Some(ChainSummary::Unresolvable(w)) => format!("Unresolvable({w})"),
+            Some(ChainSummary::NotClaimed) => "NotClaimed".into(),
+            None => "None".into(),
+        }
     }
 }

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -168,10 +168,10 @@ fn v2_chain_summary(env: &Envelope) -> Option<ChainSummary> {
         return Some(ChainSummary::NotClaimed);
     }
     Some(match resolve_grant_chain(&stmt.mandate) {
-        Err(e) => ChainSummary::Unresolvable(format!("{e:?}")),
+        Err(e) => ChainSummary::Unresolvable(e.to_string()),
         Ok(chain) => match verify_grant_chain(chain.as_slice()) {
             Ok(()) => ChainSummary::Holds { hops: chain.len() },
-            Err(e) => ChainSummary::Widened(format!("{e:?}")),
+            Err(e) => ChainSummary::Widened(e.to_string()),
         },
     })
 }
@@ -189,6 +189,54 @@ fn effect_verdict_json(v: &EffectVerdict) -> serde_json::Value {
         "trusted_witnesses": v.trusted_witnesses,
         "notes": v.notes,
     })
+}
+
+/// Serialize the authority verdict for `--json` output.
+///
+/// `unverified` is a distinct outcome from `pass`, not a softer pass: it means
+/// a layer could not be checked at all (today, revocation). Machine consumers
+/// gating on this must be able to tell those apart, so the outcome string is
+/// carried verbatim rather than collapsed to a boolean.
+fn mandate_summary_json(m: &MandateSummary) -> serde_json::Value {
+    match m {
+        MandateSummary::Pass => serde_json::json!({
+            "outcome": "pass",
+            "reasons": [],
+        }),
+        MandateSummary::Unverified(reasons) => serde_json::json!({
+            "outcome": "unverified",
+            "reasons": reasons,
+        }),
+        MandateSummary::Fail(reasons) => serde_json::json!({
+            "outcome": "fail",
+            "reasons": reasons,
+        }),
+    }
+}
+
+/// Serialize the delegation-chain outcome for `--json` output.
+///
+/// `not_claimed` is reported rather than omitted: a mandate that carries no
+/// ancestors made no lineage claim, which is different from one whose chain we
+/// checked and accepted. Silence would let a consumer read the absence as a pass.
+fn chain_summary_json(c: &ChainSummary) -> serde_json::Value {
+    match c {
+        ChainSummary::NotClaimed => serde_json::json!({
+            "outcome": "not_claimed",
+        }),
+        ChainSummary::Holds { hops } => serde_json::json!({
+            "outcome": "holds",
+            "hops": hops,
+        }),
+        ChainSummary::Widened(why) => serde_json::json!({
+            "outcome": "widened",
+            "detail": why,
+        }),
+        ChainSummary::Unresolvable(why) => serde_json::json!({
+            "outcome": "unresolvable",
+            "detail": why,
+        }),
+    }
 }
 
 pub fn run(
@@ -302,6 +350,32 @@ pub fn run(
             })
             .collect();
 
+        // Authority and delegation-chain outcomes, keyed the same way. These
+        // exist in the human output already; omitting them here would leave the
+        // machine-readable surface -- the one CI gates actually consume --
+        // unable to see that an action fell outside its grant.
+        let authority_by_id: HashMap<String, serde_json::Value> = chain_envelopes
+            .iter()
+            .filter_map(|(id, env)| {
+                v2_mandate_summary(env).map(|m| (id.clone(), mandate_summary_json(&m)))
+            })
+            .collect();
+        let delegation_by_id: HashMap<String, serde_json::Value> = chain_envelopes
+            .iter()
+            .filter_map(|(id, env)| {
+                v2_chain_summary(env).map(|c| (id.clone(), chain_summary_json(&c)))
+            })
+            .collect();
+
+        // One field a gate can test without walking every check. False only for
+        // an outright Fail: `unverified` means a layer could not be checked, and
+        // treating "did not look" as "found a violation" would make the flag
+        // useless the moment any receipt lacks a revocation resolver.
+        let authority_ok = !chain_envelopes
+            .iter()
+            .filter_map(|(_, env)| v2_mandate_summary(env))
+            .any(|m| matches!(m, MandateSummary::Fail(_)));
+
         let out: Vec<_> = checks
             .iter()
             .map(|c| {
@@ -313,6 +387,12 @@ pub fn run(
                 if let Some(effect) = effect_by_id.get(&c.id) {
                     obj["effect"] = effect.clone();
                 }
+                if let Some(authority) = authority_by_id.get(&c.id) {
+                    obj["authority"] = authority.clone();
+                }
+                if let Some(delegation) = delegation_by_id.get(&c.id) {
+                    obj["delegation_chain"] = delegation.clone();
+                }
                 obj
             })
             .collect();
@@ -321,6 +401,7 @@ pub fn run(
             "total": total, "passed": passed, "failed": failed,
             "chain_linkage_ok": linkage_ok,
             "chain_linkage_detail": if linkage_ok { serde_json::Value::Null } else { serde_json::json!(linkage_detail) },
+            "authority_ok": authority_ok,
             "checks": out,
         }));
         if failed > 0 || !linkage_ok {
@@ -2141,5 +2222,72 @@ mod tests {
             Some(ChainSummary::NotClaimed) => "NotClaimed".into(),
             None => "None".into(),
         }
+    }
+
+    // ── --json surface ─────────────────────────────────────────────────
+    // The human output already shows authority and chain. These lock the
+    // machine-readable shape, because that is what CI gates read: a verifier
+    // whose most consequential verdict is invisible to `--format json` reports
+    // an out-of-scope action as clean.
+
+    #[test]
+    fn authority_json_distinguishes_pass_unverified_and_fail() {
+        let pass = mandate_summary_json(&MandateSummary::Pass);
+        assert_eq!(pass["outcome"], "pass");
+        assert_eq!(pass["reasons"].as_array().unwrap().len(), 0);
+
+        // Unverified must not serialize as a pass: "we did not look" and "we
+        // looked and it was fine" are different facts.
+        let unver = mandate_summary_json(&MandateSummary::Unverified(vec![
+            "revocation unresolvable".into(),
+        ]));
+        assert_eq!(unver["outcome"], "unverified");
+        assert_eq!(unver["reasons"][0], "revocation unresolvable");
+
+        let fail = mandate_summary_json(&MandateSummary::Fail(vec!["out of scope".into()]));
+        assert_eq!(fail["outcome"], "fail");
+        assert_eq!(fail["reasons"][0], "out of scope");
+    }
+
+    #[test]
+    fn chain_json_reports_not_claimed_rather_than_omitting_it() {
+        // Absence of a lineage claim is itself the answer. If this serialized
+        // to null/omitted, a consumer would read "no chain problems" from a
+        // receipt whose chain was never checked.
+        let nc = chain_summary_json(&ChainSummary::NotClaimed);
+        assert_eq!(nc["outcome"], "not_claimed");
+
+        let holds = chain_summary_json(&ChainSummary::Holds { hops: 3 });
+        assert_eq!(holds["outcome"], "holds");
+        assert_eq!(holds["hops"], 3);
+
+        let widened = chain_summary_json(&ChainSummary::Widened("scope widens at hop 0->1".into()));
+        assert_eq!(widened["outcome"], "widened");
+        assert_eq!(widened["detail"], "scope widens at hop 0->1");
+
+        let unres =
+            chain_summary_json(&ChainSummary::Unresolvable("parent grant is missing".into()));
+        assert_eq!(unres["outcome"], "unresolvable");
+        assert_eq!(unres["detail"], "parent grant is missing");
+    }
+
+    #[test]
+    fn chain_errors_render_as_prose_not_debug_structs() {
+        use treeship_core::statements::{ChainResolveError, GrantChainError};
+
+        // These strings reach the operator verbatim. A Debug-formatted
+        // `AncestorMissing { parent_grant_id: "grn_..." }` is a leaked internal
+        // representation, not a diagnosis.
+        let e = ChainResolveError::AncestorMissing {
+            parent_grant_id: "grn_abc123".into(),
+        };
+        let s = e.to_string();
+        assert!(s.contains("grn_abc123"), "must name the grant: {s}");
+        assert!(!s.contains('{'), "must not be Debug-formatted: {s}");
+
+        let g = GrantChainError::ScopeWidened { parent: 1 };
+        let gs = g.to_string();
+        assert!(gs.contains("scope"), "must name the violated invariant: {gs}");
+        assert!(!gs.contains('{'), "must not be Debug-formatted: {gs}");
     }
 }

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -43,6 +43,7 @@ use super::invitation::{canonical_json_digest, parse_rfc3339_to_unix};
 use super::SubjectRef;
 use crate::attestation::{Signer, SignerError};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use sha2::{Digest, Sha256};
 use ed25519_dalek::{Signature, VerifyingKey};
 
 /// Statement type tag for the mandate/effect receipt.
@@ -133,6 +134,17 @@ pub struct Mandate {
 
     /// Revocation source + (optional) revoked-at timestamp.
     pub revocation: Revocation,
+
+    /// Ancestors of this grant, root-first, each carrying its own
+    /// `issuer_sig`. Optional and skipped when empty so existing v2 receipts
+    /// keep byte-identical canonical bytes.
+    ///
+    /// Carried inline rather than fetched: `issuer_sig` already exists so one
+    /// receipt can be checked offline, and that promise breaks the moment
+    /// verifying a delegated action requires N network round-trips. The
+    /// carrier's *ordering* is not trusted -- see `resolve_grant_chain`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub chain: Vec<Grant>,
 }
 
 /// A metered cost attached to an effect.
@@ -762,6 +774,20 @@ pub struct Grant {
     pub max_delegation: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub objective_hash: Option<String>,
+
+    /// Grantor's detached signature over this grant's canonical bytes.
+    /// Deliberately absent from `canonical_for_signing` -- a signature cannot
+    /// cover itself. Required for any grant carried in a mandate chain;
+    /// `resolve_grant_chain` refuses unsigned ancestors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issuer_sig: Option<String>,
+
+    /// Content id of the grant this one was delegated from. `None` marks a
+    /// root grant. Signed, so lineage cannot be re-parented after issuance --
+    /// and because ids are content-derived, this is a hash commitment to the
+    /// exact parent, not a reference to a name someone else could also claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_grant_id: Option<String>,
 }
 
 impl Grant {
@@ -771,19 +797,42 @@ impl Grant {
     /// bump, never a silent extension.
     pub fn canonical_for_signing(&self) -> String {
         let scope_digest = canonical_json_digest(&self.scope);
+        // v2 differs from v1 in two ways: `parent_grant_id` is covered, and
+        // `grant_id` is NOT. The id is derived from these bytes (see
+        // `derive_grant_id`), so including it would be circular -- and it
+        // matches how artifact ids work elsewhere: derived from the signed
+        // bytes, never stored inside them.
         format!(
-            "v1|grant|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
-            self.grant_id,
+            "v2|grant|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             self.grantor,
             scope_digest,
             self.audience,
             self.parent_request_id.as_deref().unwrap_or(""),
+            self.parent_grant_id.as_deref().unwrap_or(""),
             self.delegation_depth,
             self.issued_at,
             self.expiry,
             self.max_delegation,
             self.objective_hash.as_deref().unwrap_or(""),
         )
+    }
+
+    /// The grant's content id: `grn_` + first 16 hex of sha256 over the
+    /// canonical bytes. Mirrors `artifact_id = "art_" + hex(sha256(PAE))[..16]`.
+    ///
+    /// Ids stop being claims and become facts: two grants collide only under a
+    /// hash break, and a `parent_grant_id` therefore commits to one specific
+    /// parent rather than to whatever grant happens to assert that name.
+    pub fn derive_grant_id(&self) -> String {
+        let digest = Sha256::digest(self.canonical_for_signing().as_bytes());
+        format!("grn_{}", hex::encode(&digest[..8]))
+    }
+
+    /// True when the declared `grant_id` matches the derived one. A mismatch
+    /// means the id was chosen rather than computed, so nothing that
+    /// references it by id can be trusted to reference *this* grant.
+    pub fn id_is_consistent(&self) -> bool {
+        self.grant_id == self.derive_grant_id()
     }
 
     /// Sign the grant's canonical bytes; returns the base64url-no-pad
@@ -799,6 +848,12 @@ impl Grant {
     /// math checks out. Does not consult trust roots -- the caller decides
     /// whether `grantor` is a pinned issuer.
     pub fn verify_canonical(&self, signature_b64url: &str) -> bool {
+        // A valid signature over content whose id was chosen by hand is still
+        // unusable for chain walking: the parent pointer would resolve to a
+        // name, not to these bytes. Fail closed before touching the crypto.
+        if !self.id_is_consistent() {
+            return false;
+        }
         let pk_bytes = match URL_SAFE_NO_PAD.decode(self.grantor.as_bytes()) {
             Ok(b) if b.len() == 32 => b,
             _ => return false,
@@ -821,6 +876,102 @@ impl Grant {
         )
         .is_ok()
     }
+}
+
+/// Why a mandate's grant chain could not be resolved into a trustworthy order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChainResolveError {
+    /// A grant's declared id does not match its content.
+    InconsistentId { grant_id: String },
+    /// `mandate.grant_id` names a grant that is not in the carried chain.
+    LeafMissing { grant_id: String },
+    /// A `parent_grant_id` points at a grant that is not present.
+    AncestorMissing { parent_grant_id: String },
+    /// Following parent links revisited a grant: the links form a cycle.
+    Cycle { grant_id: String },
+    /// The carrier supplied grants that the walk never reached. Extra grants
+    /// are refused rather than ignored -- silently dropping them would let a
+    /// carrier stuff a chain with decoys.
+    UnreachableExtras { count: usize },
+    /// A grant carried no signature, so its content is unattested.
+    Unsigned { grant_id: String },
+    /// A grant's signature does not verify against its grantor.
+    BadSignature { grant_id: String },
+}
+
+/// Reconstruct the delegation chain for a mandate, root-first, from the
+/// grants it carries.
+///
+/// The carrier hands over a set; this function derives the *order* from the
+/// signed `parent_grant_id` links rather than trusting the sequence it was
+/// given. That is the whole point: `verify_grant_chain` checks attenuation
+/// between adjacent pairs, so if an attacker picks the pairing, the check
+/// establishes nothing. Here, reordering is a no-op, truncation shows up as a
+/// missing ancestor, and splicing shows up as an unreachable extra.
+///
+/// Every grant must be signed by its own grantor and carry a content-consistent
+/// id. Fails closed on anything it cannot establish.
+pub fn resolve_grant_chain(mandate: &Mandate) -> Result<Vec<Grant>, ChainResolveError> {
+    use std::collections::{HashMap, HashSet};
+
+    // Index by content id, checking each grant is self-consistent and attested.
+    let mut by_id: HashMap<String, &Grant> = HashMap::new();
+    for g in &mandate.chain {
+        if !g.id_is_consistent() {
+            return Err(ChainResolveError::InconsistentId {
+                grant_id: g.grant_id.clone(),
+            });
+        }
+        let sig = match g.issuer_sig.as_deref() {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Err(ChainResolveError::Unsigned {
+                    grant_id: g.grant_id.clone(),
+                })
+            }
+        };
+        if !g.verify_canonical(sig) {
+            return Err(ChainResolveError::BadSignature {
+                grant_id: g.grant_id.clone(),
+            });
+        }
+        by_id.insert(g.grant_id.clone(), g);
+    }
+
+    // Walk leaf -> root through signed parent links.
+    let mut leaf_first: Vec<Grant> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut cursor = Some(mandate.grant_id.clone());
+
+    while let Some(id) = cursor {
+        if !seen.insert(id.clone()) {
+            return Err(ChainResolveError::Cycle { grant_id: id });
+        }
+        let g = match by_id.get(&id) {
+            Some(g) => *g,
+            None => {
+                return Err(if leaf_first.is_empty() {
+                    ChainResolveError::LeafMissing { grant_id: id }
+                } else {
+                    ChainResolveError::AncestorMissing {
+                        parent_grant_id: id,
+                    }
+                })
+            }
+        };
+        leaf_first.push(g.clone());
+        cursor = g.parent_grant_id.clone();
+    }
+
+    // Anything the walk never reached is a decoy, not a spare.
+    if seen.len() != by_id.len() {
+        return Err(ChainResolveError::UnreachableExtras {
+            count: by_id.len() - seen.len(),
+        });
+    }
+
+    leaf_first.reverse(); // verify_grant_chain wants root-first
+    Ok(leaf_first)
 }
 
 /// Why a grant chain failed its attenuation invariants.
@@ -1236,6 +1387,7 @@ mod tests {
                 path: "hub://acme/revocations".into(),
                 revoked_at: None,
             },
+            chain: Vec::new(),
         }
     }
 
@@ -1504,9 +1656,11 @@ mod tests {
         Grant {
             grant_id: id.into(),
             grantor: grantor.into(),
+            issuer_sig: None,
             scope: scope.iter().map(|s| (*s).into()).collect(),
             audience: "acme-payments-api".into(),
             parent_request_id: None,
+            parent_grant_id: None,
             delegation_depth: depth,
             issued_at: "2026-07-11T19:00:00Z".into(),
             expiry: expiry.into(),
@@ -1527,6 +1681,9 @@ mod tests {
             "2026-07-11T21:00:00Z",
             3,
         );
+        // Ids are content-derived now; verify_canonical refuses a hand-chosen
+        // one, so compute it before signing.
+        g.grant_id = g.derive_grant_id();
 
         let sig = g.sign_canonical(&signer).unwrap();
         assert!(g.verify_canonical(&sig));
@@ -1672,5 +1829,141 @@ mod tests {
     fn single_grant_chain_ok() {
         let root = grant("g0", "k", &["payments.*"], 0, "2026-07-11T21:00:00Z", 3);
         assert_eq!(verify_grant_chain(&[root]), Ok(()));
+    }
+
+    // ---- grant chain resolution ----
+
+
+    /// Mint a signed grant with a content-consistent id.
+    fn mk_grant(
+        signer: &Ed25519Signer,
+        grantor_pk: &str,
+        scope: Vec<&str>,
+        depth: u32,
+        parent: Option<&str>,
+    ) -> Grant {
+        let mut g = Grant {
+            grant_id: String::new(),
+            grantor: grantor_pk.to_string(),
+            issuer_sig: None,
+            scope: scope.into_iter().map(String::from).collect(),
+            audience: "acme".into(),
+            parent_request_id: None,
+            parent_grant_id: parent.map(String::from),
+            delegation_depth: depth,
+            issued_at: "2026-07-20T10:00:00Z".into(),
+            expiry: "2026-07-20T11:00:00Z".into(),
+            max_delegation: 3,
+            objective_hash: None,
+        };
+        g.grant_id = g.derive_grant_id();
+        g.issuer_sig = Some(g.sign_canonical(signer).unwrap());
+        g
+    }
+
+    fn chain_fixture() -> (Grant, Grant, Ed25519Signer) {
+        let signer = Ed25519Signer::generate("issuer").unwrap();
+        let pk = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+        let root = mk_grant(&signer, &pk, vec!["payments.*"], 0, None);
+        let leaf = mk_grant(
+            &signer,
+            &pk,
+            vec!["payments.charge"],
+            1,
+            Some(&root.grant_id),
+        );
+        (root, leaf, signer)
+    }
+
+    fn mandate_with(leaf: &Grant, chain: Vec<Grant>) -> Mandate {
+        let mut m = base_mandate();
+        m.grant_id = leaf.grant_id.clone();
+        m.chain = chain;
+        m
+    }
+
+    #[test]
+    fn grant_id_is_content_derived_and_stable() {
+        let (root, _, _) = chain_fixture();
+        assert!(root.grant_id.starts_with("grn_"));
+        assert_eq!(root.grant_id, root.derive_grant_id());
+        // Changing any covered field must move the id.
+        let mut altered = root.clone();
+        altered.scope = vec!["payments.refund".into()];
+        assert_ne!(altered.derive_grant_id(), root.grant_id);
+    }
+
+    #[test]
+    fn hand_chosen_id_fails_verification() {
+        let (mut root, _, _) = chain_fixture();
+        let sig = root.issuer_sig.clone().unwrap();
+        root.grant_id = "grn_deadbeefdeadbeef".into();
+        assert!(
+            !root.verify_canonical(&sig),
+            "an id that was chosen rather than computed must not verify"
+        );
+    }
+
+    #[test]
+    fn resolves_root_first_regardless_of_carrier_order() {
+        let (root, leaf, _) = chain_fixture();
+        // Carrier hands them over leaf-first; resolution must not care.
+        let m = mandate_with(&leaf, vec![leaf.clone(), root.clone()]);
+        let resolved = resolve_grant_chain(&m).expect("resolves");
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0].grant_id, root.grant_id, "root must come first");
+        assert_eq!(resolved[1].grant_id, leaf.grant_id);
+    }
+
+    #[test]
+    fn truncated_chain_is_rejected() {
+        let (_, leaf, _) = chain_fixture();
+        // Drop the root: the leaf still points at it, so the walk must fail
+        // rather than treating the leaf as its own root.
+        let m = mandate_with(&leaf, vec![leaf.clone()]);
+        match resolve_grant_chain(&m) {
+            Err(ChainResolveError::AncestorMissing { .. }) => {}
+            other => panic!("truncation must be caught, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spliced_decoy_grant_is_rejected() {
+        let (root, leaf, signer) = chain_fixture();
+        let pk = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+        // A valid, signed, unrelated grant smuggled into the chain. It must
+        // differ in content from root -- an identical grant has an identical
+        // content id, which is the point of deriving ids from content.
+        let decoy = mk_grant(&signer, &pk, vec!["email.send"], 0, None);
+        assert_ne!(decoy.grant_id, root.grant_id);
+        let m = mandate_with(&leaf, vec![root.clone(), leaf.clone(), decoy]);
+        match resolve_grant_chain(&m) {
+            Err(ChainResolveError::UnreachableExtras { count }) => assert_eq!(count, 1),
+            other => panic!("unreachable extras must be refused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unsigned_ancestor_is_rejected() {
+        let (mut root, leaf, _) = chain_fixture();
+        root.issuer_sig = None;
+        let m = mandate_with(&leaf, vec![root, leaf.clone()]);
+        assert!(matches!(
+            resolve_grant_chain(&m),
+            Err(ChainResolveError::Unsigned { .. })
+        ));
+    }
+
+    #[test]
+    fn resolved_chain_feeds_attenuation_check() {
+        // End to end: resolution proves the shape, verify_grant_chain then
+        // judges the attenuation. Only together do they mean anything.
+        let (root, leaf, _) = chain_fixture();
+        let m = mandate_with(&leaf, vec![leaf.clone(), root.clone()]);
+        let resolved = resolve_grant_chain(&m).expect("resolves");
+        assert!(
+            verify_grant_chain(&resolved).is_ok(),
+            "narrowing scope at depth+1 must satisfy attenuation"
+        );
     }
 }

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -899,6 +899,39 @@ pub enum ChainResolveError {
     BadSignature { grant_id: String },
 }
 
+impl std::fmt::Display for ChainResolveError {
+    /// Operator-facing wording. The CLI prints these verbatim, so each names
+    /// the grant it is talking about: "unresolvable" without a subject leaves
+    /// a reader nothing to go and look at.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InconsistentId { grant_id } => {
+                write!(f, "grant {grant_id} declares an id that does not match its content")
+            }
+            Self::LeafMissing { grant_id } => {
+                write!(f, "the mandate names grant {grant_id}, which is not in the carried chain")
+            }
+            Self::AncestorMissing { parent_grant_id } => {
+                write!(f, "parent grant {parent_grant_id} is missing from the chain")
+            }
+            Self::Cycle { grant_id } => {
+                write!(f, "parent links revisit grant {grant_id}: the chain is a cycle")
+            }
+            Self::UnreachableExtras { count } => {
+                write!(f, "{count} carried grant(s) are not reachable from the mandate")
+            }
+            Self::Unsigned { grant_id } => {
+                write!(f, "grant {grant_id} carries no issuer signature")
+            }
+            Self::BadSignature { grant_id } => {
+                write!(f, "grant {grant_id} has a signature that does not verify")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ChainResolveError {}
+
 /// Reconstruct the delegation chain for a mandate, root-first, from the
 /// grants it carries.
 ///
@@ -992,6 +1025,37 @@ pub enum GrantChainError {
     /// child.audience differs from parent.audience.
     AudienceChanged { parent: usize },
 }
+
+impl std::fmt::Display for GrantChainError {
+    /// `parent` is the index of the *parent* in the resolved root-first chain,
+    /// so the violation is reported as the hop between it and its child --
+    /// which is where an operator has to look to fix it.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "the chain is empty"),
+            Self::BadTimestamp { index } => {
+                write!(f, "grant at hop {index} has an unparseable issued_at/expiry")
+            }
+            Self::ScopeWidened { parent } => {
+                write!(f, "scope widens at hop {}->{}", parent, parent + 1)
+            }
+            Self::ExpiryWidened { parent } => {
+                write!(f, "expiry extends past the parent at hop {}->{}", parent, parent + 1)
+            }
+            Self::DepthNotIncremented { parent } => {
+                write!(f, "delegation depth does not increment by one at hop {}->{}", parent, parent + 1)
+            }
+            Self::DepthExceedsMax { parent } => {
+                write!(f, "delegation depth exceeds the parent's max_delegation at hop {}->{}", parent, parent + 1)
+            }
+            Self::AudienceChanged { parent } => {
+                write!(f, "audience changes at hop {}->{}", parent, parent + 1)
+            }
+        }
+    }
+}
+
+impl std::error::Error for GrantChainError {}
 
 /// Verify attenuation across an ordered grant chain (`chain[0]` is the root,
 /// `chain[last]` is the leaf the action was minted from). Every adjacent pair
@@ -1965,5 +2029,59 @@ mod tests {
             verify_grant_chain(&resolved).is_ok(),
             "narrowing scope at depth+1 must satisfy attenuation"
         );
+    }
+
+    #[test]
+    fn leaf_not_in_chain_is_rejected() {
+        // The mandate names a grant the carrier did not supply. Distinct from
+        // AncestorMissing: nothing has been walked yet, so the failure has to
+        // point at the leaf rather than at a parent link.
+        let (root, leaf, _) = chain_fixture();
+        let mut m = mandate_with(&leaf, vec![root.clone()]);
+        m.grant_id = leaf.grant_id.clone();
+        match resolve_grant_chain(&m) {
+            Err(ChainResolveError::LeafMissing { grant_id }) => {
+                assert_eq!(grant_id, leaf.grant_id);
+            }
+            other => panic!("a mandate naming an absent leaf must fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ancestor_signed_by_a_stranger_is_rejected() {
+        // Content-consistent id, well-formed signature -- but produced by a key
+        // that is not the declared grantor. The id check cannot catch this
+        // because `grantor` is covered by the canonical: only the crypto can.
+        let (root, leaf, _) = chain_fixture();
+        let stranger = Ed25519Signer::generate("stranger").unwrap();
+        let mut forged = root.clone();
+        forged.issuer_sig = Some(forged.sign_canonical(&stranger).unwrap());
+        assert_eq!(
+            forged.grant_id, root.grant_id,
+            "signing with another key must not change the content id"
+        );
+
+        let m = mandate_with(&leaf, vec![forged, leaf.clone()]);
+        match resolve_grant_chain(&m) {
+            Err(ChainResolveError::BadSignature { grant_id }) => {
+                assert_eq!(grant_id, root.grant_id);
+            }
+            other => panic!("a grant signed by a non-grantor must fail, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inconsistent_id_is_caught_before_signature_check() {
+        // A tampered id must be refused as InconsistentId, not surface later as
+        // BadSignature -- the reason an operator is given should name the
+        // actual defect.
+        let (root, leaf, _) = chain_fixture();
+        let mut tampered = root.clone();
+        tampered.grant_id = "grn_0000000000000000".into();
+        let m = mandate_with(&leaf, vec![tampered, leaf.clone()]);
+        assert!(matches!(
+            resolve_grant_chain(&m),
+            Err(ChainResolveError::InconsistentId { .. })
+        ));
     }
 }

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -55,7 +55,8 @@ pub use session_participant::{
 // `Unverified` rather than a false `Pass` for any layer it cannot check.
 pub mod action_v2;
 pub use action_v2::{
-    action_in_scope, payload_type_v2, verify_effect, verify_grant_chain, verify_mandate,
+    action_in_scope, payload_type_v2, resolve_grant_chain, verify_effect, verify_grant_chain,
+    verify_mandate, ChainResolveError,
     ActionStatementV2, Cost, Effect, EffectConfidence, EffectVerdict, Grant, GrantChainError,
     Mandate, MandateVerdict, NoRevocationSource, NoWitnessAuthority, Revocation, RevocationSource,
     RevocationStatus, RuntimeIdentity, Witness, WitnessAuthority, TYPE_ACTION_V2,


### PR DESCRIPTION
Completes the Moltbook **permission trajectories** item — the most repeated cluster in the signal corpus, and the last one that was blocked.

The mandate line asks whether *this hop* was inside its grant. It can't ask whether the grant itself descends legitimately from a root — so an action could sit perfectly inside a grant that was never validly delegated and still print clean.

Four states under the authority line:
- `chain: N hop(s), attenuation holds`
- `chain: WIDENED (why)` — a hop widens scope, extends expiry, jumps depth, or changes audience
- `chain: unresolvable (why)` — missing ancestor, cycle, decoy, bad signature
- silent — no ancestors carried, so no claim was made and none is judged

**Order is derived before invariants are checked.** `resolve_grant_chain` reads the signed parent links, then `verify_grant_chain` judges attenuation across the pairs it produced. Reversing that lets the carrier pick which pairs get compared — the exact failure this exists to prevent.

Tests cover holds (carrier hands leaf-first, resolution reorders), widened (every grant validly signed, one hop still claims scope its parent never had), truncated, absent, and v1. CLI 150 passed.

Stacks on #247 and #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNs7dkbFXYSmsmPfJuuKge