### PR TITLE
grant: treeship grant issue -- mint the chains we can already verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "base64",
  "clap",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -912,6 +912,51 @@ treeship deny [OPTIONS] [N]
 |---|---|
 | `[N]` | Index of the pending approval to deny (default: 1) |
 
+## `treeship grant`
+
+Mint and inspect signed capability grants
+
+```
+treeship grant [OPTIONS] <COMMAND>
+```
+
+### `treeship grant issue`
+
+Mint a signed grant. With --parent, mints a delegated child
+
+```
+treeship grant issue [OPTIONS] --scope <SCOPE> --audience <AUDIENCE> --expiry <EXPIRY>
+```
+
+| Option | Description |
+|---|---|
+| `--scope <SCOPE>` | Capability this grant admits. Repeatable. A single trailing `*` acts as a prefix wildcard: `payments.*` |
+| `--audience <AUDIENCE>` | Who the grant is for. A delegated grant may not change it |
+| `--expiry <EXPIRY>` | RFC 3339. A delegated grant may not outlive its parent |
+| `--parent <PARENT>` | Delegate from this grant id, narrowing its authority |
+| `--max-delegation <MAX_DELEGATION>` | How many further delegations this grant permits beneath it [default: 3] |
+| `--objective-hash <OBJECTIVE_HASH>` | Optional hash binding the grant to a stated objective |
+
+### `treeship grant list`
+
+List every grant minted in this workspace
+
+```
+treeship grant list [OPTIONS]
+```
+
+### `treeship grant show`
+
+Show one grant, re-deriving its id and re-checking its signature
+
+```
+treeship grant show [OPTIONS] <GRANT_ID>
+```
+
+| Argument | Description |
+|---|---|
+| `<GRANT_ID>` | -- |
+
 ## `treeship doctor`
 
 Diagnostic check -- verify everything is working

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -46,6 +46,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Feature | Status | CLI | Docs |
 |---|---|---|---|
 | Approval Use Journal | `stable` | `treeship approval uses`, `treeship approval status`, `treeship approval journal verify` | [Approval Use Journal](/docs/concepts/approval-use-journal), [Approval Authority](/docs/concepts/approval-authority) |
+| Capability grants + delegation chains | `beta` | `treeship grant issue`, `treeship grant list`, `treeship grant show` | -- |
 | Per-agent keys & onboarding | `stable` | `treeship onboard`, `treeship agent register` | [Trust model](/docs/concepts/trust-model), [How it works](/docs/guides/how-it-works) |
 | Agent Identity Certificates | `beta` | `treeship agent register` | [Agent Identity](/docs/concepts/agent-identity) |
 | Agent Cards | `stable` | `treeship agents`, `treeship agents review`, `treeship agents approve`, `treeship agents remove` | [Agent Cards](/docs/concepts/agent-cards), [agents](/docs/cli/agents) |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -205,6 +205,21 @@
     - packages/core/src/statements/approval_use.rs
   notes: "Workspace-local store of consumed approval grants. Enforces max_uses + idempotency-key replay safety. Approvals are scoped by default (--allowed-* / --max-uses, or explicit --unscoped)."
 
+- id: capability-grants
+  name: Capability grants + delegation chains
+  section: identity
+  status: beta
+  cli:
+    - treeship grant issue
+    - treeship grant list
+    - treeship grant show
+  packages:
+    - treeship-core
+  tests:
+    - packages/core/src/statements/action_v2.rs
+    - packages/cli/src/commands/grant.rs
+  notes: "The authority an action/v2 receipt runs under. Grant ids are content-derived (grn_ + sha256 of the signed canonical), so a parent pointer commits to one specific grant rather than to a name. Issuing refuses to widen: a delegated grant may only narrow scope, shorten expiry, keep the same audience, and stay inside max_delegation, with depth derived from the parent rather than declared. beta, not stable: grants have no revocation resolver, and no docs page yet."
+
 - id: per-agent-keys
   name: Per-agent keys & onboarding
   section: identity

--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -1,0 +1,458 @@
+//! `treeship grant` -- mint and inspect signed capability grants.
+//!
+//! v0.21 and v0.22 shipped the machinery to *verify* a delegation chain:
+//! content-derived ids, signed parent links, order derived from those links
+//! rather than trusted from the carrier, attenuation invariants. None of it was
+//! reachable, because nothing could mint a grant. This is the other half.
+//!
+//! Two decisions worth stating, because both are load-bearing:
+//!
+//! **Attenuation is enforced at mint, not only at verify.** `--parent` refuses
+//! to produce a grant that widens scope, outlives its parent, changes audience,
+//! or exceeds the parent's `max_delegation`. A verifier catching that later is
+//! the backstop; refusing to create it is the fix. An invalid chain that exists
+//! is a chain someone will eventually be asked to trust.
+//!
+//! **Grants are workspace-scoped**, resolved relative to the active config the
+//! same way the approval-use journal and cards are. A project-local Treeship
+//! gets its own grants; the global config gets another set. The trust scope
+//! stays honest -- these grants answer for the workspace they were minted in.
+
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use treeship_core::statements::{parse_rfc3339_to_unix, Grant};
+
+use crate::ctx;
+use crate::printer::{Format, Printer};
+
+fn grants_dir_for(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("grants")
+}
+
+fn grant_path(dir: &Path, id: &str) -> PathBuf {
+    dir.join(format!("{id}.json"))
+}
+
+fn read_grant(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Error>> {
+    let p = grant_path(dir, id);
+    let raw = std::fs::read_to_string(&p)
+        .map_err(|_| format!("grant not found: {id}\n  run: treeship grant list"))?;
+    let g: Grant = serde_json::from_str(&raw)?;
+    Ok(g)
+}
+
+pub struct IssueArgs {
+    pub scope: Vec<String>,
+    pub audience: String,
+    pub expiry: String,
+    pub parent: Option<String>,
+    pub max_delegation: u32,
+    pub objective_hash: Option<String>,
+    pub config: Option<String>,
+}
+
+/// Why a proposed child grant may not be minted from its parent.
+///
+/// Mirrors `GrantChainError`'s invariants deliberately: a grant this refuses is
+/// exactly a grant `verify_grant_chain` would later reject, and catching it here
+/// means the invalid artifact never exists to be presented to anyone.
+fn attenuation_error(parent: &Grant, child: &Grant) -> Option<String> {
+    if !child.scope.iter().all(|s| scope_covered(s, &parent.scope)) {
+        return Some(format!(
+            "scope widens: {:?} is not within the parent's {:?}",
+            child.scope, parent.scope
+        ));
+    }
+    match (
+        parse_rfc3339_to_unix(&child.expiry),
+        parse_rfc3339_to_unix(&parent.expiry),
+    ) {
+        (Some(c), Some(p)) if c > p => {
+            return Some(format!(
+                "expiry outlives the parent: {} is after {}",
+                child.expiry, parent.expiry
+            ))
+        }
+        (None, _) => return Some(format!("expiry does not parse: {}", child.expiry)),
+        (_, None) => {
+            return Some(format!(
+                "the parent's expiry does not parse: {}",
+                parent.expiry
+            ))
+        }
+        _ => {}
+    }
+    if child.audience != parent.audience {
+        return Some(format!(
+            "audience changes: {} is not the parent's {}",
+            child.audience, parent.audience
+        ));
+    }
+    if child.delegation_depth > parent.max_delegation {
+        return Some(format!(
+            "delegation depth {} exceeds the parent's max_delegation {}",
+            child.delegation_depth, parent.max_delegation
+        ));
+    }
+    None
+}
+
+/// Whether `needle` is admitted by `haystack`, honouring a single trailing `*`.
+/// Same shape as the core scope check; kept local so the mint-time refusal
+/// cannot drift into being more permissive than the verifier.
+fn scope_covered(needle: &str, haystack: &[String]) -> bool {
+    haystack.iter().any(|allowed| {
+        if let Some(prefix) = allowed.strip_suffix('*') {
+            needle.starts_with(prefix)
+        } else {
+            allowed == needle
+        }
+    })
+}
+
+/// `treeship grant issue` -- mint a signed grant, optionally delegated from an
+/// existing one.
+pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    if args.scope.is_empty() {
+        return Err("at least one --scope is required\n  example: --scope payments.charge".into());
+    }
+    if parse_rfc3339_to_unix(&args.expiry).is_none() {
+        return Err(format!(
+            "--expiry must be RFC 3339: {}\n  example: --expiry 2026-12-31T23:59:59Z",
+            args.expiry
+        )
+        .into());
+    }
+
+    let ctx = ctx::open(args.config.as_deref())?;
+    let signer = ctx.keys.default_signer()?;
+    let dir = grants_dir_for(&ctx.config_path);
+    std::fs::create_dir_all(&dir)?;
+
+    let parent = match &args.parent {
+        Some(pid) => Some(read_grant(&dir, pid)?),
+        None => None,
+    };
+
+    // Depth is derived from the parent, never accepted from the caller: a
+    // self-declared depth inside the very chain being verified is the thing
+    // `resolve_grant_chain` exists to stop trusting.
+    let delegation_depth = parent.as_ref().map(|p| p.delegation_depth + 1).unwrap_or(0);
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let issued_at = format_rfc3339(now);
+
+    let mut g = Grant {
+        grant_id: String::new(),
+        grantor: URL_SAFE_NO_PAD.encode(signer.public_key_bytes()),
+        issuer_sig: None,
+        scope: args.scope.clone(),
+        audience: args.audience.clone(),
+        parent_request_id: None,
+        parent_grant_id: parent.as_ref().map(|p| p.grant_id.clone()),
+        delegation_depth,
+        issued_at,
+        expiry: args.expiry.clone(),
+        max_delegation: args.max_delegation,
+        objective_hash: args.objective_hash.clone(),
+    };
+
+    // A grant whose expiry has already passed is dead on arrival: it will fail
+    // every window check it is ever presented to. Minting one is never
+    // deliberate, and the failure would surface far from its cause.
+    if let Some(exp) = parse_rfc3339_to_unix(&g.expiry) {
+        if exp <= now {
+            return Err(format!(
+                "refusing to mint: --expiry {} is not in the future (now {})\n  \
+                 a grant that has already expired can never verify",
+                g.expiry, g.issued_at
+            )
+            .into());
+        }
+    }
+
+    // Refuse to mint an invalid link. A chain that cannot pass verification
+    // should not be creatable in the first place.
+    if let Some(p) = &parent {
+        if let Some(why) = attenuation_error(p, &g) {
+            return Err(format!(
+                "refusing to mint: a delegated grant may only narrow authority\n  {why}"
+            )
+            .into());
+        }
+    }
+
+    // Id is derived from the signed bytes, then the signature covers those same
+    // bytes. Order matters: deriving after signing would let the two disagree.
+    g.grant_id = g.derive_grant_id();
+    g.issuer_sig = Some(g.sign_canonical(signer.as_ref())?);
+
+    debug_assert!(g.id_is_consistent(), "freshly minted grant must self-verify");
+
+    let path = grant_path(&dir, &g.grant_id);
+    std::fs::write(&path, serde_json::to_string_pretty(&g)?)?;
+
+    if printer.format == Format::Json {
+        printer.json(&serde_json::json!({
+            "grant_id": g.grant_id,
+            "grantor": g.grantor,
+            "scope": g.scope,
+            "audience": g.audience,
+            "expiry": g.expiry,
+            "delegation_depth": g.delegation_depth,
+            "parent_grant_id": g.parent_grant_id,
+            "max_delegation": g.max_delegation,
+            "path": path.display().to_string(),
+        }));
+        return Ok(());
+    }
+
+    let scope_str = g.scope.join(", ");
+    let depth_str = g.delegation_depth.to_string();
+    printer.success(
+        &format!("grant issued  {}", g.grant_id),
+        &[
+            ("scope", &scope_str),
+            ("audience", &g.audience),
+            ("expiry", &g.expiry),
+            ("depth", &depth_str),
+        ],
+    );
+    printer.hint(&format!(
+        "treeship grant issue --parent {} --scope <narrower>",
+        g.grant_id
+    ));
+    Ok(())
+}
+
+/// `treeship grant list` -- every grant minted in this workspace.
+pub fn list(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let dir = grants_dir_for(&ctx.config_path);
+
+    let mut grants: Vec<Grant> = Vec::new();
+    if dir.exists() {
+        for entry in std::fs::read_dir(&dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            // A grant we cannot parse is reported by its absence from the list
+            // rather than crashing the command; `show` will surface the error.
+            if let Ok(raw) = std::fs::read_to_string(&path) {
+                if let Ok(g) = serde_json::from_str::<Grant>(&raw) {
+                    grants.push(g);
+                }
+            }
+        }
+    }
+    grants.sort_by(|a, b| a.issued_at.cmp(&b.issued_at));
+
+    if printer.format == Format::Json {
+        let out: Vec<_> = grants
+            .iter()
+            .map(|g| {
+                serde_json::json!({
+                    "grant_id": g.grant_id,
+                    "scope": g.scope,
+                    "audience": g.audience,
+                    "expiry": g.expiry,
+                    "delegation_depth": g.delegation_depth,
+                    "parent_grant_id": g.parent_grant_id,
+                })
+            })
+            .collect();
+        printer.json(&serde_json::json!({ "grants": out, "total": grants.len() }));
+        return Ok(());
+    }
+
+    if grants.is_empty() {
+        printer.info("no grants in this workspace");
+        printer.hint("treeship grant issue --scope <s> --audience <a> --expiry <rfc3339>");
+        return Ok(());
+    }
+    for g in &grants {
+        printer.info(&format!(
+            "{}  depth {}  {}  expires {}",
+            g.grant_id,
+            g.delegation_depth,
+            g.scope.join(", "),
+            g.expiry
+        ));
+    }
+    printer.hint("treeship grant show <grant-id>");
+    Ok(())
+}
+
+/// `treeship grant show <id>` -- one grant, with its id re-derived and its
+/// signature re-checked rather than taken from the file.
+pub fn show(
+    id: &str,
+    config: Option<&str>,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let dir = grants_dir_for(&ctx.config_path);
+    let g = read_grant(&dir, id)?;
+
+    // Re-verify rather than trust the file. A grant on disk is just bytes, and
+    // the point of a content-derived id is that it can be checked.
+    let id_ok = g.id_is_consistent();
+    let sig_ok = g
+        .issuer_sig
+        .as_deref()
+        .map(|s| g.verify_canonical(s))
+        .unwrap_or(false);
+
+    if printer.format == Format::Json {
+        printer.json(&serde_json::json!({
+            "grant": g,
+            "id_consistent": id_ok,
+            "signature_valid": sig_ok,
+        }));
+        return Ok(());
+    }
+
+    let scope_str = g.scope.join(", ");
+    let depth_str = g.delegation_depth.to_string();
+    let parent_str = g
+        .parent_grant_id
+        .clone()
+        .unwrap_or_else(|| "-- (root)".into());
+    let id_str = yes_no(id_ok);
+    let sig_str = yes_no(sig_ok);
+    printer.success(
+        &g.grant_id,
+        &[
+            ("grantor", &g.grantor),
+            ("scope", &scope_str),
+            ("audience", &g.audience),
+            ("issued", &g.issued_at),
+            ("expiry", &g.expiry),
+            ("depth", &depth_str),
+            ("parent", &parent_str),
+            ("id matches content", &id_str),
+            ("issuer signature", &sig_str),
+        ],
+    );
+    Ok(())
+}
+
+fn yes_no(b: bool) -> String {
+    if b { "yes".into() } else { "NO".into() }
+}
+
+/// RFC 3339 in UTC from a unix timestamp, without pulling in a date crate the
+/// workspace does not already depend on.
+fn format_rfc3339(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+
+    // Civil-from-days (Howard Hinnant's algorithm), epoch-shifted to 0000-03-01.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grant(scope: &[&str], audience: &str, expiry: &str, depth: u32, max: u32) -> Grant {
+        Grant {
+            grant_id: "grn_test".into(),
+            grantor: "k".into(),
+            issuer_sig: None,
+            scope: scope.iter().map(|s| s.to_string()).collect(),
+            audience: audience.into(),
+            parent_request_id: None,
+            parent_grant_id: None,
+            delegation_depth: depth,
+            issued_at: "2026-08-05T10:00:00Z".into(),
+            expiry: expiry.into(),
+            max_delegation: max,
+            objective_hash: None,
+        }
+    }
+
+    #[test]
+    fn narrowing_is_allowed() {
+        let p = grant(&["payments.*"], "acme", "2026-12-31T00:00:00Z", 0, 3);
+        let c = grant(&["payments.charge"], "acme", "2026-06-30T00:00:00Z", 1, 3);
+        assert_eq!(attenuation_error(&p, &c), None);
+    }
+
+    #[test]
+    fn widening_scope_is_refused_at_mint() {
+        let p = grant(&["payments.charge"], "acme", "2026-12-31T00:00:00Z", 0, 3);
+        let c = grant(&["payments.refund"], "acme", "2026-12-31T00:00:00Z", 1, 3);
+        let why = attenuation_error(&p, &c).expect("must refuse");
+        assert!(why.contains("scope widens"), "{why}");
+    }
+
+    #[test]
+    fn outliving_the_parent_is_refused_at_mint() {
+        let p = grant(&["payments.*"], "acme", "2026-06-30T00:00:00Z", 0, 3);
+        let c = grant(&["payments.charge"], "acme", "2026-12-31T00:00:00Z", 1, 3);
+        let why = attenuation_error(&p, &c).expect("must refuse");
+        assert!(why.contains("outlives"), "{why}");
+    }
+
+    #[test]
+    fn changing_audience_is_refused_at_mint() {
+        let p = grant(&["payments.*"], "acme", "2026-12-31T00:00:00Z", 0, 3);
+        let c = grant(&["payments.charge"], "other", "2026-06-30T00:00:00Z", 1, 3);
+        let why = attenuation_error(&p, &c).expect("must refuse");
+        assert!(why.contains("audience"), "{why}");
+    }
+
+    #[test]
+    fn exceeding_max_delegation_is_refused_at_mint() {
+        let p = grant(&["payments.*"], "acme", "2026-12-31T00:00:00Z", 0, 1);
+        let c = grant(&["payments.charge"], "acme", "2026-06-30T00:00:00Z", 2, 1);
+        let why = attenuation_error(&p, &c).expect("must refuse");
+        assert!(why.contains("max_delegation"), "{why}");
+    }
+
+    #[test]
+    fn wildcard_scope_covers_its_prefix_only() {
+        assert!(scope_covered("payments.charge", &["payments.*".into()]));
+        assert!(!scope_covered("email.send", &["payments.*".into()]));
+        // An exact entry must not behave like a prefix.
+        assert!(!scope_covered(
+            "payments.charge.extra",
+            &["payments.charge".into()]
+        ));
+    }
+
+    #[test]
+    fn rfc3339_formatting_round_trips_through_the_parser() {
+        // The formatter is hand-rolled, so pin it against the parser the rest
+        // of the codebase uses rather than against my own arithmetic.
+        for secs in [0u64, 1_000_000_000, 1_784_545_200, 2_000_000_000] {
+            let s = format_rfc3339(secs);
+            assert_eq!(
+                parse_rfc3339_to_unix(&s),
+                Some(secs),
+                "{s} did not round-trip"
+            );
+        }
+    }
+}

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod dashboard;
 pub mod declare;
 pub mod discovery;
 pub mod doctor;
+pub mod grant;
 pub mod harness;
 pub mod harnesses;
 pub mod history;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -468,6 +468,22 @@ enum Command {
     #[command(subcommand, hide = true)]
     Approval(ApprovalCommand),
 
+    /// Mint and inspect signed capability grants
+    ///
+    /// A grant is the authority an action/v2 receipt runs under. Delegating
+    /// mints a narrower child grant that commits to its parent by content
+    /// hash, so a verifier can walk the chain offline. Issuing refuses to
+    /// widen: a delegated grant may only narrow scope, shorten expiry, and
+    /// keep the same audience.
+    ///
+    /// Examples:
+    ///   treeship grant issue --scope payments.charge --audience acme --expiry 2026-12-31T23:59:59Z
+    ///   treeship grant issue --parent grn_a1b2c3d4e5f60718 --scope payments.charge.small --audience acme --expiry 2026-06-30T00:00:00Z
+    ///   treeship grant list
+    ///   treeship grant show grn_a1b2c3d4e5f60718
+    #[command(subcommand)]
+    Grant(GrantCommand),
+
     /// Background daemon for automatic file watching
     ///
     /// The daemon watches your project for file changes and automatically
@@ -1198,6 +1214,38 @@ enum ApprovalCommand {
 enum ApprovalJournalCommand {
     /// Walk every record, recompute digests, check the chain.
     Verify,
+}
+
+// --- grant -----------------------------------------------------------------
+
+#[derive(Subcommand)]
+enum GrantCommand {
+    /// Mint a signed grant. With --parent, mints a delegated child.
+    Issue {
+        /// Capability this grant admits. Repeatable. A single trailing `*`
+        /// acts as a prefix wildcard: `payments.*`.
+        #[arg(long, required = true)]
+        scope: Vec<String>,
+        /// Who the grant is for. A delegated grant may not change it.
+        #[arg(long)]
+        audience: String,
+        /// RFC 3339. A delegated grant may not outlive its parent.
+        #[arg(long)]
+        expiry: String,
+        /// Delegate from this grant id, narrowing its authority.
+        #[arg(long)]
+        parent: Option<String>,
+        /// How many further delegations this grant permits beneath it.
+        #[arg(long, default_value_t = 3)]
+        max_delegation: u32,
+        /// Optional hash binding the grant to a stated objective.
+        #[arg(long)]
+        objective_hash: Option<String>,
+    },
+    /// List every grant minted in this workspace.
+    List,
+    /// Show one grant, re-deriving its id and re-checking its signature.
+    Show { grant_id: String },
 }
 
 // --- harness ---------------------------------------------------------------
@@ -2729,6 +2777,32 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
         Command::Approve(a) => commands::approve::approve(a.n, cli.config.as_deref(), printer),
 
         Command::Deny(a) => commands::approve::deny(a.n, cli.config.as_deref(), printer),
+
+        Command::Grant(sub) => match sub {
+            GrantCommand::Issue {
+                scope,
+                audience,
+                expiry,
+                parent,
+                max_delegation,
+                objective_hash,
+            } => commands::grant::issue(
+                commands::grant::IssueArgs {
+                    scope: scope.clone(),
+                    audience: audience.clone(),
+                    expiry: expiry.clone(),
+                    parent: parent.clone(),
+                    max_delegation: *max_delegation,
+                    objective_hash: objective_hash.clone(),
+                    config: cli.config.clone(),
+                },
+                printer,
+            ),
+            GrantCommand::List => commands::grant::list(cli.config.as_deref(), printer),
+            GrantCommand::Show { grant_id } => {
+                commands::grant::show(grant_id, cli.config.as_deref(), printer)
+            }
+        },
 
         Command::Approval(sub) => match sub {
             ApprovalCommand::Uses { grant_id } => commands::approval::uses(


### PR DESCRIPTION
First half of v0.23, the emission release.

v0.21 and v0.22 shipped the machinery to *verify* a delegation chain — content-derived ids, signed parent links, order derived from those links rather than trusted from the carrier, attenuation invariants. None of it was reachable from the CLI, because nothing could mint a grant. This is the other half.

## Surface

```
treeship grant issue --scope payments.* --audience acme --expiry 2027-12-31T23:59:59Z
treeship grant issue --parent grn_... --scope payments.charge --audience acme --expiry 2027-06-30T00:00:00Z
treeship grant list
treeship grant show grn_...
```

Grants are workspace-scoped, resolved relative to the active config the same way the approval-use journal and cards are, so a project-local Treeship answers for its own grants rather than a shared global set.

## Attenuation is enforced at mint, not only at verify

`--parent` refuses to produce a grant that widens scope, outlives its parent, changes audience, or exceeds the parent's `max_delegation`. A verifier catching that later is the backstop; refusing to create it is the fix. An invalid chain that exists is one somebody will eventually be asked to trust.

Delegation depth is **derived** from the parent, never accepted from the caller — the same reason `resolve_grant_chain` stopped trusting a self-declared one.

Verified end-to-end: all three refusals exit 1, a narrowing delegation mints cleanly, and `grant show` re-derives the id and re-checks the signature off disk (`id matches content: yes`, `issuer signature: yes`, `parent: grn_...`).

## One thing this found in itself

Reading back a chain the command had just produced showed a child grant whose expiry (`2026-06-30`) preceded its own `issued_at` (`2026-08-05`) — valid under the attenuation rules, dead on arrival in practice. `issue` now refuses an expiry that has already passed: it would fail every window check it is ever presented to, minting one is never deliberate, and the failure would surface a long way from its cause.

## Tests

7 unit tests covering each refusal path and the wildcard-scope semantics, plus a round-trip test pinning the hand-rolled RFC 3339 formatter against the parser the rest of the codebase uses rather than against my own arithmetic.

## Next

`treeship attest action --v2`, which consumes a grant and emits a receipt carrying the mandate, the effect block, and the resolved ancestor chain. That is what makes every verifier feature from 0.21 and 0.22 reachable by a CLI user.
