### PR TITLE
grant: bind a grant to the key entitled to spend it

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -953,6 +953,8 @@ treeship grant issue [OPTIONS] --scope <SCOPE> --audience <AUDIENCE> --expiry <E
 | `--parent <PARENT>` | Delegate from this grant id, narrowing its authority |
 | `--max-delegation <MAX_DELEGATION>` | How many further delegations this grant permits beneath it [default: 3] |
 | `--objective-hash <OBJECTIVE_HASH>` | Optional hash binding the grant to a stated objective |
+| `--grantee <GRANTEE>` | Public key (base64url, no padding) entitled to exercise this grant. Without it the grant is a bearer token: anyone holding the file can spend it |
+| `--grantee-self` | Bind the grant to this workspace's own key. The safe default for a self-grant, without pasting your own public key |
 
 ### `treeship grant list`
 

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
 use serde_json::Value;
 use treeship_core::{
     attestation::{sign, Signer},
@@ -358,6 +360,7 @@ fn action_v2(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std:
         args.grant_file.as_deref(),
     )?;
 
+
     let revocation_path = args
         .revocation_path
         .clone()
@@ -381,6 +384,28 @@ fn action_v2(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std:
     stmt.meta = meta;
 
     let signer = resolve_actor_signer(&ctx, &args.actor)?;
+
+    // Refuse to spend a grant issued to somebody else. A grant file is only
+    // bytes: copying one into another workspace was enough to emit a receipt
+    // claiming its authority, because `grantor` says who issued it and
+    // `audience` says which system it acts against, and nothing said who was
+    // allowed to use it. Verify reports this too, but the artifact should never
+    // exist -- an invalid claim that exists is one somebody is eventually asked
+    // to trust.
+    let own_key =
+        URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+    if !leaf.exercisable_by(&own_key) {
+        return Err(format!(
+            "refusing to attest: grant {} was issued to a different key\n  \
+             grantee:        {}\n  this workspace: {}\n  \
+             a grant stops being a bearer token once it names its holder",
+            leaf.grant_id,
+            leaf.grantee.as_deref().unwrap_or("(none)"),
+            own_key,
+        )
+        .into());
+    }
+
     let pt = payload_type_v2("action");
     let result = sign(&pt, &stmt, signer.as_ref())?;
 
@@ -496,6 +521,9 @@ fn mandate_from_grant(leaf: &Grant, chain: Vec<Grant>, revocation_path: &str) ->
     Mandate {
         grant_id: leaf.grant_id.clone(),
         grantor: leaf.grantor.clone(),
+        // Mirrored so a verifier can check the receipt's signer against the key
+        // the grant was issued to without resolving the whole chain.
+        grantee: leaf.grantee.clone(),
         issuer_sig: leaf.issuer_sig.clone(),
         objective_hash: leaf.objective_hash.clone(),
         scope: leaf.scope.clone(),

--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -92,6 +92,13 @@ pub struct IssueArgs {
     pub parent: Option<String>,
     pub max_delegation: u32,
     pub objective_hash: Option<String>,
+    /// Public key entitled to exercise the grant. `None` mints a bearer grant,
+    /// which `issue` warns about rather than silently producing.
+    pub grantee: Option<String>,
+    /// Bind the grant to the issuing workspace's own key. Convenience for the
+    /// common self-grant case, so the safe path does not require pasting your
+    /// own public key.
+    pub grantee_self: bool,
     pub config: Option<String>,
 }
 
@@ -191,9 +198,20 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
         .unwrap_or(0);
     let issued_at = format_rfc3339(now);
 
+    let own_key = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+    if args.grantee.is_some() && args.grantee_self {
+        return Err("--grantee and --grantee-self are mutually exclusive".into());
+    }
+    let grantee = match (&args.grantee, args.grantee_self) {
+        (Some(k), _) => Some(k.clone()),
+        (None, true) => Some(own_key.clone()),
+        (None, false) => None,
+    };
+
     let mut g = Grant {
         grant_id: String::new(),
-        grantor: URL_SAFE_NO_PAD.encode(signer.public_key_bytes()),
+        grantor: own_key.clone(),
+        grantee,
         issuer_sig: None,
         scope: args.scope.clone(),
         audience: args.audience.clone(),
@@ -292,6 +310,18 @@ pub fn issue(args: IssueArgs, printer: &Printer) -> Result<(), Box<dyn std::erro
             ("depth", &depth_str),
         ],
     );
+    // A bearer grant is a legitimate mode, not an error -- but it is spendable
+    // by anyone who obtains the file, and that has to be said out loud at the
+    // moment it is created rather than discovered when someone else uses it.
+    if !g.binds_holder() {
+        printer.warn(
+            "bearer grant: anyone holding this file can exercise it",
+            &[(
+                "bind it",
+                "re-issue with --grantee-self, or --grantee <public-key>",
+            )],
+        );
+    }
     printer.hint(&format!(
         "treeship grant issue --parent {} --scope <narrower>",
         g.grant_id
@@ -453,6 +483,7 @@ mod tests {
         Grant {
             grant_id: "grn_test".into(),
             grantor: "k".into(),
+            grantee: None,
             issuer_sig: None,
             scope: scope.iter().map(|s| s.to_string()).collect(),
             audience: audience.into(),

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -1957,6 +1957,7 @@ mod tests {
         let mandate = Mandate {
             grant_id: "grant_1".into(),
             grantor: "key_parent".into(),
+            grantee: None,
             issuer_sig: None,
             objective_hash: Some("sha256:abc".into()),
             scope: vec!["payments.charge".into()],
@@ -2239,6 +2240,7 @@ mod tests {
         let mandate = |scope: Vec<String>| Mandate {
             grant_id: "grant_1".into(),
             grantor: "key_parent".into(),
+            grantee: None,
             issuer_sig: None,
             objective_hash: None,
             scope,
@@ -2313,6 +2315,7 @@ mod tests {
             let mut g = Grant {
                 grant_id: String::new(),
                 grantor: pk.clone(),
+                grantee: None,
                 issuer_sig: None,
                 scope: scope.into_iter().map(String::from).collect(),
                 audience: "acme".into(),
@@ -2332,6 +2335,7 @@ mod tests {
         let mandate_for = |leaf: &Grant, chain: Vec<Grant>| Mandate {
             grant_id: leaf.grant_id.clone(),
             grantor: pk.clone(),
+            grantee: None,
             issuer_sig: leaf.issuer_sig.clone(),
             objective_hash: None,
             scope: leaf.scope.clone(),
@@ -2472,6 +2476,7 @@ mod tests {
         let mandate = Mandate {
             grant_id: "grant_1".into(),
             grantor: "key_parent".into(),
+            grantee: None,
             issuer_sig: None,
             objective_hash: None,
             scope: vec!["payments.charge".into()],

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -159,16 +159,67 @@ fn v2_effect_verdict(env: &Envelope) -> Option<EffectVerdict> {
 /// wires no revocation resolver yet, so that layer resolves Unknown and the
 /// verdict degrades to Unverified -- claiming a grant is live because we never
 /// looked would be exactly the false pass this verifier exists to refuse.
-fn v2_mandate_summary(env: &Envelope) -> Option<MandateSummary> {
+fn v2_mandate_summary(env: &Envelope, verifier: Option<&Verifier>) -> Option<MandateSummary> {
     if env.payload_type != payload_type_v2("action") {
         return None;
     }
     let stmt = env.unmarshal_statement::<ActionStatementV2>().ok()?;
-    Some(match verify_mandate(&stmt, &NoRevocationSource) {
+    let mut verdict = match verify_mandate(&stmt, &NoRevocationSource) {
         MandateVerdict::Pass => MandateSummary::Pass,
         MandateVerdict::Unverified(r) => MandateSummary::Unverified(r),
         MandateVerdict::Fail(r) => MandateSummary::Fail(r),
-    })
+    };
+
+    // Holder binding needs something `verify_mandate` cannot see: the key that
+    // actually signed this envelope. The statement names who was entitled to
+    // act; only the envelope says who did.
+    if let Some(expected) = stmt.mandate.grantee.as_deref().filter(|g| !g.is_empty()) {
+        match signer_pubkey_b64(env, verifier) {
+            Some(actual) if actual == expected => {}
+            Some(actual) => {
+                // A receipt signed by a key the grant did not name. Both
+                // signatures can be genuine and this still be someone spending
+                // authority that was never issued to them.
+                let reason = format!(
+                    "receipt was signed by {actual} but the grant names {expected} as its holder"
+                );
+                verdict = match verdict {
+                    MandateSummary::Fail(mut r) => {
+                        r.push(reason);
+                        MandateSummary::Fail(r)
+                    }
+                    _ => MandateSummary::Fail(vec![reason]),
+                };
+            }
+            None => {
+                // The signing key is not resolvable here, so entitlement is a
+                // layer we could not check -- reported, never assumed clear.
+                let reason =
+                    "grant names a holder, but the signing key could not be resolved to compare"
+                        .to_string();
+                verdict = match verdict {
+                    MandateSummary::Fail(r) => MandateSummary::Fail(r),
+                    MandateSummary::Unverified(mut r) => {
+                        r.push(reason);
+                        MandateSummary::Unverified(r)
+                    }
+                    MandateSummary::Pass => MandateSummary::Unverified(vec![reason]),
+                };
+            }
+        }
+    }
+    Some(verdict)
+}
+
+/// Base64url-no-pad public key of whoever signed `env`, resolved through the
+/// verifier's trusted key map. `None` when there is no verifier, no signature,
+/// or the key id is not one we hold.
+fn signer_pubkey_b64(env: &Envelope, verifier: Option<&Verifier>) -> Option<String> {
+    let v = verifier?;
+    let keyid = env.signatures.first()?.keyid.as_str();
+    let key = v.public_key(keyid)?;
+    use base64::Engine as _;
+    Some(base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key.to_bytes()))
 }
 
 /// Resolve and judge the delegation chain behind a v2 action's mandate.
@@ -438,7 +489,7 @@ pub fn run(
         let authority_by_id: HashMap<String, serde_json::Value> = chain_envelopes
             .iter()
             .filter_map(|(id, env)| {
-                v2_mandate_summary(env).map(|m| (id.clone(), mandate_summary_json(&m)))
+                v2_mandate_summary(env, Some(&verifier)).map(|m| (id.clone(), mandate_summary_json(&m)))
             })
             .collect();
         let delegation_by_id: HashMap<String, serde_json::Value> = chain_envelopes
@@ -475,7 +526,7 @@ pub fn run(
         // unverified, one gating a payment should not.
         let summaries: Vec<MandateSummary> = chain_envelopes
             .iter()
-            .filter_map(|(_, env)| v2_mandate_summary(env))
+            .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier)))
             .collect();
         let authority_ok = !summaries
             .iter()
@@ -535,6 +586,7 @@ pub fn run(
             &chain_envelopes,
             &checks,
             &ctx.storage,
+            &verifier,
             printer,
             target,
             linkage_ok,
@@ -721,6 +773,7 @@ fn print_full_timeline(
     chain: &[(String, Envelope)],
     checks: &[ArtifactCheck],
     storage: &Store,
+    verifier: &Verifier,
     printer: &Printer,
     target: &str,
     linkage_ok: bool,
@@ -736,7 +789,7 @@ fn print_full_timeline(
     let steps: Vec<StepInfo> = chain
         .iter()
         .enumerate()
-        .map(|(i, (id, env))| extract_step_info(i + 1, id, env, storage))
+        .map(|(i, (id, env))| extract_step_info(i + 1, id, env, storage, Some(verifier)))
         .collect();
 
     // Header
@@ -1231,7 +1284,13 @@ fn determine_connector(
     "\u{2193} chained".to_string()
 }
 
-fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) -> StepInfo {
+fn extract_step_info(
+    index: usize,
+    id: &str,
+    env: &Envelope,
+    storage: &Store,
+    verifier: Option<&Verifier>,
+) -> StepInfo {
     let mut info = StepInfo {
         index,
         id: id.to_string(),
@@ -1281,7 +1340,7 @@ fn extract_step_info(index: usize, id: &str, env: &Envelope, storage: &Store) ->
                 info.runtime_model = rt.model.clone();
             }
             // Surface the effect line only when there is an effect to judge.
-            info.mandate_verdict = v2_mandate_summary(env);
+            info.mandate_verdict = v2_mandate_summary(env, verifier);
             info.chain_summary = v2_chain_summary(env);
             if let Some(verdict) = v2_effect_verdict(env) {
                 info.effect_effective = Some(verdict.effective_confidence);
@@ -1990,7 +2049,7 @@ mod tests {
         // effect verdict rather than silently taking the v1 branch.
         let dir = std::env::temp_dir().join("ts_verify_v2_effect_test");
         let store = Store::open(&dir).unwrap();
-        let info = extract_step_info(0, "art_test", &env, &store);
+        let info = extract_step_info(0, "art_test", &env, &store, None);
 
         assert_eq!(info.actor, "agent://worker");
         assert_eq!(
@@ -2266,7 +2325,7 @@ mod tests {
         ok.timestamp = "2026-07-20T10:30:00Z".into();
         ok.audience = Some("acme".into());
         let ok_env = sign(&payload_type_v2("action"), &ok, &signer).unwrap().envelope;
-        let info = extract_step_info(0, "art_ok", &ok_env, &store);
+        let info = extract_step_info(0, "art_ok", &ok_env, &store, None);
         match info.mandate_verdict {
             Some(MandateSummary::Unverified(ref r)) => {
                 assert!(!r.is_empty(), "unverified must name the layer it could not check");
@@ -2280,7 +2339,7 @@ mod tests {
         bad.timestamp = "2026-07-20T10:30:00Z".into();
         bad.audience = Some("acme".into());
         let bad_env = sign(&payload_type_v2("action"), &bad, &signer).unwrap().envelope;
-        let bad_info = extract_step_info(1, "art_bad", &bad_env, &store);
+        let bad_info = extract_step_info(1, "art_bad", &bad_env, &store, None);
         match bad_info.mandate_verdict {
             Some(MandateSummary::Fail(ref r)) => {
                 assert!(r.iter().any(|x| x.contains("scope")), "reason should name scope: {r:?}");
@@ -2294,7 +2353,7 @@ mod tests {
             .unwrap()
             .envelope;
         assert!(
-            v2_mandate_summary(&v1_env).is_none(),
+            v2_mandate_summary(&v1_env, None).is_none(),
             "v1 receipts must not claim anything about authority"
         );
     }
@@ -2509,7 +2568,7 @@ mod tests {
             .unwrap()
             .envelope;
 
-        let info = extract_step_info(0, "art_pending", &env, &store);
+        let info = extract_step_info(0, "art_pending", &env, &store, None);
         assert_eq!(
             info.effect_finality,
             Some(EffectFinality::Initiated),

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1241,6 +1241,15 @@ enum GrantCommand {
         /// Optional hash binding the grant to a stated objective.
         #[arg(long)]
         objective_hash: Option<String>,
+        /// Public key (base64url, no padding) entitled to exercise this grant.
+        /// Without it the grant is a bearer token: anyone holding the file can
+        /// spend it.
+        #[arg(long)]
+        grantee: Option<String>,
+        /// Bind the grant to this workspace's own key. The safe default for a
+        /// self-grant, without pasting your own public key.
+        #[arg(long)]
+        grantee_self: bool,
     },
     /// List every grant minted in this workspace.
     List,
@@ -2872,6 +2881,8 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 parent,
                 max_delegation,
                 objective_hash,
+                grantee,
+                grantee_self,
             } => commands::grant::issue(
                 commands::grant::IssueArgs {
                     scope: scope.clone(),
@@ -2880,6 +2891,8 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     parent: parent.clone(),
                     max_delegation: *max_delegation,
                     objective_hash: objective_hash.clone(),
+                    grantee: grantee.clone(),
+                    grantee_self: *grantee_self,
                     config: cli.config.clone(),
                 },
                 printer,

--- a/packages/cli/tests/action_v2_emit_e2e.rs
+++ b/packages/cli/tests/action_v2_emit_e2e.rs
@@ -59,6 +59,9 @@ impl Workspace {
         let mut g = Grant {
             grant_id: String::new(),
             grantor: URL_SAFE_NO_PAD.encode(signer.public_key_bytes()),
+            // Bound to the same key that signs the receipts in this suite, so
+            // these fixtures exercise the holder-bound path rather than bearer.
+            grantee: Some(URL_SAFE_NO_PAD.encode(signer.public_key_bytes())),
             issuer_sig: None,
             scope: scope.iter().map(|s| (*s).to_string()).collect(),
             audience: audience.into(),

--- a/packages/cli/tests/action_v2_verify_e2e.rs
+++ b/packages/cli/tests/action_v2_verify_e2e.rs
@@ -64,6 +64,15 @@ impl Workspace {
         self.root.join(".treeship/artifacts")
     }
 
+    /// This workspace's default public key, base64url-no-pad — the form a
+    /// grant's `grantee` uses.
+    fn public_key_b64(&self) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        let keys = KeyStore::open(self.keys_dir()).expect("open keystore");
+        let signer = keys.default_signer().expect("default key");
+        URL_SAFE_NO_PAD.encode(signer.public_key_bytes())
+    }
+
     /// Sign `stmt` with the workspace's default key and write it to the store,
     /// returning the artifact id `verify` will be pointed at.
     fn plant_v2(&self, stmt: &ActionStatementV2) -> String {
@@ -356,5 +365,54 @@ fn a_violation_is_counted_as_a_failure_not_as_unverified() {
     assert_eq!(
         j["authority_unverified"], 0,
         "a Fail is not an Unverified: {j}"
+    );
+}
+
+#[test]
+fn a_receipt_signed_by_a_key_the_grant_did_not_name_fails_authority() {
+    // `attest` refuses to build this, so the only way it exists is if someone
+    // constructed it outside our CLI -- which is exactly the case a verifier
+    // has to survive. Both signatures are genuine; the receipt is still
+    // somebody spending authority that was never issued to them.
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.mandate.grantee = Some("a-key-that-is-not-this-workspace".into());
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    let auth = &j["checks"][0]["authority"];
+    assert_eq!(
+        auth["outcome"], "fail",
+        "a receipt signed by a non-grantee must fail authority: {j}"
+    );
+    assert!(
+        auth["reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|r| r.as_str().unwrap_or_default().contains("holder")),
+        "the reason must name the holder mismatch: {j}"
+    );
+    assert_eq!(j["authority_ok"], false, "{j}");
+}
+
+#[test]
+fn a_receipt_signed_by_the_named_grantee_clears_the_holder_layer() {
+    // Same shape, but the grant names the key that signs. Only revocation
+    // should remain unverified.
+    let ws = Workspace::new();
+    let mut stmt = action(vec!["payments.charge"], "payments.charge");
+    stmt.mandate.grantee = Some(ws.public_key_b64());
+    let id = ws.plant_v2(&stmt);
+
+    let j = ws.verify_json(&id);
+    let auth = &j["checks"][0]["authority"];
+    assert_eq!(auth["outcome"], "unverified", "{j}");
+    let reasons = auth["reasons"].as_array().unwrap();
+    assert!(
+        reasons
+            .iter()
+            .all(|r| !r.as_str().unwrap_or_default().contains("holder")),
+        "the holder layer must be clear: {j}"
     );
 }

--- a/packages/cli/tests/action_v2_verify_e2e.rs
+++ b/packages/cli/tests/action_v2_verify_e2e.rs
@@ -104,6 +104,7 @@ fn mandate(scope: Vec<&str>) -> Mandate {
     Mandate {
         grant_id: "grant_e2e".into(),
         grantor: "key_parent".into(),
+        grantee: None,
         issuer_sig: None,
         objective_hash: None,
         scope: scope.into_iter().map(String::from).collect(),

--- a/packages/core/src/attestation/verify.rs
+++ b/packages/core/src/attestation/verify.rs
@@ -81,6 +81,16 @@ impl Verifier {
         self.keys.insert(key_id.into(), pub_key);
     }
 
+    /// The trusted public key registered under `key_id`, if any.
+    ///
+    /// Exposed so a caller can answer questions the signature check does not:
+    /// a valid signature proves *some* trusted key signed the envelope, not
+    /// that it was the key a mandate names as entitled to act. Comparing those
+    /// two needs the bytes behind the id.
+    pub fn public_key(&self, key_id: &str) -> Option<&VerifyingKey> {
+        self.keys.get(key_id)
+    }
+
     /// Verifies all signatures in the envelope.
     ///
     /// Returns `Ok(VerifyResult)` only if **every** signature in the envelope

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -135,6 +135,16 @@ pub struct Mandate {
     /// Revocation source + (optional) revoked-at timestamp.
     pub revocation: Revocation,
 
+    /// Base64url-no-pad Ed25519 public key the grant was issued to, mirrored
+    /// from `Grant::grantee` so a verifier can check the receipt's signer
+    /// against it without resolving the chain.
+    ///
+    /// `None` means the grant was bearer. A verifier must report that rather
+    /// than pass silently: a valid signature proves who signed the receipt and
+    /// who issued the grant, never that the two are related.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grantee: Option<String>,
+
     /// Ancestors of this grant, root-first, each carrying its own
     /// `issuer_sig`. Optional and skipped when empty so existing v2 receipts
     /// keep byte-identical canonical bytes.
@@ -766,6 +776,22 @@ pub fn verify_mandate(
         }
     }
 
+    // -- holder binding. A mandate with no `grantee` came from a bearer grant:
+    // authentic, in scope, in window, and spendable by anyone who obtained the
+    // grant bytes. The signature proves who issued the grant and who signed
+    // this receipt; it never proves the two were related.
+    //
+    // Unverified rather than Fail: bearer is a legitimate mode, and the honest
+    // report is that entitlement is a layer we could not check, not that a
+    // violation was found. Silence here would let "correctly signed" read as
+    // "the right party did this".
+    if m.grantee.as_deref().unwrap_or("").is_empty() {
+        unver.push(
+            "grant names no grantee (bearer): any holder of the grant could have produced this"
+                .into(),
+        );
+    }
+
     if !fail.is_empty() {
         MandateVerdict::Fail(fail)
     } else if !unver.is_empty() {
@@ -976,6 +1002,21 @@ pub struct Grant {
     /// exact parent, not a reference to a name someone else could also claim.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_grant_id: Option<String>,
+
+    /// Base64url-no-pad Ed25519 public key of the agent entitled to exercise
+    /// this grant. Signed, so a holder cannot rebind it to themselves.
+    ///
+    /// `None` makes the grant a **bearer credential**: whoever holds the bytes
+    /// holds the authority. That was the only mode before this field existed,
+    /// and it is why a grant file copied into another workspace let a different
+    /// key emit a receipt claiming its authority with nothing to object --
+    /// `grantor` says who issued it and `audience` says which system it acts
+    /// against, but nothing said who was allowed to spend it.
+    ///
+    /// Verification treats absence as a disclosed weakness, not a pass: see
+    /// [`Grant::binds_holder`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grantee: Option<String>,
 }
 
 impl Grant {
@@ -990,19 +1031,45 @@ impl Grant {
         // `derive_grant_id`), so including it would be circular -- and it
         // matches how artifact ids work elsewhere: derived from the signed
         // bytes, never stored inside them.
+        // v3 adds `grantee`. It has to be inside the signed bytes: a holder who
+        // could add or strip it would be choosing who the grant is for, which
+        // is the grantor's decision alone. Bumping the version rather than
+        // appending silently means a v2 line can never be read as a v3 line
+        // with an empty grantee.
         format!(
-            "v2|grant|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            "v3|grant|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
             self.grantor,
             scope_digest,
             self.audience,
             self.parent_request_id.as_deref().unwrap_or(""),
             self.parent_grant_id.as_deref().unwrap_or(""),
+            self.grantee.as_deref().unwrap_or(""),
             self.delegation_depth,
             self.issued_at,
             self.expiry,
             self.max_delegation,
             self.objective_hash.as_deref().unwrap_or(""),
         )
+    }
+
+    /// Whether this grant names the key allowed to exercise it.
+    ///
+    /// `false` means bearer: authentic, verifiable, and spendable by anyone who
+    /// obtains the bytes. Callers must surface that rather than treat a valid
+    /// signature as sufficient -- the signature proves who *issued* the grant,
+    /// never who is entitled to use it.
+    pub fn binds_holder(&self) -> bool {
+        self.grantee.as_deref().is_some_and(|g| !g.is_empty())
+    }
+
+    /// Whether `holder_pubkey` (base64url-no-pad Ed25519) may exercise this
+    /// grant. A bearer grant returns `true` for every key, which is exactly the
+    /// property [`Grant::binds_holder`] exists to let callers warn about.
+    pub fn exercisable_by(&self, holder_pubkey: &str) -> bool {
+        match self.grantee.as_deref() {
+            Some(g) if !g.is_empty() => g == holder_pubkey,
+            _ => true,
+        }
     }
 
     /// The grant's content id: `grn_` + first 16 hex of sha256 over the
@@ -1829,6 +1896,10 @@ mod tests {
         Mandate {
             grant_id: "grant_9c2f".into(),
             grantor: "key_parent".into(),
+            // Bound, so tests of the scope / audience / window / revocation
+            // layers are not perpetually Unverified on the holder layer. The
+            // bearer case has its own test.
+            grantee: Some("key_holder".into()),
             issuer_sig: None,
             objective_hash: Some("sha256:abc".into()),
             scope: vec!["payments.charge".into()],
@@ -2098,6 +2169,60 @@ mod tests {
         );
     }
 
+    // ---- holder binding ----
+
+    #[test]
+    fn a_bearer_mandate_is_reported_not_passed() {
+        // No grantee means anyone holding the grant bytes could have produced
+        // this receipt. The signature proves who issued the grant and who
+        // signed the receipt; it never proves the two were related.
+        let mut s = good_stmt();
+        s.mandate.grantee = None;
+        match verify_mandate(&s, &StaticRevocation(RevocationStatus::NotRevoked)) {
+            MandateVerdict::Unverified(r) => assert!(
+                r.iter().any(|x| x.contains("bearer")),
+                "the reason must name it: {r:?}"
+            ),
+            other => panic!("bearer must not pass silently, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_bound_mandate_clears_the_holder_layer() {
+        let s = good_stmt();
+        assert_eq!(
+            verify_mandate(&s, &StaticRevocation(RevocationStatus::NotRevoked)),
+            MandateVerdict::Pass
+        );
+    }
+
+    #[test]
+    fn exercisable_by_is_exact_and_bearer_admits_everyone() {
+        let mut g = grant("g", "k", &["a"], 0, "2026-07-11T21:00:00Z", 3);
+        g.grantee = Some("holder-key".into());
+        assert!(g.binds_holder());
+        assert!(g.exercisable_by("holder-key"));
+        assert!(!g.exercisable_by("someone-else"));
+
+        // Bearer: true for every key, which is exactly what `binds_holder`
+        // exists to let a caller warn about.
+        g.grantee = None;
+        assert!(!g.binds_holder());
+        assert!(g.exercisable_by("anyone-at-all"));
+    }
+
+    #[test]
+    fn grantee_is_covered_by_the_signed_bytes() {
+        // A holder who could add or strip the grantee would be choosing who the
+        // grant is for -- the grantor's decision alone.
+        let mut a = grant("g", "k", &["a"], 0, "2026-07-11T21:00:00Z", 3);
+        let mut b = a.clone();
+        a.grantee = Some("alice".into());
+        b.grantee = Some("bob".into());
+        assert_ne!(a.canonical_for_signing(), b.canonical_for_signing());
+        assert_ne!(a.derive_grant_id(), b.derive_grant_id());
+    }
+
     // ---- grant object + chain attenuation ----
 
     fn grant(
@@ -2111,6 +2236,7 @@ mod tests {
         Grant {
             grant_id: id.into(),
             grantor: grantor.into(),
+            grantee: None,
             issuer_sig: None,
             scope: scope.iter().map(|s| (*s).into()).collect(),
             audience: "acme-payments-api".into(),
@@ -2300,6 +2426,7 @@ mod tests {
         let mut g = Grant {
             grant_id: String::new(),
             grantor: grantor_pk.to_string(),
+            grantee: None,
             issuer_sig: None,
             scope: scope.into_iter().map(String::from).collect(),
             audience: "acme".into(),


### PR DESCRIPTION
Grants were **bearer credentials**. `grantor` says who issued one, `audience` says which system it acts against — nothing said who was allowed to *use* it.

## Demonstrated

Two isolated workspaces. A mints a grant; B copies the file; B — different key, different actor — emits a receipt claiming A's authority:

```
$ HOME=/tmp/wsB treeship attest action --v2 --actor agent://attacker \
    --action payments.charge --grant grn_9606f6a9ca4bbb11
✓ action/v2 attested

$ HOME=/tmp/wsB treeship verify last --format json
  outcome  : pass
  authority: unverified ["revocation could not be checked: …"]
```

Both signatures are genuine. Nothing binds them, so nothing objects.

## Fix

`Grant::grantee` and `Mandate::grantee` — the base64url Ed25519 key allowed to exercise the grant, **inside the signed bytes**. It has to be signed: a holder who could add or strip it would be choosing who the grant is for, which is the grantor's decision alone. Canonical bumps to **v3** rather than appending silently, so a v2 line can never be read as a v3 line with an empty grantee.

Three places now behave:

| Where | Behaviour |
|---|---|
| `grant issue` | `--grantee <key>` / `--grantee-self` binds at mint. Unbound still works and warns, naming what bearer means |
| `attest action --v2` | **Refuses** a grant issued to another key |
| `verify_mandate` | Reports a bearer mandate as `Unverified` naming the holder layer — not `Pass`, and not `Fail`, because bearer is allowed and the honest statement is that entitlement could not be checked |

After:

```
✗ refusing to attest: grant grn_3a74a0fdf6371676 was issued to a different key
  grantee:        grFDRdzr2e8vZNHsfi9gemnxy8E9aDajWltGhbKUQD0
  this workspace: TuIJYuZswNFjY65HvuL__55H_UQ68seWY_l8fuXnSWI
```

## On the three tests that changed

Three existing tests asserted `Pass` on bearer fixtures. They exercise the audience, window, and revocation layers — so their **fixtures** are now bound rather than their assertions loosened. Four new tests cover the holder layer directly, including that `grantee` moves the canonical and therefore the derived id.

21 suites green, 0 failures. Command matrix regenerated.

## Provenance

From the Moltbook checkpoint thread — `foundryledger`'s *"a witness statement doesn't verify who's reading it aloud"*, which is Hardy's 1988 confused deputy with the grant as the ambient authority. `woodbot` cited the same paper two replies later.

Worth noting what this is **not**: verify still cannot compare the receipt's signing key to `grantee`, because the envelope carries a keyid and resolving it needs the keystore plumbed through `v2_mandate_summary`. That is the natural follow-up. Today the enforcement is at mint and the disclosure is at verify.