### PR TITLE
fix(redact): stop leaking credentials into signed receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,11 @@ jobs:
           - packages/verify-js
           - bridges/mcp
           - bridges/a2a
+          # Runs the shared redaction vectors (tests/vectors/redaction.json)
+          # against the plugin's TypeScript redactor. The Rust CLI runs the
+          # same file. Without both in CI the two copies drift silently --
+          # receipts keep being produced, they just stop being safe.
+          - integrations/openclaw-plugin
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@treeship/openclaw-plugin",
   "version": "0.24.0",
-  "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
+  "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer \u2014 below the agent \u2014 so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {
     "name": "Zerker Labs",
@@ -23,7 +23,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && node --test test/*.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/integrations/openclaw-plugin/src/index.ts
+++ b/integrations/openclaw-plugin/src/index.ts
@@ -22,10 +22,157 @@
 // every tool call is paired (intent, result) rather than result-only.
 
 import { execFile, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { homedir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+// Mirrors packages/cli/src/redact.rs. Kept in sync by
+// test/redaction.test.mjs, which runs the shared vector file through both.
+//
+// The 2026-08 audit found this plugin recording `{ command: cmd }` verbatim
+// and then auto-publishing the receipt at session end. A bearer token typed
+// into a shell became a signed, immutable, published artifact.
+//
+// Two changes came out of that. This function is the smaller one: it
+// understands argv structure, so it can redact the argument *after*
+// `--token`, which a substring denylist cannot. The larger one is that the
+// full command is now recorded as a digest and the redacted text is
+// secondary -- a digest still proves which command ran without disclosing it.
+
+const VALUE_FLAGS = new Set([
+  "--token", "--api-key", "--api_key", "--apikey", "--secret", "--password",
+  "--passwd", "--pass", "--auth", "--authorization", "--credential",
+  "--credentials", "--private-key", "--access-key", "--secret-key",
+  "--session-token", "--bearer", "--key", "-p", "-u", "--user", "--header",
+  "-H", "--data-urlencode",
+]);
+
+const SENSITIVE_ENV = [
+  "KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD", "AUTH", "CREDENTIAL",
+  "SESSION", "COOKIE", "SIGNATURE", "PASSPHRASE",
+];
+
+const SENSITIVE_QUERY = new Set([
+  "token", "access_token", "id_token", "refresh_token", "key", "api_key",
+  "apikey", "secret", "password", "passwd", "auth", "signature", "sig",
+  "x-amz-signature", "sas", "code",
+]);
+
+const CREDENTIAL_PREFIXES = [
+  "sk_live_", "sk_test_", "rk_live_", "pk_live_", "ghp_", "gho_", "ghu_",
+  "ghs_", "ghr_", "github_pat_", "glpat-", "xoxb-", "xoxp-", "xoxa-", "xoxs-",
+  "AKIA", "ASIA", "AIza", "ya29.", "sk-ant-", "sk-proj-", "hf_", "npm_",
+  "dop_v1_", "shpat_", "SG.", "-----BEGIN",
+];
+
+const REDACTED = "[REDACTED]";
+
+function isValueFlag(t: string): boolean {
+  // Must actually look like a flag. Comparing dash-stripped names on both
+  // sides made bare words match: `gh auth login` treated `auth` as `--auth`
+  // and redacted `login`. Over-redaction destroys the evidence a receipt
+  // exists to carry, so the leading dash is required.
+  if (!t.startsWith("-")) return false;
+  const l = t.toLowerCase();
+  if (VALUE_FLAGS.has(l)) return true;
+  const bare = l.replace(/^-+/, "");
+  for (const f of VALUE_FLAGS) if (f.replace(/^-+/, "") === bare) return true;
+  return false;
+}
+
+function redactUrl(tok: string): string | null {
+  const i = tok.indexOf("://");
+  if (i === -1) return null;
+  const scheme = tok.slice(0, i + 3);
+  const rest = tok.slice(i + 3);
+  const slash = rest.indexOf("/");
+  const authority = slash === -1 ? rest : rest.slice(0, slash);
+  const tail = slash === -1 ? "" : rest.slice(slash);
+
+  let out = scheme;
+  const at = authority.lastIndexOf("@");
+  if (at !== -1) {
+    const userinfo = authority.slice(0, at);
+    const host = authority.slice(at + 1);
+    const colon = userinfo.indexOf(":");
+    out += colon === -1
+      ? `${userinfo}@${host}`
+      : `${userinfo.slice(0, colon)}:${REDACTED}@${host}`;
+  } else {
+    out += authority;
+  }
+
+  const q = tail.indexOf("?");
+  if (q === -1) {
+    out += tail;
+  } else {
+    out += tail.slice(0, q) + "?";
+    out += tail.slice(q + 1).split("&").map((pair) => {
+      const eq = pair.indexOf("=");
+      if (eq === -1) return pair;
+      const k = pair.slice(0, eq);
+      return SENSITIVE_QUERY.has(k.toLowerCase()) ? `${k}=${REDACTED}` : pair;
+    }).join("&");
+  }
+  return out === tok ? null : out;
+}
+
+function redactAssignment(tok: string): string | null {
+  const eq = tok.indexOf("=");
+  if (eq === -1) return null;
+  const name = tok.slice(0, eq);
+  // A URL's first `=` is a query parameter, not an assignment.
+  if (name.includes("://") || name.includes("?")) return null;
+  if (isValueFlag(name)) return `${name}=${REDACTED}`;
+  const upper = name.toUpperCase();
+  if (SENSITIVE_ENV.some((f) => upper.includes(f))) return `${name}=${REDACTED}`;
+  return null;
+}
+
+function looksLikeUserinfoPair(tok: string): boolean {
+  const c = tok.indexOf(":");
+  if (c <= 0 || c === tok.length - 1) return false;
+  if (tok.includes("://") || tok.includes("/")) return false;
+  const pass = tok.slice(c + 1);
+  if (/^\d+$/.test(pass)) return false;
+  return true;
+}
+
+export function redactCommand(cmd: string): string {
+  const out: string[] = [];
+  let redactNext = false;
+  for (const tok of cmd.split(/\s+/).filter(Boolean)) {
+    if (redactNext) {
+      redactNext = false;
+      // A flag here means the value was omitted; redacting it hides nothing.
+      if (tok.startsWith("-") && tok.length > 1) { out.push(tok); continue; }
+      out.push(REDACTED);
+      continue;
+    }
+    const asn = redactAssignment(tok);
+    if (asn !== null) { out.push(asn); continue; }
+    if (isValueFlag(tok)) { redactNext = true; out.push(tok); continue; }
+    if (CREDENTIAL_PREFIXES.some((p) => tok.includes(p))) { out.push(REDACTED); continue; }
+    if (tok.includes("://")) {
+      const u = redactUrl(tok);
+      if (u !== null) { out.push(u); continue; }
+    }
+    if (looksLikeUserinfoPair(tok)) { out.push(REDACTED); continue; }
+    out.push(tok);
+  }
+  return out.join(" ");
+}
+
+export function commandDigest(cmd: string): string {
+  return "sha256:" + createHash("sha256").update(cmd, "utf8").digest("hex");
+}
+
 
 // ---------------------------------------------------------------------------
 // OpenClaw SDK types (best-effort). The real types live in `openclaw`'s
@@ -348,7 +495,15 @@ function onAfterToolCall(event: unknown, _ctx: unknown): void {
           "--tool",
           "bash",
           "--meta",
-          JSON.stringify({ command: cmd, phase: "result" }),
+          // Digest first, redacted text second. The digest proves which
+          // command ran and discloses nothing; the redacted text is
+          // best-effort context. Recording `command: cmd` verbatim here is
+          // what the 2026-08 audit found being auto-published.
+          JSON.stringify({
+            command_digest: commandDigest(cmd),
+            command: redactCommand(cmd),
+            phase: "result",
+          }),
           "--agent-name",
           "openclaw",
         ]);
@@ -462,10 +617,21 @@ function onSessionEnd(_ctx: unknown): void {
   ]);
   if (!close.ok) return;
 
-  // Best-effort publish. URL goes nowhere productive from a Gateway-side
-  // process, but we trigger the publish so the agent can read the URL out
-  // of the local receipt on its next session-status check.
-  runAsync(["session", "report"]);
+  // Publishing is opt-in. This used to run unconditionally, which meant a
+  // session's receipt was uploaded to the configured Hub with no operator in
+  // the loop -- so anything the capture path got wrong became a public,
+  // immutable artifact before anyone could look at it. Immutability is the
+  // point of a receipt and the reason an accidental disclosure cannot be
+  // taken back, so the upload needs a deliberate decision behind it.
+  //
+  // The local receipt is still written either way; `treeship session report`
+  // publishes it whenever the operator chooses to.
+  if (
+    process.env.TREESHIP_AUTO_PUBLISH === "1" ||
+    process.env.TREESHIP_AUTO_PUBLISH === "true"
+  ) {
+    runAsync(["session", "report"]);
+  }
 }
 
 function inferProviderFromModel(model: string): string | null {

--- a/integrations/openclaw-plugin/test/redaction.test.mjs
+++ b/integrations/openclaw-plugin/test/redaction.test.mjs
@@ -1,0 +1,53 @@
+// Runs the shared redaction vectors against the plugin's TypeScript redactor.
+//
+// The Rust CLI runs the same file (packages/cli/tests/redaction_vectors.rs).
+// Two implementations of a security control drift, and drift here is silent:
+// the plugin keeps producing receipts, they just stop being safe. A shared
+// vector file makes the divergence a test failure instead of an incident.
+//
+//   node --test test/redaction.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const VECTORS = join(here, "..", "..", "..", "tests", "vectors", "redaction.json");
+
+const { redactCommand } = await import("../dist/index.js");
+const vectors = JSON.parse(readFileSync(VECTORS, "utf8"));
+
+test("every audit-known leak is redacted", async (t) => {
+  for (const v of vectors.leaks) {
+    await t.test(v.name, () => {
+      const got = redactCommand(v.input);
+      for (const secret of v.must_not_contain) {
+        assert.ok(
+          !got.includes(secret),
+          `secret survived redaction\n  input:  ${v.input}\n  output: ${got}\n  leaked: ${secret}`,
+        );
+      }
+      // Redacting the entire line would satisfy the assertion above while
+      // destroying the receipt's evidence value. Check what must survive.
+      for (const keep of v.preserved ?? []) {
+        assert.ok(
+          got.includes(keep),
+          `over-redacted, lost context\n  input:  ${v.input}\n  output: ${got}\n  missing: ${keep}`,
+        );
+      }
+    });
+  }
+});
+
+test("benign commands are returned unchanged", async (t) => {
+  for (const v of vectors.benign) {
+    await t.test(v.name, () => {
+      assert.equal(
+        redactCommand(v.input),
+        v.input,
+        `over-redacted a command with nothing sensitive in it`,
+      );
+    });
+  }
+});

--- a/packages/cli/src/commands/hook.rs
+++ b/packages/cli/src/commands/hook.rs
@@ -28,48 +28,6 @@ fn find_project_config() -> Option<PathBuf> {
     }
 }
 
-/// Sanitize a command string by redacting tokens, keys, passwords, and other
-/// sensitive values that appear as inline environment variables or flags.
-/// Uses simple string matching (no regex crate dependency).
-fn sanitize_command(cmd: &str) -> String {
-    let sensitive_patterns = [
-        "KEY=",
-        "TOKEN=",
-        "SECRET=",
-        "PASSWORD=",
-        "PASSWD=",
-        "AUTH=",
-        "API_KEY=",
-        "STRIPE_KEY=",
-        "OPENAI_API_KEY=",
-        "CREDENTIAL=",
-        "AWS_SECRET",
-        "PRIVATE_KEY=",
-        "ACCESS_KEY=",
-        "--api-key=",
-        "--token=",
-        "--secret=",
-        "--password=",
-        "--auth=",
-        "--api_key=",
-        "--apikey=",
-    ];
-    let parts: Vec<&str> = cmd.split_whitespace().collect();
-    let sanitized: Vec<String> = parts
-        .iter()
-        .map(|part| {
-            let upper = part.to_uppercase();
-            for pattern in &sensitive_patterns {
-                if upper.contains(pattern) {
-                    return "[REDACTED]".to_string();
-                }
-            }
-            part.to_string()
-        })
-        .collect();
-    sanitized.join(" ")
-}
-
 /// Set file permissions to 0600 (owner read/write only) on Unix.
 #[cfg(unix)]
 fn set_restrictive_permissions(path: &Path) {
@@ -126,7 +84,7 @@ pub fn pre(command: &str, printer: &Printer) -> Result<(), Box<dyn std::error::E
     }
 
     // Sanitize the command before storing to prevent leaking secrets
-    let safe_command = sanitize_command(command);
+    let safe_command = crate::redact::redact_command(command);
 
     // Store pre-execution state for post-hook
     let pending_hook = serde_json::json!({

--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -17,45 +17,16 @@ use treeship_core::{
 
 use crate::{ctx, printer::Printer};
 
-/// Sanitize a command string by redacting tokens, keys, passwords, and other
-/// sensitive values that appear as inline environment variables or flags.
-fn sanitize_command(cmd: &str) -> String {
-    let sensitive_patterns = [
-        "KEY=",
-        "TOKEN=",
-        "SECRET=",
-        "PASSWORD=",
-        "PASSWD=",
-        "AUTH=",
-        "API_KEY=",
-        "STRIPE_KEY=",
-        "OPENAI_API_KEY=",
-        "CREDENTIAL=",
-        "AWS_SECRET",
-        "PRIVATE_KEY=",
-        "ACCESS_KEY=",
-        "--api-key=",
-        "--token=",
-        "--secret=",
-        "--password=",
-        "--auth=",
-        "--api_key=",
-        "--apikey=",
-    ];
-    let parts: Vec<&str> = cmd.split_whitespace().collect();
-    let sanitized: Vec<String> = parts
-        .iter()
-        .map(|part| {
-            let upper = part.to_uppercase();
-            for pattern in &sensitive_patterns {
-                if upper.contains(pattern) {
-                    return "[REDACTED]".to_string();
-                }
-            }
-            part.to_string()
-        })
-        .collect();
-    sanitized.join(" ")
+/// Whether to record a line of raw program output in the receipt.
+///
+/// Off by default. A digest is a claim about output that discloses nothing;
+/// the text itself is a disclosure decision, and disclosure decisions should
+/// be made deliberately by the operator rather than inherited from a default.
+fn record_output_summary() -> bool {
+    matches!(
+        std::env::var("TREESHIP_RECORD_OUTPUT_SUMMARY").as_deref(),
+        Ok("1") | Ok("true")
+    )
 }
 
 pub fn run(
@@ -97,7 +68,7 @@ pub fn run(
     // finished -- and a command that rewrites its own toolchain is exactly
     // the case worth catching.
     let exec_identity =
-        crate::execution_identity::ExecutionIdentity::capture(args, sanitize_command);
+        crate::execution_identity::ExecutionIdentity::capture(args, crate::redact::redact_argv);
 
     // ── 1. Output digest: capture stdout/stderr while streaming ────────
     let start = Instant::now();
@@ -234,7 +205,7 @@ pub fn run(
 
     // ── Build meta and sign ────────────────────────────────────────────
     let raw_command = args.join(" ");
-    let safe_command = sanitize_command(&raw_command);
+    let safe_command = crate::redact::redact_command(&raw_command);
     let mut meta = serde_json::json!({
         "command":        safe_command,
         "exitCode":       exit_code,
@@ -243,8 +214,20 @@ pub fn run(
         "output_lines":   output_lines,
     });
 
-    if !output_summary.is_empty() {
-        meta["output_summary"] = serde_json::Value::String(sanitize_command(&output_summary));
+    // Program output is recorded as a digest, not text. `output_digest` above
+    // already proves what the command produced, so the raw line adds nothing a
+    // verifier needs -- and it is the one field with no structure to redact
+    // from. The old code ran arbitrary stdout through a *command-flag*
+    // denylist, which could only ever match `KEY=value` shapes; a bearer token
+    // in an error message passed straight through into a signed, immutable,
+    // publishable receipt.
+    //
+    // Opt in with TREESHIP_RECORD_OUTPUT_SUMMARY=1 when the output is known to
+    // be safe. Even then it goes through `redact_text`, which is best-effort
+    // and documented as such.
+    if !output_summary.is_empty() && record_output_summary() {
+        meta["output_summary"] =
+            serde_json::Value::String(crate::redact::redact_text(&output_summary));
     }
     if files_changed_count > 0 {
         meta["files_changed"] = serde_json::json!(files_changed_count);

--- a/packages/cli/src/execution_identity.rs
+++ b/packages/cli/src/execution_identity.rs
@@ -116,13 +116,20 @@ impl ExecutionIdentity {
 
     /// Capture identity for `argv` as it is about to be executed.
     ///
-    /// `redact` is applied to every argument before it is stored. Callers
-    /// MUST pass the same redactor used for any other rendering of the same
-    /// command: a receipt that scrubs `command` while recording a verbatim
+    /// `redact` receives the **whole argv** and returns the redacted form.
+    /// Callers MUST pass the same redactor used for any other rendering of the
+    /// same command: a receipt that scrubs `command` while recording a verbatim
     /// `argv` has not protected anything, it has just moved the secret one
-    /// field over. Resolution and digesting use the real values; only what
-    /// is written down is redacted.
-    pub fn capture(argv: &[String], redact: impl Fn(&str) -> String) -> Self {
+    /// field over. Resolution and digesting use the real values; only what is
+    /// written down is redacted.
+    ///
+    /// This takes the sequence rather than mapping over elements, and that is
+    /// the whole point. A per-element redactor cannot see that the argument
+    /// after `--token` is a secret -- it is handed the bare string
+    /// `"secret123"`, which is indistinguishable from any other word. That is
+    /// exactly how the 2026-08 audit found live credentials in `argv` while
+    /// `command` next to it was scrubbed.
+    pub fn capture(argv: &[String], redact: impl Fn(&[String]) -> Vec<String>) -> Self {
         let program = argv.first().map(String::as_str).unwrap_or_default();
         let executable_path = resolve_executable(program);
         let executable_sha256 = executable_path.as_deref().and_then(digest_file);
@@ -130,7 +137,7 @@ impl ExecutionIdentity {
         Self {
             executable_path: executable_path.map(|p| p.to_string_lossy().into_owned()),
             executable_sha256,
-            argv: argv.iter().map(|a| redact(a)).collect(),
+            argv: redact(argv),
             cwd: std::env::current_dir()
                 .ok()
                 .map(|p| p.to_string_lossy().into_owned()),
@@ -244,30 +251,51 @@ mod tests {
             "--env".into(),
             "prod".into(),
         ];
-        let redact = |a: &str| {
-            if a.to_uppercase().contains("TOKEN=") {
-                "[REDACTED]".to_string()
-            } else {
-                a.to_string()
-            }
-        };
-        let id = ExecutionIdentity::capture(&argv, redact);
+        let id = ExecutionIdentity::capture(&argv, crate::redact::redact_argv);
         let serialized = serde_json::to_string(&id).unwrap();
         assert!(
             !serialized.contains("sk-live-SECRET"),
             "secret survived into the receipt: {serialized}"
         );
-        assert_eq!(id.argv[1], "[REDACTED]");
+        // The flag name survives, only its value goes -- `--token=[REDACTED]`
+        // still tells a reader a token was passed, which is evidence.
+        assert_eq!(id.argv[1], "--token=[REDACTED]");
         // Non-secret arguments must survive intact, or the field is useless.
         assert_eq!(id.argv[0], "deploy");
         assert_eq!(id.argv[3], "prod");
     }
 
+    /// The form the 2026-08 audit found leaking: a secret passed as the
+    /// argument *after* a flag rather than joined with `=`.
+    ///
+    /// The previous redactor was applied per element, so it was handed the
+    /// bare string "sk-live-SECRET" with no way to know what it was. Only a
+    /// redactor that sees the whole sequence can catch this.
+    #[test]
+    fn space_separated_secret_argument_is_redacted() {
+        let argv = vec![
+            "deploy".to_string(),
+            "--token".into(),
+            "sk-live-SECRET".into(),
+            "--env".into(),
+            "prod".into(),
+        ];
+        let id = ExecutionIdentity::capture(&argv, crate::redact::redact_argv);
+        let serialized = serde_json::to_string(&id).unwrap();
+        assert!(
+            !serialized.contains("sk-live-SECRET"),
+            "secret survived into the receipt: {serialized}"
+        );
+        assert_eq!(id.argv[2], "[REDACTED]");
+        assert_eq!(id.argv[4], "prod");
+    }
+
     #[test]
     fn resolves_a_program_on_path_to_an_absolute_path() {
-        let id = ExecutionIdentity::capture(&["sh".to_string(), "-c".into(), "true".into()], |a| {
-            a.to_string()
-        });
+        let id = ExecutionIdentity::capture(
+            &["sh".to_string(), "-c".into(), "true".into()],
+            |a: &[String]| a.to_vec(),
+        );
         let path = id.executable_path.expect("sh should resolve on PATH");
         assert!(
             Path::new(&path).is_absolute(),
@@ -278,7 +306,7 @@ mod tests {
 
     #[test]
     fn digests_the_binary_that_would_run() {
-        let id = ExecutionIdentity::capture(&["sh".to_string()], |a| a.to_string());
+        let id = ExecutionIdentity::capture(&["sh".to_string()], |a: &[String]| a.to_vec());
         let digest = id.executable_sha256.expect("sh should be readable");
         assert!(digest.starts_with("sha256:"));
         assert_eq!(digest.len(), "sha256:".len() + 64);
@@ -300,10 +328,14 @@ mod tests {
         }
 
         let first =
-            ExecutionIdentity::capture(&[fake.to_string_lossy().into_owned()], |a| a.to_string());
+            ExecutionIdentity::capture(&[fake.to_string_lossy().into_owned()], |a: &[String]| {
+                a.to_vec()
+            });
         std::fs::write(&fake, b"#!/bin/sh\necho impostor v2\n").unwrap();
         let second =
-            ExecutionIdentity::capture(&[fake.to_string_lossy().into_owned()], |a| a.to_string());
+            ExecutionIdentity::capture(&[fake.to_string_lossy().into_owned()], |a: &[String]| {
+                a.to_vec()
+            });
 
         assert_eq!(first.executable_path, second.executable_path);
         assert_ne!(
@@ -317,9 +349,10 @@ mod tests {
     /// from `rm a b`, and that difference is the entire command.
     #[test]
     fn argv_preserves_argument_boundaries() {
-        let id = ExecutionIdentity::capture(&["sh".to_string(), "a b".into(), "c".into()], |a| {
-            a.to_string()
-        });
+        let id = ExecutionIdentity::capture(
+            &["sh".to_string(), "a b".into(), "c".into()],
+            |a: &[String]| a.to_vec(),
+        );
         assert_eq!(id.argv, vec!["sh", "a b", "c"]);
     }
 
@@ -341,10 +374,10 @@ mod tests {
 
     #[test]
     fn unresolvable_program_yields_no_path_rather_than_a_guess() {
-        let id =
-            ExecutionIdentity::capture(&["ts-definitely-not-a-real-binary-xyz".to_string()], |a| {
-                a.to_string()
-            });
+        let id = ExecutionIdentity::capture(
+            &["ts-definitely-not-a-real-binary-xyz".to_string()],
+            |a: &[String]| a.to_vec(),
+        );
         assert!(id.executable_path.is_none());
         assert!(id.executable_sha256.is_none());
         // argv and cwd are still worth recording.
@@ -355,6 +388,8 @@ mod tests {
     #[test]
     fn default_identity_reports_itself_empty() {
         assert!(ExecutionIdentity::default().is_empty());
-        assert!(!ExecutionIdentity::capture(&["sh".to_string()], |a| a.to_string()).is_empty());
+        assert!(
+            !ExecutionIdentity::capture(&["sh".to_string()], |a: &[String]| a.to_vec()).is_empty()
+        );
     }
 }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -4,6 +4,7 @@ mod ctx;
 mod execution_identity;
 mod otel;
 mod printer;
+mod redact;
 mod templates;
 mod tui;
 

--- a/packages/cli/src/redact.rs
+++ b/packages/cli/src/redact.rs
@@ -1,0 +1,570 @@
+//! Redaction for anything that reaches a signed receipt.
+//!
+//! # Why this is not just a bigger denylist
+//!
+//! The previous implementation split a command on whitespace and checked each
+//! token for a substring like `TOKEN=` or `--password=`. Every pattern ended
+//! in `=`, so the single most common way to pass a secret on a command line
+//! survived untouched:
+//!
+//! ```text
+//! curl --token secret123      -> ["curl", "--token", "secret123"]
+//! ```
+//!
+//! Neither token matches, because `--token` is not `--token=` and `secret123`
+//! looks like any other word. Same for `-H "Authorization: Bearer sk_live_.."`,
+//! `curl -u user:password`, and `https://host/x?signature=SECRET`.
+//!
+//! So this module does two different jobs, and it is important not to confuse
+//! them:
+//!
+//! * [`redact_command`] understands argv *structure* -- it knows that the token
+//!   after `--token` is a value, that `-H` takes a header, that a URL can carry
+//!   userinfo and query credentials. Structure is what makes it able to redact
+//!   a secret it has never seen and cannot recognise.
+//!
+//! * [`redact_text`] gets arbitrary program output, where there is no structure
+//!   to lean on. It can only match shapes it already knows -- known credential
+//!   prefixes and `key: value` pairs. **It will miss novel secrets**, and that
+//!   is not a bug that can be fixed by adding patterns.
+//!
+//! Which is why the real defence is structural and lives at the call sites:
+//! program output is recorded as a digest, and the raw text is opt-in. A
+//! denylist decides what to hide and is wrong by default; a digest decides what
+//! to reveal and is safe by default. Treat everything here as defence in depth
+//! behind that choice, never as the thing keeping credentials out of receipts.
+
+/// Flags whose *following* argument is a credential.
+///
+/// Matched case-insensitively, and also in `--flag=value` form.
+const VALUE_FLAGS: &[&str] = &[
+    "--token",
+    "--api-key",
+    "--api_key",
+    "--apikey",
+    "--secret",
+    "--password",
+    "--passwd",
+    "--pass",
+    "--auth",
+    "--authorization",
+    "--credential",
+    "--credentials",
+    "--private-key",
+    "--access-key",
+    "--secret-key",
+    "--session-token",
+    "--bearer",
+    "--key",
+    "-p",
+    "-u",
+    "--user",
+    "--header",
+    "-H",
+    "--data-urlencode",
+];
+
+/// Environment-variable name fragments that mark an inline `NAME=value`
+/// assignment as sensitive.
+const SENSITIVE_ENV_FRAGMENTS: &[&str] = &[
+    "KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "AUTH",
+    "CREDENTIAL",
+    "SESSION",
+    "COOKIE",
+    "SIGNATURE",
+    "PASSPHRASE",
+];
+
+/// Query-string parameter names that carry credentials in signed URLs.
+const SENSITIVE_QUERY_KEYS: &[&str] = &[
+    "token",
+    "access_token",
+    "id_token",
+    "refresh_token",
+    "key",
+    "api_key",
+    "apikey",
+    "secret",
+    "password",
+    "passwd",
+    "auth",
+    "signature",
+    "sig",
+    "x-amz-signature",
+    "sas",
+    "code",
+];
+
+/// Literal prefixes that identify a credential wherever it appears, including
+/// in unstructured output. Deliberately narrow: every entry here is a shape a
+/// vendor documents as always-secret.
+const CREDENTIAL_PREFIXES: &[&str] = &[
+    "sk_live_",
+    "sk_test_",
+    "rk_live_",
+    "pk_live_",
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxs-",
+    "AKIA",
+    "ASIA",
+    "AIza",
+    "ya29.",
+    "sk-ant-",
+    "sk-proj-",
+    "hf_",
+    "npm_",
+    "dop_v1_",
+    "shpat_",
+    "SG.",
+    "-----BEGIN",
+];
+
+/// Header names whose value is a credential.
+const SENSITIVE_HEADERS: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token",
+    "x-amz-security-token",
+    "x-goog-api-key",
+    "api-key",
+];
+
+pub const REDACTED: &str = "[REDACTED]";
+
+fn strip_leading_dashes(s: &str) -> &str {
+    s.trim_start_matches('-')
+}
+
+/// Does this token name a flag whose next argument is a credential?
+fn is_value_flag(token: &str) -> bool {
+    // Must actually look like a flag. Comparing dash-stripped names on both
+    // sides made bare words match: `gh auth login` treated `auth` as `--auth`
+    // and redacted `login`, and `git config user.name` lost `.name` to
+    // `--user`. Over-redaction destroys the evidence a receipt exists to
+    // carry, so the leading dash is required.
+    if !token.starts_with('-') {
+        return false;
+    }
+    let bare = strip_leading_dashes(token);
+    VALUE_FLAGS.iter().any(|f| {
+        token.eq_ignore_ascii_case(f) || bare.eq_ignore_ascii_case(strip_leading_dashes(f))
+    })
+}
+
+/// `NAME=value` where NAME looks sensitive, or `--flag=value` where the flag is
+/// a credential flag. Returns the redacted form.
+fn redact_assignment(token: &str) -> Option<String> {
+    let (name, _) = token.split_once('=')?;
+    // A URL's first `=` belongs to a query parameter, not an assignment.
+    // Treating `https://h/f?signature=X&y=1` as `name=value` would match
+    // "SIGNATURE" in the name and redact everything after the first `=`,
+    // destroying the rest of the query. URLs are handled by `redact_url`.
+    if name.contains("://") || name.contains('?') {
+        return None;
+    }
+    if is_value_flag(name) {
+        return Some(format!("{name}={REDACTED}"));
+    }
+    let upper = name.to_ascii_uppercase();
+    if SENSITIVE_ENV_FRAGMENTS.iter().any(|f| upper.contains(f)) {
+        return Some(format!("{name}={REDACTED}"));
+    }
+    None
+}
+
+/// Redact credentials carried inside a URL: `scheme://user:pass@host` userinfo,
+/// and sensitive query parameters.
+fn redact_url(token: &str) -> Option<String> {
+    let scheme_end = token.find("://")?;
+    let (scheme, rest) = token.split_at(scheme_end + 3);
+    let mut out = String::from(scheme);
+
+    // userinfo -- everything before the last '@' in the authority component.
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let (authority, tail) = rest.split_at(authority_end);
+    match authority.rsplit_once('@') {
+        Some((userinfo, host)) => {
+            // Keep the username, drop the password: `user:pass@` -> `user:[REDACTED]@`
+            match userinfo.split_once(':') {
+                Some((user, _)) => out.push_str(&format!("{user}:{REDACTED}@{host}")),
+                None => out.push_str(&format!("{userinfo}@{host}")),
+            }
+        }
+        None => out.push_str(authority),
+    }
+
+    // query parameters
+    match tail.split_once('?') {
+        Some((path, query)) => {
+            out.push_str(path);
+            out.push('?');
+            let redacted: Vec<String> = query
+                .split('&')
+                .map(|pair| match pair.split_once('=') {
+                    Some((k, _))
+                        if SENSITIVE_QUERY_KEYS
+                            .iter()
+                            .any(|s| k.eq_ignore_ascii_case(s)) =>
+                    {
+                        format!("{k}={REDACTED}")
+                    }
+                    _ => pair.to_string(),
+                })
+                .collect();
+            out.push_str(&redacted.join("&"));
+        }
+        None => out.push_str(tail),
+    }
+
+    if out == token {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+/// Does this token contain a literal credential prefix?
+fn has_credential_prefix(token: &str) -> bool {
+    CREDENTIAL_PREFIXES.iter().any(|p| token.contains(p))
+}
+
+/// A `user:password` pair passed positionally, as `curl -u` takes.
+fn looks_like_userinfo_pair(token: &str) -> bool {
+    match token.split_once(':') {
+        // Not a URL, not a time, not a Windows path, both halves non-empty.
+        Some((user, pass)) => {
+            !user.is_empty()
+                && !pass.is_empty()
+                && !token.contains("://")
+                && !token.contains('/')
+                && !pass.chars().all(|c| c.is_ascii_digit())
+                && user.chars().all(|c| !c.is_whitespace())
+        }
+        None => false,
+    }
+}
+
+/// Redact a command line, using argv structure.
+///
+/// Handles inline `NAME=value` assignments, `--flag=value`, **space-separated
+/// `--flag value`**, header arguments, `user:pass` pairs, URL userinfo and
+/// query credentials, and known credential prefixes.
+pub fn redact_command(cmd: &str) -> String {
+    let mut out: Vec<String> = Vec::new();
+    // Set when the previous token was a flag that takes a credential value.
+    let mut redact_next = false;
+
+    for token in cmd.split_whitespace() {
+        if redact_next {
+            redact_next = false;
+            // A following token that is itself a flag is not the value -- the
+            // value was omitted. Redacting it would corrupt the record and
+            // hide nothing.
+            if token.starts_with('-') && token.len() > 1 {
+                out.push(token.to_string());
+                continue;
+            }
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        if token.contains('=') {
+            if let Some(r) = redact_assignment(token) {
+                out.push(r);
+                continue;
+            }
+        }
+
+        if is_value_flag(token) {
+            redact_next = true;
+            out.push(token.to_string());
+            continue;
+        }
+
+        if has_credential_prefix(token) {
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        if token.contains("://") {
+            if let Some(r) = redact_url(token) {
+                out.push(r);
+                continue;
+            }
+        }
+
+        if looks_like_userinfo_pair(token) {
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        out.push(token.to_string());
+    }
+
+    out.join(" ")
+}
+
+/// Redact argv that is already split into arguments.
+///
+/// Preferred over [`redact_command`] wherever the real argv is available:
+/// joining on spaces and re-splitting loses the argument boundaries, so a
+/// quoted `-H "Authorization: Bearer x"` becomes three tokens and the
+/// structural rules no longer see one header argument.
+pub fn redact_argv(argv: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(argv.len());
+    let mut redact_next = false;
+
+    for arg in argv {
+        if redact_next {
+            redact_next = false;
+            if arg.starts_with('-') && arg.len() > 1 {
+                out.push(arg.clone());
+                continue;
+            }
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        if arg.contains('=') {
+            if let Some(r) = redact_assignment(arg) {
+                out.push(r);
+                continue;
+            }
+        }
+
+        if is_value_flag(arg) {
+            redact_next = true;
+            out.push(arg.clone());
+            continue;
+        }
+
+        // A whole header passed as one argument: "Authorization: Bearer x".
+        if let Some((name, _)) = arg.split_once(':') {
+            if SENSITIVE_HEADERS
+                .iter()
+                .any(|h| name.trim().eq_ignore_ascii_case(h))
+            {
+                out.push(format!("{}: {REDACTED}", name.trim()));
+                continue;
+            }
+        }
+
+        if has_credential_prefix(arg) {
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        if arg.contains("://") {
+            if let Some(r) = redact_url(arg) {
+                out.push(r);
+                continue;
+            }
+        }
+
+        if looks_like_userinfo_pair(arg) {
+            out.push(REDACTED.to_string());
+            continue;
+        }
+
+        out.push(arg.clone());
+    }
+
+    out
+}
+
+/// Redact unstructured text -- program output, error messages.
+///
+/// **This is best-effort and will miss secrets it has no pattern for.** There
+/// is no argv structure here to reason from, so it can only catch known
+/// credential prefixes and `sensitive-name: value` pairs. Callers must not
+/// treat a redacted string as safe to publish; record a digest instead and
+/// make the raw text opt-in.
+pub fn redact_text(text: &str) -> String {
+    let mut out: Vec<String> = Vec::new();
+
+    for line in text.lines() {
+        // `Authorization: Bearer ...` and friends, anywhere in the line.
+        let lowered = line.to_ascii_lowercase();
+        if let Some(h) = SENSITIVE_HEADERS
+            .iter()
+            .find(|h| lowered.contains(&format!("{h}:")))
+        {
+            let idx = lowered.find(&format!("{h}:")).unwrap_or(0);
+            out.push(format!("{}{}: {REDACTED}", &line[..idx], h));
+            continue;
+        }
+
+        let redacted: Vec<String> = line
+            .split_whitespace()
+            .map(|tok| {
+                if has_credential_prefix(tok) {
+                    REDACTED.to_string()
+                } else if tok.contains('=') {
+                    redact_assignment(tok).unwrap_or_else(|| tok.to_string())
+                } else if tok.contains("://") {
+                    redact_url(tok).unwrap_or_else(|| tok.to_string())
+                } else {
+                    tok.to_string()
+                }
+            })
+            .collect();
+        out.push(redacted.join(" "));
+    }
+
+    out.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every form the 2026-08 audit listed as bypassing the old sanitizer.
+    /// These are the regression vectors; each one leaked before this module.
+    #[test]
+    fn audit_bypass_vectors_are_redacted() {
+        let cases = [
+            "curl --token secret123 https://api.example.com",
+            "mytool --password hunter2",
+            "psql --user admin --pass s3cr3t",
+            "aws --secret-key AKIAIOSFODNN7EXAMPLE",
+            "curl -u user:password https://example.com",
+            "deploy --api-key abcdef123456",
+        ];
+        for case in cases {
+            let got = redact_command(case);
+            assert!(
+                got.contains(REDACTED),
+                "nothing redacted in {case:?} -> {got:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn space_separated_flag_value_is_redacted() {
+        // The exact case the old sanitizer missed: no `=`, so no pattern hit.
+        assert_eq!(
+            redact_command("curl --token secret123 https://api.example.com"),
+            "curl --token [REDACTED] https://api.example.com"
+        );
+    }
+
+    #[test]
+    fn secret_value_never_survives_verbatim() {
+        let got = redact_command("curl --token secret123 --password hunter2");
+        assert!(!got.contains("secret123"), "{got}");
+        assert!(!got.contains("hunter2"), "{got}");
+    }
+
+    #[test]
+    fn bearer_header_as_single_argv_entry_is_redacted() {
+        let argv = vec![
+            "curl".to_string(),
+            "-H".to_string(),
+            "Authorization: Bearer sk_live_abc123".to_string(),
+        ];
+        let got = redact_argv(&argv);
+        assert!(!got.join(" ").contains("sk_live_abc123"), "{got:?}");
+    }
+
+    #[test]
+    fn signed_url_query_credentials_are_redacted() {
+        let got = redact_command("curl https://example.com/f?signature=SECRETVALUE&x=1");
+        assert!(!got.contains("SECRETVALUE"), "{got}");
+        // Non-sensitive params survive -- redaction should not destroy context.
+        assert!(got.contains("x=1"), "{got}");
+    }
+
+    #[test]
+    fn url_userinfo_password_is_redacted_but_user_kept() {
+        let got = redact_command("git clone https://alice:hunter2@github.com/o/r.git");
+        assert!(!got.contains("hunter2"), "{got}");
+        assert!(got.contains("alice"), "{got}");
+    }
+
+    #[test]
+    fn inline_env_assignment_still_redacted() {
+        // The old sanitizer's one real capability must not regress.
+        for case in [
+            "AWS_SECRET_ACCESS_KEY=abc123 aws s3 ls",
+            "TOKEN=xyz ./deploy",
+            "STRIPE_KEY=sk_live_1 node app.js",
+        ] {
+            let got = redact_command(case);
+            assert!(got.contains(REDACTED), "{case} -> {got}");
+        }
+    }
+
+    #[test]
+    fn credential_prefixes_are_caught_anywhere() {
+        for tok in [
+            "ghp_abc123",
+            "AKIAIOSFODNN7",
+            "xoxb-1-2-3",
+            "sk-ant-api03-x",
+        ] {
+            let got = redact_command(&format!("echo {tok}"));
+            assert!(got.contains(REDACTED), "{tok} -> {got}");
+        }
+    }
+
+    #[test]
+    fn output_text_redacts_known_shapes() {
+        let got = redact_text("error: bad credential ghp_abcdef123456 rejected");
+        assert!(!got.contains("ghp_abcdef123456"), "{got}");
+    }
+
+    #[test]
+    fn benign_commands_are_untouched() {
+        // Over-redaction destroys the evidence value of a receipt. A command
+        // with nothing sensitive must come back byte-identical.
+        for case in [
+            "cargo build --release",
+            "git commit -m fix",
+            "ls -la /tmp",
+            "npm run test",
+        ] {
+            assert_eq!(redact_command(case), case, "over-redacted {case}");
+        }
+    }
+
+    #[test]
+    fn flag_without_value_does_not_eat_the_next_flag() {
+        // `--token` immediately followed by another flag means the value was
+        // omitted; redacting `--verbose` would corrupt the record for nothing.
+        let got = redact_command("tool --token --verbose run");
+        assert_eq!(got, "tool --token --verbose run");
+    }
+
+    #[test]
+    fn timestamps_are_not_mistaken_for_userinfo() {
+        let got = redact_command("echo 12:30");
+        assert_eq!(got, "echo 12:30");
+    }
+
+    #[test]
+    fn redact_argv_preserves_argument_boundaries() {
+        // Joining and re-splitting would turn this into 4 tokens and lose the
+        // header structure. redact_argv sees one argument.
+        let argv = vec!["-H".to_string(), "Cookie: session=abc123secret".to_string()];
+        let got = redact_argv(&argv);
+        assert_eq!(got.len(), 2, "{got:?}");
+        assert!(!got[1].contains("abc123secret"), "{got:?}");
+    }
+}

--- a/packages/cli/tests/redaction_vectors.rs
+++ b/packages/cli/tests/redaction_vectors.rs
@@ -1,0 +1,173 @@
+//! Runs the shared redaction vectors against the real `treeship wrap` path.
+//!
+//! The OpenClaw plugin runs the same vector file
+//! (`integrations/openclaw-plugin/test/redaction.test.mjs`). Two
+//! implementations of one security control drift, and drift here is silent --
+//! receipts keep being produced, they just stop being safe.
+//!
+//! # Why this asserts on the decoded payload
+//!
+//! The first version of this test grepped the artifact files for the secret
+//! and passed with redaction **completely disabled**. A DSSE envelope stores
+//! its payload base64-encoded, so the plaintext never appears in the file and
+//! the search could not fail. It also invoked `wrap` with a flag that does not
+//! exist, so every run errored out and wrote nothing at all.
+//!
+//! Two independent reasons the same test was vacuous, which is why the
+//! negative control below is part of the test rather than something that was
+//! run once by hand: `wrap` must produce an artifact, and that artifact's
+//! decoded payload must contain the command. If either stops being true this
+//! fails loudly instead of passing for free.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
+
+fn vectors_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("vectors")
+        .join("redaction.json")
+}
+
+/// Run `treeship wrap` on a vector and return every signed payload it wrote,
+/// decoded. `echo` stands in for the real program: only what gets *recorded*
+/// matters, and the arguments are preserved verbatim.
+fn wrap_and_decode(input: &str) -> Vec<String> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let config = tmp.path().join("config.json");
+    let bin = PathBuf::from(env!("CARGO_BIN_EXE_treeship"));
+
+    let init = Command::new(&bin)
+        .arg("init")
+        .arg("--config")
+        .arg(&config)
+        .output()
+        .expect("run treeship init");
+    assert!(
+        init.status.success(),
+        "init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let args: Vec<&str> = input.split_whitespace().collect();
+    let mut cmd = Command::new(&bin);
+    // cwd inside the temp dir so a repo-local .treeship cannot be picked up.
+    cmd.current_dir(tmp.path())
+        .arg("wrap")
+        .arg("--config")
+        .arg(&config)
+        .arg("--")
+        .arg("echo");
+    for a in &args[1..] {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("run treeship wrap");
+    assert!(
+        out.status.success(),
+        "wrap failed for {input:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let dir = tmp.path().join("artifacts");
+    let mut payloads = Vec::new();
+    for entry in fs::read_dir(&dir).expect("artifacts dir").flatten() {
+        let path = entry.path();
+        if !path.file_name().is_some_and(|n| {
+            n.to_string_lossy().starts_with("art_") && n.to_string_lossy().ends_with(".json")
+        }) {
+            continue;
+        }
+        payloads.push(decode_payload(&path));
+    }
+
+    // An empty result would make every assertion below vacuous -- which is
+    // exactly how the first version of this test passed while broken.
+    assert!(
+        !payloads.is_empty(),
+        "wrap wrote no artifact for {input:?}; nothing was checked"
+    );
+    payloads
+}
+
+fn decode_payload(path: &Path) -> String {
+    let raw = fs::read_to_string(path).expect("read artifact");
+    let v: serde_json::Value = serde_json::from_str(&raw).expect("parse artifact");
+    let envelope = v.get("envelope").unwrap_or(&v);
+    let payload = envelope["payload"]
+        .as_str()
+        .expect("artifact has a DSSE payload");
+    let bytes = STANDARD_NO_PAD
+        .decode(payload.trim_end_matches('='))
+        .expect("payload is base64");
+    String::from_utf8(bytes).expect("payload is utf-8")
+}
+
+#[test]
+fn shared_vectors_do_not_leak_into_signed_payloads() {
+    let raw = fs::read_to_string(vectors_path()).expect("read shared redaction vectors");
+    let vectors: serde_json::Value = serde_json::from_str(&raw).expect("parse vectors");
+    let leaks = vectors["leaks"].as_array().expect("leaks array");
+    assert!(!leaks.is_empty(), "vector file has no leak cases");
+
+    for v in leaks {
+        let input = v["input"].as_str().expect("input");
+        let name = v["name"].as_str().unwrap_or("<unnamed>");
+        let payloads = wrap_and_decode(input);
+        let joined = payloads.join("\n");
+
+        for secret in v["must_not_contain"].as_array().expect("must_not_contain") {
+            let secret = secret.as_str().expect("secret string");
+            assert!(
+                !joined.contains(secret),
+                "vector {name:?}: secret {secret:?} reached the signed payload\n\
+                 input:   {input}\n\
+                 payload: {joined}"
+            );
+        }
+
+        // The opposite failure, and not a hypothetical one: redacting the
+        // whole line satisfies every assertion above while destroying the
+        // evidence the receipt exists to carry. This check is what caught
+        // `is_value_flag` matching the bare word `auth` in `gh auth login`
+        // and redacting `login` -- the leak assertions were all green.
+        // The vector's program name is not in the payload: this harness
+        // substitutes `echo` for it so the vectors cannot actually run curl,
+        // git or aws. Skipping it here keeps the check honest -- asserting on
+        // something the harness deliberately removed would be testing the
+        // harness, not the redactor.
+        let program = input.split_whitespace().next().unwrap_or("");
+        for keep in v["preserved"].as_array().unwrap_or(&vec![]) {
+            let keep = keep.as_str().expect("preserved string");
+            if keep == program {
+                continue;
+            }
+            assert!(
+                joined.contains(keep),
+                "vector {name:?}: over-redacted, lost {keep:?}\n\
+                 input:   {input}\n\
+                 payload: {joined}"
+            );
+        }
+    }
+}
+
+/// The control that the previous version of this test needed and did not have.
+///
+/// Proves the harness can observe a leak at all: the command really does reach
+/// the signed payload, so a redaction failure would be caught rather than
+/// silently passing. Asserts on a value no redaction rule touches.
+#[test]
+fn harness_can_observe_the_command_in_the_payload() {
+    let payloads = wrap_and_decode("echo harmlessmarkervalue");
+    let joined = payloads.join("\n");
+    assert!(
+        joined.contains("harmlessmarkervalue"),
+        "the wrapped command never reached the payload, so the leak assertions \
+         in this file cannot fail and prove nothing.\npayload: {joined}"
+    );
+}

--- a/tests/vectors/redaction.json
+++ b/tests/vectors/redaction.json
@@ -1,0 +1,131 @@
+{
+  "_comment": [
+    "Shared redaction vectors. Two implementations must agree on these:",
+    "  packages/cli/src/redact.rs            (redact_command)",
+    "  integrations/openclaw-plugin/src/     (redactCommand)",
+    "",
+    "Every entry under `leaks` is a form the pre-2026-08 sanitizer passed",
+    "through verbatim into a signed receipt. The audit found the OpenClaw",
+    "plugin then auto-publishing that receipt, so these are not hypothetical.",
+    "",
+    "`must_not_contain` is the real assertion -- checking for the presence of",
+    "[REDACTED] would pass on an implementation that redacts the wrong token.",
+    "`preserved` guards the opposite failure: a redactor that destroys the",
+    "whole command line hides the secret and the evidence together."
+  ],
+  "leaks": [
+    {
+      "name": "space-separated token flag",
+      "why": "the exact case the old denylist missed: no `=`, so no pattern hit",
+      "input": "curl --token secret123 https://api.example.com",
+      "must_not_contain": ["secret123"],
+      "preserved": ["curl", "--token", "https://api.example.com"]
+    },
+    {
+      "name": "space-separated password flag",
+      "input": "mytool --password hunter2 --verbose",
+      "must_not_contain": ["hunter2"],
+      "preserved": ["mytool", "--verbose"]
+    },
+    {
+      "name": "short user:password pair",
+      "why": "curl -u takes one positional argument containing both halves",
+      "input": "curl -u admin:s3cr3t https://example.com/api",
+      "must_not_contain": ["s3cr3t"],
+      "preserved": ["curl"]
+    },
+    {
+      "name": "signed URL query parameter",
+      "input": "curl https://example.com/obj?signature=SECRETSIG&expires=123",
+      "must_not_contain": ["SECRETSIG"],
+      "preserved": ["expires=123"]
+    },
+    {
+      "name": "URL userinfo password",
+      "why": "the username is evidence and should survive; the password is not",
+      "input": "git clone https://alice:hunter2@github.com/org/repo.git",
+      "must_not_contain": ["hunter2"],
+      "preserved": ["alice", "github.com"]
+    },
+    {
+      "name": "access token as query parameter",
+      "input": "curl https://api.example.com/v1/me?access_token=ya29.SECRETVALUE",
+      "must_not_contain": ["ya29.SECRETVALUE"],
+      "preserved": ["curl"]
+    },
+    {
+      "name": "stripe live key by prefix",
+      "why": "no flag structure to lean on; only the vendor prefix identifies it",
+      "input": "echo sk_live_abcdef123456",
+      "must_not_contain": ["sk_live_abcdef123456"],
+      "preserved": ["echo"]
+    },
+    {
+      "name": "github token by prefix",
+      "input": "gh auth login --with-token ghp_abcdef1234567890",
+      "must_not_contain": ["ghp_abcdef1234567890"],
+      "preserved": ["gh", "auth", "login"]
+    },
+    {
+      "name": "aws access key id by prefix",
+      "input": "aws configure set aws_access_key_id AKIAIOSFODNN7EXAMPLE",
+      "must_not_contain": ["AKIAIOSFODNN7EXAMPLE"],
+      "preserved": ["aws", "configure"]
+    },
+    {
+      "name": "slack bot token by prefix",
+      "input": "curl -d token=xoxb-111-222-abcdef https://slack.com/api/x",
+      "must_not_contain": ["xoxb-111-222-abcdef"],
+      "preserved": ["curl"]
+    },
+    {
+      "name": "inline env assignment",
+      "why": "the one thing the old sanitizer did catch; must not regress",
+      "input": "AWS_SECRET_ACCESS_KEY=abc123secret aws s3 ls",
+      "must_not_contain": ["abc123secret"],
+      "preserved": ["aws", "s3", "ls"]
+    },
+    {
+      "name": "flag-joined value",
+      "input": "deploy --api-key=verysecretvalue --env prod",
+      "must_not_contain": ["verysecretvalue"],
+      "preserved": ["deploy", "prod"]
+    },
+    {
+      "name": "session cookie assignment",
+      "input": "COOKIE=sessionabc123 ./run.sh",
+      "must_not_contain": ["sessionabc123"],
+      "preserved": ["./run.sh"]
+    },
+    {
+      "name": "private key material",
+      "input": "echo -----BEGIN RSA PRIVATE KEY-----",
+      "must_not_contain": ["BEGIN RSA PRIVATE KEY"],
+      "preserved": ["echo"]
+    }
+  ],
+  "benign": [
+    {
+      "name": "cargo build",
+      "why": "over-redaction destroys the evidence value of a receipt",
+      "input": "cargo build --release"
+    },
+    { "name": "git commit", "input": "git commit -m fix" },
+    { "name": "list files", "input": "ls -la /tmp" },
+    { "name": "npm test", "input": "npm run test" },
+    {
+      "name": "plain url",
+      "why": "a URL with no credentials must pass through untouched",
+      "input": "curl https://example.com/health"
+    },
+    {
+      "name": "timestamp is not a user:password pair",
+      "input": "echo 12:30"
+    },
+    {
+      "name": "flag with omitted value does not consume the next flag",
+      "why": "redacting --verbose here would corrupt the record and hide nothing",
+      "input": "tool --token --verbose run"
+    }
+  ]
+}


### PR DESCRIPTION
**P0-1 from the 2026-08 external audit, confirmed.** Two independent paths put live credentials into signed, immutable, auto-published artifacts.

## The sanitizer could not see the common case

It split on whitespace and substring-matched patterns that **all ended in `=`**:

```
curl --token secret123   ->   ["curl", "--token", "secret123"]
```

Neither token matches — `--token` is not `--token=`, and `secret123` is just a word. Same for `-H "Authorization: Bearer …"`, `curl -u user:pass`, `?signature=…`. The same function existed **twice** (wrap.rs and hook.rs), so both copies had the hole.

## `argv` was worse than `command`

`ExecutionIdentity::capture` mapped the redactor over **each element individually**, so it received the bare string `"secret123"` with no way to know what it was. `capture` now takes the whole argv — the sequence is precisely the information needed, because *the previous argument was `--token`* is the only thing that makes the value recognisable.

## Program output had no business being there

`output_summary` ran arbitrary stdout through a **command-flag** denylist. `output_digest` sits right next to it and already proves what the command produced, so the raw line was disclosure with no verification value. Now digest-only; raw is opt-in.

## The OpenClaw plugin

Recorded `{ command: cmd }` verbatim — zero redaction anywhere in the file — then ran `session report` at SessionEnd **unconditionally**, which uploads to the configured Hub. Now digest + redacted text, and publishing requires `TREESHIP_AUTO_PUBLISH=1`. The local receipt is still written either way.

---

## On the tests, because two of them were worthless first

**The Rust vector test passed with redaction completely disabled.** Two separate reasons: it invoked `wrap` with a `--label` flag that doesn't exist, so every run errored and wrote nothing; and it grepped artifact files for plaintext, but a DSSE payload is base64, so the secret could never appear. It now decodes the payload, asserts an artifact was produced, and carries a control test proving the harness can observe an unredacted command at all.

**Then the JS test caught a bug the Rust one couldn't.** `is_value_flag` stripped leading dashes from both sides, so the bare word `auth` in `gh auth login` matched `--auth` and redacted `login`. Over-redaction destroys the evidence a receipt exists to carry — and every leak assertion was green while it happened. Both implementations now require a leading dash; both suites assert on preserved context.

Vectors live in `tests/vectors/redaction.json` and run against both implementations in CI, so the copies can't drift quietly.

## Verification

Decoded signed payload before → after, same command:

```
command: echo --token secret123        command: echo --token [REDACTED]
argv:    ["echo","--token","secret123"]   argv: ["echo","--token","[REDACTED]"]
```

Negative control fails as it must · clippy `-D warnings` clean · 574 Rust tests · 23 plugin tests.

## Not in this PR

- **P0-2** (Hub content addressing) — I mis-filed this as "needs a product decision" in the audit doc; it's a bug with a mechanical fix.
- **Already-published receipts** need review and credential rotation. That's an operational task, not a code change.