### PR TITLE
ci: fail when the paper template changes without the downstream copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: python3 scripts/check-specs-index.py
       - name: Published crates embed only files inside their own root
         run: python3 scripts/check-vendored-fonts.py
+      - name: Paper-receipt template matches the copy vendored downstream
+        run: python3 scripts/check-downstream-template.py
       - name: Generated feature matrix matches the inventory
         # The generator needs only the `yaml` package (package-lock.json is
         # gitignored in docs/, so no npm ci; skip the full fumadocs install).

--- a/scripts/check-downstream-template.py
+++ b/scripts/check-downstream-template.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Fail when the paper-receipt template changes without acknowledging the copy.
+
+`packages/core/src/session/preview_template.html` is vendored into the website
+(zerkerlabs/treeship.dev, `lib/receipt-preview/preview_template.html`) so the
+online preview at /receipt/<id>/preview renders byte-identically to the
+preview.html the CLI writes into a local package. That equivalence is the point
+of the paper surface: pull the network cable and read the same document.
+
+The website can check its own copy has not been edited in place. It cannot know
+this file changed. That is the direction the failure actually travels, and it
+already happened once: the Authority band was added here while the website copy
+sat two bands behind, so the online receipt would have silently dropped the
+authority story -- rendering fine, saying less.
+
+So this is a deliberate snapshot. Changing the template fails CI until you bump
+EXPECTED_SHA256, and the failure message names the file downstream that has to
+move with it. Annoying by design: the alternative is a fork nobody notices.
+
+To update:
+  1. change the template
+  2. copy it to the website repo and refresh its SOURCE.json
+  3. put the new hash below
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = ROOT / "packages" / "core" / "src" / "session" / "preview_template.html"
+
+# sha256 of the template as last synced downstream.
+EXPECTED_SHA256 = "ba08ea3dd0ca4dfcb672dfe1cc6f7c674063cce544801a8c3cd5bd19e3cf3887"
+
+DOWNSTREAM = (
+    "zerkerlabs/treeship.dev  lib/receipt-preview/preview_template.html\n"
+    "                         lib/receipt-preview/SOURCE.json"
+)
+
+
+def main() -> int:
+    if not TEMPLATE.is_file():
+        print(f"  err   template missing: {TEMPLATE.relative_to(ROOT)}")
+        return 1
+
+    actual = hashlib.sha256(TEMPLATE.read_bytes()).hexdigest()
+    if actual == EXPECTED_SHA256:
+        print("  ✓ paper-receipt template matches the copy vendored downstream")
+        return 0
+
+    print(f"  err   {TEMPLATE.relative_to(ROOT)} changed")
+    print(f"        recorded {EXPECTED_SHA256[:16]}…")
+    print(f"        actual   {actual[:16]}…")
+    print()
+    print("This template is vendored downstream. Update it there or the online")
+    print("preview will render an older receipt than the packaged one:")
+    print()
+    print(f"  {DOWNSTREAM}")
+    print()
+    print("Then set EXPECTED_SHA256 in this script to:")
+    print(f"  {actual}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The paper receipt template is vendored into the website (treeship.dev PR #39) so `/receipt/<id>/preview` renders byte-identically to the `preview.html` the CLI writes locally. That equivalence is the whole value of the paper surface — pull the network cable, read the same document of record.

## This already broke once, today

The Authority band landed in `preview_template.html` while the website copy sat two bands behind:

| Band | core | website copy |
|---|---|---|
| Approval gates | ✅ | ✅ |
| **Authority** | ✅ | ❌ |

The online receipt would have rendered perfectly and silently omitted the authority story. No error, no warning — just a shorter document than the offline one.

## Why the check has to live here

The website can verify its own copy was not edited in place, and PR #39 now does. It cannot know *this* file changed. That is the direction the failure travels, so this is the side that has to object.

Deliberate snapshot: changing the template fails CI until `EXPECTED_SHA256` is bumped, and the failure names the two downstream files that must move with it. Annoying by design — the alternative is a fork nobody notices until a counterparty reads two different receipts for the same session.

Verified both directions: passes on the current template, fails with the correct new hash when it changes.