### PR TITLE
receipt: show what each action was authorized to do

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1330,7 +1330,18 @@ pub fn close(
     receipt_manifest.closed_at = Some(now_rfc3339());
     receipt_manifest.summary = summary.clone();
 
+    // Stash before the move: the authority pass needs to re-read each v2
+    // envelope out of storage, which the composer cannot do.
     let mut receipt = ReceiptComposer::compose(&receipt_manifest, &events, artifact_entries);
+
+    // Resolution is time-dependent, so the clock is read once for the whole
+    // section rather than per action -- two effects in one session judged
+    // against different "now"s would be a worse report than none.
+    let now_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    receipt.authority = collect_authority(&ctx, &receipt_manifest, now_unix);
 
     // Stamp the in-band incompleteness signal. Defaults to 0 (omitted
     // from canonical JSON via skip_serializing_if) so receipts produced
@@ -2040,6 +2051,7 @@ pub fn report(
             None,
             None,
             None,
+            None,
             &resolved_id,
             &receipt_digest,
             package_digest.as_deref(),
@@ -2064,6 +2076,7 @@ pub fn report(
             if format == "json" {
                 return emit_report_output(
                     format,
+                    None,
                     None,
                     None,
                     None,
@@ -2100,6 +2113,7 @@ pub fn report(
             if format == "json" {
                 return emit_report_output(
                     format,
+                    None,
                     None,
                     None,
                     None,
@@ -2150,6 +2164,7 @@ pub fn report(
                     None,
                     None,
                     None,
+                    None,
                     &resolved_id,
                     &receipt_digest,
                     package_digest.as_deref(),
@@ -2166,6 +2181,7 @@ pub fn report(
             if format == "json" {
                 return emit_report_output(
                     format,
+                    None,
                     None,
                     None,
                     None,
@@ -2193,12 +2209,14 @@ pub fn report(
     // Derive the raw JSON URL and package download URL from the
     // receipt URL's origin. The marketing site routes them at known
     // paths (PR 2 / PR 3 of this same release).
-    let (raw_json_url, package_download_url) = derive_share_urls(&receipt_url, &resolved_id);
+    let (raw_json_url, paper_preview_url, package_download_url) =
+        derive_share_urls(&receipt_url, &resolved_id);
 
     emit_report_output(
         format,
         Some(&receipt_url),
         Some(&raw_json_url),
+        Some(&paper_preview_url),
         Some(&package_download_url),
         &resolved_id,
         &receipt_digest,
@@ -2211,9 +2229,10 @@ pub fn report(
     )
 }
 
-/// Derive `raw_json_url` and `package_download_url` from a hub-issued
-/// `receipt_url`. The convention: the marketing site serves
+/// Derive share URLs from a hub-issued `receipt_url`. The convention:
+/// the marketing site serves
 ///   /receipt/<id>             (the SSR page)
+///   /receipt/<id>/preview     (packaged paper preview.html)
 ///   /api/receipt/<id>         (raw JSON proxy of the hub receipt)
 ///   /api/receipt/<id>/agent   (agent-native curated JSON)
 ///   /receipt/<id>/package     (downloadable .treeship.tar.gz)
@@ -2221,15 +2240,16 @@ pub fn report(
 /// Stripping `/receipt/<id>` from the receipt_url gives us the origin;
 /// we attach the canonical paths from there. Falls back to
 /// www.treeship.dev when the receipt_url's origin can't be parsed.
-fn derive_share_urls(receipt_url: &str, session_id: &str) -> (String, String) {
+fn derive_share_urls(receipt_url: &str, session_id: &str) -> (String, String, String) {
     // Find "/receipt/" in the URL and split there.
     let origin = match receipt_url.find("/receipt/") {
         Some(idx) => &receipt_url[..idx],
         None => "https://www.treeship.dev",
     };
     let raw = format!("{origin}/api/receipt/{session_id}");
+    let preview = format!("{origin}/receipt/{session_id}/preview");
     let pkg = format!("{origin}/receipt/{session_id}/package");
-    (raw, pkg)
+    (raw, preview, pkg)
 }
 
 /// Compute a content-addressed manifest digest for a package
@@ -2343,6 +2363,7 @@ fn emit_report_output(
     format: &str,
     receipt_url: Option<&str>,
     raw_json_url: Option<&str>,
+    paper_preview_url: Option<&str>,
     package_download_url: Option<&str>,
     session_id: &str,
     receipt_digest: &str,
@@ -2362,6 +2383,7 @@ fn emit_report_output(
             "schema":               "treeship/share-result/v1",
             "session_id":           session_id,
             "receipt_url":          receipt_url,
+            "paper_preview_url":    paper_preview_url,
             "raw_json_url":         raw_json_url,
             "package_download_url": package_download_url,
             "receipt_digest":       receipt_digest,
@@ -2386,6 +2408,9 @@ fn emit_report_output(
         printer.blank();
         if let Some(url) = receipt_url {
             printer.info(&format!("  receipt:  {url}"));
+        }
+        if let Some(url) = paper_preview_url {
+            printer.info(&format!("  preview:  {url}"));
         }
         if let Some(url) = raw_json_url {
             printer.info(&format!("  raw json: {url}"));
@@ -2748,5 +2773,156 @@ mod work_history_tests {
         assert_eq!(selfish["tools_exercised"], serde_json::json!([]));
         treeship_core::predicates::validate("session.v1", Some(&selfish))
             .expect("bare-session record must also conform");
+    }
+}
+
+// ── Authority section ────────────────────────────────────────────────
+//
+// The composer sees manifest + events + artifact metadata. It cannot open an
+// envelope or run a verifier, so the authority story -- what each action was
+// allowed to do and whether it stayed inside that -- has to be assembled here,
+// where storage and the verify logic already are.
+//
+// Without this the paper receipt reports signatures and merkle structure and
+// says nothing about authority, which reads as a complete account while
+// omitting the half a counterparty is actually deciding on.
+
+use treeship_core::session::receipt::{AuthorityEntry, AuthoritySection};
+use treeship_core::statements::{
+    check_resolution, payload_type_v2, resolve_grant_chain, verify_effect, verify_grant_chain,
+    verify_mandate, ActionStatementV2, MandateVerdict, NoRevocationSource, NoWitnessAuthority,
+};
+
+/// Build the authority section for every action/v2 emitted during the session
+/// window.
+///
+/// Deliberately NOT sourced from `receipt.artifacts`. That list is the chain
+/// walked back from `.last` via `parent_id`, so an action/v2 that was never
+/// linked into the chain -- which is every one of them today, since `attest
+/// action --v2` sets no parent by default -- would be invisible. An authority
+/// section that silently omits actions is worse than none: it reads as a
+/// complete account of what was authorized.
+///
+/// So this reads the store directly, bounded by the session's own window. The
+/// merkle tree and `artifacts` are untouched; this section describes a
+/// deliberately wider set and says so.
+///
+/// Returns `None` when the window contained no action/v2, so a session with
+/// nothing to say about authority says nothing rather than rendering an empty
+/// band that reads like a clean bill.
+fn collect_authority(
+    ctx: &ctx::Ctx,
+    manifest: &SessionManifest,
+    now_unix: i64,
+) -> Option<AuthoritySection> {
+    let v2 = payload_type_v2("action");
+    let mut out = AuthoritySection::default();
+
+    // Inclusive lower bound, open upper bound: `closed_at` is stamped just
+    // before this runs, so anything signed at exactly that instant belongs.
+    let started = manifest.started_at.as_str();
+    let closed = manifest.closed_at.as_deref();
+
+    let mut in_window: Vec<_> = ctx
+        .storage
+        .list_by_type(&v2)
+        .into_iter()
+        .filter(|e| {
+            e.signed_at.as_str() >= started && closed.is_none_or(|c| e.signed_at.as_str() <= c)
+        })
+        .collect();
+    in_window.sort_by(|a, b| a.signed_at.cmp(&b.signed_at));
+
+    for a in &in_window {
+        let Ok(rec) = ctx.storage.read(a.id.as_str()) else {
+            continue;
+        };
+        let Ok(stmt) = rec.envelope.unmarshal_statement::<ActionStatementV2>() else {
+            continue;
+        };
+        let m = &stmt.mandate;
+
+        // Revocation has no resolver, so this reports Unverified naming that
+        // layer rather than a false clean.
+        let (verdict, reasons) = match verify_mandate(&stmt, &NoRevocationSource) {
+            MandateVerdict::Pass => ("pass", Vec::new()),
+            MandateVerdict::Unverified(r) => ("unverified", r),
+            MandateVerdict::Fail(r) => ("fail", r),
+        };
+
+        // A lone leaf is not a chain: a mandate carrying no ancestors made no
+        // lineage claim, and reporting that as a passing chain would name a
+        // check that never ran.
+        let (delegation, hops) = if m.chain.is_empty() {
+            ("not_claimed", None)
+        } else {
+            match resolve_grant_chain(m) {
+                Err(_) => ("unresolvable", None),
+                Ok(chain) => match verify_grant_chain(chain.as_slice()) {
+                    Ok(()) => ("holds", Some(chain.len() as u32)),
+                    Err(_) => ("widened", Some(chain.len() as u32)),
+                },
+            }
+        };
+
+        let effect_finality = stmt
+            .effect
+            .as_ref()
+            .and_then(|_| verify_effect(&stmt, &NoWitnessAuthority).effective_finality)
+            .map(|f| finality_word(f).to_string());
+        let resolution = stmt
+            .effect
+            .as_ref()
+            .map(|e| resolution_word(&check_resolution(e, now_unix)).to_string());
+
+        let holder_bound = m.grantee.as_deref().is_some_and(|g| !g.is_empty());
+        match verdict {
+            "fail" => out.violations += 1,
+            "unverified" => out.unverified += 1,
+            _ => {}
+        }
+        if !holder_bound {
+            out.bearer += 1;
+        }
+        out.checked += 1;
+
+        out.actions.push(AuthorityEntry {
+            artifact_id: a.id.to_string(),
+            action: stmt.action.clone(),
+            verdict: verdict.into(),
+            reasons,
+            scope: m.scope.clone(),
+            audience: m.audience.clone(),
+            grant_id: m.grant_id.clone(),
+            holder_bound,
+            delegation: delegation.into(),
+            delegation_hops: hops,
+            effect_finality,
+            resolution,
+        });
+    }
+
+    (out.checked > 0).then_some(out)
+}
+
+fn finality_word(f: treeship_core::statements::EffectFinality) -> &'static str {
+    use treeship_core::statements::EffectFinality as F;
+    match f {
+        F::NotAttempted => "not_attempted",
+        F::Initiated => "initiated",
+        F::Finalized => "finalized",
+        F::Failed => "failed",
+        F::Indeterminate => "indeterminate",
+    }
+}
+
+fn resolution_word(r: &treeship_core::statements::ResolutionStatus) -> &'static str {
+    use treeship_core::statements::ResolutionStatus as R;
+    match r {
+        R::Resolved => "resolved",
+        R::Indefinite => "indefinite",
+        R::Pending { .. } => "pending",
+        R::Breached { .. } => "breached",
+        R::BadDeadline => "bad_deadline",
     }
 }

--- a/packages/core/src/session/preview_template.html
+++ b/packages/core/src/session/preview_template.html
@@ -381,6 +381,10 @@ async function render(){
   const nodeIdx={};nodes.forEach((n,i)=>nodeIdx[n.agent_instance_id]=i);
   const totalActions=nodes.reduce((s,n)=>s+num(n.tool_calls),0)||1;
   const fin=financialActionEvidence(se,arts);
+  // Absent on receipts from sessions with no action/v2, and on every receipt
+  // written before the section existed. Both render as no band at all rather
+  // than an empty one, because an empty authority band reads like a clean bill.
+  const auth=(R.authority&&R.authority.checked)?R.authority:null;
 
   let h='<div class="sheet">';
 
@@ -396,6 +400,7 @@ async function render(){
   h+='<a class="nav-item" href="#files" data-section="files">Files <span class="nav-count">'+((se.files_written||[]).length+(se.files_read||[]).length)+'</span></a>';
   h+='<a class="nav-item" href="#commands" data-section="commands">Commands <span class="nav-count">'+procs.length+'</span></a>';
   h+='<div class="nav-label">Trust</div>';
+  if(auth)h+='<a class="nav-item" href="#authority" data-section="authority">Authority <span class="nav-count">'+auth.checked+'</span></a>';
   h+='<a class="nav-item" href="#security" data-section="security">Findings <span class="nav-count">'+findings.length+'</span></a>';
   if(fin.rows.length)h+='<a class="nav-item" href="#financial" data-section="financial">Financial <span class="nav-count">'+fin.rows.length+'</span></a>';
   h+='<a class="nav-item" href="#trust-chain" data-section="trust-chain">Trust chain</a>';
@@ -627,12 +632,59 @@ async function render(){
     h+='</div></div></section>';
   }
 
+  // ── AUTHORITY ──
+  // What each action/v2 was allowed to do, and whether it stayed inside that.
+  // The signature bands above answer "was this altered". This answers the
+  // question a counterparty is actually deciding on. Omitted entirely when the
+  // session had no action/v2 -- an empty band would read as a clean bill.
+  if(auth){
+    h+='<section class="band" id="authority"><div class="band-label">Authority</div><div class="band-sub">What each action was authorized to do, and whether it stayed inside that. Layers we could not check are named, not omitted.</div><div class="band-body">';
+    // Lead with the counts so the shape is legible before any detail loads.
+    var sumCol = auth.violations?'var(--fail)':(auth.unverified?'var(--warn)':'var(--pass)');
+    var sumGly = auth.violations?'✗':(auth.unverified?'○':'✓');
+    h+='<div class="row-list"><div class="finding">';
+    h+='<div class="mono" style="padding-top:1px;color:'+sumCol+'">'+sumGly+'</div><div>';
+    h+='<div style="font-size:.8rem;font-weight:600">'+auth.checked+' authorized action'+(auth.checked===1?'':'s')+'</div>';
+    h+='<div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">'+auth.violations+' outside grant · '+auth.unverified+' with an unchecked layer · '+auth.bearer+' bearer</div></div>';
+    h+='<span class="badge '+(auth.violations?'badge-risk':(auth.unverified?'badge-warn':'badge-ok'))+'">'+(auth.violations?'outside grant':(auth.unverified?'unverified':'in scope'))+'</span></div></div>';
+    h+='<div class="row-list" style="margin-top:10px">';
+    (auth.actions||[]).forEach(function(a){
+      var vb = a.verdict==='fail' ? 'badge-risk' : (a.verdict==='unverified' ? 'badge-warn' : 'badge-ok');
+      var vt = a.verdict==='fail' ? 'outside grant' : (a.verdict==='unverified' ? 'unverified' : 'in scope');
+      var gc = a.verdict==='fail' ? 'var(--fail)' : (a.verdict==='unverified' ? 'var(--warn)' : 'var(--pass)');
+      var gl = a.verdict==='fail' ? '✗' : (a.verdict==='unverified' ? '○' : '✓');
+      h+='<div class="finding"><div class="mono" style="padding-top:1px;color:'+gc+'">'+gl+'</div><div style="min-width:0">';
+      h+='<div style="font-size:.8rem;font-weight:600">'+esc(a.action||'')+'</div>';
+      h+='<div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">allowed: '+esc((a.scope||[]).join(', '))+' · for '+esc(a.audience||'')+'</div>';
+      // Holder: bearer is a real state, not a blank. Say it.
+      h+='<div class="mono" style="font-size:.62rem;margin-top:3px;color:'+(a.holder_bound?'var(--faint)':'var(--warn,#8a6d1f)')+'">holder: '+(a.holder_bound?'bound to a named key':'BEARER — anyone holding the grant could have done this')+'</div>';
+      // Delegation: not_claimed is absence of a claim, never a passing check.
+      var dl = a.delegation==='holds' ? ('chain holds · '+(a.delegation_hops||0)+' hop'+((a.delegation_hops||0)===1?'':'s'))
+             : a.delegation==='not_claimed' ? 'no lineage claimed'
+             : a.delegation==='widened' ? 'CHAIN WIDENS — a hop granted more than it held'
+             : 'chain unresolvable';
+      h+='<div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">delegation: '+dl+'</div>';
+      if(a.effect_finality||a.resolution){
+        var owed = a.resolution==='breached' ? ' · OVERDUE' : (a.resolution==='indefinite' ? ' · nothing scheduled to resolve it' : (a.resolution==='pending' ? ' · still owed' : ''));
+        h+='<div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">effect: '+esc(a.effect_finality||'not stated')+esc(owed)+'</div>';
+      }
+      (a.reasons||[]).forEach(function(r){
+        h+='<div class="mono" style="font-size:.6rem;color:var(--faint);margin-top:3px">— '+esc(r)+'</div>';
+      });
+      h+='<div class="mono" style="font-size:.58rem;color:var(--faint);margin-top:3px">grant '+esc(a.grant_id||'')+'</div>';
+      h+='</div><span class="badge '+vb+'">'+vt+'</span></div>';
+    });
+    h+='</div>';
+    h+='<div class="pad faint" style="font-size:.66rem;margin-top:8px">Covers every action/v2 signed inside this session’s window, which is a wider set than the artifact chain above. Revocation is never checked: no resolver is wired, so a live grant cannot be distinguished from a withdrawn one.</div>';
+    h+='</section>';
+  }
+
   // ── APPROVAL GATES ──
   h+='<section class="band" id="approvals"><div class="band-label">Approval gates</div><div class="band-sub">Human approval checkpoints during the session.</div><div class="band-body">';
   if(fin.approvals.length){
     h+='<div class="row-list">';
     fin.approvals.forEach(a=>{
-      h+='<div class="finding"><span class="badge badge-ok">✔ approved</span><div><div style="font-size:.8rem;font-weight:600">Approval artifact</div><div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">'+esc(a.artifact_id||a.id||'')+' · '+timeOf(a.signed_at||a.timestamp||'')+'</div></div></div>';
+      h+='<div class="finding"><div class="mono" style="padding-top:1px;color:var(--pass)">✓</div><div><div style="font-size:.8rem;font-weight:600">Approval artifact</div><div class="mono" style="font-size:.62rem;color:var(--faint);margin-top:3px">'+esc(a.artifact_id||a.id||'')+' · '+timeOf(a.signed_at||a.timestamp||'')+'</div></div><span class="badge badge-ok">approved</span></div>';
     });
     h+='</div>';
   }else{

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -52,6 +52,72 @@ pub struct SessionReceipt {
     /// Tool usage summary: declared vs actual tools used during the session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_usage: Option<ToolUsage>,
+
+    /// What each action/v2 in this session was authorized to do, and whether it
+    /// stayed inside that.
+    ///
+    /// Absent when the session contained no action/v2 receipts, which keeps
+    /// older receipts byte-identical. Present-but-empty never happens: a
+    /// session with nothing to say about authority says nothing, rather than
+    /// showing an empty band that reads like a clean bill.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority: Option<AuthoritySection>,
+}
+
+/// Per-action authority for a session.
+///
+/// The signature layer answers "was this receipt tampered with". This answers
+/// the question underneath it: was the action allowed, by whom, and what could
+/// we not check. A session receipt that reports only the former reads as
+/// complete while omitting the half a counterparty is actually deciding on.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthoritySection {
+    pub actions: Vec<AuthorityEntry>,
+    /// How many action/v2 receipts were judged.
+    pub checked: u32,
+    /// Actions that fell outside their grant. Any non-zero value is the
+    /// headline.
+    pub violations: u32,
+    /// Actions where some layer could not be checked. Not violations, and not
+    /// clean either -- counted separately so neither can hide in the other.
+    pub unverified: u32,
+    /// Actions run under a grant naming no holder, spendable by anyone who
+    /// obtained it.
+    pub bearer: u32,
+}
+
+/// One action's authority record.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthorityEntry {
+    pub artifact_id: String,
+    /// The action label, e.g. `payments.charge`.
+    pub action: String,
+    /// `pass` | `unverified` | `fail`.
+    pub verdict: String,
+    /// Why, in the verifier's own words. Empty on a clean pass.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+    /// What the grant admitted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope: Vec<String>,
+    pub audience: String,
+    pub grant_id: String,
+    /// Whether the grant named the key entitled to exercise it. `false` means
+    /// bearer, and the surface must say so rather than leave it blank.
+    pub holder_bound: bool,
+    /// `not_claimed` | `holds` | `widened` | `unresolvable`.
+    pub delegation: String,
+    /// Hops in the resolved chain, when one was claimed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegation_hops: Option<u32>,
+    /// How far the state change got: `not_attempted` | `initiated` |
+    /// `finalized` | `failed` | `indeterminate`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect_finality: Option<String>,
+    /// Whether anything is still owed: `resolved` | `indefinite` | `pending` |
+    /// `breached` | `bad_deadline`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<String>,
 }
 
 /// Tool authorization and usage summary for the session.
@@ -362,6 +428,10 @@ impl ReceiptComposer {
             merkle: merkle_section,
             render,
             tool_usage,
+            // Composed from storage by the caller, which is the layer that can
+            // load envelopes and run the verifier. The composer sees only
+            // manifest + events + artifact metadata.
+            authority: None,
         }
     }
 

--- a/packages/core/src/verify/mod.rs
+++ b/packages/core/src/verify/mod.rs
@@ -443,6 +443,7 @@ mod tests {
                 generate_preview: true,
             },
             tool_usage,
+            authority: None,
         }
     }
 


### PR DESCRIPTION
The paper receipt is the artifact a counterparty actually reads, and it said nothing about authority.

I ran a session containing an action/v2 — mandate, delegated grant, bound holder, unresolved effect — and grepped the receipt it produced:

```
mandate 0 · authority 0 · grantee 0 · finality 0 · delegation 0 · grant_id 0 · effect_confidence 0
```

The timeline showed three events: session started, echo ran, session closed. **The v2 attestation was not even an event.** `treeship verify --format json` knew all of it. The document of record showed an empty tool band and moved on.

## The band

Adds `SessionReceipt.authority` and renders it between Tool authorization and Approval gates:

- what the action was allowed to do (scope, audience) and whether it stayed inside
- **holder**: bound to a named key, or `BEARER — anyone holding the grant could have done this` in warning colour, because bearer is a real state and a blank reads as fine
- **delegation**: hops when a chain resolves, `no lineage claimed` when none was made — never a passing check for an absent one
- **effect**: how far it got, and whether anything is still owed
- every layer we could not check, in the verifier’s own words

Counts lead so the shape is legible before any detail loads: `0 outside grant · 2 with an unchecked layer · 1 bearer`.

## Two decisions worth stating

**Collected from the store over the session window, not from `receipt.artifacts`.** That list is the chain walked back from `.last` via `parent_id`, and `attest action --v2` sets no parent — so sourcing from it showed **one of two** actions in testing. An authority section that silently drops actions is worse than none. The band says plainly that it covers a wider set than the chain. The merkle tree and `artifacts` are untouched.

**Absent, not empty**, when a session had no action/v2. Older receipts stay byte-identical, and nobody sees a blank band that reads like a clean bill.

## Also fixes #246

The Approval gates band I merged earlier today puts its badge in the 22px glyph column of the `22px 1fr auto` grid, so it overlapped the title. Canonical order is glyph → content → badge-last. I copied the same bug into my first draft of this band and caught it by rendering.

Full workspace green — 499 core, 0 failures.