### PR TITLE
Release v0.23.0 — grant store dedupe, grants docs, version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.22.0"
+    "version": "0.23.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 ## Unreleased
 
+## 0.23.0 (2026-08-05)
+
+The emission release. v0.21 and v0.22 built a verifier that could check
+mandates, delegation chains, effect finality, and resolution deadlines — and
+none of it was reachable, because nothing could mint a grant or emit an
+action/v2 receipt. Both halves now exist, so the loop closes:
+
+```
+treeship grant issue --scope 'payments.*' --audience acme --expiry 2027-12-31T23:59:59Z
+treeship grant issue --parent grn_… --scope payments.charge --audience acme --expiry 2027-06-30T00:00:00Z
+treeship attest action --v2 --actor agent://worker --action payments.charge --grant grn_… \
+  --effect-confidence not_verified --finality initiated
+treeship verify last --format json
+```
+
+```json
+"authority":        { "outcome": "unverified", "reasons": ["revocation could not be checked: …"] },
+"delegation_chain": { "hops": 2, "outcome": "holds" },
+"resolution":       { "outcome": "indefinite" },
+"effect":           { "effective_finality": "initiated" }
+```
+
+### Added
+- **`treeship grant issue` / `list` / `show`.** Mint a signed capability grant,
+  or delegate a narrower one with `--parent`. Ids are content-derived
+  (`grn_` + `hex(sha256(canonical))[..16]`), so a parent pointer is a hash
+  commitment to one specific grant rather than a reference to a name anyone
+  could claim. Grants are workspace-scoped, resolved from the active config the
+  same way the approval-use journal is.
+
+  Attenuation is enforced **at mint**, not only at verify: issuing refuses a
+  child that widens scope, outlives its parent, changes audience, or exceeds
+  `max_delegation`, and `delegation_depth` is derived from the parent rather
+  than accepted from the caller. A verifier catching an invalid chain later is
+  the backstop; refusing to create one is the fix, because an invalid chain
+  that exists is one somebody will eventually be asked to trust. Also refuses
+  an expiry already in the past — a grant that can never verify is never
+  minted deliberately.
+
+  `grant show` re-derives the id and re-checks the signature off disk rather
+  than trusting the file, and will open an unsound grant in order to report it
+  as unsound.
+
+- **`treeship attest action --v2`.** Emits a real action/v2 receipt carrying the
+  mandate from a grant (`--grant` or `--grant-file`), an optional effect block
+  (`--effect-confidence`, `--finality`, `--readback`, `--context-snapshot`,
+  `--resolution-deadline`, `--on-deadline`), and runtime identity. Ancestors are
+  walked from `parent_grant_id` and carried inline, so a delegated action still
+  verifies offline with no fetch.
+
+  A root grant leaves `mandate.chain` empty rather than carrying its lone leaf.
+  A one-element chain has no adjacent pair to check, so reporting it as
+  "attenuation holds" would name a check that never ran; `not_claimed` is the
+  honest answer.
+
+### Fixed
+- **`treeship-core` reaches crates.io again.** It did not publish in v0.22.0
+  while npm and PyPI did — `packages/core/src/session/package.rs` embedded a
+  webfont from `design/fonts/`, outside the crate root, and `cargo publish`
+  builds from a tarball containing only files under that root. The include
+  landed after v0.21.0, which is why the previous release was clean. Each crate
+  now vendors the font under its own `assets/fonts/`.
+
+  Two guards, because the version preflight could never have caught this —
+  every version was correct, the crate simply could not be built:
+  `scripts/check-vendored-fonts.py` flags a published crate embedding anything
+  from outside its root, and CI now runs `cargo package -p treeship-core`, the
+  same verify step publish does.
+
+### Notes
+- Revocation is still unchecked, so the authority axis reports `unverified`
+  rather than `pass` and names the layer it could not check. The hub endpoint
+  remains an unsigned, hardcoded-empty stub; reading it would convert an honest
+  "I don't know" into a false "not revoked" for every grant ever issued.
+- Capability grants ship as **beta**, not stable, for that reason.
+
 ### Added
 - **`treeship attest action --v2`** — CLI emission of `treeship/action/v2`
   receipts. Pass `--grant <id>` (workspace store) or `--grant-file <path>`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "base64",
  "clap",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.22.0"
+    "@treeship/core-wasm": "0.23.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.22.0",
+    "@treeship/core-wasm": "0.23.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/docs/content/docs/cli/grant.mdx
+++ b/docs/content/docs/cli/grant.mdx
@@ -1,0 +1,125 @@
+---
+title: grant
+description: Mint and inspect signed capability grants — the authority an action/v2 receipt runs under.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+A **grant** is the authority an action runs under: a scope, an audience, a window, and a signature from whoever issued it. `treeship attest action --v2` consumes one and records it in the receipt as a *mandate*, so a verifier can later ask not just "was this signed?" but "was it allowed?"
+
+Grants live at `<config-dir>/grants/<grant-id>.json` — workspace-scoped, so a project-local Treeship answers for its own grants rather than a shared global set.
+
+## Subcommands
+
+```bash
+treeship grant issue --scope <scope> --audience <aud> --expiry <rfc3339> [--parent <grant-id>]
+treeship grant list
+treeship grant show <grant-id>
+```
+
+## Issuing a root grant
+
+```bash
+treeship grant issue \
+  --scope 'payments.*' \
+  --audience acme \
+  --expiry 2027-12-31T23:59:59Z
+```
+
+```
+✓ grant issued  grn_5210541d0135a22e
+  scope:     payments.*
+  audience:  acme
+  expiry:    2027-12-31T23:59:59Z
+  depth:     0
+```
+
+`--scope` is repeatable. A single trailing `*` acts as a prefix wildcard, so `payments.*` admits `payments.charge` but not `email.send`.
+
+## The id is derived, not chosen
+
+```
+grant_id = "grn_" + hex(sha256(canonical_for_signing()))[..16]
+```
+
+Same shape as `artifact_id`. This matters for delegation: because a child commits to its parent by **content hash**, a parent pointer names one specific grant rather than a string anyone else could also claim. An id that does not match its content is refused wherever a grant is about to be used.
+
+## Delegating
+
+```bash
+treeship grant issue \
+  --parent grn_5210541d0135a22e \
+  --scope payments.charge \
+  --audience acme \
+  --expiry 2027-06-30T00:00:00Z
+```
+
+A delegated grant may only **narrow** authority, and `issue` refuses to mint one that does not:
+
+| Refused when the child… | Example against a `payments.*` parent |
+|---|---|
+| widens scope | `--scope email.send` — outside the parent entirely |
+| outlives its parent | an expiry later than the parent's |
+| changes audience | `--audience other` when the parent is for `acme` |
+| exceeds `max_delegation` | the parent capped how deep delegation may go |
+| has an expiry already in the past | it could never verify, so minting it is never deliberate |
+
+Narrowing is fine: `--scope payments.refund` is admitted by `payments.*`, and so is `--scope payments.charge`. Each refusal exits `1`.
+
+`delegation_depth` is **derived** from the parent, never accepted from you. A depth declared inside the very chain being verified is not evidence of anything.
+
+<Callout type="info">
+Refusing at mint is deliberate. `treeship verify` would catch an invalid chain later, but an invalid chain that exists is one somebody will eventually be asked to trust. Better that it never gets created.
+</Callout>
+
+## Inspecting
+
+`grant show` re-derives the id and re-checks the signature off disk rather than trusting the file:
+
+```bash
+treeship grant show grn_7ceb15dca9f96b0c
+```
+
+```
+✓ grn_7ceb15dca9f96b0c
+  grantor:             5YHXUAE4HhqiKxYd5TrQN2fOXvJcxykU4T8wBie9fmc
+  scope:               payments.charge
+  audience:            acme
+  expiry:              2027-06-30T00:00:00Z
+  depth:               1
+  parent:              grn_5210541d0135a22e
+  id matches content:  yes
+  issuer signature:    yes
+```
+
+An unsound grant still opens here — that is the point of the command. It reports `no` rather than refusing to show you the thing you are trying to diagnose.
+
+## Using a grant
+
+```bash
+treeship attest action --v2 \
+  --actor agent://worker \
+  --action payments.charge \
+  --grant grn_7ceb15dca9f96b0c \
+  --effect-confidence not_verified \
+  --finality initiated
+```
+
+`treeship verify` then reports the authority and delegation axes:
+
+```json
+"authority":        { "outcome": "unverified", "reasons": ["revocation could not be checked: …"] },
+"delegation_chain": { "hops": 2, "outcome": "holds" }
+```
+
+The ancestors are carried inline in the receipt, so the chain verifies **offline** — no fetch, no hub, no network.
+
+<Callout type="warn">
+**Revocation is not checked.** The CLI wires no revocation resolver, so the authority axis reports `unverified` rather than `pass`, and names revocation as the layer it could not check. This is deliberate: the hub's revocation endpoint is an unsigned, always-empty stub, and reading it would turn an honest "I don't know" into a false "not revoked" for every grant ever issued. A grant you need to withdraw must be withdrawn out of band today.
+</Callout>
+
+## What a grant does not do
+
+- **It does not enforce.** Treeship records what authority an action claimed and lets anyone check whether the action stayed inside it. Nothing stops an agent acting outside its grant; verification is how that becomes visible.
+- **It does not expire itself.** An expired grant fails the window check at verify time; nothing deletes it from disk.
+- **A root grant makes no lineage claim.** Its receipts report `not_claimed` on the delegation axis, not a chain that passes — there is nothing to check, and saying otherwise would imply a check that never ran.

--- a/docs/content/docs/cli/meta.json
+++ b/docs/content/docs/cli/meta.json
@@ -16,6 +16,7 @@
     "match",
     "keys",
     "trust",
+    "grant",
     "agents",
     "harness",
     "wrap",

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -47,7 +47,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Feature | Status | CLI | Docs |
 |---|---|---|---|
 | Approval Use Journal | `stable` | `treeship approval uses`, `treeship approval status`, `treeship approval journal verify` | [Approval Use Journal](/docs/concepts/approval-use-journal), [Approval Authority](/docs/concepts/approval-authority) |
-| Capability grants + delegation chains | `beta` | `treeship grant issue`, `treeship grant list`, `treeship grant show` | -- |
+| Capability grants + delegation chains | `beta` | `treeship grant issue`, `treeship grant list`, `treeship grant show` | [grant](/docs/cli/grant) |
 | Per-agent keys & onboarding | `stable` | `treeship onboard`, `treeship agent register` | [Trust model](/docs/concepts/trust-model), [How it works](/docs/guides/how-it-works) |
 | Agent Identity Certificates | `beta` | `treeship agent register` | [Agent Identity](/docs/concepts/agent-identity) |
 | Agent Cards | `stable` | `treeship agents`, `treeship agents review`, `treeship agents approve`, `treeship agents remove` | [Agent Cards](/docs/concepts/agent-cards), [agents](/docs/cli/agents) |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -229,10 +229,12 @@
     - treeship grant show
   packages:
     - treeship-core
+  docs:
+    - docs/content/docs/cli/grant.mdx
   tests:
     - packages/core/src/statements/action_v2.rs
     - packages/cli/src/commands/grant.rs
-  notes: "The authority an action/v2 receipt runs under. Grant ids are content-derived (grn_ + sha256 of the signed canonical), so a parent pointer commits to one specific grant rather than to a name. Issuing refuses to widen: a delegated grant may only narrow scope, shorten expiry, keep the same audience, and stay inside max_delegation, with depth derived from the parent rather than declared. beta, not stable: grants have no revocation resolver, and no docs page yet."
+  notes: "The authority an action/v2 receipt runs under. Grant ids are content-derived (grn_ + sha256 of the signed canonical), so a parent pointer commits to one specific grant rather than to a name. Issuing refuses to widen: a delegated grant may only narrow scope, shorten expiry, keep the same audience, and stay inside max_delegation, with depth derived from the parent rather than declared. beta, not stable: revocation has no resolver, so the authority axis reports unverified rather than pass."
 
 - id: per-agent-keys
   name: Per-agent keys & onboarding

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.22.0",
-    "@treeship/cli-darwin-arm64": "0.22.0",
-    "@treeship/cli-darwin-x64": "0.22.0"
+    "@treeship/cli-linux-x64": "0.23.0",
+    "@treeship/cli-darwin-arm64": "0.23.0",
+    "@treeship/cli-darwin-x64": "0.23.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.22.0", path = "../core" }
+treeship-core = { version = "0.23.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde_json::Value;
 use treeship_core::{
@@ -16,6 +16,9 @@ use treeship_core::{
     trust::{decode_ed25519_pubkey, TrustRootKind, TrustRootStore},
 };
 
+// The grant store is owned by `commands::grant`; emission borrows its layout
+// and read path rather than restating them.
+use crate::commands::grant::{grants_dir_for, read_grant_file, read_grant_id};
 use crate::commands::verify::{check_scope_violation, find_approval_by_nonce, now_rfc3339};
 use crate::{ctx, printer::Printer};
 use treeship_core::session::event::EventType;
@@ -440,42 +443,6 @@ fn action_v2(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std:
     printer.hint(&format!("treeship verify {}", result.artifact_id));
     printer.blank();
     Ok(result.artifact_id)
-}
-
-/// Same layout `treeship grant issue` uses: `<config_dir>/grants/<id>.json`.
-fn grants_dir_for(config_path: &Path) -> PathBuf {
-    config_path
-        .parent()
-        .unwrap_or_else(|| Path::new("."))
-        .join("grants")
-}
-
-fn read_grant_file(path: &Path) -> Result<Grant, Box<dyn std::error::Error>> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|e| format!("could not read grant file {}: {e}", path.display()))?;
-    let g: Grant = serde_json::from_str(&raw)
-        .map_err(|e| format!("grant file is not valid Grant JSON ({}): {e}", path.display()))?;
-    if !g.id_is_consistent() {
-        return Err(format!(
-            "grant {} declares an id that does not match its content\n  \
-             refused: a hand-chosen id cannot anchor a mandate chain",
-            g.grant_id
-        )
-        .into());
-    }
-    Ok(g)
-}
-
-fn read_grant_id(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Error>> {
-    let path = dir.join(format!("{id}.json"));
-    if !path.exists() {
-        return Err(format!(
-            "grant not found: {id}\n  looked in {}\n  mint one with: treeship grant issue …",
-            dir.display()
-        )
-        .into());
-    }
-    read_grant_file(&path)
 }
 
 /// Load the leaf grant and, when it is delegated, every ancestor reachable

--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -26,23 +26,63 @@ use treeship_core::statements::{parse_rfc3339_to_unix, Grant};
 use crate::ctx;
 use crate::printer::{Format, Printer};
 
-fn grants_dir_for(config_path: &Path) -> PathBuf {
+// The grant store's layout and read path live here and only here. `attest
+// action --v2` loads grants through these rather than keeping its own copy:
+// two definitions of "where grants live" agree right up until one of them
+// changes.
+
+/// `<config_dir>/grants/`, resolved from the active config so a project-local
+/// Treeship answers for its own grants.
+pub(crate) fn grants_dir_for(config_path: &Path) -> PathBuf {
     config_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join("grants")
 }
 
-fn grant_path(dir: &Path, id: &str) -> PathBuf {
+pub(crate) fn grant_path(dir: &Path, id: &str) -> PathBuf {
     dir.join(format!("{id}.json"))
 }
 
-fn read_grant(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Error>> {
-    let p = grant_path(dir, id);
-    let raw = std::fs::read_to_string(&p)
-        .map_err(|_| format!("grant not found: {id}\n  run: treeship grant list"))?;
-    let g: Grant = serde_json::from_str(&raw)?;
+/// Parse a grant without judging it. Used by `grant show`, whose whole job is
+/// to report whether what is on disk is sound -- a loader that refused unsound
+/// grants would leave the one command meant to diagnose them unable to open
+/// them.
+pub(crate) fn read_grant_unchecked(path: &Path) -> Result<Grant, Box<dyn std::error::Error>> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read grant file {}: {e}", path.display()))?;
+    let g: Grant = serde_json::from_str(&raw)
+        .map_err(|e| format!("grant file is not valid Grant JSON ({}): {e}", path.display()))?;
     Ok(g)
+}
+
+/// Parse a grant that is about to be *used*, refusing one whose declared id
+/// does not match its content. A hand-chosen id cannot anchor a mandate chain:
+/// a parent pointer to it names a string, not a grant.
+pub(crate) fn read_grant_file(path: &Path) -> Result<Grant, Box<dyn std::error::Error>> {
+    let g = read_grant_unchecked(path)?;
+    if !g.id_is_consistent() {
+        return Err(format!(
+            "grant {} declares an id that does not match its content\n  \
+             refused: a hand-chosen id cannot anchor a mandate chain",
+            g.grant_id
+        )
+        .into());
+    }
+    Ok(g)
+}
+
+/// Load a grant by id from the workspace store, checked.
+pub(crate) fn read_grant_id(dir: &Path, id: &str) -> Result<Grant, Box<dyn std::error::Error>> {
+    let path = grant_path(dir, id);
+    if !path.exists() {
+        return Err(format!(
+            "grant not found: {id}\n  looked in {}\n  mint one with: treeship grant issue …",
+            dir.display()
+        )
+        .into());
+    }
+    read_grant_file(&path)
 }
 
 pub struct IssueArgs {
@@ -134,7 +174,9 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
     std::fs::create_dir_all(&dir)?;
 
     let parent = match &args.parent {
-        Some(pid) => Some(read_grant(&dir, pid)?),
+        // Checked: we are about to delegate from this grant, so an
+        // inconsistent id would produce a child pointing at nothing.
+        Some(pid) => Some(read_grant_id(&dir, pid)?),
         None => None,
     };
 
@@ -300,7 +342,14 @@ pub fn show(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let ctx = ctx::open(config)?;
     let dir = grants_dir_for(&ctx.config_path);
-    let g = read_grant(&dir, id)?;
+    let path = grant_path(&dir, id);
+    if !path.exists() {
+        return Err(format!("grant not found: {id}\n  run: treeship grant list").into());
+    }
+    // Unchecked on purpose: this command reports soundness, so it has to be
+    // able to open an unsound grant and say so. The checked loader is for
+    // callers about to act on a grant.
+    let g = read_grant_unchecked(&path)?;
 
     // Re-verify rather than trust the file. A grant on disk is just bytes, and
     // the point of a content-derived id is that it can be checked.
@@ -440,6 +489,33 @@ mod tests {
             "payments.charge.extra",
             &["payments.charge".into()]
         ));
+    }
+
+    #[test]
+    fn checked_read_refuses_a_tampered_id_but_unchecked_still_opens_it() {
+        // The two readers exist for different jobs and must not collapse into
+        // one. A caller about to *use* a grant needs the refusal; `grant show`
+        // needs to open the same file and report that it is unsound. If the
+        // only loader refused, the command meant to diagnose a bad grant could
+        // never read one.
+        let dir = std::env::temp_dir().join("ts_grant_reader_split_test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut g = grant(&["payments.charge"], "acme", "2027-01-01T00:00:00Z", 0, 3);
+        g.grant_id = "grn_0000000000000000".into(); // not derived from content
+        let path = grant_path(&dir, &g.grant_id);
+        std::fs::write(&path, serde_json::to_string(&g).unwrap()).unwrap();
+
+        assert!(
+            read_grant_file(&path).is_err(),
+            "a grant whose id does not match its content must not be usable"
+        );
+        let opened = read_grant_unchecked(&path).expect("show must still be able to open it");
+        assert!(
+            !opened.id_is_consistent(),
+            "and it must be reportable as inconsistent"
+        );
+
+        std::fs::remove_file(&path).ok();
     }
 
     #[test]

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.22.0"
+version = "0.23.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.22.0"
+    "@treeship/core-wasm": "0.23.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.22.0"
+    "@treeship/core-wasm": "0.23.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.22.0"
+    "@treeship/verify": "0.23.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.22.0"
+    "@treeship/verify": "0.23.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.22.0"
+    "@treeship/verify": "0.23.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Two follow-ups from #255 / #257, plus the version bump and CHANGELOG for **v0.23.0** — the emission release.

`python3 scripts/check-release-versions.py 0.23.0` → `total: 39  ok: 39  wrong: 0  not-found: 0`

## Why 0.23.0 and not 0.22.1

The original plan was a patch to close the crates.io gap from #256. Then #255 and #257 landed, adding two new command surfaces (`treeship grant`, `attest action --v2`). A patch release that adds commands mislabels itself, so this is a minor bump. The crates.io fix rides along.

## The loop closes

```
treeship grant issue --scope 'payments.*' --audience acme --expiry 2027-12-31T23:59:59Z
treeship grant issue --parent grn_… --scope payments.charge --audience acme --expiry 2027-06-30T00:00:00Z
treeship attest action --v2 --actor agent://worker --action payments.charge --grant grn_… \
  --effect-confidence not_verified --finality initiated
treeship verify last --format json
```

```json
"authority":        { "outcome": "unverified", "reasons": ["revocation could not be checked: …"] },
"delegation_chain": { "hops": 2, "outcome": "holds" },
"resolution":       { "outcome": "indefinite" },
"effect":           { "effective_finality": "initiated" }
```

Verified against the binary built from `main`.

## What is in this PR specifically

**Grant store dedupe.** `grants_dir_for` / `read_grant_file` / `read_grant_id` existed in both `attest.rs` and `grant.rs`. They agreed — which is exactly how long two definitions of "where grants live" agree for. `grant.rs` owns them now and emission calls in.

The merge kept emission's stronger reader, which refuses a grant whose declared id does not match its content. But `grant show` exists to *report* soundness, and a loader that refused unsound grants would leave the one command meant to diagnose them unable to open one. So the read path is split — `read_grant_file` for callers about to act on a grant, `read_grant_unchecked` for the command that judges it — with a test pinning the distinction.

**Docs page.** `docs/content/docs/cli/grant.mdx`, which is what the inventory entry was waiting on. Covers issuing, delegation, the mint-time refusals, and states plainly that revocation is unchecked.

Writing it caught an error in my own table: I claimed `payments.refund` is not inside `payments.*`. It is — that is what the wildcard means. I ran every row of the refusal table against the binary and corrected the example to one that is actually outside (`email.send`). Each refusal exits `1`; narrowing exits `0`.

**Version bump + CHANGELOG.**

## Honesty carried into the release notes

- Revocation is still unchecked, so the authority axis reports `unverified` rather than `pass` and names the layer. The hub endpoint is an unsigned, hardcoded-empty stub; reading it would turn "I don't know" into a false "not revoked" for every grant ever issued.
- Capability grants ship **beta**, not stable, for that reason.
- A root grant leaves `mandate.chain` empty rather than carrying its lone leaf — a one-element chain has no adjacent pair to check, so "attenuation holds" would name a check that never ran.

## Checks

21 test suites green, 0 failures. All doc checks pass locally: hub-openapi, sdk-docs, specs-index, feature-inventory `--strict`, vendored-fonts, docs-routes, gen-cli-reference `--check`, feature-matrix `--check`, and the 10 documented-contract snippets.

## After merge

```
git tag -a v0.23.0 -m "Release v0.23.0" && git push --tags
```

This is the release that finally gets `treeship-core` back onto crates.io — it has been stuck at 0.21.0 since the 0.22.0 packaging failure.
