### PR TITLE
Release v0.22.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.21.0"
+    "version": "0.22.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 ## Unreleased
 
+## 0.22.0 (2026-08-05)
+
+The delegation-and-completion release. v0.21 answered *what was authorized* and
+*what happened*. This one answers the two questions sitting behind those: was
+the authority legitimately delegated, and did the change actually land?
+
+**CLI emission of action/v2 receipts still does not exist.** Everything below is
+verification-side and reachable today only from `treeship-core` and the SDKs; a
+CLI user cannot yet produce a receipt that exercises it. That is the whole of
+0.23.
+
+### Added
+- **Grant chain resolution.** `grant_id` is now content-derived
+  (`grn_` + `hex(sha256(canonical))[..16]`), mirroring `artifact_id`, so an id is
+  a fact rather than a claim. Grants carry a signed `parent_grant_id`, making a
+  parent pointer a hash commitment to one specific grant instead of a reference
+  to a name anyone could also assert. `Mandate.chain` carries ancestors inline
+  so a delegated action still verifies offline, and `resolve_grant_chain`
+  *derives* the order from those signed links rather than trusting the order the
+  carrier supplied — reordering becomes a no-op, truncation surfaces as a missing
+  ancestor, and splicing surfaces as an unreachable extra. Only then does
+  `verify_grant_chain` judge attenuation, on a chain whose shape is already
+  proven.
+- **Authority and delegation on `treeship verify`.** A new authority line reports
+  whether an action was in scope, in window, and not revoked, and a chain line
+  reports `holds` / `widened` / `unresolvable` / `not_claimed`. Both appear in
+  `--format json` as per-check `authority` and `delegation_chain` objects, plus a
+  top-level `authority_ok` a CI gate can test in one field. Without a revocation
+  resolver wired the authority verdict is `unverified`, never `pass`: claiming a
+  grant is live because nobody looked is the false pass this verifier exists to
+  refuse.
+- **`EffectFinality` — lifecycle, separate from evidence.**
+  `NotAttempted / Initiated / Finalized / Failed / Indeterminate`, orthogonal to
+  `EffectConfidence`. Collapsing the two lets a receipt be accurate in every
+  field and false as a composite: a write accepted, acknowledged, assigned an
+  id, served back on read, and never committed. `verify_effect` caps an unbacked
+  `Finalized` exactly as it already caps an unbacked `Verified` — those are the
+  only two claims that assert something definite, so the only two an actor can
+  inflate. `NotAttempted` with a bound `input_hash` is the "no authority moved"
+  receipt, making a timeout an explicit signed negative instead of silence.
+- **Resolution deadlines.** `Resolution { deadline, on_deadline }` and
+  `check_resolution` bound an unresolved effect. An effect that never resolves
+  emits nothing forever, which is worse than a timeout — a timeout at least
+  produces a countable transition. `Indefinite` is reported as its own outcome
+  rather than folded into "resolved", because unresolved-with-no-deadline is the
+  failure shape, not the safe default. `check_resolution` takes `now_unix`
+  explicitly; a verifier that reached for the system clock would give different
+  answers on replay.
+
+### Fixed
+- `ChainResolveError` and `GrantChainError` have real `Display` impls. The CLI
+  was formatting them with `{:?}`, so operators read
+  `AncestorMissing { parent_grant_id: "grn_..." }` — an internal representation,
+  not a diagnosis.
+- The AUD-19 seed test is hermetic. It relied on first-open minting a
+  co-located seed, but `read_or_create_machine_seed` falls back to
+  `~/.treeship/machine_seed` first — which exists on any machine that has run
+  `treeship init`. The test therefore failed for every developer who had
+  actually used the tool while passing on clean CI.
+- `docs-drift` is green again. Two stacked failures: the feature inventory
+  pointed at `packages/core/src/verify.rs`, gone since the module became a
+  directory, and `docs/specs/receipt-system.md` had no row in the specs index.
+  The first masked the second.
+
+### Notes
+- Both new `Effect` fields are optional and skipped when absent, so existing v2
+  receipts keep byte-identical canonical bytes.
+- Known wart, deliberately left: `EffectConfidence` serializes `snake_case`, so
+  a receipt carries `not_verified` while `--format json` reports
+  `not-verified`. Changing it breaks a field emitted since v0.21 and is a
+  decision to make on purpose, not as a side effect of adding a neighbouring
+  one. Documented on `effect_label`.
+- Revocation remains unresolvable by design. The hub endpoint is an unsigned,
+  hardcoded-empty stub; wiring a resolver to it would convert an honest
+  `Unverified` into a false `NotRevoked` for every grant ever issued.
+
 ## 0.21.0 (2026-07-21)
 
 The accountability release. Treeship starts answering not just "was this signed?"

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.21.0"
+    "@treeship/core-wasm": "0.22.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.21.0",
+    "@treeship/core-wasm": "0.22.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.21.0",
-    "@treeship/cli-darwin-arm64": "0.21.0",
-    "@treeship/cli-darwin-x64": "0.21.0"
+    "@treeship/cli-linux-x64": "0.22.0",
+    "@treeship/cli-darwin-arm64": "0.22.0",
+    "@treeship/cli-darwin-x64": "0.22.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.21.0", path = "../core" }
+treeship-core = { version = "0.22.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.21.0"
+version = "0.22.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.21.0"
+    "@treeship/core-wasm": "0.22.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.21.0"
+    "@treeship/core-wasm": "0.22.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.21.0"
+    "@treeship/verify": "0.22.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.21.0"
+    "@treeship/verify": "0.22.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.21.0"
+    "@treeship/verify": "0.22.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Version bump across all 39 release sites + CHANGELOG for **v0.22.0**, the delegation-and-completion release.

`python3 scripts/check-release-versions.py 0.22.0` → `total: 39  ok: 39  wrong: 0  not-found: 0`

## What is in it

Everything merged since v0.21.0: #253 (docs-drift), #248 (hermetic keys test), #247 (authority axis), #250 (grant chain resolution + chain axis + JSON exposure + Display impls), #252 (effect finality + resolution deadlines + end-to-end verification test). #249 was closed as absorbed into #250.

## Stated plainly in the changelog

**CLI emission of action/v2 receipts still does not exist.** All of this is verification-side and reachable today only from `treeship-core` and the SDKs. A CLI user cannot yet produce a receipt that exercises any of it — that is the whole of 0.23. Shipping a second consecutive verifier-only release without saying so would be the kind of overclaim this project exists to refuse.

Also recorded honestly: revocation stays `Unverified` by design (the hub endpoint is an unsigned hardcoded-empty stub), and the `not_verified` / `not-verified` casing mismatch between the wire form and `--format json` is documented rather than silently changed, since fixing it breaks a field emitted since v0.21.

## After merge

```
git tag -a v0.22.0 -m "Release v0.22.0" && git push --tags
```

The tag fires `release.yml`, whose preflight re-checks every version site against the tag before any artifact is built.