### PR TITLE
feat(cli): emit action/v2 receipts from attest action --v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Added
+- **`treeship attest action --v2`** — CLI emission of `treeship/action/v2`
+  receipts. Pass `--grant <id>` (workspace store) or `--grant-file <path>`,
+  optionally bind effect (`--effect-confidence`, `--finality`, `--readback`, …)
+  and runtime identity (`--provider`, `--model`, …). `treeship verify` then
+  surfaces authority / effect / runtime on a receipt the CLI itself produced —
+  the half that was verification-only through 0.22.
+
 ## 0.22.0 (2026-08-05)
 
 The delegation-and-completion release. v0.21 answered *what was authorized* and

--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -92,6 +92,23 @@ treeship attest action [OPTIONS] --actor <URI> --action <LABEL>
 |---|---|
 | `--actor <URI>` | Actor URI -- who performed the action |
 | `--action <LABEL>` | Action label -- what was done |
+| `--v2` | Emit a `treeship/action/v2` receipt (mandate + optional effect/runtime) instead of action.v1. Requires `--grant` or `--grant-file` |
+| `--grant <ID>` | Workspace grant id (`grn_…`) this action runs under. Loads `.treeship/grants/&lt;id&gt;.json` and walks `parent_grant_id` to build the mandate chain. Mutually exclusive with `--grant-file` |
+| `--grant-file <PATH>` | Path to a Grant JSON file (same shape `treeship grant issue` writes). Mutually exclusive with `--grant` |
+| `--revocation-path <PATH>` | Revocation resolver path recorded on the mandate (e.g. `hub://acme/revocations`). Defaults to `hub://local/revocations`. Without a wired resolver, `treeship verify` reports authority as `unverified` — never a false pass |
+| `--audience <AUD>` | Audience this action targeted. Defaults to the grant's audience |
+| `--effect-confidence <LEVEL>` | Actor's effect-confidence claim: verified \| partial \| ambiguous \| unknown \| not_verified. Implies an effect block |
+| `--finality <STAGE>` | Lifecycle stage: not_attempted \| initiated \| finalized \| failed \| indeterminate. Implies an effect block |
+| `--readback <sha256:HEX>` | Externally-observed post-state hash (`sha256:…`). Independent evidence the actor cannot mint. Implies an effect block |
+| `--context-snapshot <sha256:HEX>` | Hash of the context the agent acted from. Implies an effect block |
+| `--side-effect <LABEL>` | Side effect label. Repeatable. Implies an effect block |
+| `--bytes-moved <N>` | Bytes moved by the action. Implies an effect block |
+| `--resolution-deadline <TIMESTAMP>` | RFC 3339 deadline for an unresolved effect. Implies an effect block. Pair with `--on-deadline` |
+| `--on-deadline <EVENT>` | Obligation when `--resolution-deadline` passes: timeout \| escalate \| tombstone \| inherit |
+| `--provider <NAME>` | Model provider (runtime identity), e.g. `anthropic` |
+| `--model <ID>` | Model identifier (runtime identity), e.g. `claude-opus-4` |
+| `--tool-schema-hash <sha256:HEX>` | Hash of the tool schemas available this turn (`sha256:…`) |
+| `--system-prompt-hash <sha256:HEX>` | Hash of the system prompt the agent ran under (`sha256:…`) |
 | `--input-digest <sha256:HEX>` | SHA-256 digest of the input consumed |
 | `--output-digest <sha256:HEX>` | SHA-256 digest of the output produced |
 | `--content-uri <URI>` | URI to referenced content (for large/external payloads). Sets the action's subject.uri so it can be matched against an approval's --allowed-subject scope. Same role as the older --content-uri flag, named to read symmetrically with the --allowed-subject flag on `attest approval` |

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -31,6 +31,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Feature | Status | CLI | Docs |
 |---|---|---|---|
 | Receipts (signed artifacts) | `stable` | `treeship attest action`, `treeship wrap`, `treeship log` | [Artifacts](/docs/concepts/artifacts) |
+| action/v2 receipt emission (CLI) | `beta` | `treeship attest action --v2` | -- |
 | Session reports | `stable` | `treeship session start`, `treeship session close`, `treeship session report` | [Session Receipts](/docs/concepts/session-receipts), [session](/docs/cli/session) |
 | Session packages (.treeship bundles) | `stable` | `treeship package inspect`, `treeship package verify`, `treeship bundle export`, `treeship bundle import` | [package](/docs/cli/package), [bundle](/docs/cli/bundle) |
 | Offline verifier (Rust CLI) | `stable` | `treeship verify`, `treeship package verify`, `treeship merkle verify` | [verify](/docs/cli/verify), [Verification surfaces](/docs/concepts/verification-surfaces) |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -42,6 +42,20 @@
     - packages/core/src/artifacts/verify.rs
   notes: "DSSE envelopes (Ed25519 over PAE bytes, deterministic declaration-order JSON), content-addressed art_ IDs."
 
+- id: action-v2-emission
+  name: action/v2 receipt emission (CLI)
+  section: core
+  status: beta
+  cli:
+    - treeship attest action --v2
+  packages:
+    - treeship-core
+    - treeship-cli
+  tests:
+    - packages/cli/tests/action_v2_emit_e2e.rs
+    - packages/cli/tests/action_v2_verify_e2e.rs
+  notes: "CLI emits treeship/action/v2 receipts bound to a signed grant (--grant / --grant-file), with optional effect and runtime blocks. Verification of mandate/effect shipped in 0.21–0.22; emission is the 0.23 half."
+
 - id: session-reports
   name: Session reports
   section: core

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -478,8 +478,14 @@ fn read_grant_id(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Erro
     read_grant_file(&path)
 }
 
-/// Load the leaf grant and every ancestor reachable via `parent_grant_id`.
-/// The returned chain includes the leaf (required by `resolve_grant_chain`).
+/// Load the leaf grant and, when it is delegated, every ancestor reachable
+/// via `parent_grant_id`.
+///
+/// A root grant (no `parent_grant_id`) returns an **empty** chain. Carrying
+/// the leaf alone would make `verify` report `delegation_chain: holds` for a
+/// grant that never claimed lineage — the honesty regression a single-hop
+/// receipt must not create. `resolve_grant_chain` only runs when the carrier
+/// asserted ancestors; empty means `not_claimed`.
 fn load_grant_and_chain(
     grants_dir: &Path,
     grant_id: Option<&str>,
@@ -490,6 +496,11 @@ fn load_grant_and_chain(
         (None, Some(path)) => read_grant_file(Path::new(path))?,
         _ => unreachable!("validate_v2_flags requires exactly one grant source"),
     };
+
+    // No parent → no lineage claim. Leave mandate.chain empty.
+    if leaf.parent_grant_id.is_none() {
+        return Ok((leaf, Vec::new()));
+    }
 
     let mut chain = Vec::new();
     let mut seen = HashSet::new();

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -1,12 +1,16 @@
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
 use serde_json::Value;
 use treeship_core::{
     attestation::{sign, Signer},
     journal::{self, Journal},
     statements::{
         irreversibility_requires_quarantine, is_irreversibility_class, nonce_digest, payload_type,
-        ActionStatement, ApprovalScope, ApprovalStatement, ApprovalUse, DecisionStatement,
-        EndorsementStatement, HandoffStatement, ReceiptStatement, SubjectRef,
-        IRREVERSIBILITY_CLASSES, TYPE_APPROVAL_USE,
+        payload_type_v2, ActionStatement, ActionStatementV2, ApprovalScope, ApprovalStatement,
+        ApprovalUse, DeadlineEvent, DecisionStatement, Effect, EffectConfidence, EffectFinality,
+        EndorsementStatement, Grant, HandoffStatement, Mandate, ReceiptStatement, Resolution,
+        Revocation, RuntimeIdentity, SubjectRef, IRREVERSIBILITY_CLASSES, TYPE_APPROVAL_USE,
     },
     storage::Record,
     trust::{decode_ed25519_pubkey, TrustRootKind, TrustRootStore},
@@ -63,6 +67,26 @@ pub(crate) fn resolve_actor_signer(
 pub struct ActionArgs {
     pub actor: String,
     pub action: String,
+    /// Emit `treeship/action/v2` instead of action.v1.
+    pub v2: bool,
+    /// Workspace grant id (`grn_…`) under `.treeship/grants/`.
+    pub grant: Option<String>,
+    /// Path to a Grant JSON file (same shape `grant issue` writes).
+    pub grant_file: Option<String>,
+    pub revocation_path: Option<String>,
+    pub audience: Option<String>,
+    pub effect_confidence: Option<String>,
+    pub finality: Option<String>,
+    pub readback: Option<String>,
+    pub context_snapshot: Option<String>,
+    pub side_effects: Vec<String>,
+    pub bytes_moved: Option<u64>,
+    pub resolution_deadline: Option<String>,
+    pub on_deadline: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub tool_schema_hash: Option<String>,
+    pub system_prompt_hash: Option<String>,
     pub input_digest: Option<String>,
     pub output_digest: Option<String>,
     pub content_uri: Option<String>,
@@ -79,6 +103,54 @@ pub struct ActionArgs {
 }
 
 pub fn action(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std::error::Error>> {
+    validate_v2_flags(&args)?;
+    if args.v2 {
+        return action_v2(args, printer);
+    }
+    action_v1(args, printer)
+}
+
+fn validate_v2_flags(args: &ActionArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let v2_only = args.grant.is_some()
+        || args.grant_file.is_some()
+        || args.revocation_path.is_some()
+        || args.audience.is_some()
+        || args.effect_confidence.is_some()
+        || args.finality.is_some()
+        || args.readback.is_some()
+        || args.context_snapshot.is_some()
+        || !args.side_effects.is_empty()
+        || args.bytes_moved.is_some()
+        || args.resolution_deadline.is_some()
+        || args.on_deadline.is_some()
+        || args.provider.is_some()
+        || args.model.is_some()
+        || args.tool_schema_hash.is_some()
+        || args.system_prompt_hash.is_some();
+    if v2_only && !args.v2 {
+        return Err(
+            "mandate/effect/runtime flags require --v2\n  \
+             example: treeship attest action --v2 --actor agent://me --action tool.call --grant grn_…"
+                .into(),
+        );
+    }
+    if args.v2 && args.grant.is_some() && args.grant_file.is_some() {
+        return Err("--grant and --grant-file are mutually exclusive".into());
+    }
+    if args.v2 && args.grant.is_none() && args.grant_file.is_none() {
+        return Err(
+            "--v2 requires --grant <id> or --grant-file <path>\n  \
+             mint one with: treeship grant issue --scope <action> --audience <aud> --expiry <rfc3339>"
+                .into(),
+        );
+    }
+    if args.resolution_deadline.is_some() ^ args.on_deadline.is_some() {
+        return Err("--resolution-deadline and --on-deadline must be set together".into());
+    }
+    Ok(())
+}
+
+fn action_v1(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std::error::Error>> {
     let ctx = ctx::open(args.config.as_deref())?;
 
     let mut meta: Option<Value> = args
@@ -227,6 +299,349 @@ pub fn action(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std
     printer.hint(&format!("treeship verify {}", result.artifact_id));
     printer.blank();
     Ok(result.artifact_id)
+}
+
+/// Emit a `treeship/action/v2` receipt bound to a signed grant.
+fn action_v2(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std::error::Error>> {
+    let ctx = ctx::open(args.config.as_deref())?;
+
+    let mut meta: Option<Value> = args
+        .meta
+        .as_deref()
+        .map(|m| serde_json::from_str(m))
+        .transpose()
+        .map_err(|e| format!("--meta is not valid JSON: {e}"))?;
+
+    // Approval-use consume still runs against a v1-shaped statement so the
+    // existing journal / scope checks stay one code path. The signed receipt
+    // itself is v2.
+    let mut scope_stmt = ActionStatement::new(&args.actor, &args.action);
+    scope_stmt.subject = SubjectRef {
+        digest: args.input_digest.clone(),
+        uri: args.content_uri.clone(),
+        artifact_id: None,
+    };
+    scope_stmt.parent_id = args.parent_id.clone();
+    scope_stmt.approval_nonce = args.approval_nonce.clone();
+
+    let consumed_use_id = if let Some(ref raw_nonce) = args.approval_nonce {
+        Some(consume_approval(
+            &ctx,
+            raw_nonce,
+            &scope_stmt,
+            args.idempotency_key.as_deref(),
+            printer,
+        )?)
+    } else {
+        None
+    };
+
+    if let Some(ref use_id) = consumed_use_id {
+        let mut obj = match meta.take() {
+            Some(Value::Object(map)) => map,
+            Some(_other) => {
+                return Err("--meta must be a JSON object when --approval-nonce is set".into())
+            }
+            None => serde_json::Map::new(),
+        };
+        obj.insert("approval_use_id".into(), Value::String(use_id.clone()));
+        meta = Some(Value::Object(obj));
+    }
+
+    let grants_dir = grants_dir_for(&ctx.config_path);
+    let (leaf, chain) = load_grant_and_chain(
+        &grants_dir,
+        args.grant.as_deref(),
+        args.grant_file.as_deref(),
+    )?;
+
+    let revocation_path = args
+        .revocation_path
+        .clone()
+        .unwrap_or_else(|| "hub://local/revocations".into());
+    let mandate = mandate_from_grant(&leaf, chain, &revocation_path);
+
+    let mut stmt = ActionStatementV2::new(&args.actor, &args.action, mandate);
+    stmt.audience = Some(
+        args.audience
+            .clone()
+            .unwrap_or_else(|| leaf.audience.clone()),
+    );
+    stmt.subject = SubjectRef {
+        digest: args.input_digest.clone(),
+        uri: args.content_uri.clone(),
+        artifact_id: None,
+    };
+    stmt.parent_id = args.parent_id.clone();
+    stmt.effect = build_effect(&args)?;
+    stmt.runtime = build_runtime(&args);
+    stmt.meta = meta;
+
+    let signer = resolve_actor_signer(&ctx, &args.actor)?;
+    let pt = payload_type_v2("action");
+    let result = sign(&pt, &stmt, signer.as_ref())?;
+
+    let record = Record {
+        artifact_id: result.artifact_id.clone(),
+        digest: result.digest.clone(),
+        payload_type: pt.clone(),
+        key_id: signer.key_id().to_string(),
+        signed_at: stmt.timestamp.clone(),
+        parent_id: args.parent_id.clone(),
+        envelope: result.envelope.clone(),
+        hub_url: None,
+    };
+    ctx.storage.write(&record)?;
+    write_last(&ctx.config.storage_dir, &result.artifact_id);
+
+    if consumed_use_id.is_some() {
+        if let Err(e) = backfill_action_artifact_id(
+            &ctx,
+            consumed_use_id.as_deref().unwrap(),
+            &result.artifact_id,
+        ) {
+            printer.warn(
+                "could not backfill action_artifact_id onto journal record",
+                &[("error", &e.to_string())],
+            );
+        }
+    }
+
+    if let Some(path) = &args.out {
+        let json = result.envelope.to_json()?;
+        if path == "-" {
+            println!("{}", String::from_utf8_lossy(&json));
+        } else {
+            std::fs::write(path, &json)?;
+        }
+    }
+
+    let signed_str = stmt.timestamp.clone();
+    let grant_id = leaf.grant_id.clone();
+    let mut fields: Vec<(&str, String)> = vec![
+        ("id", result.artifact_id.clone()),
+        ("type", "action/v2".into()),
+        ("actor", args.actor.clone()),
+        ("action", args.action.clone()),
+        ("grant", grant_id),
+        ("signed", signed_str),
+    ];
+    if let Some(p) = &args.parent_id {
+        fields.push(("parent", p.clone()));
+    }
+    if let Some(ref effect) = stmt.effect {
+        if let Some(c) = effect.effect_confidence {
+            fields.push(("effect", effect_confidence_label(c).into()));
+        }
+    }
+
+    let field_refs: Vec<(&str, &str)> = fields.iter().map(|(k, v)| (*k, v.as_str())).collect();
+    printer.success("action/v2 attested", &field_refs);
+    printer.hint(&format!("treeship verify {}", result.artifact_id));
+    printer.blank();
+    Ok(result.artifact_id)
+}
+
+/// Same layout `treeship grant issue` uses: `<config_dir>/grants/<id>.json`.
+fn grants_dir_for(config_path: &Path) -> PathBuf {
+    config_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("grants")
+}
+
+fn read_grant_file(path: &Path) -> Result<Grant, Box<dyn std::error::Error>> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read grant file {}: {e}", path.display()))?;
+    let g: Grant = serde_json::from_str(&raw)
+        .map_err(|e| format!("grant file is not valid Grant JSON ({}): {e}", path.display()))?;
+    if !g.id_is_consistent() {
+        return Err(format!(
+            "grant {} declares an id that does not match its content\n  \
+             refused: a hand-chosen id cannot anchor a mandate chain",
+            g.grant_id
+        )
+        .into());
+    }
+    Ok(g)
+}
+
+fn read_grant_id(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Error>> {
+    let path = dir.join(format!("{id}.json"));
+    if !path.exists() {
+        return Err(format!(
+            "grant not found: {id}\n  looked in {}\n  mint one with: treeship grant issue …",
+            dir.display()
+        )
+        .into());
+    }
+    read_grant_file(&path)
+}
+
+/// Load the leaf grant and every ancestor reachable via `parent_grant_id`.
+/// The returned chain includes the leaf (required by `resolve_grant_chain`).
+fn load_grant_and_chain(
+    grants_dir: &Path,
+    grant_id: Option<&str>,
+    grant_file: Option<&str>,
+) -> Result<(Grant, Vec<Grant>), Box<dyn std::error::Error>> {
+    let leaf = match (grant_id, grant_file) {
+        (Some(id), None) => read_grant_id(grants_dir, id)?,
+        (None, Some(path)) => read_grant_file(Path::new(path))?,
+        _ => unreachable!("validate_v2_flags requires exactly one grant source"),
+    };
+
+    let mut chain = Vec::new();
+    let mut seen = HashSet::new();
+    let mut cursor = Some(leaf.grant_id.clone());
+    while let Some(id) = cursor {
+        if !seen.insert(id.clone()) {
+            return Err(format!("grant chain cycles at {id}").into());
+        }
+        // Prefer workspace store; for a --grant-file leaf that is not yet
+        // stored, fall back to the leaf we already hold.
+        let g = if id == leaf.grant_id {
+            leaf.clone()
+        } else {
+            read_grant_id(grants_dir, &id)?
+        };
+        cursor = g.parent_grant_id.clone();
+        chain.push(g);
+    }
+    // resolve_grant_chain does not trust carrier order, but root-first is the
+    // conventional on-disk shape and matches how grant issue writes parents.
+    chain.reverse();
+    Ok((leaf, chain))
+}
+
+fn mandate_from_grant(leaf: &Grant, chain: Vec<Grant>, revocation_path: &str) -> Mandate {
+    Mandate {
+        grant_id: leaf.grant_id.clone(),
+        grantor: leaf.grantor.clone(),
+        issuer_sig: leaf.issuer_sig.clone(),
+        objective_hash: leaf.objective_hash.clone(),
+        scope: leaf.scope.clone(),
+        audience: leaf.audience.clone(),
+        parent_request_id: leaf.parent_request_id.clone(),
+        delegation_depth: leaf.delegation_depth,
+        issued_at: leaf.issued_at.clone(),
+        expiry: leaf.expiry.clone(),
+        max_delegation: leaf.max_delegation,
+        revocation: Revocation {
+            path: revocation_path.into(),
+            revoked_at: None,
+        },
+        chain,
+    }
+}
+
+fn build_effect(args: &ActionArgs) -> Result<Option<Effect>, Box<dyn std::error::Error>> {
+    let wants = args.effect_confidence.is_some()
+        || args.finality.is_some()
+        || args.readback.is_some()
+        || args.context_snapshot.is_some()
+        || !args.side_effects.is_empty()
+        || args.bytes_moved.is_some()
+        || args.resolution_deadline.is_some()
+        || args.input_digest.is_some()
+        || args.output_digest.is_some();
+    if !wants {
+        return Ok(None);
+    }
+
+    let resolution = match (&args.resolution_deadline, &args.on_deadline) {
+        (Some(deadline), Some(event)) => Some(Resolution {
+            deadline: deadline.clone(),
+            on_deadline: parse_deadline_event(event)?,
+        }),
+        _ => None,
+    };
+
+    Ok(Some(Effect {
+        input_hash: args.input_digest.clone(),
+        output_hash: args.output_digest.clone(),
+        readback: args.readback.clone(),
+        bytes_moved: args.bytes_moved,
+        cost: None,
+        side_effects: args.side_effects.clone(),
+        context_snapshot: args.context_snapshot.clone(),
+        effect_confidence: args
+            .effect_confidence
+            .as_deref()
+            .map(parse_effect_confidence)
+            .transpose()?,
+        witnesses: Vec::new(),
+        finality: args.finality.as_deref().map(parse_finality).transpose()?,
+        resolution,
+    }))
+}
+
+fn build_runtime(args: &ActionArgs) -> Option<RuntimeIdentity> {
+    let rt = RuntimeIdentity {
+        provider: args.provider.clone(),
+        model: args.model.clone(),
+        tool_schema_hash: args.tool_schema_hash.clone(),
+        system_prompt_hash: args.system_prompt_hash.clone(),
+    };
+    if rt.is_unbound() {
+        None
+    } else {
+        Some(rt)
+    }
+}
+
+fn parse_effect_confidence(s: &str) -> Result<EffectConfidence, Box<dyn std::error::Error>> {
+    match s {
+        "verified" => Ok(EffectConfidence::Verified),
+        "partial" => Ok(EffectConfidence::Partial),
+        "ambiguous" => Ok(EffectConfidence::Ambiguous),
+        "unknown" => Ok(EffectConfidence::Unknown),
+        "not_verified" | "not-verified" => Ok(EffectConfidence::NotVerified),
+        other => Err(format!(
+            "unknown --effect-confidence '{other}'\n  \
+             expected: verified | partial | ambiguous | unknown | not_verified"
+        )
+        .into()),
+    }
+}
+
+fn effect_confidence_label(c: EffectConfidence) -> &'static str {
+    match c {
+        EffectConfidence::Verified => "verified",
+        EffectConfidence::Partial => "partial",
+        EffectConfidence::Ambiguous => "ambiguous",
+        EffectConfidence::Unknown => "unknown",
+        EffectConfidence::NotVerified => "not_verified",
+    }
+}
+
+fn parse_finality(s: &str) -> Result<EffectFinality, Box<dyn std::error::Error>> {
+    match s {
+        "not_attempted" | "not-attempted" => Ok(EffectFinality::NotAttempted),
+        "initiated" => Ok(EffectFinality::Initiated),
+        "finalized" => Ok(EffectFinality::Finalized),
+        "failed" => Ok(EffectFinality::Failed),
+        "indeterminate" => Ok(EffectFinality::Indeterminate),
+        other => Err(format!(
+            "unknown --finality '{other}'\n  \
+             expected: not_attempted | initiated | finalized | failed | indeterminate"
+        )
+        .into()),
+    }
+}
+
+fn parse_deadline_event(s: &str) -> Result<DeadlineEvent, Box<dyn std::error::Error>> {
+    match s {
+        "timeout" => Ok(DeadlineEvent::Timeout),
+        "escalate" => Ok(DeadlineEvent::Escalate),
+        "tombstone" => Ok(DeadlineEvent::Tombstone),
+        "inherit" => Ok(DeadlineEvent::Inherit),
+        other => Err(format!(
+            "unknown --on-deadline '{other}'\n  \
+             expected: timeout | escalate | tombstone | inherit"
+        )
+        .into()),
+    }
 }
 
 // --- approval ---------------------------------------------------------------

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1398,11 +1398,17 @@ struct WrapArgs {
 enum AttestCommand {
     /// Record that an actor performed an action
     ///
+    /// With `--v2`, emits a `treeship/action/v2` receipt bound to a signed
+    /// grant (mandate + optional effect/runtime). Without it, emits the
+    /// classic action.v1 receipt.
+    ///
     /// Examples:
     ///   treeship attest action --actor agent://researcher --action tool.call
     ///   treeship attest action --actor agent://checkout --action stripe.charge.create \
     ///     --input-digest sha256:abc123 --output-digest sha256:def456 \
     ///     --parent art_a1b2c3d4 --approval-nonce abc123xyz
+    ///   treeship attest action --v2 --actor agent://checkout --action payments.charge \
+    ///     --grant grn_a1b2c3d4e5f60718 --effect-confidence not_verified
     Action(AttestActionArgs),
 
     /// Record that an approver authorized an intent
@@ -1470,6 +1476,86 @@ struct AttestActionArgs {
     /// Action label -- what was done
     #[arg(long, required = true, value_name = "LABEL")]
     action: String,
+
+    /// Emit a `treeship/action/v2` receipt (mandate + optional effect/runtime)
+    /// instead of action.v1. Requires `--grant` or `--grant-file`.
+    #[arg(long)]
+    v2: bool,
+
+    /// Workspace grant id (`grn_…`) this action runs under. Loads
+    /// `.treeship/grants/<id>.json` and walks `parent_grant_id` to build the
+    /// mandate chain. Mutually exclusive with `--grant-file`.
+    #[arg(long, value_name = "ID")]
+    grant: Option<String>,
+
+    /// Path to a Grant JSON file (same shape `treeship grant issue` writes).
+    /// Mutually exclusive with `--grant`.
+    #[arg(long, value_name = "PATH")]
+    grant_file: Option<String>,
+
+    /// Revocation resolver path recorded on the mandate
+    /// (e.g. `hub://acme/revocations`). Defaults to `hub://local/revocations`.
+    /// Without a wired resolver, `treeship verify` reports authority as
+    /// `unverified` — never a false pass.
+    #[arg(long, value_name = "PATH")]
+    revocation_path: Option<String>,
+
+    /// Audience this action targeted. Defaults to the grant's audience.
+    #[arg(long, value_name = "AUD")]
+    audience: Option<String>,
+
+    /// Actor's effect-confidence claim: verified | partial | ambiguous |
+    /// unknown | not_verified. Implies an effect block.
+    #[arg(long, value_name = "LEVEL")]
+    effect_confidence: Option<String>,
+
+    /// Lifecycle stage: not_attempted | initiated | finalized | failed |
+    /// indeterminate. Implies an effect block.
+    #[arg(long, value_name = "STAGE")]
+    finality: Option<String>,
+
+    /// Externally-observed post-state hash (`sha256:…`). Independent evidence
+    /// the actor cannot mint. Implies an effect block.
+    #[arg(long, value_name = "sha256:HEX")]
+    readback: Option<String>,
+
+    /// Hash of the context the agent acted from. Implies an effect block.
+    #[arg(long, value_name = "sha256:HEX")]
+    context_snapshot: Option<String>,
+
+    /// Side effect label. Repeatable. Implies an effect block.
+    #[arg(long, value_name = "LABEL")]
+    side_effect: Vec<String>,
+
+    /// Bytes moved by the action. Implies an effect block.
+    #[arg(long, value_name = "N")]
+    bytes_moved: Option<u64>,
+
+    /// RFC 3339 deadline for an unresolved effect. Implies an effect block.
+    /// Pair with `--on-deadline`.
+    #[arg(long, value_name = "TIMESTAMP")]
+    resolution_deadline: Option<String>,
+
+    /// Obligation when `--resolution-deadline` passes:
+    /// timeout | escalate | tombstone | inherit.
+    #[arg(long, value_name = "EVENT")]
+    on_deadline: Option<String>,
+
+    /// Model provider (runtime identity), e.g. `anthropic`.
+    #[arg(long, value_name = "NAME")]
+    provider: Option<String>,
+
+    /// Model identifier (runtime identity), e.g. `claude-opus-4`.
+    #[arg(long, value_name = "ID")]
+    model: Option<String>,
+
+    /// Hash of the tool schemas available this turn (`sha256:…`).
+    #[arg(long, value_name = "sha256:HEX")]
+    tool_schema_hash: Option<String>,
+
+    /// Hash of the system prompt the agent ran under (`sha256:…`).
+    #[arg(long, value_name = "sha256:HEX")]
+    system_prompt_hash: Option<String>,
 
     /// SHA-256 digest of the input consumed
     #[arg(long, value_name = "sha256:HEX")]
@@ -2847,6 +2933,23 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     commands::attest::ActionArgs {
                         actor: a.actor.clone(),
                         action: a.action.clone(),
+                        v2: a.v2,
+                        grant: a.grant.clone(),
+                        grant_file: a.grant_file.clone(),
+                        revocation_path: a.revocation_path.clone(),
+                        audience: a.audience.clone(),
+                        effect_confidence: a.effect_confidence.clone(),
+                        finality: a.finality.clone(),
+                        readback: a.readback.clone(),
+                        context_snapshot: a.context_snapshot.clone(),
+                        side_effects: a.side_effect.clone(),
+                        bytes_moved: a.bytes_moved,
+                        resolution_deadline: a.resolution_deadline.clone(),
+                        on_deadline: a.on_deadline.clone(),
+                        provider: a.provider.clone(),
+                        model: a.model.clone(),
+                        tool_schema_hash: a.tool_schema_hash.clone(),
+                        system_prompt_hash: a.system_prompt_hash.clone(),
                         input_digest: a.input_digest.clone(),
                         output_digest: a.output_digest.clone(),
                         content_uri: subject_uri,

--- a/packages/cli/tests/action_v2_emit_e2e.rs
+++ b/packages/cli/tests/action_v2_emit_e2e.rs
@@ -217,6 +217,51 @@ fn v2_without_grant_is_refused() {
 }
 
 #[test]
+fn root_grant_reports_delegation_not_claimed() {
+    // A single-hop grant never asserted lineage. Stuffing the leaf into
+    // mandate.chain would make verify report `holds` for a check that
+    // never ran — the honesty bug caught in the grant-issue × emit integration.
+    let ws = Workspace::new();
+    let grant = ws.plant_grant(&["tool.call"], "local", "2099-01-01T00:00:00Z");
+    assert!(
+        grant.parent_grant_id.is_none(),
+        "plant_grant must mint a root"
+    );
+
+    let out = ws
+        .cmd()
+        .args([
+            "--format",
+            "json",
+            "attest",
+            "action",
+            "--v2",
+            "--actor",
+            "agent://worker",
+            "--action",
+            "tool.call",
+            "--grant",
+            &grant.grant_id,
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "attest failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let emitted: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).unwrap();
+    let id = emitted["id"].as_str().unwrap();
+
+    let j = ws.verify_json(id);
+    assert_eq!(
+        j["checks"][0]["delegation_chain"]["outcome"], "not_claimed",
+        "root grant must not claim a holding chain: {j}"
+    );
+}
+
+#[test]
 fn grant_file_emits_without_workspace_store() {
     let ws = Workspace::new();
     let grant = ws.plant_grant(&["tool.call"], "local", "2099-01-01T00:00:00Z");

--- a/packages/cli/tests/action_v2_emit_e2e.rs
+++ b/packages/cli/tests/action_v2_emit_e2e.rs
@@ -1,0 +1,255 @@
+//! End-to-end: the CLI itself emits an action/v2 receipt that `verify` can read.
+//!
+//! Verification-side coverage already plants envelopes by hand. Emission is the
+//! half that was missing through 0.22 — without this test, a CLI user still
+//! cannot produce a receipt that exercises the mandate/effect path we ship.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use tempfile::TempDir;
+use treeship_core::{keys::Store as KeyStore, statements::Grant};
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Workspace {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = Self { _tmp: tmp, root };
+        let out = ws.cmd().args(["init"]).output().unwrap();
+        assert!(
+            out.status.success(),
+            "init failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        ws
+    }
+
+    fn cmd(&self) -> Command {
+        let mut c = Command::new(cli_path());
+        c.env("HOME", &self.root);
+        c.current_dir(&self.root);
+        c
+    }
+
+    fn keys_dir(&self) -> PathBuf {
+        self.root.join(".treeship/keys")
+    }
+
+    fn grants_dir(&self) -> PathBuf {
+        self.root.join(".treeship/grants")
+    }
+
+    /// Mint a root grant the same way `grant issue` will, written into the
+    /// workspace store so `--grant <id>` can load it.
+    fn plant_grant(&self, scope: &[&str], audience: &str, expiry: &str) -> Grant {
+        let keys = KeyStore::open(self.keys_dir()).expect("open keystore");
+        let signer = keys.default_signer().expect("default key");
+        // issued_at well in the past so the mandate window check is not the
+        // story regardless of the host clock; expiry is caller-chosen.
+        let mut g = Grant {
+            grant_id: String::new(),
+            grantor: URL_SAFE_NO_PAD.encode(signer.public_key_bytes()),
+            issuer_sig: None,
+            scope: scope.iter().map(|s| (*s).to_string()).collect(),
+            audience: audience.into(),
+            parent_request_id: None,
+            parent_grant_id: None,
+            delegation_depth: 0,
+            issued_at: "2020-01-01T00:00:00Z".into(),
+            expiry: expiry.into(),
+            max_delegation: 3,
+            objective_hash: None,
+        };
+        g.grant_id = g.derive_grant_id();
+        g.issuer_sig = Some(g.sign_canonical(signer.as_ref()).unwrap());
+
+        let dir = self.grants_dir();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(format!("{}.json", g.grant_id)),
+            serde_json::to_string_pretty(&g).unwrap(),
+        )
+        .unwrap();
+        g
+    }
+
+    fn verify_json(&self, id: &str) -> serde_json::Value {
+        let out = self
+            .cmd()
+            .args(["verify", id, "--format", "json"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "verify failed: {}\n{}",
+            String::from_utf8_lossy(&out.stderr),
+            stdout
+        );
+        serde_json::from_str(&stdout)
+            .unwrap_or_else(|e| panic!("verify emitted non-JSON ({e}): {stdout}"))
+    }
+}
+
+#[test]
+fn cli_emits_action_v2_that_verify_reads() {
+    let ws = Workspace::new();
+    let grant = ws.plant_grant(&["payments.charge"], "acme", "2099-01-01T00:00:00Z");
+
+    let out = ws
+        .cmd()
+        .args([
+            "--format",
+            "json",
+            "attest",
+            "action",
+            "--v2",
+            "--actor",
+            "agent://worker",
+            "--action",
+            "payments.charge",
+            "--grant",
+            &grant.grant_id,
+            "--effect-confidence",
+            "not_verified",
+            "--finality",
+            "initiated",
+            "--provider",
+            "anthropic",
+            "--model",
+            "claude-opus-4",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "attest action --v2 failed: {stderr}\n{stdout}"
+    );
+
+    let emitted: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("non-JSON attest ({e}): {stdout}"));
+    let id = emitted["id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("attest JSON missing id: {emitted}"));
+    assert_eq!(emitted["type"], "action/v2");
+    assert_eq!(emitted["grant"], grant.grant_id);
+
+    let j = ws.verify_json(id);
+    let check = &j["checks"][0];
+
+    // Signature must verify — emission wrote a real DSSE envelope.
+    assert_eq!(
+        check["outcome"], "pass",
+        "emitted v2 receipt must verify: {j}"
+    );
+
+    // Authority is unverified without a revocation resolver — never a false pass.
+    assert_eq!(
+        check["authority"]["outcome"], "unverified",
+        "authority must be unverified without a revocation resolver: {j}"
+    );
+
+    // Effect claim reaches verify (kebab label on the machine surface).
+    assert_eq!(
+        check["effect"]["claimed_confidence"], "not-verified",
+        "effect claim should surface: {j}"
+    );
+    assert_eq!(
+        check["effect"]["claimed_finality"], "initiated",
+        "finality claim should surface: {j}"
+    );
+
+    // Runtime is bound into the signed payload; the human timeline surfaces it.
+    let text = ws
+        .cmd()
+        .args(["verify", id, "--full"])
+        .output()
+        .unwrap();
+    let text_out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&text.stdout),
+        String::from_utf8_lossy(&text.stderr)
+    );
+    assert!(
+        text_out.contains("claude-opus-4"),
+        "runtime model should appear on verify --full timeline: {text_out}"
+    );
+}
+
+#[test]
+fn v2_without_grant_is_refused() {
+    let ws = Workspace::new();
+    let out = ws
+        .cmd()
+        .args([
+            "attest",
+            "action",
+            "--v2",
+            "--actor",
+            "agent://worker",
+            "--action",
+            "payments.charge",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "must refuse --v2 without a grant");
+    let err = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    assert!(
+        err.contains("--grant") || err.contains("grant-file"),
+        "error should name the missing grant flag: {err}"
+    );
+}
+
+#[test]
+fn grant_file_emits_without_workspace_store() {
+    let ws = Workspace::new();
+    let grant = ws.plant_grant(&["tool.call"], "local", "2099-01-01T00:00:00Z");
+    let grant_path = ws.grants_dir().join(format!("{}.json", grant.grant_id));
+
+    // Move it out of the store so --grant would fail; --grant-file must work.
+    let external = ws.root.join("external-grant.json");
+    std::fs::rename(&grant_path, &external).unwrap();
+
+    let out = ws
+        .cmd()
+        .args([
+            "--format",
+            "json",
+            "attest",
+            "action",
+            "--v2",
+            "--actor",
+            "agent://worker",
+            "--action",
+            "tool.call",
+            "--grant-file",
+            external.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "attest --grant-file failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let emitted: serde_json::Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .expect("attest JSON");
+    assert_eq!(emitted["type"], "action/v2");
+    assert_eq!(emitted["status"], "ok");
+}


### PR DESCRIPTION
## Summary
- Add `treeship attest action --v2` so the CLI can emit `treeship/action/v2` receipts (mandate + optional effect/runtime), closing the emission gap left after 0.21–0.22 verification landed.
- Bind authority via `--grant <id>` (workspace `.treeship/grants/`) or `--grant-file`, walking `parent_grant_id` into the mandate chain; optional effect/runtime flags (`--effect-confidence`, `--finality`, `--readback`, `--provider`, `--model`, …).
- E2E coverage: CLI emit → `verify` surfaces authority/effect/runtime; refuse `--v2` without a grant; `--grant-file` works outside the store. Composes with `feat/grant-issue-cli` once that lands (same grant JSON layout).

## Test plan
- [x] `cargo test -p treeship-cli --test action_v2_emit_e2e` (3/3)
- [ ] `cargo test -p treeship-cli --test action_v2_verify_e2e`
- [ ] Manual: plant/issue a grant, `attest action --v2 --grant …`, `verify --full` shows authority + effect + runtime
- [ ] Confirm docs-drift: command matrix + feature inventory already regenerated
- [ ] After `grant issue` merges: smoke `--grant` against a freshly minted `grn_…`


Made with [Cursor](https://cursor.com)