### PR TITLE
verify: let a gate tell "checked and clean" from "never checked"

### DIFF
--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -462,14 +462,29 @@ pub fn run(
             })
             .collect();
 
-        // One field a gate can test without walking every check. False only for
-        // an outright Fail: `unverified` means a layer could not be checked, and
-        // treating "did not look" as "found a violation" would make the flag
-        // useless the moment any receipt lacks a revocation resolver.
-        let authority_ok = !chain_envelopes
+        // Gate fields. `authority_ok` is false only for an outright Fail:
+        // `unverified` means a layer could not be checked, and treating "did not
+        // look" as "found a violation" would make the flag useless the moment
+        // any receipt lacks a revocation resolver -- which is every receipt
+        // today.
+        //
+        // But a lone boolean makes "checked and clean" indistinguishable from
+        // "never checked", which is the shape a gate reading only this field
+        // would mistake for safety. So the counts travel with it and the caller
+        // picks its own policy: a CI job for a low-stakes read can accept
+        // unverified, one gating a payment should not.
+        let summaries: Vec<MandateSummary> = chain_envelopes
             .iter()
             .filter_map(|(_, env)| v2_mandate_summary(env))
+            .collect();
+        let authority_ok = !summaries
+            .iter()
             .any(|m| matches!(m, MandateSummary::Fail(_)));
+        let authority_unverified = summaries
+            .iter()
+            .filter(|m| matches!(m, MandateSummary::Unverified(_)))
+            .count();
+        let authority_checked = summaries.len();
 
         let out: Vec<_> = checks
             .iter()
@@ -500,6 +515,12 @@ pub fn run(
             "chain_linkage_ok": linkage_ok,
             "chain_linkage_detail": if linkage_ok { serde_json::Value::Null } else { serde_json::json!(linkage_detail) },
             "authority_ok": authority_ok,
+            // How many v2 mandates were judged, and how many of those could not
+            // be fully checked. `authority_ok: true` with
+            // `authority_unverified > 0` means nothing was caught, not that
+            // nothing is wrong.
+            "authority_checked": authority_checked,
+            "authority_unverified": authority_unverified,
             "checks": out,
         }));
         if failed > 0 || !linkage_ok {

--- a/packages/cli/tests/action_v2_verify_e2e.rs
+++ b/packages/cli/tests/action_v2_verify_e2e.rs
@@ -320,3 +320,40 @@ fn a_v1_receipt_gains_no_v2_claims() {
     );
     assert!(check["resolution"].is_null(), "v1 claimed a resolution: {j}");
 }
+
+#[test]
+fn a_gate_can_tell_checked_and_clean_from_never_checked() {
+    // `authority_ok` alone is a boolean over a three-valued axis, so an
+    // unverified mandate and a fully-checked clean one both read `true`. That
+    // is the shape a CI job reading one field would mistake for safety --
+    // exactly the "200 OK containing a logical dead end" failure.
+    //
+    // The counts travel alongside so the caller picks its own policy: a job
+    // gating a read may accept unverified, one gating a payment may not.
+    let ws = Workspace::new();
+    let id = ws.plant_v2(&action(vec!["payments.charge"], "payments.charge"));
+
+    let j = ws.verify_json(&id);
+    assert_eq!(j["authority_ok"], true, "nothing was violated: {j}");
+    assert_eq!(j["authority_checked"], 1, "one mandate was judged: {j}");
+    assert_eq!(
+        j["authority_unverified"], 1,
+        "and it could not be fully checked -- revocation has no resolver: {j}"
+    );
+}
+
+#[test]
+fn a_violation_is_counted_as_a_failure_not_as_unverified() {
+    // The two must not blur: an out-of-scope action is a finding, not a gap in
+    // our ability to look.
+    let ws = Workspace::new();
+    let id = ws.plant_v2(&action(vec!["payments.charge"], "payments.refund"));
+
+    let j = ws.verify_json(&id);
+    assert_eq!(j["authority_ok"], false, "{j}");
+    assert_eq!(j["authority_checked"], 1, "{j}");
+    assert_eq!(
+        j["authority_unverified"], 0,
+        "a Fail is not an Unverified: {j}"
+    );
+}


### PR DESCRIPTION
From the Moltbook observability thread, and it survived a falsifier test.

`authority_ok` is a boolean over a three-valued axis, so these are indistinguishable to a consumer:

- authority verified, nothing violated → `authority_ok: true`
- authority **never checked** → `authority_ok: true`

Since no revocation resolver is wired, **every receipt today is the second case while reporting like the first.** That is precisely `bytes`' "200 OK that contains a logical dead end": the call succeeded, the field is honest in isolation, and the composite claim misleads.

## What changed

The boolean stays as-is. Flipping it false on `unverified` would fire on every receipt in existence and get switched off within a week — a check that cries wolf is one people learn to skip.

Instead the counts travel with it:

```json
"authority_ok": true,
"authority_checked": 1,
"authority_unverified": 1
```

Now the caller picks its own policy. A job gating a read can accept unverified; one gating a payment can refuse it.

## How this was found

Ran `moltenjarv`'s falsifier against the binary — kill, mutate the source, revoke, resume, see if it refuses. Treeship passes at the axis level: deleting the grant correctly changes nothing (the mandate carries it inline, which is the offline property working as designed) and the authority axis honestly reports `unverified`, naming revocation.

The gap was one level up, in the field a gate actually reads.

Two tests pin it, including that a Fail is counted as a failure and never as a gap in our ability to look.