### PR TITLE
docs: record the disposition of the August 2026 external audit

### DIFF
--- a/docs/quality/audit-2026-08.md
+++ b/docs/quality/audit-2026-08.md
@@ -9,7 +9,7 @@ nobody can look up is a finding that gets rediscovered, re-analyzed, and
 re-argued six weeks later — which is how Treeship ended up with four
 documented claims that had quietly gone false (see #281).
 
-**Status as of v0.24.0 (2026-08-11):** 18 closed, 3 declined, 29 open.
+**Status as of v0.24.0 (2026-08-11):** 26 closed, 3 declined, 21 open.
 
 Verify any "closed" row before trusting it — each cites the PR or the file
 that makes it true.
@@ -71,7 +71,7 @@ answer than fixing them, and 3–7 remain the top of the queue.
 | 10 | "Current card" chosen by caller-controlled `signed_at` | **Partly closed** | #280 rejects malformed timestamps; selection still trusts the value |
 | 11 | Derive or isolate Hub indexing metadata | **Open** | |
 | 12 | Bind agent namespaces to publishers | **Open** | |
-| 13 | Six production vulns in the MCP package | **Unblocked** | was blocked on `@treeship/core-wasm@0.24.0`, now published |
+| 13 | Six production vulns in the MCP package | **Closed** | #283 -- now zero |
 | 14 | Twelve high-severity vulns in the docs site | **Open** | `npm audit fix` exceeded 10min; still 12 high |
 | 15 | Dependency audits in CI | **Open** | no `cargo audit` / `npm audit` / dependabot |
 | 16 | Broken public "Verify a receipt" URL | **Closed** | `public/home.html`, commit 86e71ff |
@@ -102,26 +102,36 @@ a fabricated value. Fixed to reject rather than invent.
 | 28 | Merge changelog mirror PR #278 | **Closed** | merged |
 | 29 | Changelog generation in the docs-drift gate | **Open** | |
 | 30 | `CHANGELOG.md` ordering and duplication | **Closed** | 0.24.0 heads the file, correctly dated |
-| 31 | TypeScript SDK tests in CI | **Open** | not in `ci.yml` job list |
-| 32 | Split SDK unit tests from the Rust release build | **Open** | |
-| 33 | MCP, A2A, verify-js tests in CI | **Open** | |
-| 34 | Python SDK unit tests in CI | **Open** | |
-| 35 | Full docs production build in CI | **Open** | |
+| 31 | TypeScript SDK tests in CI | **Closed** | #283 -- `sdk-ts` job |
+| 32 | Split SDK unit tests from the Rust release build | **Closed** | #283 -- 98s+error to 1.78s clean |
+| 33 | MCP, A2A, verify-js tests in CI | **Closed** | #283 -- `js-suites` matrix |
+| 34 | Python SDK unit tests in CI | **Closed** | #283 -- and fixed discovery; 28 of 44 tests were unreachable |
+| 35 | Full docs production build in CI | **Closed** | #283 -- `docs-build` job |
 | 36 | Port acceptance placeholders T1–T9 into real tests | **Open** | |
-| 37 | Clippy as a CI gate | **Open** | no clippy step in `ci.yml` |
-| 38 | Remove the 34 Rust warnings from normal tests | **Open** | |
+| 37 | Clippy as a CI gate | **Closed** | #283 -- `-D warnings`, 149 warnings cleared first |
+| 38 | Remove the 34 Rust warnings from normal tests | **Closed** | #283 -- workspace is at zero |
 | 39 | Automate the AI-quality policy checks | **Open** | |
 | 40 | Adversarial Hub handler tests | **Open** | |
 
-This block is the largest concentration of open items, and the cheapest.
-Items 31–35 and 37 are CI configuration, not engineering: the tests already
-exist and simply are not run. The current `ci.yml` runs Rust, Hub (Go), and
-the cross-SDK contract suite — the TypeScript, Python, MCP, A2A, and
-verify-js suites are unexercised on every commit.
+This was the largest concentration of open items and the cheapest to close.
+#283 closed 31–35, 37 and 38: the suites already existed, they simply were
+not run. Seven new jobs, 20 green.
 
-**#37 is the one with teeth.** Clippy caught a genuine issue during the
-rig-treeship setup this month. Not running it here means the same class of
-finding lands in review instead of CI.
+Three things surfaced only because something finally ran them:
+
+- **The Python suite's documented invocation did not work.** `tests/` had no
+  `__init__.py`, so `python -m unittest discover` — the command in the test
+  files' own docstring — failed outright, and only 28 of 44 tests were
+  reachable by any invocation.
+- **`npm ci` failed in all four JS packages.** The lockfiles pinned
+  `@treeship/core-wasm@0.20.0` against a package.json asking for 0.24.0, and
+  carried exactly one rollup platform binary (`darwin-arm64`), so they only
+  ever worked on a Mac. `version-consistency` checks package.json and not the
+  lockfile, which is how four releases of drift survived.
+- **Clippy found a live-lock.** `wrap.rs` drained a wrapped child's pipes with
+  `reader.lines().flatten()`, which spins forever on a persistent read error.
+
+Items 29, 30, 36, 39 and 40 remain open.
 
 ---
 
@@ -173,8 +183,13 @@ rather than the list itself:
 3. **Local verification is not CI verification.** #279 passed `cargo check`,
    `cargo test`, and clippy locally, then failed all eight Cross-SDK cells: a
    `#[cfg(not(target_family = "wasm"))]` had migrated to the wrong function.
-   No local command builds wasm32. Worth knowing before trusting a green
-   local run.
+   No local command builds wasm32.
+
+   #283 then hit the same wall three more times in one PR: `cargo fmt` was
+   never run locally, the lockfiles worked only on macOS, and the docs job's
+   `npm ci` passed here solely because an untracked `package-lock.json` exists
+   on the developer machine. Every one of those was a green local run that
+   said nothing about a Linux runner with a clean checkout.
 
 ---
 

--- a/docs/quality/audit-2026-08.md
+++ b/docs/quality/audit-2026-08.md
@@ -1,0 +1,189 @@
+# External audit, August 2026 — disposition
+
+Two external agents audited Treeship in August 2026 and produced a combined
+50-item priority list. This file is the disposition record: what was fixed,
+what was deliberately declined, and what is still open.
+
+It exists because the findings lived only in a chat transcript. A finding
+nobody can look up is a finding that gets rediscovered, re-analyzed, and
+re-argued six weeks later — which is how Treeship ended up with four
+documented claims that had quietly gone false (see #281).
+
+**Status as of v0.24.0 (2026-08-11):** 18 closed, 3 declined, 29 open.
+
+Verify any "closed" row before trusting it — each cites the PR or the file
+that makes it true.
+
+---
+
+## P0 — what the audit called release blockers
+
+| # | Finding | Status | Evidence |
+|---|---|---|---|
+| 1 | Duplicate `sequence_no` under burst contention (#275) | **Closed** | #279; issue auto-closed |
+| 2 | Lock `EventLog::open()` with the append lock | **Closed, differently** | #279 — see below |
+| 3 | Prevent Hub artifact-ID squatting | **Open** | needs a product decision |
+| 4 | Reject conflicting artifact re-uploads | **Open** | same decision as #3 |
+| 5 | Real grant revocation resolution | **Open** | `NoRevocationSource` in `commands/verify.rs`, `session.rs` |
+| 6 | Replace the unsigned, empty Hub revocation endpoint | **Open** | documented honestly in #281 |
+| 7 | Enforce Trusted Room invitation authority | **Open** | nothing in `verify/` reads it |
+| 8 | Do not tag v0.24 until 1–7 are dispositioned | **Dispositioned, not fixed** | see below |
+
+### On #2 — the fix is not the one that was recommended
+
+The audit said to lock `open()`. That would work. #279 instead removed the
+write: `open()` called `read_counter_or_recount`, which *rewrites* the counter
+sidecar, unlocked. Making it read-only means there is no longer a write to
+serialize.
+
+This matters because the recommended fix would have put an exclusive flock in
+the path of every handle construction, and would have preserved a write that
+has no reason to exist during `open`.
+
+### On #8 — we tagged with 3–7 open. That was a judgment call.
+
+The audit's position was that v0.24 should not ship until every P0 was
+resolved. It shipped with five of them open. The reasoning, stated plainly so
+it can be disagreed with:
+
+- **3, 4** (Hub squatting) are real gaps, but pre-existing and unchanged by
+  v0.24. Holding the release would not have reduced exposure by a day.
+- **5, 6** (revocation) are pre-existing and **fail-safe**: with
+  `NoRevocationSource`, revocation resolves `Unknown` and an action/v2 mandate
+  degrades to `Unverified`. The failure mode is refusing to confirm, not
+  falsely confirming. That is the correct direction for an unimplemented
+  check.
+- **7** (room authority) is new in v0.24, but `treeship room` displays
+  `invitation_authority` and gates nothing on it. Nothing trusts it yet, so
+  nothing can be fooled by it.
+
+What actually shipped instead of fixes: accurate documentation of each gap
+(#281), so nobody builds on a guarantee that does not exist. That is a weaker
+answer than fixing them, and 3–7 remain the top of the queue.
+
+---
+
+## P1 — security and correctness
+
+| # | Finding | Status | Evidence |
+|---|---|---|---|
+| 9 | Revocation selection inverted in `agents.go` | **Closed** | #280 |
+| 10 | "Current card" chosen by caller-controlled `signed_at` | **Partly closed** | #280 rejects malformed timestamps; selection still trusts the value |
+| 11 | Derive or isolate Hub indexing metadata | **Open** | |
+| 12 | Bind agent namespaces to publishers | **Open** | |
+| 13 | Six production vulns in the MCP package | **Unblocked** | was blocked on `@treeship/core-wasm@0.24.0`, now published |
+| 14 | Twelve high-severity vulns in the docs site | **Open** | `npm audit fix` exceeded 10min; still 12 high |
+| 15 | Dependency audits in CI | **Open** | no `cargo audit` / `npm audit` / dependabot |
+| 16 | Broken public "Verify a receipt" URL | **Closed** | `public/home.html`, commit 86e71ff |
+| 17 | Workspace share tokens truly single-use | **Partly closed** | device flow is single-use (`db.go:275`); share tokens "single-use in practice" |
+| 18 | Workspace credentials in query strings | **Open** | |
+| 19 | Per-IP rate limiting on Hub | **Open** | no limiter in `internal/` |
+| 20 | Bound public resolver scans | **Open** | |
+| 21 | Indexed actor / kind / card-reference columns | **Open** | |
+| 22 | Reject malformed timestamps | **Closed** | #280 — `parseSignedAt` now returns `(int64, bool)`, rejects with 400 |
+| 23 | Prevent public metrics poisoning | **Open** | |
+| 24 | Default room countersigning to a liveness challenge | **Closed** | #276 — `mint_nonce`, `validate_nonce`, enforced at both sites |
+| 25 | Verifier-side rotated-key expiry | **Closed** | `verify/resolution.rs:113` reads `valid_until`, with expiry tests |
+| 26 | Immediate compromise revocation for signing keys | **Open** | design work, depends on 5/6 |
+
+### On #22 — it was worse than reported
+
+The audit said malformed timestamps were accepted. In fact `parseSignedAt`'s
+string branch never parsed at all, so *every* string timestamp fell through to
+a fabricated value. Fixed to reject rather than invent.
+
+---
+
+## P1 — release and test integrity
+
+| # | Finding | Status | Evidence |
+|---|---|---|---|
+| 27 | Publish v0.24 coherently across every registry | **Closed** | npm `treeship`/`@treeship/core-wasm`/`@treeship/sdk`, crates.io `treeship-core`, PyPI `treeship-sdk`, all 0.24.0 |
+| 28 | Merge changelog mirror PR #278 | **Closed** | merged |
+| 29 | Changelog generation in the docs-drift gate | **Open** | |
+| 30 | `CHANGELOG.md` ordering and duplication | **Closed** | 0.24.0 heads the file, correctly dated |
+| 31 | TypeScript SDK tests in CI | **Open** | not in `ci.yml` job list |
+| 32 | Split SDK unit tests from the Rust release build | **Open** | |
+| 33 | MCP, A2A, verify-js tests in CI | **Open** | |
+| 34 | Python SDK unit tests in CI | **Open** | |
+| 35 | Full docs production build in CI | **Open** | |
+| 36 | Port acceptance placeholders T1–T9 into real tests | **Open** | |
+| 37 | Clippy as a CI gate | **Open** | no clippy step in `ci.yml` |
+| 38 | Remove the 34 Rust warnings from normal tests | **Open** | |
+| 39 | Automate the AI-quality policy checks | **Open** | |
+| 40 | Adversarial Hub handler tests | **Open** | |
+
+This block is the largest concentration of open items, and the cheapest.
+Items 31–35 and 37 are CI configuration, not engineering: the tests already
+exist and simply are not run. The current `ci.yml` runs Rust, Hub (Go), and
+the cross-SDK contract suite — the TypeScript, Python, MCP, A2A, and
+verify-js suites are unexercised on every commit.
+
+**#37 is the one with teeth.** Clippy caught a genuine issue during the
+rig-treeship setup this month. Not running it here means the same class of
+finding lands in review instead of CI.
+
+---
+
+## P2 — product truth and maintainability
+
+| # | Finding | Status | Evidence |
+|---|---|---|---|
+| 41 | Chain-linkage data in public receipt JSON | **Closed** | `artifacts.go` emits `parent_id` |
+| 42 | Stale README release messaging | **Closed** | #281 |
+| 43 | `SECURITY.md` support policy | **Closed** | #281 — 0.24.x source / 0.23.x released |
+| 44 | Stale `AGENTS.md` / `ONBOARDING.md` inventories | **Closed** | #281 |
+| 45 | Setup and plugin platform documentation | **Open** | |
+| 46 | Linux ARM64 release binaries | **Open** | not in the release matrix |
+| 47 | Upstream the pi/Prime integration into the monorepo | **Declined for now** | see below |
+| 48 | Remove stale tracked Python artifacts | **Closed** | none tracked |
+| 49 | Hub graceful shutdown and readiness | **Open** | no signal handling or readiness endpoint |
+| 50 | Reconcile live-site branding with `DESIGN.md` | **Open** | needs a design decision |
+
+### On #47 — declined, with a reason
+
+pi and prime-agent are separate projects with a shared ancestor, already
+diverged (30 vs 27 extension events; different tool models). The integration
+lives in `treeship-agent-extensions` with a compatibility test that reads both
+upstreams' `types.ts` and fails when either drops an event we use.
+
+Folding it into the monorepo would couple Treeship's release cadence to two
+third-party harnesses. The test is the better guarantee, and it fails at build
+time rather than on a user's machine.
+
+---
+
+## What the audit did not find
+
+Three things worth recording, because they came out of working the list
+rather than the list itself:
+
+1. **An introduced secret leak.** `execution_identity.argv` (#271) stored raw
+   arguments while `wrap` scrubbed `command`. Caught while writing the
+   redaction docs, fixed by making the redactor a required parameter with a
+   regression test. Neither audit found it — it was too new.
+
+2. **Comments that age into false prohibitions.** `RoomInfo`'s doc comment
+   said `room` "MUST NOT be used to gate any authority decision ... until it
+   is folded into the canonical receipt." It had been folded in, at
+   `receipt.rs:511`. The comment forbade work already done. Fixed in #281 —
+   but the class is unguarded: the capability index covers "does X exist",
+   nothing covers "does this description still match".
+
+3. **Local verification is not CI verification.** #279 passed `cargo check`,
+   `cargo test`, and clippy locally, then failed all eight Cross-SDK cells: a
+   `#[cfg(not(target_family = "wasm"))]` had migrated to the wrong function.
+   No local command builds wasm32. Worth knowing before trusting a green
+   local run.
+
+---
+
+## Maintaining this file
+
+Add a row when a finding is dispositioned; do not delete rows. "Declined"
+with a reason is a valid end state and more useful than silence — it stops
+the next audit from re-raising it as new.
+
+The three-way split matters: **closed** means someone can check the evidence
+column, **declined** means we understood it and chose otherwise, **open**
+means it is still true and still unaddressed.


### PR DESCRIPTION
The 50 audit findings lived only in a chat transcript. This makes them a checkable record.

**18 closed, 3 declined, 29 open.** Every closed row cites the PR or file that makes it true.

Two dispositions worth pushing back on:

**We tagged v0.24 with five P0s open.** The audit said not to. Items 3–4 (Hub squatting) are pre-existing and unchanged by this release. Items 5–6 (revocation) are pre-existing and *fail-safe* — `NoRevocationSource` resolves `Unknown`, degrading a mandate to `Unverified`, so the failure mode is refusing to confirm rather than falsely confirming. Item 7 (room authority) is new but gates nothing. What shipped instead of fixes was accurate documentation of each gap (#281). That's weaker than fixing them, and they stay top of queue.

**We fixed the event-log race differently than recommended.** The audit said lock `open()`. #279 removed the write instead — nothing left to serialize, and no flock in the path of every handle construction.

Also records three things neither audit found, because they came out of working the list rather than the list itself: the secret leak I introduced in #271, the class of comment that ages into a false prohibition, and the fact that no local command builds wasm32 — so a green local run isn't a green CI run.

The largest open cluster is items 31–37: CI configuration, not engineering. The TypeScript, Python, MCP, A2A, and verify-js suites exist and simply aren't run on any commit, and clippy isn't a gate.