### PR TITLE
Release v0.24.0 — Trusted Rooms, execution identity, three fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.23.0"
+    "version": "0.24.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 0.24.0 (2026-08-10)
+
+**Trusted Rooms, end to end — plus three fixes worth upgrading for.**
+
+### Fixed
+
+- **Legitimate receipts no longer report tampering.** Every `receipt.v1`
+  landing mid-chain reported `chain SIGNED LINKAGE BROKEN — possible
+  tampering` against correctly-signed evidence. `mint_session_record` writes
+  the parent as `subject.artifactId`; the linkage check looked only for a
+  top-level `parentId`. Measured on a real store: 4 of 4 receipts affected,
+  9 of 9 actions fine. A false tampering alarm is worse than a noisy check —
+  it teaches operators to ignore the one signal the product exists to give.
+- **Keystores are portable.** `storage_dir`/`keys_dir` were always absolute,
+  so `mv ~/.treeship ~/.treeship.bak` produced a "backup" whose config still
+  pointed at whatever replaced it. Relative paths now resolve against the
+  config's own directory. Absolute paths are untouched.
+- **The Claude Code plugin monitor stopped shouting.** It emitted a line
+  whenever any counter changed, and `events` ticks on essentially every tool
+  call — one working session produced well over a hundred notifications. Now
+  reports state transitions only: two lines for a full session.
+
+### Added
+
+- **`treeship room create` / `status` / `participants`.** Sugar over
+  `treeship session`; a room is a session whose participant set evolves via
+  invitations. `invitation_authority` is carried and signed but not yet
+  enforced — conformance checking is the follow-up.
+- **`room` rides inside the signed receipt.** `RoomInfo` on `SessionManifest`
+  and mirrored into the DSSE-signed `session.v1`, so `invitation_authority`
+  is attested rather than living only in an editable local file.
+- **The room roster is derived, not stored.** `room participants` walks
+  two-signature participant artifacts instead of reading a list from
+  `session.json` — which anyone with write access could edit, and which was
+  silently incomplete whenever the best-effort append was skipped.
+- **Liveness challenge on countersign.** Opt-in `--challenge` /
+  `--challenge-response` proves the joining agent controls its key *now*,
+  not whenever `join` ran. Omitting both countersigns exactly as before.
+- **`treeship session mint-challenge`.** 128 bits from `OsRng`, because the
+  challenge flag shipped without anything to produce a value and the help
+  text suggested a six-character example. Weak nonces are now refused at both
+  ends: a guessable nonce can be pre-signed, and the proof means nothing.
+- **`Custody` on the session receipt.** Records when a *service* signed on an
+  actor's behalf rather than the actor signing for itself. Deliberately a
+  separate axis from `attestation_class`, which grades how evidence was
+  captured; this grades who held the key. Absent means self-custody, so
+  existing receipts are byte-identical.
+- **`execution_identity` on wrapped commands.** Resolved executable path,
+  sha256, argv, cwd, uid/gid. `git` is `git` only until `PATH` says
+  otherwise; two receipts with identical argv and different digests are two
+  different events. Environment **names** only, never values.
+- **A public Go client for the Hub** (`pkg/dpop`, `pkg/hubclient`). DPoP proof
+  signing existed only in Rust, so a Go service had no path to the API.
+  Tested against the real server verifier, not a stub.
+- **The capability index now covers Hub endpoints and core types.** CI fails
+  when a live endpoint belongs to no feature entry, and a generated
+  `capability-map.json` records every reachable surface — 34 CLI commands,
+  22 routes, 109 wire types.
+
+### Documentation
+
+- New concept pages: what a receipt proves (and does not), logs vs receipts,
+  effect receipts, secrets and redaction, authority delta, wrapping real
+  commands. The redaction page documents, with a measured table, which secret
+  shapes the scrubber catches and which it misses.
+
 ## Unreleased
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "base64",
  "clap",
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.23.0"
+    "@treeship/core-wasm": "0.24.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.23.0",
+    "@treeship/core-wasm": "0.24.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,9 +19,9 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.23.0",
-    "@treeship/cli-darwin-arm64": "0.23.0",
-    "@treeship/cli-darwin-x64": "0.23.0"
+    "@treeship/cli-linux-x64": "0.24.0",
+    "@treeship/cli-darwin-arm64": "0.24.0",
+    "@treeship/cli-darwin-x64": "0.24.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.23.0", path = "../core" }
+treeship-core = { version = "0.24.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.23.0"
+version = "0.24.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.23.0"
+    "@treeship/core-wasm": "0.24.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeship/verify",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeship/core-wasm": "0.20.0"

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.23.0"
+    "@treeship/core-wasm": "0.24.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.23.0"
+    "@treeship/verify": "0.24.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.23.0"
+    "@treeship/verify": "0.24.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "@treeship/verify": "0.20.0"
       },

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.23.0"
+    "@treeship/verify": "0.24.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Version bump across 39 sites plus the CHANGELOG. Prepared with `scripts/release.sh prepare 0.24.0` — **no tag created**, per the two-phase process.

## Why upgrade

Three fixes, two of which affect anyone on 0.23.0 today:

- **Legitimate receipts reported tampering.** Every `receipt.v1` landing mid-chain showed `possible tampering` against correctly-signed evidence. Measured on a real store: 4 of 4 receipts affected.
- **Keystores were un-movable.** `mv ~/.treeship ~/.treeship.bak` produced a "backup" pointing at whatever replaced it.
- **The plugin monitor emitted a notification per event** — well over a hundred in one session.

## What's new

**Trusted Rooms, end to end:** `treeship room create/status/participants`, `room` inside the signed receipt, a roster derived from two-signature participant artifacts rather than an editable list, an opt-in liveness challenge with proper nonce minting, and `Custody` so a service signing for an agent says so.

**Execution identity:** wrap receipts now record which binary actually ran — resolved path, sha256, argv, cwd, uid/gid. Environment names only, never values.

**A public Go client** so a Go service can reach the Hub at all.

**The capability index** now covers Hub endpoints and core types, with CI failing on drift in both directions.

## Known, not blocking

**#275** — duplicate `sequence_no` under burst contention in the session event log. Rare, pre-existing, unrelated to anything here, and filed rather than shipped silently. It deserves real investigation, not a rushed patch inside a release.

## After merge

Tag only on explicit approval:

```
scripts/release.sh tag 0.24.0 --sha <merged-main-sha>
git push origin v0.24.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)