### PR TITLE
feat(session): add liveness challenge to room-join countersign

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -381,6 +381,29 @@ treeship session countersign [OPTIONS] <PARTICIPANT_ID>
 |---|---|
 | `<PARTICIPANT_ID>` | Participant artifact id (output of `treeship session join`) |
 
+| Option | Description |
+|---|---|
+| `--challenge <NONCE>` | The nonce YOU (the host) issue for the room-join liveness challenge, right before finalizing. Any string; pick something unpredictable. Must be supplied together with --challenge-response |
+| `--challenge-response <PATH>` | Path to the joining agent's signed response to --challenge (output of `treeship session answer-challenge`). Use `-` for stdin |
+
+### `treeship session answer-challenge`
+
+Sign the host's room-join liveness nonce with the joining agent's own key. Run by the JOINING AGENT after `session join`, in response to a nonce the host chose out of band
+
+```
+treeship session answer-challenge [OPTIONS] --challenge <NONCE> --actor <URI> <PARTICIPANT_ID>
+```
+
+| Argument | Description |
+|---|---|
+| `<PARTICIPANT_ID>` | Participant artifact id (output of `treeship session join`) |
+
+| Option | Description |
+|---|---|
+| `--challenge <NONCE>` | The nonce the host issued out of band for this join |
+| `--actor <URI>` | Joining agent's actor URI. Must resolve to the same key that ran `treeship session join` |
+| `--out <PATH>` | Output path (default: &lt;participant_id&gt;.challenge-response.json) |
+
 ## `treeship verify`
 
 Verify an artifact or its full parent chain

--- a/packages/cli/src/commands/invitation.rs
+++ b/packages/cli/src/commands/invitation.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
 use treeship_core::{
-    attestation::Envelope,
+    attestation::{Envelope, Signer},
     journal::{self, Journal},
     statements::{
         invitation::{
@@ -38,6 +38,7 @@ use treeship_core::{
     },
     storage::Record,
     trust::{decode_ed25519_pubkey, TrustRootKind, TrustRootStore},
+    verify::session_join_challenge::{check_join_challenge, join_challenge_canonical},
 };
 
 use crate::{
@@ -145,6 +146,23 @@ pub struct JoinArgs {
 
 pub struct CountersignArgs {
     pub participant_id: String,
+    pub format: String,
+    /// The nonce the host issued for the room-join liveness challenge.
+    /// Must be supplied together with `challenge_response`, or neither.
+    pub challenge: Option<String>,
+    /// Path to (or `-` for stdin) the joining agent's signed response to
+    /// `challenge`, produced by `treeship session answer-challenge`.
+    pub challenge_response: Option<String>,
+}
+
+pub struct AnswerChallengeArgs {
+    pub participant_id: String,
+    /// The nonce the host issued out of band for this join.
+    pub challenge: String,
+    /// Joining agent's actor URI. Must resolve to the same key that
+    /// signed the pending participant event.
+    pub actor: String,
+    pub out: Option<String>,
     pub format: String,
 }
 
@@ -838,6 +856,51 @@ pub fn countersign(
         );
     }
 
+    // Optional liveness gate: proves the joining agent controls its key
+    // RIGHT NOW, at countersign time, not just whenever `session join` ran.
+    // Opt-in and additive -- omitting both flags countersigns exactly as
+    // before. Supplying only one is refused rather than silently ignored,
+    // since a half-supplied challenge is the AI-assisted-development
+    // policy's "vacuous pass" failure mode dressed up as a flag.
+    match (&args.challenge, &args.challenge_response) {
+        (None, None) => {}
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(
+                "--challenge and --challenge-response must be supplied together (or neither)"
+                    .into(),
+            );
+        }
+        (Some(nonce), Some(response_src)) => {
+            let response_text = if response_src == "-" {
+                use std::io::Read;
+                let mut s = String::new();
+                std::io::stdin().read_to_string(&mut s)?;
+                s
+            } else {
+                std::fs::read_to_string(response_src)
+                    .map_err(|e| format!("read --challenge-response {response_src}: {e}"))?
+            };
+            let response: serde_json::Value = serde_json::from_str(&response_text)
+                .map_err(|e| format!("challenge response is not valid JSON: {e}"))?;
+            let joiner_pk_bytes: [u8; 32] = URL_SAFE_NO_PAD
+                .decode(stmt.joining_agent.as_bytes())
+                .ok()
+                .and_then(|b| b.try_into().ok())
+                .ok_or("participant.joining_agent is not a 32-byte base64url Ed25519 pubkey")?;
+            let joiner_vk = ed25519_dalek::VerifyingKey::from_bytes(&joiner_pk_bytes)
+                .map_err(|e| format!("participant.joining_agent pubkey invalid: {e}"))?;
+            check_join_challenge(
+                &response,
+                &stmt.session_ref,
+                &args.participant_id,
+                &stmt.joining_agent,
+                nonce,
+                &joiner_vk,
+            )
+            .map_err(|e| format!("join-challenge verification failed: {e}; countersign refused"))?;
+        }
+    }
+
     let finalized =
         SessionParticipantStatement::attach_host_countersign(&rec.envelope, &*host_signer)
             .map_err(|e| format!("attach host countersign: {e}"))?;
@@ -859,15 +922,17 @@ pub fn countersign(
     };
     c.storage.write(&new_record)?;
 
+    let challenge_verified = args.challenge.is_some();
     let format = Format::from_str(&args.format);
     if format == Format::Json {
         printer.json(&serde_json::json!({
-            "status":          "finalized",
-            "participant_id":  args.participant_id,
-            "session_ref":     stmt.session_ref,
-            "invitation_ref":  stmt.invitation_ref,
-            "joining_agent":   stmt.joining_agent,
-            "signatures":      2,
+            "status":             "finalized",
+            "participant_id":     args.participant_id,
+            "session_ref":        stmt.session_ref,
+            "invitation_ref":     stmt.invitation_ref,
+            "joining_agent":      stmt.joining_agent,
+            "signatures":         2,
+            "challenge_verified": challenge_verified,
         }));
         return Ok(());
     }
@@ -877,8 +942,117 @@ pub fn countersign(
             ("participant_id", &args.participant_id),
             ("session_ref", &stmt.session_ref),
             ("invitation_ref", &stmt.invitation_ref),
+            (
+                "challenge_verified",
+                if challenge_verified { "true" } else { "false" },
+            ),
         ],
     );
+    if !challenge_verified {
+        printer.hint(
+            "no --challenge supplied — this join was NOT liveness-checked at countersign time",
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `treeship session answer-challenge`
+// ---------------------------------------------------------------------------
+
+/// Sign the host's room-join liveness nonce with the joining agent's own
+/// key. Run by the JOINING AGENT, after `session join`, in response to a
+/// nonce the host generated immediately before running `session
+/// countersign --challenge <nonce> --challenge-response <this output>`.
+pub fn answer_challenge(
+    ctx_override: Option<&str>,
+    args: AnswerChallengeArgs,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let c = ctx::open(ctx_override)?;
+
+    let rec = c
+        .storage
+        .read(&args.participant_id)
+        .map_err(|e| format!("participant artifact {}: {e}", args.participant_id))?;
+    if rec.payload_type != payload_type("session-participant") {
+        return Err(format!(
+            "artifact {} is not a session-participant envelope (type={})",
+            args.participant_id, rec.payload_type,
+        )
+        .into());
+    }
+    if rec.envelope.signatures.len() != 1 {
+        return Err(format!(
+            "participant artifact {} already carries {} signatures; \
+             a liveness challenge only makes sense before the host's countersign",
+            args.participant_id,
+            rec.envelope.signatures.len(),
+        )
+        .into());
+    }
+
+    let stmt: SessionParticipantStatement = rec
+        .envelope
+        .unmarshal_statement()
+        .map_err(|e| format!("decode participant payload: {e}"))?;
+
+    // The answering key must be the one bound in the pending participant
+    // event -- answering with a DIFFERENT key would prove liveness of the
+    // wrong agent.
+    let signer = crate::commands::attest::resolve_actor_signer(&c, &args.actor)?;
+    let signer_pk_b64 = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+    if signer_pk_b64 != stmt.joining_agent {
+        return Err(format!(
+            "the pending participant event is bound to {}, but --actor {} resolves to {} \
+             -- answer with the same key that ran `session join`",
+            stmt.joining_agent, args.actor, signer_pk_b64,
+        )
+        .into());
+    }
+
+    let signed_at = now_rfc3339();
+    let canonical = join_challenge_canonical(
+        &stmt.session_ref,
+        &args.participant_id,
+        &stmt.joining_agent,
+        &args.challenge,
+        &signed_at,
+    );
+    let sig = signer.sign(&canonical)?;
+    let response = serde_json::json!({
+        "nonce": args.challenge,
+        "signed_at": signed_at,
+        "signature": URL_SAFE_NO_PAD.encode(sig),
+    });
+
+    let default_name = format!("{}.challenge-response.json", args.participant_id);
+    let out_path = args.out.as_deref().unwrap_or(&default_name);
+    std::fs::write(out_path, serde_json::to_vec_pretty(&response)?)?;
+
+    let format = Format::from_str(&args.format);
+    if format == Format::Json {
+        printer.json(&serde_json::json!({
+            "status":         "signed",
+            "participant_id": args.participant_id,
+            "nonce":          args.challenge,
+            "signed_at":      signed_at,
+            "file":           out_path,
+        }));
+        return Ok(());
+    }
+    printer.success(
+        "challenge signed",
+        &[
+            ("participant_id", args.participant_id.as_str()),
+            ("nonce", args.challenge.as_str()),
+            ("file", out_path),
+        ],
+    );
+    printer.hint(&format!(
+        "hand this file to the host: treeship session countersign {} --challenge {} --challenge-response {out_path}",
+        args.participant_id, args.challenge,
+    ));
     Ok(())
 }
 

--- a/packages/cli/src/commands/invitation.rs
+++ b/packages/cli/src/commands/invitation.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
 use treeship_core::{
-    attestation::{Envelope, Signer},
+    attestation::Envelope,
     journal::{self, Journal},
     statements::{
         invitation::{

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -889,9 +889,28 @@ enum SessionCommand {
     /// the participant envelope carries two signatures (joining agent +
     /// host) and verifies as a finalized join.
     ///
+    /// Pass --challenge/--challenge-response together to gate the
+    /// countersign on a liveness proof: the host picks a nonce, the
+    /// joining agent answers it with `session answer-challenge`, and
+    /// countersign refuses to finalize unless the answer verifies against
+    /// the SAME nonce and the pending event's joining_agent key. Proves
+    /// the joining agent is live right now, not just whenever `join` ran
+    /// -- closes the gap for joins whose pending envelope was pasted
+    /// across machines/sandboxes rather than countersigned immediately.
+    ///
     /// Examples:
     ///   treeship session countersign art_part_abc123
+    ///   treeship session countersign art_part_abc123 --challenge n_8f2a \
+    ///     --challenge-response ./art_part_abc123.challenge-response.json
     Countersign(SessionCountersignArgs),
+
+    /// Sign the host's room-join liveness nonce with the joining agent's
+    /// own key. Run by the JOINING AGENT after `session join`, in
+    /// response to a nonce the host chose out of band.
+    ///
+    /// Examples:
+    ///   treeship session answer-challenge art_part_abc123 --challenge n_8f2a --actor agent://researcher
+    AnswerChallenge(SessionAnswerChallengeArgs),
 }
 
 #[derive(Args)]
@@ -957,6 +976,40 @@ struct SessionJoinArgs {
 struct SessionCountersignArgs {
     /// Participant artifact id (output of `treeship session join`).
     participant_id: String,
+
+    /// The nonce YOU (the host) issue for the room-join liveness
+    /// challenge, right before finalizing. Any string; pick something
+    /// unpredictable. Must be supplied together with --challenge-response.
+    #[arg(long, value_name = "NONCE")]
+    challenge: Option<String>,
+
+    /// Path to the joining agent's signed response to --challenge (output
+    /// of `treeship session answer-challenge`). Use `-` for stdin.
+    #[arg(long, value_name = "PATH")]
+    challenge_response: Option<String>,
+
+    /// Output format: text (default) or json.
+    #[arg(long, value_name = "FORMAT", default_value = "text")]
+    format: String,
+}
+
+#[derive(Args)]
+struct SessionAnswerChallengeArgs {
+    /// Participant artifact id (output of `treeship session join`).
+    participant_id: String,
+
+    /// The nonce the host issued out of band for this join.
+    #[arg(long, value_name = "NONCE")]
+    challenge: String,
+
+    /// Joining agent's actor URI. Must resolve to the same key that ran
+    /// `treeship session join`.
+    #[arg(long, value_name = "URI")]
+    actor: String,
+
+    /// Output path (default: <participant_id>.challenge-response.json)
+    #[arg(long, value_name = "PATH")]
+    out: Option<String>,
 
     /// Output format: text (default) or json.
     #[arg(long, value_name = "FORMAT", default_value = "text")]
@@ -2717,6 +2770,19 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 cli.config.as_deref(),
                 commands::invitation::CountersignArgs {
                     participant_id: a.participant_id.clone(),
+                    format: a.format.clone(),
+                    challenge: a.challenge.clone(),
+                    challenge_response: a.challenge_response.clone(),
+                },
+                printer,
+            ),
+            SessionCommand::AnswerChallenge(a) => commands::invitation::answer_challenge(
+                cli.config.as_deref(),
+                commands::invitation::AnswerChallengeArgs {
+                    participant_id: a.participant_id.clone(),
+                    challenge: a.challenge.clone(),
+                    actor: a.actor.clone(),
+                    out: a.out.clone(),
                     format: a.format.clone(),
                 },
                 printer,

--- a/packages/cli/tests/invitation_cli.rs
+++ b/packages/cli/tests/invitation_cli.rs
@@ -318,6 +318,240 @@ fn treeship_session_invite_then_join_roundtrip() {
     );
 }
 
+/// Room-join liveness challenge, happy path: join -> answer-challenge ->
+/// countersign --challenge/--challenge-response. The finalized envelope
+/// still verifies exactly as the unchallenged roundtrip does -- the
+/// challenge is an additive, ephemeral gate at countersign time, not a
+/// change to the two-sig envelope schema.
+#[test]
+fn treeship_session_join_liveness_challenge_roundtrip() {
+    let ws = Workspace::new();
+    ws.init();
+    let register = ws
+        .cmd()
+        .args(["agent", "register", "--name", "bob", "--own-key"])
+        .output()
+        .expect("register joining agent");
+    assert!(register.status.success());
+    let session_id = ws.session_start();
+    let pubkey = ws.default_pubkey_b64();
+    ws.add_trust("host_default", &pubkey, "session_host");
+
+    let invite_out = ws
+        .cmd()
+        .args(["session", "invite", &session_id, "--format", "json"])
+        .args(["--open", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session invite");
+    assert!(invite_out.status.success());
+    let mint: serde_json::Value = serde_json::from_slice(&invite_out.stdout).unwrap();
+    let blob = mint["bootstrap_blob"].as_str().unwrap().to_string();
+    let blob_path = ws.root.join("invite.blob");
+    std::fs::write(&blob_path, &blob).unwrap();
+
+    let join_out = ws
+        .cmd()
+        .args(["session", "join", "--format", "json"])
+        .args(["--invite-file"])
+        .arg(&blob_path)
+        .args(["--actor", "agent://joiner"])
+        .args(["--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session join");
+    assert!(join_out.status.success());
+    let join: serde_json::Value = serde_json::from_slice(&join_out.stdout).unwrap();
+    let participant_id = join["participant_id"].as_str().unwrap().to_string();
+
+    // Joining agent answers the host's nonce.
+    let nonce = "n_test_liveness_1";
+    let response_path = ws.root.join("response.json");
+    let answer_out = ws
+        .cmd()
+        .args(["session", "answer-challenge", &participant_id])
+        .args(["--challenge", nonce])
+        .args(["--actor", "agent://joiner"])
+        .args(["--out"])
+        .arg(&response_path)
+        .args(["--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session answer-challenge");
+    assert!(
+        answer_out.status.success(),
+        "answer-challenge failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&answer_out.stdout),
+        String::from_utf8_lossy(&answer_out.stderr),
+    );
+    assert!(response_path.exists());
+
+    // Host countersigns, gated on the liveness response.
+    let cs_out = ws
+        .cmd()
+        .args(["session", "countersign", &participant_id])
+        .args(["--challenge", nonce])
+        .args(["--challenge-response"])
+        .arg(&response_path)
+        .args(["--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session countersign");
+    let stdout = String::from_utf8_lossy(&cs_out.stdout).to_string();
+    assert!(
+        cs_out.status.success(),
+        "countersign with challenge failed: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&cs_out.stderr),
+    );
+    let cs: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(cs["status"], "finalized");
+    assert_eq!(cs["challenge_verified"], true);
+
+    // Still verifies as a normal finalized participant envelope.
+    let verify_out = ws
+        .cmd()
+        .args(["verify", &participant_id, "--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("verify countersigned participant");
+    assert!(verify_out.status.success());
+    let verified: serde_json::Value = serde_json::from_slice(&verify_out.stdout).unwrap();
+    assert_eq!(verified["outcome"], "pass");
+}
+
+/// A response answering the WRONG nonce (replay of a stale/different
+/// challenge) must not be accepted -- countersign refuses to finalize.
+#[test]
+fn treeship_session_countersign_rejects_mismatched_challenge_nonce() {
+    let ws = Workspace::new();
+    ws.init();
+    let session_id = ws.session_start();
+    let pubkey = ws.default_pubkey_b64();
+    ws.add_trust("host_default", &pubkey, "session_host");
+
+    let invite_out = ws
+        .cmd()
+        .args(["session", "invite", &session_id, "--format", "json"])
+        .args(["--open", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session invite");
+    let mint: serde_json::Value = serde_json::from_slice(&invite_out.stdout).unwrap();
+    let blob = mint["bootstrap_blob"].as_str().unwrap().to_string();
+    let blob_path = ws.root.join("invite.blob");
+    std::fs::write(&blob_path, &blob).unwrap();
+
+    let join_out = ws
+        .cmd()
+        .args(["session", "join", "--format", "json"])
+        .args(["--invite-file"])
+        .arg(&blob_path)
+        .args(["--actor", "agent://joiner"])
+        .args(["--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session join");
+    let join: serde_json::Value = serde_json::from_slice(&join_out.stdout).unwrap();
+    let participant_id = join["participant_id"].as_str().unwrap().to_string();
+
+    let response_path = ws.root.join("response.json");
+    let answer_out = ws
+        .cmd()
+        .args(["session", "answer-challenge", &participant_id])
+        .args(["--challenge", "n_real"])
+        .args(["--actor", "agent://joiner"])
+        .args(["--out"])
+        .arg(&response_path)
+        .args(["--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session answer-challenge");
+    assert!(answer_out.status.success());
+
+    // Host issues a DIFFERENT nonce than the one that was answered.
+    let cs_out = ws
+        .cmd()
+        .args(["session", "countersign", &participant_id])
+        .args(["--challenge", "n_different"])
+        .args(["--challenge-response"])
+        .arg(&response_path)
+        .args(["--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session countersign");
+    assert!(
+        !cs_out.status.success(),
+        "countersign must refuse a response answering a different nonce"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&cs_out.stdout),
+        String::from_utf8_lossy(&cs_out.stderr),
+    );
+    assert!(
+        combined.contains("does not match"),
+        "expected nonce-mismatch rejection, got: {combined}",
+    );
+}
+
+/// Supplying only one of --challenge / --challenge-response is refused
+/// rather than silently skipping the liveness check.
+#[test]
+fn treeship_session_countersign_rejects_half_supplied_challenge() {
+    let ws = Workspace::new();
+    ws.init();
+    let session_id = ws.session_start();
+    let pubkey = ws.default_pubkey_b64();
+    ws.add_trust("host_default", &pubkey, "session_host");
+
+    let invite_out = ws
+        .cmd()
+        .args(["session", "invite", &session_id, "--format", "json"])
+        .args(["--open", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session invite");
+    let mint: serde_json::Value = serde_json::from_slice(&invite_out.stdout).unwrap();
+    let blob = mint["bootstrap_blob"].as_str().unwrap().to_string();
+    let blob_path = ws.root.join("invite.blob");
+    std::fs::write(&blob_path, &blob).unwrap();
+
+    let join_out = ws
+        .cmd()
+        .args(["session", "join", "--format", "json"])
+        .args(["--invite-file"])
+        .arg(&blob_path)
+        .args(["--actor", "agent://joiner"])
+        .args(["--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session join");
+    let join: serde_json::Value = serde_json::from_slice(&join_out.stdout).unwrap();
+    let participant_id = join["participant_id"].as_str().unwrap().to_string();
+
+    let cs_out = ws
+        .cmd()
+        .args(["session", "countersign", &participant_id])
+        .args(["--challenge", "n_only_half"])
+        .args(["--format", "json", "--config"])
+        .arg(ws.config())
+        .output()
+        .expect("session countersign");
+    assert!(
+        !cs_out.status.success(),
+        "countersign must refuse a half-supplied challenge, not silently skip it"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&cs_out.stdout),
+        String::from_utf8_lossy(&cs_out.stderr),
+    );
+    assert!(
+        combined.contains("must be supplied together"),
+        "got: {combined}",
+    );
+}
+
 /// Invitation against a nonexistent / unrelated session id is still
 /// mintable (Phase 1 doesn't validate session existence at the mint
 /// site -- the host knows what session id they meant), but if we pass

--- a/packages/core/src/verify/mod.rs
+++ b/packages/core/src/verify/mod.rs
@@ -22,6 +22,12 @@ pub mod resolution;
 /// its check). Same reason: one code path across CLI, WASM, and SDKs.
 pub mod presentation;
 
+/// Session-join challenge canonical (the live-liveness gate `session
+/// countersign --challenge` uses). Same shape as `presentation`, scoped to
+/// proving the joining agent is live at countersign time, not just at join
+/// time.
+pub mod session_join_challenge;
+
 use crate::agent::AgentCertificate;
 use crate::session::package::{VerifyCheck, VerifyStatus};
 use crate::session::receipt::SessionReceipt;

--- a/packages/core/src/verify/session_join_challenge.rs
+++ b/packages/core/src/verify/session_join_challenge.rs
@@ -1,0 +1,292 @@
+//! Session-join challenge canonical: proves the JOINING AGENT controls its
+//! key right now, at the moment the host is about to countersign a pending
+//! participant event -- not just that it held the key whenever `session
+//! join` produced the pending envelope.
+//!
+//! Why this exists: `join()` and `countersign()` can run on different
+//! machines/sandboxes, with the pending participant envelope handed to the
+//! host out of band (pasted, like the invitation blob). That hand-off has
+//! no time bound. Without this, a host who countersigns hours later has no
+//! way to tell a live join from a stale-but-validly-signed envelope whose
+//! signer's sandbox is long gone, key rotated, or agent compromised.
+//!
+//! Same shape as `presentation::challenge_canonical` / `check_challenge`:
+//! every externally-supplied field is digest-folded so no field can inject
+//! separators and shift the others, and `signed_at` is bound so the
+//! reported freshness is bearer-signed, not bearer-editable. The host picks
+//! the nonce immediately before finalizing (any string; freshness is the
+//! host's responsibility, same trust model `present --challenge` already
+//! uses), so a pre-staged response cannot be replayed across join attempts.
+//!
+//! Deliberately NOT part of `SessionParticipantStatement::canonical_for_signing`:
+//! this is an ephemeral, host-side liveness gate at countersign time, not a
+//! durable claim baked into the two-sig envelope. Making it portable (so a
+//! third-party verifier can later confirm a join was live-challenged) is a
+//! schema-v2 question -- it would touch the canonical bytes both signatures
+//! already cover, which is out of scope for an additive, backward-compatible
+//! change.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use ed25519_dalek::{Signature, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+/// The canonical bytes a join-challenge response signs.
+pub fn join_challenge_canonical(
+    session_ref: &str,
+    participant_id: &str,
+    joining_agent: &str,
+    nonce: &str,
+    signed_at: &str,
+) -> Vec<u8> {
+    let d = |s: &str| hex::encode(Sha256::digest(s.as_bytes()));
+    format!(
+        "v1|room-join-challenge|{}|{}|{}|{}|{signed_at}",
+        d(session_ref),
+        d(participant_id),
+        d(joining_agent),
+        d(nonce),
+    )
+    .into_bytes()
+}
+
+/// Verify a join-challenge response against the nonce the HOST issued and
+/// the joining agent's pubkey established by the pending participant
+/// statement itself (`stmt.joining_agent`). Returns the bearer-signed
+/// `signed_at` on success; a specific, honest reason on failure.
+pub fn check_join_challenge(
+    response: &serde_json::Value,
+    session_ref: &str,
+    participant_id: &str,
+    joining_agent_pubkey_b64: &str,
+    expected_nonce: &str,
+    joining_agent_vk: &VerifyingKey,
+) -> Result<String, String> {
+    let nonce = response
+        .get("nonce")
+        .and_then(|v| v.as_str())
+        .ok_or("challenge response carries no nonce")?;
+    if nonce != expected_nonce {
+        return Err(
+            "challenge response nonce does not match the one the host issued -- this answers a DIFFERENT challenge (replay?)"
+                .into(),
+        );
+    }
+    let signed_at = response
+        .get("signed_at")
+        .and_then(|v| v.as_str())
+        .ok_or("challenge response carries no signed_at")?;
+    let sig_b64 = response
+        .get("signature")
+        .and_then(|v| v.as_str())
+        .ok_or("challenge response carries no signature")?;
+    let sig_bytes = URL_SAFE_NO_PAD
+        .decode(sig_b64)
+        .map_err(|_| "challenge response signature is not valid base64url".to_string())?;
+    let sig_arr: [u8; 64] = sig_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| "challenge response signature is not 64 bytes".to_string())?;
+    let canonical = join_challenge_canonical(
+        session_ref,
+        participant_id,
+        joining_agent_pubkey_b64,
+        expected_nonce,
+        signed_at,
+    );
+    joining_agent_vk
+        .verify_strict(&canonical, &Signature::from_bytes(&sig_arr))
+        .map_err(|_| {
+            "challenge response signature INVALID for the joining agent's key".to_string()
+        })?;
+    Ok(signed_at.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attestation::{Ed25519Signer, Signer};
+
+    fn signer() -> Ed25519Signer {
+        Ed25519Signer::from_bytes("agent", &[9u8; 32]).unwrap()
+    }
+
+    fn vk_of(s: &Ed25519Signer) -> VerifyingKey {
+        let bytes: [u8; 32] = s.public_key_bytes().try_into().unwrap();
+        VerifyingKey::from_bytes(&bytes).unwrap()
+    }
+
+    fn signed_response(
+        signer: &Ed25519Signer,
+        session_ref: &str,
+        participant_id: &str,
+        joining_agent: &str,
+        nonce: &str,
+        signed_at: &str,
+    ) -> serde_json::Value {
+        let canonical =
+            join_challenge_canonical(session_ref, participant_id, joining_agent, nonce, signed_at);
+        let sig = signer.sign(&canonical).unwrap();
+        serde_json::json!({
+            "nonce": nonce,
+            "signed_at": signed_at,
+            "signature": URL_SAFE_NO_PAD.encode(sig),
+        })
+    }
+
+    #[test]
+    fn canonical_is_deterministic_and_binds_every_field() {
+        let base = join_challenge_canonical(
+            "ssn_1",
+            "art_p1",
+            "agentpk",
+            "nonce1",
+            "2026-08-06T00:00:00Z",
+        );
+        assert_eq!(
+            base,
+            join_challenge_canonical(
+                "ssn_1",
+                "art_p1",
+                "agentpk",
+                "nonce1",
+                "2026-08-06T00:00:00Z"
+            ),
+        );
+        assert_ne!(
+            base,
+            join_challenge_canonical(
+                "ssn_2",
+                "art_p1",
+                "agentpk",
+                "nonce1",
+                "2026-08-06T00:00:00Z"
+            ),
+            "session_ref must bind"
+        );
+        assert_ne!(
+            base,
+            join_challenge_canonical(
+                "ssn_1",
+                "art_p2",
+                "agentpk",
+                "nonce1",
+                "2026-08-06T00:00:00Z"
+            ),
+            "participant_id must bind"
+        );
+        assert_ne!(
+            base,
+            join_challenge_canonical(
+                "ssn_1",
+                "art_p1",
+                "otherpk",
+                "nonce1",
+                "2026-08-06T00:00:00Z"
+            ),
+            "joining_agent must bind"
+        );
+        assert_ne!(
+            base,
+            join_challenge_canonical(
+                "ssn_1",
+                "art_p1",
+                "agentpk",
+                "nonce2",
+                "2026-08-06T00:00:00Z"
+            ),
+            "nonce must bind"
+        );
+        assert_ne!(
+            base,
+            join_challenge_canonical(
+                "ssn_1",
+                "art_p1",
+                "agentpk",
+                "nonce1",
+                "2026-08-06T01:00:00Z"
+            ),
+            "signed_at must bind"
+        );
+    }
+
+    #[test]
+    fn canonical_resists_separator_injection() {
+        // Pipe-containing fields must not collide with a differently-split
+        // canonical -- every variable field is digest-folded.
+        let a = join_challenge_canonical("ssn|1", "art|p1", "pk", "n", "2026-08-06T00:00:00Z");
+        let b = join_challenge_canonical("ssn", "1|art|p1", "pk", "n", "2026-08-06T00:00:00Z");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn valid_response_verifies() {
+        let s = signer();
+        let vk = vk_of(&s);
+        let resp = signed_response(
+            &s,
+            "ssn_1",
+            "art_p1",
+            "agentpk",
+            "n_abc",
+            "2026-08-06T00:00:00Z",
+        );
+        let signed_at =
+            check_join_challenge(&resp, "ssn_1", "art_p1", "agentpk", "n_abc", &vk).unwrap();
+        assert_eq!(signed_at, "2026-08-06T00:00:00Z");
+    }
+
+    #[test]
+    fn wrong_nonce_is_rejected() {
+        let s = signer();
+        let vk = vk_of(&s);
+        let resp = signed_response(
+            &s,
+            "ssn_1",
+            "art_p1",
+            "agentpk",
+            "n_abc",
+            "2026-08-06T00:00:00Z",
+        );
+        // Host expects a DIFFERENT nonce than the one actually signed.
+        let err =
+            check_join_challenge(&resp, "ssn_1", "art_p1", "agentpk", "n_other", &vk).unwrap_err();
+        assert!(err.contains("does not match"), "got: {err}");
+    }
+
+    #[test]
+    fn wrong_signer_is_rejected() {
+        let s = signer();
+        let other = Ed25519Signer::from_bytes("imposter", &[42u8; 32]).unwrap();
+        let vk = vk_of(&other);
+        let resp = signed_response(
+            &s,
+            "ssn_1",
+            "art_p1",
+            "agentpk",
+            "n_abc",
+            "2026-08-06T00:00:00Z",
+        );
+        let err =
+            check_join_challenge(&resp, "ssn_1", "art_p1", "agentpk", "n_abc", &vk).unwrap_err();
+        assert!(err.contains("INVALID"), "got: {err}");
+    }
+
+    #[test]
+    fn replayed_response_for_a_different_participant_is_rejected() {
+        let s = signer();
+        let vk = vk_of(&s);
+        let resp = signed_response(
+            &s,
+            "ssn_1",
+            "art_p1",
+            "agentpk",
+            "n_abc",
+            "2026-08-06T00:00:00Z",
+        );
+        // Same nonce, same signer, but a DIFFERENT participant_id -- the
+        // signature was over art_p1's canonical bytes, not art_p2's.
+        let err =
+            check_join_challenge(&resp, "ssn_1", "art_p2", "agentpk", "n_abc", &vk).unwrap_err();
+        assert!(err.contains("INVALID"), "got: {err}");
+    }
+}


### PR DESCRIPTION
## What

Adds an optional `--challenge`/`--challenge-response` gate to `session countersign`, plus a new `session answer-challenge` command, so a host countersigning a pending participant event can prove the joining agent is live right now — not just that it held the key whenever `session join` produced the pending envelope.

## Why

`join()` and `countersign()` can run on different machines, with the pending participant envelope handed to the host out-of-band (pasted, like the invitation blob). That hand-off has no time bound — a host who countersigns hours later has no way to distinguish a live join from a stale-but-validly-signed envelope whose signer's sandbox is gone, key rotated, or agent compromised.

Reuses `present`'s challenge-canonical/signature pattern verbatim (`v1|room-join-challenge|...`, digest-folded fields, bearer-signed `signed_at`) rather than inventing a new one.

## Design notes

- **Additive and opt-in.** Omitting both flags countersigns exactly as before — this does not turn `session join`/`countersign` into a mandatory two-round synchronous protocol, so the pasteable-blob asynchrony the invitation design exists for is preserved.
- **Deliberately not baked into `SessionParticipantStatement::canonical_for_signing`.** That statement's two signatures (joining_agent, then host) must cover *identical* canonical bytes — the joining agent signs at `join()` time, before any challenge exists, so a liveness field can't live in that canonical without either the joining agent pre-committing to a challenge that hasn't happened yet, or breaking the same-bytes invariant the whole trust model rests on. This PR keeps the challenge as an ephemeral, host-side gate at countersign time.
- **Follow-up, not in this PR:** a separate optional signed `room-join-liveness/v1` attestation (referencing the participant artifact id) so a verifier can grade document-proven vs live-proven joins, the same honest-gradient pattern the codebase already uses for `EffectConfidence`. Deferred behind room-in-receipt per the sequencing on the PR #266 review (room → receipt/verifier before any new CLI surface), since the attestation should probably reference `room` once that's real.

## Verified

- `cargo build --bin treeship` clean
- `cargo test -p treeship-core -p treeship-cli` — 734 passing, 0 failed, across every suite (incl. new tests in `packages/core/src/verify/session_join_challenge.rs` and `packages/cli/tests/invitation_cli.rs`)
- Not merging this myself — for review.

Originating conversation: https://github.com/zerkerlabs/treeship (Buzz channel `treeship`, thread on the Treeship×Buzz integration design)