### PR TITLE
feat(receipt): wire Custody so a service can actually emit one

### DIFF
--- a/packages/core/src/predicates/schemas/session.v1.json
+++ b/packages/core/src/predicates/schemas/session.v1.json
@@ -47,6 +47,31 @@
       "description": "Capture surface(s) the session ran under: distinct tool runtime ids from the sealed receipt (e.g. 'claude-code'), or 'cli' when no tool runtime was involved.",
       "type": "string"
     },
+    "custody": {
+      "description": "Who held the signing key, when that is not the actor. ABSENT means self-custody -- the actor signed for itself, the default and the strong case. Present means a service signed on the actor's behalf: a materially weaker claim, so it is recorded rather than inferred. Deliberately a separate axis from attestation_class, which grades how EVIDENCE was captured; this grades who held the KEY. They vary independently -- a service-mediated room can have excellent runtime-captured evidence and still be custodially signed. Under self-custody, forging a participant's action needs that participant's key; under delegated custody, a compromised service can mint any history for every actor it signs for. Same receipt shape, different threat model.",
+      "type": "object",
+      "required": ["mode", "signer", "on_behalf_of"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "description": "Only 'delegated' is ever serialized. Self-custody is the absence of this whole object, so existing receipts stay byte-identical and 'no custody block' cannot be misread as 'custody unknown'.",
+          "type": "string",
+          "enum": ["delegated"]
+        },
+        "signer": {
+          "description": "The identity whose key actually produced the signature, e.g. svc://gateway-rooms. This is who a verifier is really trusting.",
+          "type": "string"
+        },
+        "on_behalf_of": {
+          "description": "The actor the signature is claimed to be FOR, e.g. agent://fizz. A verifier can confirm the signer signed; it cannot confirm this actor agreed, and must not present it as though it could.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Why the actor did not sign for itself, e.g. 'browser-mediated room; participants hold no local key'.",
+          "type": "string"
+        }
+      }
+    },
     "attestation_class": {
       "description": "How the record's evidence was captured, per the work-history ladder: self (the agent's own receipts, no external signal), runtime (events emitted by a harness hook or bridge the agent cannot forge or omit), countersigned (a second party signed evidence in the package, e.g. consumed human approvals). Labeled, never laundered; 'anchored' is a later, derivable state (publish + witness), not set at close.",
       "type": "string",

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -395,6 +395,28 @@ impl ReceiptComposer {
         events: &[SessionEvent],
         artifact_entries: Vec<ArtifactEntry>,
     ) -> SessionReceipt {
+        Self::compose_with_custody(manifest, events, artifact_entries, None)
+    }
+
+    /// Compose a receipt for a session whose actor did NOT hold the signing
+    /// key -- a service signing on its behalf.
+    ///
+    /// Use this from any surface that mediates for actors who hold no key of
+    /// their own (a browser-based room being the motivating case). Passing
+    /// `None` is identical to [`compose`]: self-custody is the absence of the
+    /// block, so nothing is added to the signed bytes and existing receipts
+    /// stay byte-identical.
+    ///
+    /// Recording it is not optional politeness. A receipt naming
+    /// `agent://fizz` when a service actually signed is a lie of omission, and
+    /// it is the kind that surfaces in someone else's security review rather
+    /// than ours.
+    pub fn compose_with_custody(
+        manifest: &SessionManifest,
+        events: &[SessionEvent],
+        artifact_entries: Vec<ArtifactEntry>,
+        custody: Option<Custody>,
+    ) -> SessionReceipt {
         // Build agent graph
         let agent_graph = AgentGraph::from_events(events);
 
@@ -519,8 +541,7 @@ impl ReceiptComposer {
             // load envelopes and run the verifier. The composer sees only
             // manifest + events + artifact metadata.
             authority: None,
-            // Self-custody is the default and is represented by absence.
-            custody: None,
+            custody,
         }
     }
 
@@ -1670,5 +1691,130 @@ mod custody_tests {
         });
         assert_eq!(receipt["attestation_class"], "runtime");
         assert_eq!(receipt["custody"]["mode"], "delegated");
+    }
+}
+
+#[cfg(test)]
+mod custody_wiring_tests {
+    use super::*;
+
+    /// The schema is the gate: `validate("session.v1", ..)` runs fail-closed
+    /// before anything is signed, so a custody block the schema rejects would
+    /// mean a service literally cannot emit an honest receipt. That is the
+    /// state this test exists to prevent -- the type existed for a while with
+    /// no schema entry, which made it decorative.
+    #[test]
+    fn a_delegated_receipt_passes_predicate_validation() {
+        let payload = serde_json::json!({
+            "session_id": "ssn_room_demo",
+            "actor": "agent://fizz",
+            "outcome": "completed",
+            "started_at": "2026-08-10T10:00:00Z",
+            "closed_at": "2026-08-10T10:30:00Z",
+            "attestation_class": "runtime",
+            "receipt_digest": format!("sha256:{}", "a".repeat(64)),
+            "custody": {
+                "mode": "delegated",
+                "signer": "svc://gateway-rooms",
+                "on_behalf_of": "agent://fizz",
+                "reason": "browser-mediated room; participants hold no local key"
+            }
+        });
+        crate::predicates::validate("session.v1", Some(&payload))
+            .expect("a delegated-custody receipt must validate");
+    }
+
+    /// Self-custody stays byte-identical: no block, no schema objection.
+    #[test]
+    fn a_self_custody_receipt_still_validates() {
+        let payload = serde_json::json!({
+            "session_id": "ssn_plain",
+            "actor": "ship://local",
+            "outcome": "completed",
+            "started_at": "2026-08-10T10:00:00Z",
+            "closed_at": "2026-08-10T10:30:00Z",
+            "attestation_class": "self",
+            "receipt_digest": format!("sha256:{}", "b".repeat(64)),
+        });
+        crate::predicates::validate("session.v1", Some(&payload))
+            .expect("a self-custody receipt must validate");
+    }
+
+    /// A custody block missing `signer` names no one -- recording "delegated"
+    /// without saying delegated to WHOM is worse than omitting it, because it
+    /// tells a reader the actor did not sign while withholding who did.
+    ///
+    /// Core's validator does NOT catch this: it is documented as "a small,
+    /// dependency-free structural check" over TOP-LEVEL required fields and
+    /// does not recurse into nested objects. The `required` list inside the
+    /// custody schema is therefore documentation for consumers running a full
+    /// JSON Schema validator, not something core enforces.
+    ///
+    /// What actually holds the invariant is the Rust type: `signer` and
+    /// `on_behalf_of` are `String`, not `Option<String>`, so a `Custody`
+    /// cannot be constructed without them. This test pins that, and pins the
+    /// validator's limit so nobody assumes a guarantee that is not there.
+    #[test]
+    fn custody_requires_a_signer_by_type_not_by_validator() {
+        // The type will not let you omit it.
+        let c = Custody::delegated("svc://gateway-rooms", "agent://fizz");
+        assert!(!c.signer.is_empty());
+        assert!(!c.on_behalf_of.is_empty());
+
+        // And core's validator, by design, does not police nested shape --
+        // asserting otherwise would encode a guarantee we do not offer.
+        let payload = serde_json::json!({
+            "session_id": "ssn_bad",
+            "actor": "agent://fizz",
+            "outcome": "completed",
+            "started_at": "2026-08-10T10:00:00Z",
+            "closed_at": "2026-08-10T10:30:00Z",
+            "attestation_class": "self",
+            "receipt_digest": format!("sha256:{}", "c".repeat(64)),
+            "custody": { "mode": "delegated", "on_behalf_of": "agent://fizz" }
+        });
+        assert!(
+            crate::predicates::validate("session.v1", Some(&payload)).is_ok(),
+            "core validates top-level fields only; if this starts failing the \
+             validator gained nested checking and the doc comment above is stale"
+        );
+    }
+
+    /// `compose_with_custody(.., None)` must be indistinguishable from
+    /// `compose` -- otherwise adding the parameter silently changed every
+    /// existing receipt.
+    #[test]
+    fn none_custody_composes_identically() {
+        let m = SessionManifest::new(
+            "ssn_x".into(),
+            "ship://local".into(),
+            "2026-08-10T10:00:00Z".into(),
+            1_760_000_000_000,
+        );
+        let a = ReceiptComposer::compose(&m, &[], Vec::new());
+        let b = ReceiptComposer::compose_with_custody(&m, &[], Vec::new(), None);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn delegated_custody_reaches_the_composed_receipt() {
+        let m = SessionManifest::new(
+            "ssn_y".into(),
+            "agent://fizz".into(),
+            "2026-08-10T10:00:00Z".into(),
+            1_760_000_000_000,
+        );
+        let r = ReceiptComposer::compose_with_custody(
+            &m,
+            &[],
+            Vec::new(),
+            Some(Custody::delegated("svc://gateway-rooms", "agent://fizz")),
+        );
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v["custody"]["signer"], "svc://gateway-rooms");
+        assert_eq!(v["custody"]["on_behalf_of"], "agent://fizz");
     }
 }

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -43,8 +43,8 @@ use super::invitation::{canonical_json_digest, parse_rfc3339_to_unix};
 use super::SubjectRef;
 use crate::attestation::{Signer, SignerError};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use sha2::{Digest, Sha256};
 use ed25519_dalek::{Signature, VerifyingKey};
+use sha2::{Digest, Sha256};
 
 /// Statement type tag for the mandate/effect receipt.
 pub const TYPE_ACTION_V2: &str = "treeship/action/v2";
@@ -329,10 +329,7 @@ impl EffectFinality {
     /// `Indeterminate` are open: something is still owed. Only open effects can
     /// breach a resolution deadline.
     pub fn is_resolved(self) -> bool {
-        matches!(
-            self,
-            Self::NotAttempted | Self::Finalized | Self::Failed
-        )
+        matches!(self, Self::NotAttempted | Self::Finalized | Self::Failed)
     }
 }
 
@@ -1161,19 +1158,34 @@ impl std::fmt::Display for ChainResolveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::InconsistentId { grant_id } => {
-                write!(f, "grant {grant_id} declares an id that does not match its content")
+                write!(
+                    f,
+                    "grant {grant_id} declares an id that does not match its content"
+                )
             }
             Self::LeafMissing { grant_id } => {
-                write!(f, "the mandate names grant {grant_id}, which is not in the carried chain")
+                write!(
+                    f,
+                    "the mandate names grant {grant_id}, which is not in the carried chain"
+                )
             }
             Self::AncestorMissing { parent_grant_id } => {
-                write!(f, "parent grant {parent_grant_id} is missing from the chain")
+                write!(
+                    f,
+                    "parent grant {parent_grant_id} is missing from the chain"
+                )
             }
             Self::Cycle { grant_id } => {
-                write!(f, "parent links revisit grant {grant_id}: the chain is a cycle")
+                write!(
+                    f,
+                    "parent links revisit grant {grant_id}: the chain is a cycle"
+                )
             }
             Self::UnreachableExtras { count } => {
-                write!(f, "{count} carried grant(s) are not reachable from the mandate")
+                write!(
+                    f,
+                    "{count} carried grant(s) are not reachable from the mandate"
+                )
             }
             Self::Unsigned { grant_id } => {
                 write!(f, "grant {grant_id} carries no issuer signature")
@@ -1289,19 +1301,37 @@ impl std::fmt::Display for GrantChainError {
         match self {
             Self::Empty => write!(f, "the chain is empty"),
             Self::BadTimestamp { index } => {
-                write!(f, "grant at hop {index} has an unparseable issued_at/expiry")
+                write!(
+                    f,
+                    "grant at hop {index} has an unparseable issued_at/expiry"
+                )
             }
             Self::ScopeWidened { parent } => {
                 write!(f, "scope widens at hop {}->{}", parent, parent + 1)
             }
             Self::ExpiryWidened { parent } => {
-                write!(f, "expiry extends past the parent at hop {}->{}", parent, parent + 1)
+                write!(
+                    f,
+                    "expiry extends past the parent at hop {}->{}",
+                    parent,
+                    parent + 1
+                )
             }
             Self::DepthNotIncremented { parent } => {
-                write!(f, "delegation depth does not increment by one at hop {}->{}", parent, parent + 1)
+                write!(
+                    f,
+                    "delegation depth does not increment by one at hop {}->{}",
+                    parent,
+                    parent + 1
+                )
             }
             Self::DepthExceedsMax { parent } => {
-                write!(f, "delegation depth exceeds the parent's max_delegation at hop {}->{}", parent, parent + 1)
+                write!(
+                    f,
+                    "delegation depth exceeds the parent's max_delegation at hop {}->{}",
+                    parent,
+                    parent + 1
+                )
             }
             Self::AudienceChanged { parent } => {
                 write!(f, "audience changes at hop {}->{}", parent, parent + 1)
@@ -1561,7 +1591,10 @@ mod tests {
             ..Default::default()
         };
         assert!(EffectFinality::NotAttempted.is_resolved());
-        assert_eq!(check_resolution(&e, 4_000_000_000), ResolutionStatus::Resolved);
+        assert_eq!(
+            check_resolution(&e, 4_000_000_000),
+            ResolutionStatus::Resolved
+        );
     }
 
     // ---- resolution deadlines ----
@@ -1635,7 +1668,10 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert_eq!(check_resolution(&e, 4_000_000_000), ResolutionStatus::Resolved);
+        assert_eq!(
+            check_resolution(&e, 4_000_000_000),
+            ResolutionStatus::Resolved
+        );
     }
 
     #[test]
@@ -2413,7 +2449,6 @@ mod tests {
     }
 
     // ---- grant chain resolution ----
-
 
     /// Mint a signed grant with a content-consistent id.
     fn mk_grant(

--- a/packages/core/src/statements/mod.rs
+++ b/packages/core/src/statements/mod.rs
@@ -56,12 +56,11 @@ pub use session_participant::{
 pub mod action_v2;
 pub use action_v2::{
     action_in_scope, check_resolution, payload_type_v2, resolve_grant_chain, verify_effect,
-    verify_grant_chain, verify_mandate, ChainResolveError,
-    ActionStatementV2, Cost, DeadlineEvent, Effect, EffectConfidence, EffectFinality,
-    EffectVerdict, Grant, GrantChainError,
-    Mandate, MandateVerdict, NoRevocationSource, NoWitnessAuthority, Resolution, ResolutionStatus,
-    Revocation, RevocationSource,
-    RevocationStatus, RuntimeIdentity, Witness, WitnessAuthority, TYPE_ACTION_V2,
+    verify_grant_chain, verify_mandate, ActionStatementV2, ChainResolveError, Cost, DeadlineEvent,
+    Effect, EffectConfidence, EffectFinality, EffectVerdict, Grant, GrantChainError, Mandate,
+    MandateVerdict, NoRevocationSource, NoWitnessAuthority, Resolution, ResolutionStatus,
+    Revocation, RevocationSource, RevocationStatus, RuntimeIdentity, Witness, WitnessAuthority,
+    TYPE_ACTION_V2,
 };
 
 use serde::{Deserialize, Serialize};
@@ -770,7 +769,9 @@ mod tests {
         assert!(irreversibility_requires_quarantine("one_way_consequential"));
         assert!(irreversibility_requires_quarantine("one_way_terminal"));
         // Unknown classes get the strictest treatment, never a bypass.
-        assert!(irreversibility_requires_quarantine("definitely_fine_trust_me"));
+        assert!(irreversibility_requires_quarantine(
+            "definitely_fine_trust_me"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
`Custody` shipped in #271 as a type with tests — and **nothing set it**, and it wasn't in `session.v1.json`, so the fail-closed predicate validator would have rejected any receipt carrying it.

It was a schema, not a feature. I caught this about to describe it to a partner as shipped.

## Three pieces

- **`session.v1.json`** gains a `custody` object (`mode` / `signer` / `on_behalf_of` / `reason`) so a delegated receipt validates instead of dying at the gate.
- **`ReceiptComposer::compose_with_custody(..)`** — `compose` delegates to it with `None`, and a test asserts byte-identical output so adding the parameter changed nothing that already existed.
- **Tests through the real validator**, both directions.

## A limit found by a failing test

My first test asserted that a custody block missing `signer` would be rejected. It wasn't.

Core's validator is documented as *"a small, dependency-free structural check"* over **top-level** required fields — it does not recurse into nested objects. So the `required` list inside the custody schema is documentation for consumers running a full JSON Schema validator, not something core enforces.

**What actually holds the invariant is the Rust type**: `signer` and `on_behalf_of` are `String`, not `Option<String>`, so a `Custody` cannot be constructed without them.

The test now asserts that, and separately pins the validator's limit with a comment that says what to do if it ever changes. Encoding a guarantee we don't offer would have been worse than the original gap.

## Why it matters for Rooms

Gateway Rooms participants are browser-mediated and hold no key, so its receipts are **custodial**. Labeled, that's a legitimate mode with a documented upgrade path to self-custody via `session invite`/`join`/`countersign`. Unlabeled, it's a receipt naming an actor who never signed — the kind of thing that surfaces in someone else's security review.

## Verification

518 core tests, full CLI suite, docs-drift clean under `--strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)