### PR TITLE
docs: correct four claims that no longer match the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -484,8 +484,16 @@ curl http://localhost:8080/v1/verify/art_xxxxx
 - Clean `dpop_jtis` older than 5 minutes on every request
 
 ### Revocation
-- `GET /.well-known/treeship/revoked.json` --signed list of revoked key fingerprints
-- Verifiers fetch and cache 24h
+- `GET /.well-known/treeship/revoked.json` -- revoked key fingerprints.
+  **Currently a hardcoded empty list, and unsigned**, despite carrying a
+  fresh `signed_at`. It is served with `Cache-Control: max-age=86400`, so a
+  verifier that trusted it would cache "nothing is revoked" for a day. Do not
+  treat it as authoritative until it is actually populated and signed.
+- The CLI does not consult it: `verify` and `session` both pass
+  `NoRevocationSource`, so the revocation layer resolves `Unknown` and an
+  action/v2 mandate degrades to `Unverified`. That is the fail-safe posture --
+  claiming a grant is live because nobody looked would be a false pass -- but
+  it means capability revocation is designed, not delivered.
 
 ### Honest boundary
 - Trust root is the machine. Root access breaks all guarantees.

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -65,12 +65,13 @@ treeship/
   LICENSE                  Apache 2.0
 
   packages/
-    core/                  Rust library (120 tests)
+    core/                  Rust library
       src/
         attestation/       DSSE envelopes, PAE, Ed25519, content-addressed IDs
         statements/        6 types: action, approval, handoff, endorsement, receipt, bundle
         merkle/            Append-only tree, checkpoints, inclusion proofs
-        keys/              AES-256-CTR + HMAC encrypted keystore
+        keys/              AES-256-GCM encrypted keystore
+                               (legacy CTR+HMAC read path for pre-v0.10.3)
         storage/           Local artifact store
         bundle/            Pack/export/import .treeship files
         rules.rs           Policy engine with YAML config
@@ -86,7 +87,7 @@ treeship/
         tui/                Ratatui interactive dashboard
         otel/               OpenTelemetry export (feature-flagged)
 
-    hub/                   Go HTTP server (12 endpoints)
+    hub/                   Go HTTP server
       main.go              Chi router, CORS, all routes
       internal/
         db/                SQLite schema + queries
@@ -110,16 +111,16 @@ treeship/
     mcp/                   MCP bridge (@treeship/mcp)
       src/                 client.ts, attest.ts, utils.ts, types.ts
 
-  docs/                    Fumadocs site (57 pages, Next.js)
+  docs/                    Fumadocs site (Next.js)
     content/
       docs/
         cli/               17 command reference pages
         api/               10 Hub API reference pages
-        concepts/          8 pages (trust model, security, actors, approvals)
-        guides/            4 pages (quickstart, how-it-works, templates)
-        integrations/      6 pages (claude-code, cursor, openclaw, hermes, langchain, mcp)
-        commerce/          3 pages (payment proofs, compliance)
-        sdk/               2 pages
+        concepts/          trust model, security, actors, approvals, receipts
+        guides/            quickstart, how-it-works, templates, wrapping commands
+        integrations/      claude-code, cursor, openclaw, hermes, langchain, mcp, …
+        commerce/          payment proofs, compliance
+        sdk/               TypeScript and Python SDK reference
       blog/                15 technical posts
 
   npm/                     npm binary wrapper (zero-Rust install)
@@ -246,7 +247,7 @@ cd treeship
 
 # Rust (core + CLI)
 cargo build
-cargo test -p treeship-core    # 120 tests
+cargo test -p treeship-core
 
 # Go (Hub)
 cd packages/hub

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Treeship produces evidence: every **captured** action becomes a signed, timestam
 
 ## The 60-second local demo
 
-No account, no server — and after the install, no network. Every output block below is real, captured from v0.20.
+No account, no server — and after the install, no network. Every output block below is real, captured from v0.24.
 
 ```bash
 npm install -g treeship
@@ -100,7 +100,7 @@ From then on, that agent's actions verify as **proven**, not asserted:
   action:        deploy.production
 ```
 
-And the agent can hand any counterparty a **presentation** — card, certificate chain, revocations — that verifies fully offline, revealing only the capabilities that verifier needs (selective disclosure, new in v0.20):
+And the agent can hand any counterparty a **presentation** — card, certificate chain, revocations — that verifies fully offline, revealing only the capabilities that verifier needs (selective disclosure):
 
 ```bash
 treeship present agent://deployer --disclose 'deploy.*' --out deployer.presentation.json
@@ -276,7 +276,7 @@ The CLI is distributed via npm + [GitHub Releases](https://github.com/zerkerlabs
 
 ## SDK examples
 
-Both SDKs shell out to the `treeship` binary for signing — install the CLI and run `treeship init` first. These examples run as written against v0.20.
+Both SDKs shell out to the `treeship` binary for signing — install the CLI and run `treeship init` first. These examples run as written against v0.24.
 
 ### TypeScript (`@treeship/sdk`)
 
@@ -329,7 +329,7 @@ Treeship builds on existing primitives rather than inventing cryptography:
 
 ## Status and roadmap
 
-Current release: **v0.20.0**. The [`CHANGELOG.md`](./CHANGELOG.md) is the source of truth for what each release shipped; the living roadmap is [`docs/specs/vision.md`](./docs/specs/vision.md).
+Current release: **v0.24.0**. The [`CHANGELOG.md`](./CHANGELOG.md) is the source of truth for what each release shipped; the living roadmap is [`docs/specs/vision.md`](./docs/specs/vision.md).
 
 **Shipped**
 - Signed artifacts, hash chains, Merkle inclusion + consistency proofs, signed checkpoints
@@ -339,7 +339,7 @@ Current release: **v0.20.0**. The [`CHANGELOG.md`](./CHANGELOG.md) is the source
 - Registry-free presentations with certificate chains and nonce challenges (v0.17)
 - Work history and checkpoint-pinned, recomputable agent profiles (v0.18); evidence-based agent matching
 - Split trust-root powers (v0.19); DPoP hub auth and device-flow login
-- **Selective capability disclosure** — present a verifier only the capabilities it needs (v0.20)
+- **Selective capability disclosure** — present a verifier only the capabilities it needs
 - MCP + A2A bridges, Claude Code plugin, TypeScript/Python SDKs, WASM verifier on Node/Deno/browser/edge
 
 **Experimental, explicitly non-authoritative**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,9 +30,10 @@ We will acknowledge your report within 48 hours and aim to release a fix within 
 
 | Version | Supported              |
 |---------|------------------------|
-| 0.20.x  | Yes (current)          |
-| 0.19.x  | Security fixes only    |
-| < 0.19  | No longer supported    |
+| 0.24.x  | Yes (current source)   |
+| 0.23.x  | Yes (latest released)  |
+| 0.22.x  | Security fixes only    |
+| < 0.22  | No longer supported    |
 
 ## Security model
 

--- a/packages/cli/src/commands/room.rs
+++ b/packages/cli/src/commands/room.rs
@@ -9,11 +9,13 @@
 //! a session.
 //!
 //! Nothing in this module gates any authority decision on
-//! `invitation_authority`. Per `RoomInfo`'s doc comment
-//! (packages/core/src/session/manifest.rs), `invitation_authority` is
-//! informational/display-only until it is folded into the canonical
-//! receipt and verified end to end -- that's tracked as follow-up work,
-//! not this PR.
+//! `invitation_authority`. It is signed -- the composer binds `room` into
+//! the `session.v1` receipt -- but signed is not enforced: nothing checks
+//! that the invitations actually minted in a session conform to the
+//! authority the receipt declares. Until that conformance check lands
+//! (see `RoomInfo`'s doc comment in packages/core/src/session/manifest.rs,
+//! and Phase 3 of docs/specs/agent-invitations-rooms.md), this module
+//! displays `invitation_authority` and gates nothing on it.
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 

--- a/packages/core/src/session/manifest.rs
+++ b/packages/core/src/session/manifest.rs
@@ -125,18 +125,22 @@ impl Default for InvitationAuthority {
 /// Absent entirely on legacy manifests and on any session that never calls
 /// `treeship room create`.
 ///
-/// **Not yet canonical.** `SessionManifest` is local working state, not the
-/// signed artifact -- `ReceiptComposer::compose` (`receipt.rs`) does not
-/// currently read this field, so `room` (including `invitation_authority`,
-/// which decides who may mint invitations) lives only in the local
-/// `session.json` and is not bound into the DSSE-signed `session.v1`
-/// receipt. That's fine today because nothing reads or enforces it yet, but
-/// it means `room` MUST NOT be used to gate any authority decision (e.g. a
-/// future `treeship room create/invite` CLI trusting `invitation_authority`
-/// off disk) until it is folded into the canonical receipt and verified --
-/// an unsigned field that gates authority is exactly the
-/// wire-controllable-dispatch-field failure class `CLAUDE.md` calls out.
-/// Tracked as required follow-up work before any room CLI lands.
+/// **Signed, but not yet enforced.** `SessionManifest` is local working
+/// state; the signed artifact is the `session.v1` receipt. As of #266 the
+/// composer DOES copy this field into that receipt (`receipt.rs`, in
+/// `compose_with_custody`), so `room` -- including `invitation_authority` --
+/// is bound into the DSSE-signed bytes.
+///
+/// That closes half the gap. It does NOT make `invitation_authority`
+/// trustworthy as an authorization input: the receipt attests what the host
+/// wrote at close time, and nothing verifies that the invitations actually
+/// minted in the session conform to it. So a receipt can honestly attest
+/// `DelegatedTo{[X]}` while an invitation from Y sits in the same session.
+///
+/// The remaining work is conformance checking -- the spec's Phase 3
+/// `participation_conformance` row -- and until it lands, treat
+/// `invitation_authority` as a signed CLAIM, not an enforced rule. `treeship
+/// room` today displays it and gates nothing, which is the honest posture.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RoomInfo {
     /// Stable room identifier, distinct from `session_id` -- a room can in


### PR DESCRIPTION
Audit follow-up. Four documented claims were true when written and quietly stopped being true. Three are mine.

### `manifest.rs` / `room.rs` — a prohibition that outlived its reason

`RoomInfo`'s doc comment said the composer "does not currently read this field," and that `room` **"MUST NOT be used to gate any authority decision ... until it is folded into the canonical receipt."**

It was folded in at `receipt.rs:511`, with a regression test asserting it reaches the signed payload (`commands/session.rs:2754`). The comment described the codebase from before that change, and forbade work already done.

I restated it rather than deleting it, because **the prohibition is still half-right for a different reason.** `room` is now signed — but signed is not enforced. Nothing checks that the invitations actually minted in a session conform to the authority the receipt declares, so a receipt can honestly attest `DelegatedTo{[X]}` while an invitation from Y sits in the same session.

That distinction is the whole point, and the old comment collapsed it into "not signed yet." The new one says `invitation_authority` is a signed **claim**, not an enforced rule, and points at the Phase 3 `participation_conformance` row that closes it.

### `AGENTS.md` — "signed list of revoked key fingerprints"

It is unsigned, hardcoded empty, and served with `Cache-Control: max-age=86400` while carrying a fresh `signed_at`. A verifier that trusted it would cache "nothing is revoked" for a day on the strength of a field that means nothing.

Also documents what the CLI actually does: `verify` and `session` both pass `NoRevocationSource`, so revocation resolves `Unknown` and an action/v2 mandate degrades to `Unverified`. That is the correct fail-safe — claiming a grant is live because nobody looked would be a false pass — but it means revocation is designed, not delivered, and the spec read as though it shipped.

### `ONBOARDING.md` — "AES-256-CTR + HMAC"

Keystore encryption is AES-256-GCM (`keys/mod.rs:1100`). CTR+HMAC is the legacy pre-v0.10.3 read path, still supported for old keystores, and was described as the current scheme.

### `SECURITY.md` / `README.md` — version drift

Matrix now reads 0.24.x current source / 0.23.x latest released. README version claims restamped where they describe current behavior. The "new in v0.20" framings were **dropped rather than restamped** — restamping a historical claim makes it false in the other direction.

Also removed brittle counts from `ONBOARDING.md` (test totals, endpoint and page counts). They were already wrong and no CI keeps them right. An unverifiable number is worse than no number.

---

Docs and comments only — no behavior change. `cargo check -p treeship-core -p treeship-cli` clean.

**Why this keeps happening:** all four are the same failure — a true statement about a moving codebase, with nothing tying it to the thing it describes. The capability index covers the "does X exist" half. Prose that describes *how* something works is still unguarded, and comments that say "not yet" are the worst of it: they age into prohibitions against work that's already landed.