### PR TITLE
grant: stop silently overwriting a grant while reporting a new issue

### DIFF
--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -238,8 +238,21 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
 
     debug_assert!(g.id_is_consistent(), "freshly minted grant must self-verify");
 
+    // Two grants with the same content have the same id -- that is what content
+    // addressing means. `issued_at` is second-precision, so issuing the same
+    // grant twice inside one second derives the same id and the second write
+    // silently replaced the first. Five commands, five success lines, three
+    // grants on disk.
+    //
+    // The honest behaviour is not a fresh id but an accurate report: this grant
+    // already exists, and the caller now holds its id. Overwriting a signed
+    // artifact while claiming to have issued a new one is the "success that did
+    // not happen" this verifier exists to refuse.
     let path = grant_path(&dir, &g.grant_id);
-    std::fs::write(&path, serde_json::to_string_pretty(&g)?)?;
+    let already_existed = path.exists();
+    if !already_existed {
+        std::fs::write(&path, serde_json::to_string_pretty(&g)?)?;
+    }
 
     if printer.format == Format::Json {
         printer.json(&serde_json::json!({
@@ -252,6 +265,10 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
             "parent_grant_id": g.parent_grant_id,
             "max_delegation": g.max_delegation,
             "path": path.display().to_string(),
+            // Machine consumers must be able to tell "I created this" from "this
+            // was already here", or a caller counting successful issuances
+            // overcounts exactly the way the human output used to.
+            "already_existed": already_existed,
         }));
         return Ok(());
     }
@@ -259,7 +276,15 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
     let scope_str = g.scope.join(", ");
     let depth_str = g.delegation_depth.to_string();
     printer.success(
-        &format!("grant issued  {}", g.grant_id),
+        &format!(
+            "{}  {}",
+            if already_existed {
+                "grant already exists"
+            } else {
+                "grant issued"
+            },
+            g.grant_id
+        ),
         &[
             ("scope", &scope_str),
             ("audience", &g.audience),


### PR DESCRIPTION
Five `grant issue` commands, five success lines, **three grants on disk**.

```
✓ grant issued  grn_7d3e2e5c23e757bc
✓ grant issued  grn_8663fdf66092b89d
✓ grant issued  grn_8663fdf66092b89d   ← overwrote the previous file
✓ grant issued  grn_8663fdf66092b89d   ← again
✓ grant issued  grn_8663fdf66092b89d   ← again
```

`issued_at` is second-precision, so grants with otherwise identical content minted inside the same second derive the same content id — correctly; that is what content addressing means — and each write replaced the previous file silently.

Shipped in v0.23.0. Mine.

## The fix is the report, not the id

Two identical grants **are** the same grant under content addressing, so minting one twice should be idempotent. What was wrong was claiming to have issued something new. `issue` now leaves the existing file alone and says `grant already exists`, and `--format json` carries `already_existed` so a caller counting issuances cannot overcount the way the human output did.

```
✓ grant issued         grn_3b13a900de767281
✓ grant already exists grn_3b13a900de767281
✓ grant already exists grn_3b13a900de767281
```

One file. Three honest reports.

Found by testing the same-second case after reading the Moltbook thread on 200-OK-with-a-logical-dead-end failures — a success flag that survives because nothing downstream is positioned to contradict it.