### PR TITLE
effect: separate lifecycle from evidence, and bound unresolved effects

### DIFF
--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -7,11 +7,13 @@ use treeship_core::{
         invitation::InvitationStatement,
         payload_type, payload_type_v2,
         session_participant::{verify_participant_envelope, SessionParticipantStatement},
-        resolve_grant_chain, verify_effect, verify_grant_chain, verify_mandate, ActionStatement,
+        check_resolution, resolve_grant_chain, verify_effect, verify_grant_chain, verify_mandate,
+        ActionStatement,
         ActionStatementV2, ApprovalScope,
-        ApprovalStatement, DecisionStatement, EffectConfidence, EffectVerdict, HandoffStatement,
+        ApprovalStatement, DeadlineEvent, DecisionStatement, EffectConfidence, EffectFinality,
+        EffectVerdict, HandoffStatement,
         MandateVerdict, NoRevocationSource, NoWitnessAuthority,
-        ReceiptStatement,
+        ReceiptStatement, ResolutionStatus,
     },
     storage::Store,
     trust::TrustRootStore,
@@ -80,6 +82,12 @@ struct StepInfo {
     mandate_verdict: Option<MandateSummary>,
     // action/v2 delegation chain outcome, when the mandate carries ancestors.
     chain_summary: Option<ChainSummary>,
+    // action/v2 lifecycle stage: how far the state change got, as opposed to
+    // how well the effect is evidenced.
+    effect_finality: Option<EffectFinality>,
+    effect_finality_claimed: Option<EffectFinality>,
+    // action/v2 resolution obligation, evaluated against the clock at print time.
+    resolution: Option<ResolutionStatus>,
     // action/v2 runtime identity (who/what executed the action).
     runtime_model: Option<String>,
 }
@@ -182,13 +190,76 @@ fn effect_verdict_json(v: &EffectVerdict) -> serde_json::Value {
         .claimed_confidence
         .map(|c| c != v.effective_confidence)
         .unwrap_or(false);
+    // Finality is reported beside confidence, never merged into it. They
+    // answer different questions -- how far the change got, and how well that
+    // is evidenced -- and a receipt can be honest on one axis while
+    // overclaiming the other.
+    let finality_downgraded = v
+        .claimed_finality
+        .map(|c| Some(c) != v.effective_finality)
+        .unwrap_or(false);
     serde_json::json!({
         "effective_confidence": effect_label(v.effective_confidence),
         "claimed_confidence": v.claimed_confidence.map(effect_label),
         "downgraded": downgraded,
         "trusted_witnesses": v.trusted_witnesses,
+        "effective_finality": v.effective_finality.map(finality_label),
+        "claimed_finality": v.claimed_finality.map(finality_label),
+        "finality_downgraded": finality_downgraded,
         "notes": v.notes,
     })
+}
+
+/// Human label for a lifecycle stage, matching the wire snake_case.
+fn finality_label(f: EffectFinality) -> &'static str {
+    match f {
+        EffectFinality::NotAttempted => "not_attempted",
+        EffectFinality::Initiated => "initiated",
+        EffectFinality::Finalized => "finalized",
+        EffectFinality::Failed => "failed",
+        EffectFinality::Indeterminate => "indeterminate",
+    }
+}
+
+/// Serialize an effect's resolution obligation for `--json` output.
+///
+/// `indefinite` is carried as its own outcome rather than folded into
+/// `resolved`: an unresolved effect with no declared deadline is the shape that
+/// goes unnoticed for months, and the machine surface is where a monitor would
+/// have to catch it.
+fn resolution_status_json(s: &ResolutionStatus) -> serde_json::Value {
+    match s {
+        ResolutionStatus::Resolved => serde_json::json!({ "outcome": "resolved" }),
+        ResolutionStatus::Indefinite => serde_json::json!({ "outcome": "indefinite" }),
+        ResolutionStatus::Pending { seconds_remaining } => serde_json::json!({
+            "outcome": "pending",
+            "seconds_remaining": seconds_remaining,
+        }),
+        ResolutionStatus::Breached {
+            on_deadline,
+            seconds_overdue,
+        } => serde_json::json!({
+            "outcome": "breached",
+            "on_deadline": match on_deadline {
+                DeadlineEvent::Timeout => "timeout",
+                DeadlineEvent::Escalate => "escalate",
+                DeadlineEvent::Tombstone => "tombstone",
+                DeadlineEvent::Inherit => "inherit",
+            },
+            "seconds_overdue": seconds_overdue,
+        }),
+        ResolutionStatus::BadDeadline => serde_json::json!({ "outcome": "bad_deadline" }),
+    }
+}
+
+/// Evaluate the resolution obligation for a v2 action envelope at `now_unix`.
+/// `None` for anything that is not a v2 action or carries no effect block.
+fn v2_resolution_status(env: &Envelope, now_unix: i64) -> Option<ResolutionStatus> {
+    if env.payload_type != payload_type_v2("action") {
+        return None;
+    }
+    let stmt = env.unmarshal_statement::<ActionStatementV2>().ok()?;
+    stmt.effect.as_ref().map(|e| check_resolution(e, now_unix))
 }
 
 /// Serialize the authority verdict for `--json` output.
@@ -367,6 +438,20 @@ pub fn run(
             })
             .collect();
 
+        // Resolution is time-dependent, so the clock is read once here and
+        // passed down. Reading it per-envelope would let two effects in the
+        // same run be judged against different "now"s.
+        let now_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let resolution_by_id: HashMap<String, serde_json::Value> = chain_envelopes
+            .iter()
+            .filter_map(|(id, env)| {
+                v2_resolution_status(env, now_unix).map(|r| (id.clone(), resolution_status_json(&r)))
+            })
+            .collect();
+
         // One field a gate can test without walking every check. False only for
         // an outright Fail: `unverified` means a layer could not be checked, and
         // treating "did not look" as "found a violation" would make the flag
@@ -392,6 +477,9 @@ pub fn run(
                 }
                 if let Some(delegation) = delegation_by_id.get(&c.id) {
                     obj["delegation_chain"] = delegation.clone();
+                }
+                if let Some(resolution) = resolution_by_id.get(&c.id) {
+                    obj["resolution"] = resolution.clone();
                 }
                 obj
             })
@@ -949,6 +1037,63 @@ fn print_step_card(step: &StepInfo, printer: &Printer) {
         print_box_line(&line, printer);
     }
 
+    // Lifecycle stage (action/v2), printed under effect because it answers a
+    // different question: effect grades the evidence, this says how far the
+    // change actually got. "Accepted but never committed" is invisible when
+    // those collapse into one line.
+    if let Some(stage) = step.effect_finality {
+        let mut line = format!("state:  {}", finality_label(stage));
+        if let Some(claimed) = step.effect_finality_claimed {
+            if Some(claimed) != step.effect_finality {
+                line.push_str(&format!(
+                    "  (actor claimed {}, downgraded: no independent evidence)",
+                    finality_label(claimed)
+                ));
+            }
+        }
+        print_box_line(&line, printer);
+    }
+
+    // Resolution obligation. Only worth a line when something is still owed --
+    // a resolved effect has nothing outstanding, and saying so every time
+    // would bury the two cases that matter.
+    match &step.resolution {
+        Some(ResolutionStatus::Indefinite) => {
+            print_box_line(
+                "owed:   unresolved with no deadline (nothing will ever fire)",
+                printer,
+            );
+        }
+        Some(ResolutionStatus::Breached {
+            on_deadline,
+            seconds_overdue,
+        }) => {
+            print_box_line(
+                &format!(
+                    "owed:   OVERDUE by {}s, declared action: {}",
+                    seconds_overdue,
+                    match on_deadline {
+                        DeadlineEvent::Timeout => "timeout",
+                        DeadlineEvent::Escalate => "escalate",
+                        DeadlineEvent::Tombstone => "tombstone",
+                        DeadlineEvent::Inherit => "inherit",
+                    }
+                ),
+                printer,
+            );
+        }
+        Some(ResolutionStatus::Pending { seconds_remaining }) => {
+            print_box_line(
+                &format!("owed:   unresolved, {seconds_remaining}s left to resolve"),
+                printer,
+            );
+        }
+        Some(ResolutionStatus::BadDeadline) => {
+            print_box_line("owed:   unresolved, deadline unparseable", printer);
+        }
+        Some(ResolutionStatus::Resolved) | None => {}
+    }
+
     // Approval info (if this action references an approval)
     if let (Some(ref appr_id), Some(ref approver)) = (&step.approval_id, &step.approver) {
         print_box_line(
@@ -1085,6 +1230,9 @@ fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) ->
         effect_downgraded: false,
         mandate_verdict: None,
         chain_summary: None,
+        effect_finality: None,
+        effect_finality_claimed: None,
+        resolution: None,
         effect_trusted_witnesses: 0,
         runtime_model: None,
     };
@@ -1112,7 +1260,16 @@ fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) ->
                     .claimed_confidence
                     .map(|c| c != verdict.effective_confidence)
                     .unwrap_or(false);
+                info.effect_finality = verdict.effective_finality;
+                info.effect_finality_claimed = verdict.claimed_finality;
             }
+            info.resolution = v2_resolution_status(
+                env,
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0),
+            );
             if let Some(meta) = &stmt.meta {
                 extract_meta_fields(&mut info, meta);
             }
@@ -2269,6 +2426,117 @@ mod tests {
             chain_summary_json(&ChainSummary::Unresolvable("parent grant is missing".into()));
         assert_eq!(unres["outcome"], "unresolvable");
         assert_eq!(unres["detail"], "parent grant is missing");
+    }
+
+    #[test]
+    fn unresolved_effect_reaches_step_info_as_indefinite() {
+        // End to end through a signed envelope, not just the serializer: an
+        // effect that never says it landed and declares no deadline is the
+        // 181-day pending row, and it has to be visible on the step card.
+        use treeship_core::attestation::{sign, Ed25519Signer};
+        use treeship_core::statements::{
+            payload_type_v2, ActionStatementV2, Effect, EffectFinality, Mandate, Revocation,
+        };
+
+        let mandate = Mandate {
+            grant_id: "grant_1".into(),
+            grantor: "key_parent".into(),
+            issuer_sig: None,
+            objective_hash: None,
+            scope: vec!["payments.charge".into()],
+            audience: "acme".into(),
+            parent_request_id: None,
+            delegation_depth: 0,
+            issued_at: "2026-07-20T10:00:00Z".into(),
+            expiry: "2026-07-20T11:00:00Z".into(),
+            max_delegation: 3,
+            revocation: Revocation {
+                path: "hub://acme/revocations".into(),
+                revoked_at: None,
+            },
+            chain: Vec::new(),
+        };
+        let signer = Ed25519Signer::generate("agent_worker").unwrap();
+        let dir = std::env::temp_dir().join("ts_verify_resolution_test");
+        let store = Store::open(&dir).unwrap();
+
+        let mut stmt = ActionStatementV2::new("agent://worker", "payments.charge", mandate);
+        stmt.timestamp = "2026-07-20T10:30:00Z".into();
+        stmt.audience = Some("acme".into());
+        stmt.effect = Some(Effect {
+            output_hash: Some("sha256:out".into()),
+            // Accepted, not committed, nothing scheduled to fire.
+            finality: Some(EffectFinality::Initiated),
+            ..Default::default()
+        });
+        let env = sign(&payload_type_v2("action"), &stmt, &signer)
+            .unwrap()
+            .envelope;
+
+        let info = extract_step_info(0, "art_pending", &env, &store);
+        assert_eq!(
+            info.effect_finality,
+            Some(EffectFinality::Initiated),
+            "the lifecycle stage must reach the step card"
+        );
+        assert!(
+            matches!(info.resolution, Some(ResolutionStatus::Indefinite)),
+            "an open effect with no deadline must report Indefinite, got {:?}",
+            info.resolution.is_some()
+        );
+    }
+
+    #[test]
+    fn effect_json_carries_finality_beside_confidence() {
+        use treeship_core::statements::{EffectFinality, EffectVerdict};
+
+        // The two axes must both appear and stay distinguishable. A consumer
+        // that can only see confidence cannot tell an accepted-but-uncommitted
+        // write from a committed one.
+        let v = EffectVerdict {
+            effective_confidence: EffectConfidence::Partial,
+            claimed_confidence: Some(EffectConfidence::Partial),
+            trusted_witnesses: 0,
+            notes: vec![],
+            effective_finality: Some(EffectFinality::Indeterminate),
+            claimed_finality: Some(EffectFinality::Finalized),
+        };
+        let j = effect_verdict_json(&v);
+        assert_eq!(j["effective_confidence"], "partial");
+        assert_eq!(j["downgraded"], false, "confidence was not downgraded");
+        assert_eq!(j["effective_finality"], "indeterminate");
+        assert_eq!(j["claimed_finality"], "finalized");
+        assert_eq!(
+            j["finality_downgraded"], true,
+            "the finality downgrade must be visible independently of confidence"
+        );
+    }
+
+    #[test]
+    fn resolution_json_names_indefinite_and_breached() {
+        use treeship_core::statements::DeadlineEvent;
+
+        // `indefinite` is the pending-forever shape and must not serialize as
+        // anything that reads like "fine".
+        let indef = resolution_status_json(&ResolutionStatus::Indefinite);
+        assert_eq!(indef["outcome"], "indefinite");
+
+        let breached = resolution_status_json(&ResolutionStatus::Breached {
+            on_deadline: DeadlineEvent::Escalate,
+            seconds_overdue: 1234,
+        });
+        assert_eq!(breached["outcome"], "breached");
+        assert_eq!(breached["on_deadline"], "escalate");
+        assert_eq!(breached["seconds_overdue"], 1234);
+
+        assert_eq!(
+            resolution_status_json(&ResolutionStatus::Resolved)["outcome"],
+            "resolved"
+        );
+        assert_eq!(
+            resolution_status_json(&ResolutionStatus::BadDeadline)["outcome"],
+            "bad_deadline"
+        );
     }
 
     #[test]

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -118,7 +118,17 @@ enum MandateSummary {
     Fail(Vec<String>),
 }
 
-/// Human label for an effect confidence level, matching the wire snake_case.
+/// Human label for an effect confidence level.
+///
+/// NOTE: this does *not* match the wire form, despite what this comment used to
+/// claim. `EffectConfidence` serializes `snake_case`, so a receipt carries
+/// `not_verified` while `--format json` reports `not-verified`. A consumer
+/// round-tripping between the two breaks on exactly that value.
+///
+/// Left as-is deliberately: changing it is a breaking change to a field
+/// `--format json` has emitted since v0.21, and that is a decision to make on
+/// purpose rather than as a side effect of adding a neighbouring field. New
+/// labels (see `finality_label`) follow the wire form.
 fn effect_label(c: EffectConfidence) -> &'static str {
     match c {
         EffectConfidence::Verified => "verified",

--- a/packages/cli/tests/action_v2_verify_e2e.rs
+++ b/packages/cli/tests/action_v2_verify_e2e.rs
@@ -1,0 +1,322 @@
+//! End-to-end verification of an action/v2 receipt through the real CLI.
+//!
+//! Every other v2 test calls core functions directly or stops at
+//! `extract_step_info`. That leaves the property we actually sell untested:
+//! that a v2 receipt sitting in a real store, verified by the real binary,
+//! reports its authority, delegation, and lifecycle honestly. Fixtures written
+//! by the same person who wrote the verifier are exactly the evidence Treeship
+//! tells everyone else not to accept.
+//!
+//! So: init a workspace with the binary, sign a v2 receipt with that
+//! workspace's own key, write it to that workspace's own store, and read the
+//! verdict back out of `--format json`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+use treeship_core::{
+    attestation::sign,
+    keys::Store as KeyStore,
+    statements::{
+        payload_type_v2, ActionStatementV2, DeadlineEvent, Effect, EffectConfidence,
+        EffectFinality, Mandate, Resolution, Revocation,
+    },
+    storage::{Record, Store as ArtifactStore},
+};
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Workspace {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    /// A workspace whose keystore and store are the ones the binary will open,
+    /// so a receipt planted here is signed by a key `verify` already trusts.
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = Self { _tmp: tmp, root };
+        let out = ws.cmd().args(["init"]).output().unwrap();
+        assert!(
+            out.status.success(),
+            "init failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        ws
+    }
+
+    fn cmd(&self) -> Command {
+        let mut c = Command::new(cli_path());
+        c.env("HOME", &self.root);
+        c.current_dir(&self.root);
+        c
+    }
+
+    fn keys_dir(&self) -> PathBuf {
+        self.root.join(".treeship/keys")
+    }
+    fn storage_dir(&self) -> PathBuf {
+        self.root.join(".treeship/artifacts")
+    }
+
+    /// Sign `stmt` with the workspace's default key and write it to the store,
+    /// returning the artifact id `verify` will be pointed at.
+    fn plant_v2(&self, stmt: &ActionStatementV2) -> String {
+        let keys = KeyStore::open(self.keys_dir()).expect("open keystore");
+        let signer = keys.default_signer().expect("workspace has a default key");
+        let signed = sign(&payload_type_v2("action"), stmt, signer.as_ref()).expect("sign");
+
+        let store = ArtifactStore::open(self.storage_dir()).expect("open store");
+        let record = Record {
+            artifact_id: signed.artifact_id.clone(),
+            digest: signed.digest.clone(),
+            payload_type: payload_type_v2("action"),
+            key_id: signer.key_id().to_string(),
+            signed_at: stmt.timestamp.clone(),
+            parent_id: None,
+            envelope: signed.envelope.clone(),
+            hub_url: None,
+        };
+        store.write(&record).expect("write record");
+        signed.artifact_id.to_string()
+    }
+
+    fn verify_json(&self, id: &str) -> serde_json::Value {
+        let out = self
+            .cmd()
+            .args(["verify", id, "--format", "json"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("verify emitted non-JSON ({e}): {stdout}"))
+    }
+}
+
+/// A mandate whose scope admits `payments.charge`, in window at the timestamp
+/// the statements below use.
+fn mandate(scope: Vec<&str>) -> Mandate {
+    Mandate {
+        grant_id: "grant_e2e".into(),
+        grantor: "key_parent".into(),
+        issuer_sig: None,
+        objective_hash: None,
+        scope: scope.into_iter().map(String::from).collect(),
+        audience: "acme".into(),
+        parent_request_id: None,
+        delegation_depth: 0,
+        issued_at: "2026-07-20T10:00:00Z".into(),
+        expiry: "2026-07-20T11:00:00Z".into(),
+        max_delegation: 3,
+        revocation: Revocation {
+            path: "hub://acme/revocations".into(),
+            revoked_at: None,
+        },
+        chain: Vec::new(),
+    }
+}
+
+fn action(scope: Vec<&str>, act: &str) -> ActionStatementV2 {
+    let mut s = ActionStatementV2::new("agent://worker", act, mandate(scope));
+    s.timestamp = "2026-07-20T10:30:00Z".into();
+    s.audience = Some("acme".into());
+    s
+}
+
+#[test]
+fn in_scope_action_reports_unverified_authority_not_pass() {
+    // The revocation layer has no resolver wired, so the only honest authority
+    // verdict is `unverified`. If this ever reads `pass`, the CLI started
+    // claiming a grant is live because nobody looked.
+    let ws = Workspace::new();
+    let id = ws.plant_v2(&action(vec!["payments.charge"], "payments.charge"));
+
+    let j = ws.verify_json(&id);
+    let check = &j["checks"][0];
+    assert_eq!(
+        check["authority"]["outcome"], "unverified",
+        "authority should be unverified without a revocation resolver: {j}"
+    );
+    assert!(
+        !check["authority"]["reasons"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "unverified must name the layer it could not check: {j}"
+    );
+    assert_eq!(
+        j["authority_ok"], true,
+        "unverified is not a violation, so the gate flag stays true: {j}"
+    );
+}
+
+#[test]
+fn out_of_scope_action_is_visible_to_a_machine_consumer() {
+    // The whole point of exposing authority in JSON: a CI gate reading this
+    // must be able to see that a perfectly-signed receipt recorded an action
+    // its grant did not admit.
+    let ws = Workspace::new();
+    let id = ws.plant_v2(&action(vec!["payments.charge"], "payments.refund"));
+
+    let j = ws.verify_json(&id);
+    let check = &j["checks"][0];
+    assert_eq!(
+        check["authority"]["outcome"], "fail",
+        "an out-of-scope action must fail the authority axis: {j}"
+    );
+    assert!(
+        check["authority"]["reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|r| r.as_str().unwrap_or_default().contains("scope")),
+        "the reason should name scope: {j}"
+    );
+    assert_eq!(
+        j["authority_ok"], false,
+        "a single gate field must reflect the violation: {j}"
+    );
+}
+
+#[test]
+fn unbacked_finalized_claim_is_downgraded_in_the_json_surface() {
+    // The 56%-of-writes shape, end to end: the actor says the change committed
+    // and bundles nothing an outside party could check.
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.effect = Some(Effect {
+        output_hash: Some("sha256:out".into()),
+        effect_confidence: Some(EffectConfidence::Verified),
+        finality: Some(EffectFinality::Finalized),
+        ..Default::default()
+    });
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    let effect = &j["checks"][0]["effect"];
+    assert_eq!(
+        effect["effective_finality"], "indeterminate",
+        "an unbacked Finalized must not survive to the machine surface: {j}"
+    );
+    assert_eq!(effect["claimed_finality"], "finalized");
+    assert_eq!(effect["finality_downgraded"], true);
+    // And the confidence axis is downgraded independently, not as a side effect.
+    //
+    // "not-verified" is kebab here while the receipt's own wire form is
+    // `not_verified`. That mismatch predates this work and is documented on
+    // `effect_label`; asserting the value the CLI actually emits keeps this
+    // test honest about today's behaviour rather than the intended one.
+    assert_eq!(effect["effective_confidence"], "not-verified");
+    assert_eq!(effect["downgraded"], true);
+}
+
+#[test]
+fn readback_backed_finalized_claim_survives_end_to_end() {
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.effect = Some(Effect {
+        readback: Some("sha256:observed".into()),
+        effect_confidence: Some(EffectConfidence::Verified),
+        finality: Some(EffectFinality::Finalized),
+        ..Default::default()
+    });
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    let effect = &j["checks"][0]["effect"];
+    assert_eq!(effect["effective_finality"], "finalized", "{j}");
+    assert_eq!(effect["effective_confidence"], "verified", "{j}");
+    assert_eq!(effect["finality_downgraded"], false, "{j}");
+}
+
+#[test]
+fn open_effect_with_no_deadline_is_reported_as_indefinite() {
+    // The pending-forever row. It has to be visible without anyone knowing to
+    // go looking for it.
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.effect = Some(Effect {
+        output_hash: Some("sha256:out".into()),
+        finality: Some(EffectFinality::Initiated),
+        ..Default::default()
+    });
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    assert_eq!(
+        j["checks"][0]["resolution"]["outcome"], "indefinite",
+        "an open effect with no deadline must say so: {j}"
+    );
+}
+
+#[test]
+fn open_effect_past_its_deadline_reports_breached_with_its_event() {
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.effect = Some(Effect {
+        output_hash: Some("sha256:out".into()),
+        finality: Some(EffectFinality::Initiated),
+        resolution: Some(Resolution {
+            // Long past by any wall clock this test runs under.
+            deadline: "2026-07-20T11:00:00Z".into(),
+            on_deadline: DeadlineEvent::Escalate,
+        }),
+        ..Default::default()
+    });
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    let r = &j["checks"][0]["resolution"];
+    assert_eq!(r["outcome"], "breached", "{j}");
+    assert_eq!(
+        r["on_deadline"], "escalate",
+        "the declared obligation must travel with the breach: {j}"
+    );
+}
+
+#[test]
+fn a_single_hop_mandate_reports_not_claimed_rather_than_a_passing_chain() {
+    // No ancestors carried means no lineage claim was made. Reporting that as
+    // anything pass-shaped would let a reader infer a check that never ran.
+    let ws = Workspace::new();
+    let id = ws.plant_v2(&action(vec!["payments.charge"], "payments.charge"));
+
+    let j = ws.verify_json(&id);
+    assert_eq!(
+        j["checks"][0]["delegation_chain"]["outcome"], "not_claimed",
+        "{j}"
+    );
+}
+
+#[test]
+fn a_v1_receipt_gains_no_v2_claims() {
+    // Emitted by the real CLI, which still produces v1. A v1 receipt must not
+    // sprout an authority, chain, or resolution verdict it never made.
+    let ws = Workspace::new();
+    let out = ws
+        .cmd()
+        .args([
+            "attest", "action", "--actor", "agent://legacy", "--action", "tool.call",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "attest failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let j = ws.verify_json("last");
+    let check = &j["checks"][0];
+    assert!(check["authority"].is_null(), "v1 claimed authority: {j}");
+    assert!(
+        check["delegation_chain"].is_null(),
+        "v1 claimed a chain: {j}"
+    );
+    assert!(check["resolution"].is_null(), "v1 claimed a resolution: {j}");
+}

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -238,6 +238,22 @@ pub struct Effect {
     /// only effect evidence is the actor's own `readback`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub witnesses: Vec<Witness>,
+    /// How far the state change got, as distinct from how well it is evidenced.
+    /// Optional and skipped when absent so existing v2 receipts keep
+    /// byte-identical canonical bytes.
+    ///
+    /// A `Finalized` claim is capped by [`verify_effect`] the same way
+    /// `EffectConfidence::Verified` is: both assert something definite, so both
+    /// can be inflated, so both require evidence the actor could not mint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finality: Option<EffectFinality>,
+    /// When an unresolved effect must resolve by, and what fires if it does
+    /// not. Absent means no obligation was declared -- which
+    /// [`check_resolution`] reports as `Indefinite` rather than passing over,
+    /// because an unresolved effect with no deadline is the failure shape, not
+    /// the safe default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<Resolution>,
 }
 
 /// How confident the actor is that an action's real-world effect happened,
@@ -265,6 +281,144 @@ pub enum EffectConfidence {
     /// Attempted, but the effect was not independently verified — the common
     /// honest default: the tool returned ok and nothing read it back.
     NotVerified,
+}
+
+/// How far a state change actually got. Orthogonal to [`EffectConfidence`],
+/// which grades the *evidence*: an effect can be `Finalized` with weak evidence,
+/// or `Initiated` with excellent evidence that it is still pending.
+///
+/// Collapsing the two is a real production failure, not a theoretical one. A
+/// receipt that reports a single `success: true` can be accurate in every field
+/// and false as a composite: the write was accepted, acknowledged, assigned an
+/// id, and served back on read -- and never committed. Every predicate held;
+/// "done" did not. Separating the axes is what makes that claim expressible,
+/// and the [`verify_effect`] cap on `Finalized` is what makes it checkable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectFinality {
+    /// Authority was exercised but no state change was attempted -- a timeout
+    /// or refusal before the call went out. This is the "no authority moved"
+    /// receipt: an explicit signed negative, so absence stops being
+    /// indistinguishable from a check that was never required.
+    NotAttempted,
+    /// The target accepted the change but has not confirmed it as final.
+    /// Unresolved: an acknowledgement is not a commit.
+    Initiated,
+    /// The target confirmed the change is final.
+    Finalized,
+    /// Attempted, and definitively did not take effect.
+    Failed,
+    /// Attempted; whether it took effect could not be established. Distinct
+    /// from `Initiated`, where the target at least said yes-but-not-yet. Here
+    /// nobody knows, which is a state to escalate from, not to retry blindly.
+    Indeterminate,
+}
+
+impl EffectFinality {
+    /// Whether the lifecycle reached a terminal state. `Initiated` and
+    /// `Indeterminate` are open: something is still owed. Only open effects can
+    /// breach a resolution deadline.
+    pub fn is_resolved(self) -> bool {
+        matches!(
+            self,
+            Self::NotAttempted | Self::Finalized | Self::Failed
+        )
+    }
+}
+
+/// When an unresolved effect must resolve by, and what fires if it does not.
+///
+/// Exists because an effect that never resolves emits nothing forever, which is
+/// strictly worse than a timeout: a timeout produces a countable transition,
+/// and silence produces nothing for a monitor to catch. A declared deadline
+/// turns "still pending after 181 days" from an invisible state into a
+/// checkable one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Resolution {
+    /// RFC3339. After this instant an unresolved effect is stale by definition.
+    pub deadline: String,
+    /// What the declaring party said must happen once the deadline passes.
+    pub on_deadline: DeadlineEvent,
+}
+
+/// The obligation that attaches when a resolution deadline passes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeadlineEvent {
+    /// Treat as timed out. The effect did not land; no authority moved.
+    Timeout,
+    /// Hand to a human or a higher authority. Do not decide automatically.
+    Escalate,
+    /// Mark dead and stop serving it as live state.
+    Tombstone,
+    /// The next agent in a handoff chain takes responsibility for resolving it.
+    Inherit,
+}
+
+/// Whether an effect is still owed a resolution, and whether it is overdue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolutionStatus {
+    /// The lifecycle reached a terminal state; a deadline is moot.
+    Resolved,
+    /// Unresolved with no declared deadline. Reported rather than passed over:
+    /// this is precisely the pending-forever shape, and staying quiet about it
+    /// is what let it survive unnoticed in the first place.
+    Indefinite,
+    /// Unresolved and inside its declared window.
+    Pending { seconds_remaining: i64 },
+    /// Unresolved and past its deadline. Carries the event the declaring party
+    /// committed to, so a consumer knows which obligation it inherited.
+    Breached {
+        on_deadline: DeadlineEvent,
+        seconds_overdue: i64,
+    },
+    /// A deadline was declared but does not parse, so nothing can be concluded
+    /// from it. Fails toward "unknown", never toward "in window".
+    BadDeadline,
+}
+
+/// Evaluate an effect's resolution obligation against a wall-clock instant.
+///
+/// Kept separate from [`verify_effect`] rather than folded into it: that
+/// function is a pure reconciliation over bytes and stays deterministic, while
+/// this one is time-dependent and the caller must supply `now_unix` explicitly.
+/// A verifier that silently reached for the system clock would give different
+/// answers on replay.
+///
+/// An effect with no finality declared is treated as unresolved. That is the
+/// conservative reading: a receipt that never says where its state change got
+/// to has not told us it landed.
+pub fn check_resolution(effect: &Effect, now_unix: i64) -> ResolutionStatus {
+    let resolved = effect
+        .finality
+        .map(EffectFinality::is_resolved)
+        .unwrap_or(false);
+    if resolved {
+        return ResolutionStatus::Resolved;
+    }
+
+    let res = match &effect.resolution {
+        Some(r) => r,
+        None => return ResolutionStatus::Indefinite,
+    };
+
+    // `parse_rfc3339_to_unix` yields u64; compare in i64 so the difference is
+    // signed and cannot wrap when the deadline sits either side of `now`.
+    let deadline = match parse_rfc3339_to_unix(&res.deadline) {
+        Some(t) if t <= i64::MAX as u64 => t as i64,
+        _ => return ResolutionStatus::BadDeadline,
+    };
+
+    if now_unix > deadline {
+        ResolutionStatus::Breached {
+            on_deadline: res.on_deadline,
+            seconds_overdue: now_unix - deadline,
+        }
+    } else {
+        ResolutionStatus::Pending {
+            seconds_remaining: deadline - now_unix,
+        }
+    }
 }
 
 impl Effect {
@@ -667,6 +821,14 @@ pub struct EffectVerdict {
     pub trusted_witnesses: usize,
     /// Audit notes: downgrades applied, and witnesses that were not trusted.
     pub notes: Vec<String>,
+    /// The lifecycle stage the evidence supports. Equal to the actor's claim
+    /// except that an unbacked `Finalized` is downgraded to `Indeterminate`:
+    /// "the target told me it committed" is the actor's word, and the actor's
+    /// word is what this verifier exists to not take. `None` when the receipt
+    /// declared no finality at all.
+    pub effective_finality: Option<EffectFinality>,
+    /// The actor's own finality claim, echoed for audit.
+    pub claimed_finality: Option<EffectFinality>,
 }
 
 impl EffectVerdict {
@@ -699,6 +861,8 @@ pub fn verify_effect(stmt: &ActionStatementV2, witnesses: &dyn WitnessAuthority)
                 claimed_confidence: None,
                 trusted_witnesses: 0,
                 notes: vec!["receipt carries no effect block; effect is unverified".into()],
+                effective_finality: None,
+                claimed_finality: None,
             }
         }
     };
@@ -739,11 +903,35 @@ pub fn verify_effect(stmt: &ActionStatementV2, witnesses: &dyn WitnessAuthority)
         Some(c) => c,
     };
 
+    // Finality is capped on the same principle as confidence, for the same
+    // reason: `Finalized` is the only lifecycle claim that asserts the change
+    // definitely landed, so it is the only one an actor can inflate. Lesser
+    // stages are admissions and pass through untouched.
+    //
+    // The downgrade target is `Indeterminate`, not `Initiated`: without
+    // evidence we do not know that the target even acknowledged the write, so
+    // asserting the weaker stage would be inventing a fact rather than
+    // withdrawing one.
+    let claimed_finality = effect.finality;
+    let effective_finality = match claimed_finality {
+        Some(EffectFinality::Finalized) if !has_evidence => {
+            notes.push(
+                "actor claimed the effect Finalized but bundled no independent evidence \
+                 (no readback, no trusted witness); downgraded to Indeterminate"
+                    .into(),
+            );
+            Some(EffectFinality::Indeterminate)
+        }
+        other => other,
+    };
+
     EffectVerdict {
         effective_confidence: effective,
         claimed_confidence: claimed,
         trusted_witnesses,
         notes,
+        effective_finality,
+        claimed_finality,
     }
 }
 
@@ -1218,6 +1406,209 @@ mod tests {
             "{:?}",
             v.notes
         );
+    }
+
+    // ---- effect finality (lifecycle) vs confidence (evidence) ----
+
+    #[test]
+    fn finality_and_confidence_are_independent_axes() {
+        // The composite-claim bug in one assertion: a receipt can be honest
+        // about its evidence and still overclaim completion. Weak evidence,
+        // strong completion claim -- the verifier must judge them separately.
+        let mut s = good_stmt();
+        s.effect = Some(Effect {
+            output_hash: Some("sha256:out".into()),
+            effect_confidence: Some(EffectConfidence::Partial),
+            finality: Some(EffectFinality::Finalized),
+            ..Default::default()
+        });
+        let v = verify_effect(&s, &NoWitnessAuthority);
+        // Partial is an admission, so it survives untouched...
+        assert_eq!(v.effective_confidence, EffectConfidence::Partial);
+        // ...while the unbacked Finalized does not.
+        assert_eq!(v.effective_finality, Some(EffectFinality::Indeterminate));
+        assert_eq!(v.claimed_finality, Some(EffectFinality::Finalized));
+    }
+
+    #[test]
+    fn unbacked_finalized_is_downgraded_to_indeterminate() {
+        // The 56%-of-writes case: accepted, acknowledged, served back on read,
+        // never committed. Downgrade must land on Indeterminate, not Initiated
+        // -- without evidence we cannot assert the weaker stage either, and
+        // inventing it would be a different false claim.
+        let mut s = good_stmt();
+        s.effect = Some(Effect {
+            output_hash: Some("sha256:out".into()),
+            finality: Some(EffectFinality::Finalized),
+            ..Default::default()
+        });
+        let v = verify_effect(&s, &NoWitnessAuthority);
+        assert_eq!(v.effective_finality, Some(EffectFinality::Indeterminate));
+        assert!(
+            v.notes.iter().any(|n| n.contains("Finalized")),
+            "the downgrade must be stated, not silent: {:?}",
+            v.notes
+        );
+    }
+
+    #[test]
+    fn finalized_backed_by_readback_survives() {
+        let mut s = good_stmt();
+        s.effect = Some(Effect {
+            readback: Some("sha256:observed".into()),
+            finality: Some(EffectFinality::Finalized),
+            ..Default::default()
+        });
+        let v = verify_effect(&s, &NoWitnessAuthority);
+        assert_eq!(v.effective_finality, Some(EffectFinality::Finalized));
+    }
+
+    #[test]
+    fn lesser_finality_claims_pass_through_unchanged() {
+        // Only the strongest claim can be inflated, so only it is capped.
+        // Downgrading an actor's own hedge would punish honesty.
+        for stage in [
+            EffectFinality::NotAttempted,
+            EffectFinality::Initiated,
+            EffectFinality::Failed,
+            EffectFinality::Indeterminate,
+        ] {
+            let mut s = good_stmt();
+            s.effect = Some(Effect {
+                finality: Some(stage),
+                ..Default::default()
+            });
+            let v = verify_effect(&s, &NoWitnessAuthority);
+            assert_eq!(v.effective_finality, Some(stage), "{stage:?} was altered");
+        }
+    }
+
+    #[test]
+    fn not_attempted_is_the_no_authority_moved_receipt() {
+        // A timeout before the call. The input is bound so the negative is
+        // about a specific request, and the stage is terminal so nothing is
+        // still owed. This is what makes absence expressible instead of silent.
+        let e = Effect {
+            input_hash: Some("sha256:req".into()),
+            finality: Some(EffectFinality::NotAttempted),
+            ..Default::default()
+        };
+        assert!(EffectFinality::NotAttempted.is_resolved());
+        assert_eq!(check_resolution(&e, 4_000_000_000), ResolutionStatus::Resolved);
+    }
+
+    // ---- resolution deadlines ----
+
+    fn open_effect(resolution: Option<Resolution>) -> Effect {
+        Effect {
+            finality: Some(EffectFinality::Initiated),
+            resolution,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unresolved_without_a_deadline_reports_indefinite() {
+        // The 181-day pending row. Silence here is what made it survivable;
+        // naming the state is the whole point of the field.
+        assert_eq!(
+            check_resolution(&open_effect(None), 1_800_000_000),
+            ResolutionStatus::Indefinite
+        );
+    }
+
+    /// Derive the epoch from the same parser the check uses, rather than
+    /// hand-computing one. A wrong literal here would make the test assert a
+    /// fact about my arithmetic instead of about the function.
+    const DEADLINE: &str = "2026-07-20T11:00:00Z";
+    fn deadline_unix() -> i64 {
+        parse_rfc3339_to_unix(DEADLINE).expect("fixture deadline parses") as i64
+    }
+
+    #[test]
+    fn unresolved_past_its_deadline_reports_the_declared_event() {
+        let e = open_effect(Some(Resolution {
+            deadline: DEADLINE.into(),
+            on_deadline: DeadlineEvent::Escalate,
+        }));
+        match check_resolution(&e, deadline_unix() + 90) {
+            ResolutionStatus::Breached {
+                on_deadline,
+                seconds_overdue,
+            } => {
+                assert_eq!(on_deadline, DeadlineEvent::Escalate);
+                assert_eq!(seconds_overdue, 90);
+            }
+            other => panic!("expected Breached, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unresolved_inside_its_window_is_pending() {
+        let e = open_effect(Some(Resolution {
+            deadline: DEADLINE.into(),
+            on_deadline: DeadlineEvent::Timeout,
+        }));
+        match check_resolution(&e, deadline_unix() - 60) {
+            ResolutionStatus::Pending { seconds_remaining } => {
+                assert_eq!(seconds_remaining, 60)
+            }
+            other => panic!("expected Pending, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_resolved_effect_cannot_breach() {
+        // Finalized long before "now": the deadline is moot, not breached.
+        let e = Effect {
+            finality: Some(EffectFinality::Finalized),
+            resolution: Some(Resolution {
+                deadline: "2026-07-20T11:00:00Z".into(),
+                on_deadline: DeadlineEvent::Tombstone,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(check_resolution(&e, 4_000_000_000), ResolutionStatus::Resolved);
+    }
+
+    #[test]
+    fn unparseable_deadline_fails_toward_unknown() {
+        // Never toward "in window": a deadline nobody can read must not be
+        // treated as one that has not passed yet.
+        let e = open_effect(Some(Resolution {
+            deadline: "whenever".into(),
+            on_deadline: DeadlineEvent::Timeout,
+        }));
+        assert_eq!(
+            check_resolution(&e, 1_800_000_000),
+            ResolutionStatus::BadDeadline
+        );
+    }
+
+    #[test]
+    fn missing_finality_is_treated_as_unresolved() {
+        // A receipt that never says where its state change got to has not told
+        // us it landed. Conservative reading, stated explicitly.
+        let e = Effect {
+            output_hash: Some("sha256:out".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            check_resolution(&e, 1_800_000_000),
+            ResolutionStatus::Indefinite
+        );
+    }
+
+    #[test]
+    fn finality_and_resolution_are_omitted_when_absent() {
+        // Existing v2 receipts must keep byte-identical canonical bytes.
+        let json = serde_json::to_string(&Effect {
+            output_hash: Some("sha256:out".into()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert!(!json.contains("finality"), "{json}");
+        assert!(!json.contains("resolution"), "{json}");
     }
 
     #[test]

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -55,10 +55,12 @@ pub use session_participant::{
 // `Unverified` rather than a false `Pass` for any layer it cannot check.
 pub mod action_v2;
 pub use action_v2::{
-    action_in_scope, payload_type_v2, resolve_grant_chain, verify_effect, verify_grant_chain,
-    verify_mandate, ChainResolveError,
-    ActionStatementV2, Cost, Effect, EffectConfidence, EffectVerdict, Grant, GrantChainError,
-    Mandate, MandateVerdict, NoRevocationSource, NoWitnessAuthority, Revocation, RevocationSource,
+    action_in_scope, check_resolution, payload_type_v2, resolve_grant_chain, verify_effect,
+    verify_grant_chain, verify_mandate, ChainResolveError,
+    ActionStatementV2, Cost, DeadlineEvent, Effect, EffectConfidence, EffectFinality,
+    EffectVerdict, Grant, GrantChainError,
+    Mandate, MandateVerdict, NoRevocationSource, NoWitnessAuthority, Resolution, ResolutionStatus,
+    Revocation, RevocationSource,
     RevocationStatus, RuntimeIdentity, Witness, WitnessAuthority, TYPE_ACTION_V2,
 };
 


### PR DESCRIPTION
Stacked on #250. Review that first; this PR's diff against `main` will shrink to just the effect work once #250 lands.

## What this fixes

`EffectConfidence` grades how well an effect is **evidenced**. Nothing recorded how far the state change actually **got**. Those are different questions, and collapsing them lets a receipt be accurate in every field and false as a composite: the write accepted, acknowledged, assigned an id, served back on read, and never committed.

This is not hypothetical. It came from a builder reporting it at **56% of writes** on a live system, in response to our own post on receipts — every field in their receipt was true, and the composite claim was wrong.

## Changes

**`EffectFinality`** — `NotAttempted | Initiated | Finalized | Failed | Indeterminate`, orthogonal to confidence.

`verify_effect` caps an unbacked `Finalized` exactly as it already caps an unbacked `Verified`. Same principle: those are the only two claims that assert something definite, so they are the only two an actor can inflate. Lesser stages are admissions and pass through untouched — the verifier blocks inflation, it does not punish hedging.

The downgrade target is `Indeterminate`, not `Initiated`. Without evidence we cannot assert the weaker stage either; asserting it would swap one invented fact for another.

**`NotAttempted` is the "no authority moved" receipt.** With a bound `input_hash` it is an explicit signed negative, so a timeout stops being indistinguishable from a check that was never required.

**`Resolution { deadline, on_deadline }` + `check_resolution`.** An effect that never resolves emits nothing forever — worse than a timeout, which at least produces a countable transition. `Indefinite` is its own outcome rather than folded into "resolved", because unresolved-with-no-deadline is the failure shape, not the safe default.

`check_resolution` is separate from `verify_effect` and takes `now_unix` explicitly. A verifier that reached for the system clock would give different answers on replay.

**Surfaced in both output modes** — step card and `--format json` — matching the authority/delegation_chain shape from #250. AGENTS.md §8 requires a stable JSON schema on every command, and a verdict machines cannot see is telemetry.

## Compatibility

Both fields are `Option` + `skip_serializing_if`, so existing v2 receipts keep byte-identical canonical bytes. Test asserts it.

## Tests

15 new. Notable ones: the two axes moving independently (weak evidence + strong completion claim); the downgrade landing on `Indeterminate`; every lesser stage surviving unchanged; `Indefinite` for the no-deadline case; an unparseable deadline failing toward unknown rather than toward in-window; and one end-to-end test through a signed envelope proving the wiring reaches the step card, not just the serializers.

Full workspace green except `different_seed_cannot_decrypt_even_with_identical_machine_id`, which is pre-existing on this branch and is what **#248** fixes.

## Not included

Making the receipt a **precondition** rather than an output. `verify_mandate` currently has exactly one non-test call site — `verify.rs:149`, on the read side — and `attest.rs` never consults the mandate at all. So Treeship can report that an action fell outside its grant but cannot prevent recording it. That is a breaking interface change and wants its own design pass.