### PR TITLE
docs: point the offline-verifier inventory entry at a file that exists

### DIFF
--- a/docs/content/docs/reference/specs.mdx
+++ b/docs/content/docs/reference/specs.mdx
@@ -32,6 +32,7 @@ The `Status:` headers inside some spec files lag behind the shipped product (sev
 |------|--------|-------|
 | [private-verification](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md) | Partial | Selective capability disclosure shipped in v0.20 (`present --disclose`); the statement-first ZK tiers remain design (the prior Groth16 path is quarantined) |
 | [memory-provenance-binding](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/memory-provenance-binding.md) | Design | The why-believed axis: memory provider ledger contract (zmem.sh), quarantine-gated approvals, chain-root commitment, effect-status ladder. Marks SHIPPED vs NEW per section; phases 1–2 run on today's primitives |
+| [receipt-system](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/receipt-system.md) | Draft | One signed data model rendered for three audiences, agent-first; the honesty gradient is machine-readable, not prose. Builds on the shipped action/v2 mandate + effect |
 | [trusted-rooms](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/trusted-rooms.md) | Draft | Product spec building on invitations/rooms |
 | [token-capture](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/token-capture.md) | Draft | Working notes |
 | [local-dashboard](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/local-dashboard.md) | Draft | A dashboard ships behind a hidden command; the spec is ahead of it |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -92,7 +92,7 @@
     - docs/content/docs/cli/verify.mdx
     - docs/content/docs/concepts/verification-surfaces.mdx
   tests:
-    - packages/core/src/verify.rs
+    - packages/cli/src/commands/verify.rs
   notes: "Walks the parent chain, checks every signature, verifies Merkle inclusion -- all offline. Fetched receipts earn structural-pass, never pass."
 
 - id: wasm-verifier


### PR DESCRIPTION
One-line fix for the `docs-drift` job that is red on `main` and on every open PR.

`docs/feature-inventory.yml` listed `packages/core/src/verify.rs` as the offline verifier tests. That path stopped existing when the module became a directory (`verify/mod.rs`), and the entry describes `treeship verify` regardless -- a CLI command whose tests were never in core.

Now points at `packages/cli/src/commands/verify.rs`, where the chain walk lives and is tested.

```
$ python3 scripts/check-feature-inventory.py --strict
  ok  43 feature entries parsed
0 warnings, 0 errors.
```

Worth landing first: a permanently-red check trains everyone to ignore CI, which is what this job exists to stop.