### PR TITLE
feat(session): mint challenge nonces, and refuse weak ones

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -443,6 +443,14 @@ treeship session answer-challenge [OPTIONS] --challenge <NONCE> --actor <URI> <P
 | `--actor <URI>` | Joining agent's actor URI. Must resolve to the same key that ran `treeship session join` |
 | `--out <PATH>` | Output path (default: &lt;participant_id&gt;.challenge-response.json) |
 
+### `treeship session mint-challenge`
+
+Mint a 128-bit challenge nonce for a room-join liveness check
+
+```
+treeship session mint-challenge [OPTIONS]
+```
+
 ## `treeship verify`
 
 Verify an artifact or its full parent chain

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -53,7 +53,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Agent Cards | `stable` | `treeship agents`, `treeship agents review`, `treeship agents approve`, `treeship agents remove` | [Agent Cards](/docs/concepts/agent-cards), [agents](/docs/cli/agents) |
 | Capability cards & provenance grades | `stable` | `treeship attest card`, `treeship verify-capability`, `treeship revoke-capability` | [Capability Cards](/docs/concepts/capability-cards) |
 | Harness Manager | `stable` | `treeship harness list`, `treeship harness inspect`, `treeship harness smoke` | [Agent Harnesses](/docs/concepts/harnesses), [harness](/docs/cli/harness) |
-| Multi-agent session invitations | `beta` | `treeship session invite`, `treeship session join`, `treeship session countersign` | [Multi-Agent Sessions](/docs/concepts/multi-agent-sessions) |
+| Multi-agent session invitations | `beta` | `treeship session invite`, `treeship session join`, `treeship session countersign`, `treeship session answer-challenge`, `treeship session mint-challenge` | [Multi-Agent Sessions](/docs/concepts/multi-agent-sessions) |
 | Room sessions | `experimental` | `treeship room` | [/docs/specs/agent-invitations-rooms.md](/docs/specs/agent-invitations-rooms.md) |
 
 ## Provenance & discovery

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -358,6 +358,8 @@
     - treeship session invite
     - treeship session join
     - treeship session countersign
+    - treeship session answer-challenge
+    - treeship session mint-challenge
   packages:
     - treeship-core
   docs:

--- a/packages/cli/src/commands/invitation.rs
+++ b/packages/cli/src/commands/invitation.rs
@@ -38,7 +38,9 @@ use treeship_core::{
     },
     storage::Record,
     trust::{decode_ed25519_pubkey, TrustRootKind, TrustRootStore},
-    verify::session_join_challenge::{check_join_challenge, join_challenge_canonical},
+    verify::session_join_challenge::{
+        check_join_challenge, join_challenge_canonical, mint_nonce, validate_nonce,
+    },
 };
 
 use crate::{
@@ -871,6 +873,11 @@ pub fn countersign(
             );
         }
         (Some(nonce), Some(response_src)) => {
+            // Reject a weak nonce before verifying anything against it. A
+            // guessable nonce can be pre-signed, so the signature would
+            // verify perfectly and prove nothing about liveness -- a pass
+            // that means nothing is worse than a refusal.
+            validate_nonce(nonce)?;
             let response_text = if response_src == "-" {
                 use std::io::Read;
                 let mut s = String::new();
@@ -1005,6 +1012,12 @@ pub fn answer_challenge(
     args: AnswerChallengeArgs,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Refuse to answer a weak challenge. The joining agent is the party whose
+    // key is being spent, and it should not sign a nonce an attacker could
+    // have guessed and replayed -- checking only at the host would leave the
+    // signer trusting the verifier to protect them.
+    validate_nonce(&args.challenge)?;
+
     let c = ctx::open(ctx_override)?;
 
     let rec = c
@@ -1217,4 +1230,41 @@ mod tests {
         let back = decode_bootstrap_blob(&blob).unwrap();
         assert_eq!(back.invitation_id, "art_test");
     }
+}
+
+// ---------------------------------------------------------------------------
+// `treeship session mint-challenge`
+// ---------------------------------------------------------------------------
+
+pub struct MintChallengeArgs {
+    pub format: String,
+}
+
+/// Mint a challenge nonce for a room-join liveness check.
+///
+/// Exists because the flag came before the tool did: `--challenge <NONCE>`
+/// asked an operator for a value without saying what kind, and the help text
+/// suggested `n_8f2a` -- six characters, enumerable instantly. A nonce that
+/// can be guessed can be pre-signed, and the liveness proof then proves only
+/// that a document exists.
+pub fn mint_challenge(
+    args: MintChallengeArgs,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let nonce = mint_nonce();
+    if args.format == "json" {
+        printer.json(&serde_json::json!({
+            "status": "ok",
+            "nonce":  nonce,
+            "bits":   128,
+        }));
+        return Ok(());
+    }
+    printer.success("challenge nonce minted", &[("nonce", &nonce)]);
+    printer.blank();
+    printer.hint(&format!(
+        "give this to the joining agent, then countersign with the same value:\n  \
+         treeship session answer-challenge <participant_id> --challenge {nonce}"
+    ));
+    Ok(())
 }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -916,7 +916,7 @@ enum SessionCommand {
     ///
     /// Examples:
     ///   treeship session countersign art_part_abc123
-    ///   treeship session countersign art_part_abc123 --challenge n_8f2a \
+    ///   treeship session countersign art_part_abc123 --challenge 9f2c4a1b8e5d7061f3a2c9b4e8d17520 \
     ///     --challenge-response ./art_part_abc123.challenge-response.json
     Countersign(SessionCountersignArgs),
 
@@ -925,8 +925,28 @@ enum SessionCommand {
     /// response to a nonce the host chose out of band.
     ///
     /// Examples:
-    ///   treeship session answer-challenge art_part_abc123 --challenge n_8f2a --actor agent://researcher
+    ///   treeship session answer-challenge art_part_abc123 --challenge 9f2c4a1b8e5d7061f3a2c9b4e8d17520 --actor agent://researcher
     AnswerChallenge(SessionAnswerChallengeArgs),
+
+    /// Mint a 128-bit challenge nonce for a room-join liveness check.
+    ///
+    /// Run by the HOST before countersigning. A challenge nonce is a replay
+    /// guard: if it can be guessed it can be pre-signed, and the liveness
+    /// proof then shows only that a document exists. Both `answer-challenge`
+    /// and `countersign` refuse a nonce shorter than 32 characters or drawn
+    /// from too small an alphabet.
+    ///
+    /// Examples:
+    ///   treeship session mint-challenge
+    ///   treeship session mint-challenge --format json
+    MintChallenge(SessionMintChallengeArgs),
+}
+
+#[derive(Args)]
+struct SessionMintChallengeArgs {
+    /// Output format: text (default) or json.
+    #[arg(long, default_value = "text")]
+    format: String,
 }
 
 #[derive(Args)]
@@ -2865,6 +2885,12 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     challenge: a.challenge.clone(),
                     actor: a.actor.clone(),
                     out: a.out.clone(),
+                    format: a.format.clone(),
+                },
+                printer,
+            ),
+            SessionCommand::MintChallenge(a) => commands::invitation::mint_challenge(
+                commands::invitation::MintChallengeArgs {
                     format: a.format.clone(),
                 },
                 printer,

--- a/packages/cli/tests/invitation_cli.rs
+++ b/packages/cli/tests/invitation_cli.rs
@@ -365,7 +365,7 @@ fn treeship_session_join_liveness_challenge_roundtrip() {
     let participant_id = join["participant_id"].as_str().unwrap().to_string();
 
     // Joining agent answers the host's nonce.
-    let nonce = "n_test_liveness_1";
+    let nonce = "3f9c1a7d5e2b8046c1d93a5f7e4b28d0";
     let response_path = ws.root.join("response.json");
     let answer_out = ws
         .cmd()
@@ -458,7 +458,7 @@ fn treeship_session_countersign_rejects_mismatched_challenge_nonce() {
     let answer_out = ws
         .cmd()
         .args(["session", "answer-challenge", &participant_id])
-        .args(["--challenge", "n_real"])
+        .args(["--challenge", "7d3e9f1c5a2b48609e8d7c6b5a4f3e2d"])
         .args(["--actor", "agent://joiner"])
         .args(["--out"])
         .arg(&response_path)
@@ -472,7 +472,7 @@ fn treeship_session_countersign_rejects_mismatched_challenge_nonce() {
     let cs_out = ws
         .cmd()
         .args(["session", "countersign", &participant_id])
-        .args(["--challenge", "n_different"])
+        .args(["--challenge", "a1b2c3d4e5f60718293a4b5c6d7e8f90"])
         .args(["--challenge-response"])
         .arg(&response_path)
         .args(["--format", "json", "--config"])
@@ -532,7 +532,7 @@ fn treeship_session_countersign_rejects_half_supplied_challenge() {
     let cs_out = ws
         .cmd()
         .args(["session", "countersign", &participant_id])
-        .args(["--challenge", "n_only_half"])
+        .args(["--challenge", "0f1e2d3c4b5a69788796a5b4c3d2e1f0"])
         .args(["--format", "json", "--config"])
         .arg(ws.config())
         .output()

--- a/packages/core/src/verify/session_join_challenge.rs
+++ b/packages/core/src/verify/session_join_challenge.rs
@@ -290,3 +290,95 @@ mod tests {
         assert!(err.contains("INVALID"), "got: {err}");
     }
 }
+
+/// Minimum nonce length, in characters.
+///
+/// A challenge nonce is a replay guard: its whole job is to be unguessable by
+/// anyone who did not just receive it. `n_8f2a` -- the value used in our own
+/// help text -- is 6 characters and enumerable in microseconds. An attacker
+/// who can guess the nonce can have the joining agent's key sign it in
+/// advance, and the "liveness" proof then demonstrates nothing beyond
+/// possession of a document, which is exactly what the challenge exists to
+/// improve on.
+///
+/// 32 hex characters is 128 bits, matching the invitation nonce.
+pub const MIN_NONCE_LEN: usize = 32;
+
+/// Reject a nonce too weak to serve as a replay guard.
+///
+/// Called at BOTH ends -- minting and verifying -- because a host that mints
+/// well while accepting anything still accepts a nonce an attacker chose.
+///
+/// This checks shape, not provenance. It cannot tell a `OsRng` nonce from a
+/// counter formatted to look like one, and it cannot detect reuse (see the
+/// note on `check_join_challenge`). It rules out the failure that actually
+/// happens: a human typing something short because the flag asked for a value
+/// and nothing said what kind.
+pub fn validate_nonce(nonce: &str) -> Result<(), String> {
+    if nonce.len() < MIN_NONCE_LEN {
+        return Err(format!(
+            "challenge nonce is {} characters; at least {MIN_NONCE_LEN} are required.\n  \
+             A short nonce can be guessed and pre-signed, which makes the liveness \
+             proof prove nothing.\n  Mint one with: treeship session mint-challenge",
+            nonce.len()
+        ));
+    }
+    // A long string of one repeated character is long and still guessable.
+    let distinct: std::collections::HashSet<char> = nonce.chars().collect();
+    if distinct.len() < 8 {
+        return Err(format!(
+            "challenge nonce uses only {} distinct characters; it is long but \
+             predictable.\n  Mint one with: treeship session mint-challenge",
+            distinct.len()
+        ));
+    }
+    Ok(())
+}
+
+/// Mint a 128-bit challenge nonce.
+///
+/// `OsRng`, not `thread_rng`: this is a security value, and the codebase's own
+/// rule is that ids used for collision-avoidance may use `thread_rng` while
+/// anything acting as a key, nonce, or token must not.
+pub fn mint_nonce() -> String {
+    use rand::RngCore;
+    let mut buf = [0u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut buf);
+    hex::encode(buf)
+}
+
+#[cfg(test)]
+mod nonce_tests {
+    use super::*;
+
+    #[test]
+    fn minted_nonces_are_128_bit_hex_and_unique() {
+        let a = mint_nonce();
+        assert_eq!(a.len(), 32, "expected 32 hex chars (128 bits)");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(validate_nonce(&a).is_ok());
+        // 1000 draws with no collision is not proof of entropy, but a
+        // counter or a constant would fail it immediately.
+        let set: std::collections::HashSet<String> = (0..1000).map(|_| mint_nonce()).collect();
+        assert_eq!(set.len(), 1000, "minted nonces collided");
+    }
+
+    /// The exact value from our own `--help` examples. If the docs suggest a
+    /// nonce the validator rejects, one of the two is wrong -- and it is the
+    /// docs.
+    #[test]
+    fn the_nonce_from_our_help_text_is_rejected() {
+        assert!(validate_nonce("n_8f2a").is_err());
+    }
+
+    #[test]
+    fn long_but_predictable_is_rejected() {
+        assert!(validate_nonce(&"a".repeat(64)).is_err(), "repeated char");
+        assert!(validate_nonce(&"abab".repeat(16)).is_err(), "tiny alphabet");
+    }
+
+    #[test]
+    fn a_real_nonce_passes() {
+        assert!(validate_nonce("9f2c4a1b8e5d7061f3a2c9b4e8d17520").is_ok());
+    }
+}


### PR DESCRIPTION
The liveness challenge (#267) shipped with a flag that asked for a nonce and **nothing that produced one**. `--challenge <NONCE>` left the operator to invent it, and our own help text suggested `n_8f2a` — six characters, enumerable instantly.

## Why that defeats the feature

A guessable nonce can be **pre-signed** by the joining agent ahead of time. The signature then verifies perfectly and proves nothing about liveness — and the command prints `challenge_verified: true` over a proof of nothing.

That's the "vacuous pass" the code-quality policy names, occurring inside the security feature meant to prevent it.

## The fix

- **`treeship session mint-challenge`** — 128 bits from `OsRng`. Not `thread_rng`: the codebase's rule is that collision-avoidance ids may use `thread_rng`, but anything acting as a key, nonce, or token may not.
- **`validate_nonce`** rejects under 32 characters, *and* rejects a long string drawn from fewer than 8 distinct characters. Long is not the same as unguessable.
- **Enforced at both ends.** `countersign` checks it because a verifier shouldn't accept a nonce an attacker chose. `answer-challenge` checks it because the joining agent's key is what gets spent — the signer shouldn't have to trust the verifier to protect them.

```console
$ treeship session answer-challenge art_x --challenge n_8f2a --actor agent://x
✗ challenge nonce is 6 characters; at least 32 are required.
  A short nonce can be guessed and pre-signed, which makes the liveness proof prove nothing.
  Mint one with: treeship session mint-challenge
```

## Two things the change caught

**Our own docs were wrong.** A test asserts the example nonce from `--help` is rejected. If the docs suggest a value the validator refuses, one of them is wrong — it was the docs. Both examples replaced.

**Three integration tests failed**, all using placeholder nonces. That's the enforcement working. They now use real 128-bit values, which is the shape operators will actually handle.

## Not covered

**Reuse.** Nothing detects the same nonce being answered twice across different participants. The Approval Use Journal already burns invitation nonces by digest and is the natural home for it — a wiring change, not a new mechanism. Called out in the commit rather than left implied.

## Verification

522 core tests + full CLI suite green. Docs-drift and capability map clean. New commands registered in the capability index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)