### PR TITLE
fix(verify): read receipt.v1's signed parent edge from subject.artifactId

### DIFF
--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -751,6 +751,19 @@ fn compute_chain_linkage(chain: &[(String, Envelope)]) -> (bool, String) {
                     // protocol object it extends. Treat that invitation ref as
                     // its parent instead of trusting unsigned storage metadata.
                     .or_else(|| v.get("invitation_ref"))
+                    // receipt.v1 (the session record minted by
+                    // `mint_session_record`) carries no top-level parentId. It
+                    // names the session-close artifact it seals as its signed
+                    // `subject.artifactId`, and storage records that same id as
+                    // the parent. That IS a signed edge -- it is inside the
+                    // DSSE payload -- so reading it here is not a relaxation:
+                    // a mismatch still fails below. Before this, every receipt
+                    // landing mid-chain reported "possible tampering" on
+                    // correctly-signed evidence.
+                    .or_else(|| {
+                        v.get("subject")
+                            .and_then(|s| s.get("artifactId").or_else(|| s.get("artifact_id")))
+                    })
                     .and_then(|p| p.as_str())
                     .map(str::to_string)
             });
@@ -2004,6 +2017,70 @@ fn extract_actor(envelope: &Envelope) -> String {
 mod tests {
     use super::*;
     use treeship_core::statements::{ActionStatement, ApprovalScope, SubjectRef};
+
+    // ── signed chain linkage: receipt.v1 subject edge ──────────────────
+    //
+    // `mint_session_record` writes the session-close artifact id BOTH as the
+    // unsigned storage `parent_id` and as the signed `subject.artifactId`.
+    // The linkage check must read the signed one. Regression guard for the
+    // false "possible tampering" every mid-chain receipt used to report.
+
+    /// Build a real signed receipt.v1 envelope whose subject names `subject`.
+    fn signed_receipt(subject: Option<&str>) -> Envelope {
+        use treeship_core::attestation::{sign, Ed25519Signer};
+        use treeship_core::statements::ReceiptStatement;
+
+        let mut stmt = ReceiptStatement::new("system://treeship-session", "session.v1");
+        stmt.subject = subject.map(|id| SubjectRef {
+            artifact_id: Some(id.to_string()),
+            ..Default::default()
+        });
+        let signer = Ed25519Signer::generate("key_receipt_test").unwrap();
+        sign("application/vnd.treeship.receipt.v1+json", &stmt, &signer)
+            .unwrap()
+            .envelope
+    }
+
+    #[test]
+    fn receipt_subject_artifact_id_counts_as_signed_parent() {
+        let parent = "art_1bd9b5b82f7a3de9994f462b2f886800";
+        let chain = vec![
+            (parent.to_string(), signed_receipt(None)),
+            ("art_child".to_string(), signed_receipt(Some(parent))),
+        ];
+        let (ok, detail) = compute_chain_linkage(&chain);
+        assert!(ok, "receipt subject edge should satisfy linkage: {detail}");
+    }
+
+    #[test]
+    fn receipt_subject_naming_another_artifact_still_breaks() {
+        // The subject is an ACCEPTED field, not a bypass: pointing it at
+        // something other than the walked parent must still fail, or this
+        // change would have turned a tampering check into a rubber stamp.
+        let chain = vec![
+            ("art_real_parent".to_string(), signed_receipt(None)),
+            (
+                "art_child".to_string(),
+                signed_receipt(Some("art_somewhere_else")),
+            ),
+        ];
+        let (ok, detail) = compute_chain_linkage(&chain);
+        assert!(!ok, "a subject naming a different artifact must break");
+        assert!(detail.contains("art_somewhere_else"), "detail: {detail}");
+    }
+
+    #[test]
+    fn receipt_without_subject_still_breaks() {
+        // A receipt that names no parent at all cannot prove it belongs
+        // where storage put it. Absence is not permission.
+        let chain = vec![
+            ("art_real_parent".to_string(), signed_receipt(None)),
+            ("art_child".to_string(), signed_receipt(None)),
+        ];
+        let (ok, detail) = compute_chain_linkage(&chain);
+        assert!(!ok, "missing subject must not pass linkage");
+        assert!(detail.contains("(none)"), "detail: {detail}");
+    }
 
     // ── action/v2 effect verdict wiring ────────────────────────────────
     #[test]


### PR DESCRIPTION
## The bug

Every `receipt.v1` that lands mid-chain reports tampering:

```
⚠ chain SIGNED LINKAGE BROKEN — possible tampering
  detail: art_4282bb1d8371 claims parent (none), walked from art_1bd9b5b82f7a
```

That artifact is correctly signed and its parent edge was never missing.

## Why

`mint_session_record` (`session.rs`) writes the close-artifact id **twice**:

```rust
stmt.subject = Some(SubjectRef { artifact_id: Some(close_artifact_id.to_string()), .. });
...
parent_id: Some(close_artifact_id.to_string()),   // storage — same value
```

`compute_chain_linkage` looked only for a top-level `parentId`/`parent_id`, found neither, and concluded the child claimed no parent.

The check already special-cases `session-participant/v1`, which names its signed edge `invitation_ref`. `receipt.v1` names its edge `subject.artifactId` — same class of thing, just unhandled.

## Measured, not assumed

Across the local artifact store:

| type | storage parent | signed parent | n |
|---|---|---|---|
| `action.v1` | yes | yes | 9 ✓ |
| `receipt.v1` | yes | **no** | 4 ✗ |

All 4 verify clean after this change. One of them, `art_37909a4130883d907972ad42962fcc7b`, had been reported as verifying cleanly by a session-package check while `treeship verify` called it tampering — two verifiers disagreeing about the same artifact.

## Not a relaxation

`subject` is inside the signed DSSE payload, so this reads a signed edge, not storage metadata. Three tests, all using real signed envelopes:

- `receipt_subject_artifact_id_counts_as_signed_parent` — the fix works
- `receipt_subject_naming_another_artifact_still_breaks` — a subject pointing elsewhere still fails
- `receipt_without_subject_still_breaks` — absence is not permission

## Verification

- `cargo test -p treeship-core -p treeship-cli -p treeship-core-wasm` — **745 passing, 0 failures**
- No new fmt diffs (package has pre-existing ones on `main`; `verify.rs` count unchanged at 15)
- Confirmed against the real artifact before/after with a patched build

## Why it matters

A false tampering alarm on legitimate evidence is worse than a noisy check — it teaches operators to ignore the one signal the product exists to provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)