### PR TITLE
fix(hub): serve the newest revocation, and stop inventing timestamps

### DIFF
--- a/packages/hub/internal/agents/agents.go
+++ b/packages/hub/internal/agents/agents.go
@@ -110,7 +110,19 @@ func (h *Handlers) Resolve(w http.ResponseWriter, r *http.Request) {
 			if json.Unmarshal(stmt.Payload, &p) != nil || p.Card == "" {
 				continue
 			}
-			revByCard[p.Card] = entry
+			// Artifacts arrive newest-first (ORDER BY signed_at DESC), so an
+			// unconditional assignment left the OLDEST revocation per card --
+			// the last write won. A client asking "is this card revoked, and
+			// when" would get a superseded answer.
+			//
+			// Keep the first one seen, which under that ordering is the
+			// newest. Note the ordering key is caller-supplied signed_at that
+			// the Hub does not verify; this fixes the inversion, it does not
+			// make the choice trustworthy. Clients still decide which
+			// revocations are authorized.
+			if _, seen := revByCard[p.Card]; !seen {
+				revByCard[p.Card] = entry
+			}
 		case "agent_cert.v1":
 			// The certificate chain: ship-signed bindings of this agent's
 			// URI to its per-agent key. Served verbatim so a client that

--- a/packages/hub/internal/artifacts/artifacts.go
+++ b/packages/hub/internal/artifacts/artifacts.go
@@ -29,17 +29,37 @@ type pushRequest struct {
 }
 
 // parseSignedAt handles both unix int and RFC 3339 string.
-func parseSignedAt(raw json.RawMessage) int64 {
+// parseSignedAt reads the caller-supplied signed_at, accepting a unix integer
+// or an RFC3339 string. Returns ok=false when the value is absent or
+// unparseable.
+//
+// It used to return time.Now() on every failure path -- and the string branch
+// never parsed at all, so a perfectly good RFC3339 timestamp was silently
+// replaced by server time. That turned "the client sent something we could not
+// read" into "the client sent this plausible moment," which is the worst of
+// both: the bad input is not rejected, and the fabricated value is
+// indistinguishable from a real one to everything downstream.
+//
+// This value is caller-supplied and the Hub does not verify envelopes, so it
+// is untrusted either way. But untrusted-and-recorded-as-given is auditable;
+// untrusted-and-quietly-replaced is not.
+func parseSignedAt(raw json.RawMessage) (int64, bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return 0, false
+	}
 	var ts int64
 	if json.Unmarshal(raw, &ts) == nil {
-		return ts
+		return ts, true
 	}
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
-		// best-effort parse -- just use current time if it fails
-		return time.Now().Unix()
+		for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+			if t, err := time.Parse(layout, s); err == nil {
+				return t.Unix(), true
+			}
+		}
 	}
-	return time.Now().Unix()
+	return 0, false
 }
 
 // Push handles POST /v1/artifacts [DPoP authenticated]
@@ -68,6 +88,16 @@ func (h *Handlers) Push(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	signedAt, ok := parseSignedAt(req.SignedAt)
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error": "signed_at must be a unix timestamp or an RFC3339 string",
+		})
+		return
+	}
+
 	hubURL := "https://treeship.dev/verify/" + req.ArtifactID
 
 	artifact := &db.Artifact{
@@ -75,7 +105,7 @@ func (h *Handlers) Push(w http.ResponseWriter, r *http.Request) {
 		PayloadType:  req.PayloadType,
 		EnvelopeJSON: req.EnvelopeJSON,
 		Digest:       req.Digest,
-		SignedAt:     parseSignedAt(req.SignedAt),
+		SignedAt:     signedAt,
 		ParentID:     req.ParentID,
 		HubURL:       hubURL,
 		DockID:       &dockID,

--- a/packages/hub/internal/artifacts/parse_signed_at_test.go
+++ b/packages/hub/internal/artifacts/parse_signed_at_test.go
@@ -1,0 +1,41 @@
+package artifacts
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// parseSignedAt used to return time.Now() on every failure path, and its
+// string branch never parsed at all -- a valid RFC3339 timestamp was silently
+// replaced by server time. These pin both halves of the fix: real values are
+// read, and unreadable ones are rejected rather than fabricated.
+func TestParseSignedAt(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int64
+		ok   bool
+	}{
+		{"unix integer", `1786397740`, 1786397740, true},
+		{"rfc3339", `"2026-08-10T21:35:40Z"`, 1786397740, true},
+		{"rfc3339 nano", `"2026-08-10T21:35:40.123Z"`, 1786397740, true},
+		{"absent", ``, 0, false},
+		{"null", `null`, 0, false},
+		{"garbage string", `"not-a-time"`, 0, false},
+		{"object", `{"t":1}`, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseSignedAt(json.RawMessage(tc.raw))
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+			if !ok && got != 0 {
+				t.Fatalf("rejected input must return 0, not a fabricated %d", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two audit findings, both verified in source before fixing.

## Revocations were inverted

`GetArtifactsByType` returns `ORDER BY signed_at DESC` (newest first), and the loop did an unconditional `revByCard[p.Card] = entry` — so the **last** write won, meaning the **oldest** revocation per card. A client asking "is this card revoked, and when" got a superseded answer.

Now keeps the first seen. The ordering key is still caller-supplied `signed_at` the Hub doesn't verify — this fixes the inversion, it doesn't make the choice trustworthy, and the comment says so.

## parseSignedAt fabricated timestamps

Worse than the audit reported. The string branch **never parsed at all**:

```go
var s string
if json.Unmarshal(raw, &s) == nil {
    // best-effort parse -- just use current time if it fails
    return time.Now().Unix()
}
```

A valid RFC3339 string was discarded and replaced with server time. There was no parse to fail.

Now returns `(int64, bool)` — integers and RFC3339/Nano are read properly, anything else is a **400** instead of a plausible moment.

> Untrusted-and-recorded-as-given is auditable. Untrusted-and-quietly-replaced is not.

7 test cases: integer, RFC3339, nano, absent, null, garbage string, object.

## Deliberately not here

**Artifact-ID squatting** (#3/#4) — `POST /v1/artifacts` trusts a caller-supplied `artifact_id` without recomputing it from the envelope, and `ON CONFLICT DO NOTHING` makes the first upload permanent. Confirmed real. Needs a decision about whether the Hub derives IDs or explicitly marks them untrusted — that's a design call, not a drive-by fix, and it doesn't belong in a commit about ordering.

## Verification

Full hub suite green, `go vet` clean, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)