### PR TITLE
ci: gate on dependency vulnerabilities, and fix the reachable ones

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,52 @@
+# cargo-audit configuration.
+#
+# CI runs `cargo audit -D warnings`, so anything not listed here fails the
+# build. Every entry below is a decision with a reason and a condition for
+# removing it -- an ignore list without those is just a way to make a scanner
+# quiet, and a quiet scanner is worse than no scanner because it looks like
+# coverage.
+#
+# Before adding an entry, check whether the advisory reaches the shipped
+# binary:
+#
+#     cargo tree -p treeship-cli -i <crate>
+#
+# If it does, it is not a candidate for this file. Fix it or hold the release.
+
+[advisories]
+ignore = [
+    # ---------------------------------------------------------------------
+    # Confined to treeship-zk-risc0 (pre-release, behind the non-default `zk`
+    # feature). Neither reaches `treeship-cli`; both are transitive through
+    # risc0's own dependency chain, so neither can be fixed here.
+    # ---------------------------------------------------------------------
+
+    # RUSTSEC-2023-0071 -- rsa 0.9.10, Marvin timing sidechannel (5.9 medium).
+    #
+    # Path: rsa <- rzup <- risc0-build <- risc0-zkvm <- treeship-zk-risc0.
+    # rzup is risc0's toolchain installer; the RSA use is signature
+    # verification during toolchain download, not anything Treeship signs
+    # with. There is no fixed 0.9 release -- upstream's fix requires a
+    # breaking change -- so this cannot be resolved by updating.
+    #
+    # Remove when: risc0 moves off rsa 0.9, or the `zk` feature is dropped.
+    "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2025-0055 -- tracing-subscriber 0.2.25, ANSI escape sequences in
+    # logged user input can poison terminal output.
+    #
+    # Path: tracing-subscriber <- ark-relations <- ark-crypto-primitives <-
+    # ark-groth16 <- risc0-groth16 <- risc0-zkvm <- treeship-zk-risc0.
+    # Pinned two minor versions back by the arkworks stack; `cargo update`
+    # cannot move it without arkworks releasing against 0.3.
+    #
+    # Remove when: arkworks upgrades to tracing-subscriber 0.3.20+.
+    "RUSTSEC-2025-0055",
+]
+
+# Unmaintained-crate warnings (bincode, derivative, paste, and the `lru` /
+# `rand` / `spin` unsoundness notices) are informational and are NOT ignored
+# here -- CI reports them without failing, so they stay visible. Promoting
+# them to hard failures would mean pinning the whole risc0 tree to whatever
+# its maintainers happen to depend on, which is not a decision this repo can
+# make. They are worth watching, not worth blocking a release on.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,13 +284,90 @@ jobs:
         working-directory: docs
         run: npm run build
 
+  deps-rust:
+    name: Dependency audit (Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
+      - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version ^0.22
+
+      # Advisories are ignored in .cargo/audit.toml, never inline here, so
+      # every exception carries a written reason and a condition for removing
+      # it. An ignore list buried in a CI command is how a scanner goes quiet
+      # without anyone deciding that it should.
+      #
+      # The rule for adding one: if `cargo tree -p treeship-cli -i <crate>`
+      # resolves, it reaches the shipped binary and is not a candidate.
+      - name: cargo audit
+        run: cargo audit
+
+  deps-go:
+    name: Dependency audit (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: '1.26.5'
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      # govulncheck reports only vulnerabilities whose affected symbols are
+      # actually reachable from this code, so a finding here is a real call
+      # path rather than a version-range match. That makes it worth failing
+      # on, and it is why the Go toolchain pin above matters -- most of what
+      # it finds is in the standard library the build ships with.
+      - name: govulncheck
+        working-directory: packages/hub
+        run: govulncheck ./...
+
+  deps-js:
+    name: Dependency audit (JS, ${{ matrix.pkg }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg:
+          - packages/sdk-ts
+          - packages/verify-js
+          - bridges/mcp
+          - bridges/a2a
+          - integrations/openclaw-plugin
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      # --omit=dev: a vulnerability in a test runner is not a vulnerability in
+      # anything users install. Auditing dev dependencies at the same severity
+      # is how these gates get switched off.
+      #
+      # docs/ is deliberately absent: docs/.gitignore excludes its lockfile,
+      # so there is nothing reproducible to audit. That gap is tracked as
+      # audit item 14, and committing the lockfile is what closes it.
+      - name: npm audit
+        working-directory: ${{ matrix.pkg }}
+        run: npm audit --omit=dev --audit-level=high
+
   hub:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.22'
+          # go.mod declares `go 1.22` as the minimum language version; this is
+          # the toolchain that actually builds the binary, and it must be a
+          # supported release. 1.22 stopped receiving security fixes, so the
+          # hub was being built by a compiler that would never be patched --
+          # govulncheck reports GO-2026-5856 (crypto/tls) as *called* from
+          # hub code, fixed in 1.26.5.
+          go-version: '1.26.5'
 
       - name: Build Hub
         working-directory: packages/hub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ark-bn254"
@@ -769,6 +769,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +913,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -999,7 +1019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1577,11 +1597,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1591,10 +1609,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2065,7 +2086,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2462,7 +2483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -2611,14 +2632,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2682,8 +2704,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2720,8 +2752,20 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3155,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "borsh",
  "proptest",
@@ -3243,9 +3287,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3474,7 +3518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 


### PR DESCRIPTION
**P1-9 from the 2026-08 external audit.** Nothing scanned dependencies, so nothing knew what shipped.

## One advisory reached the shipped binary

`cargo tree -p treeship-cli -i` separates real user exposure from noise in the pre-release ZK tree:

```
rustls-webpki 0.103.10 <- rustls <- ureq <- treeship-cli
```

Three advisories against it — a reachable panic parsing CRLs, and two name-constraint bypasses (URI names, and certs asserting a wildcard). **Updated to 0.103.14**, which clears all three.

Also updated crossbeam-epoch, ruint, quinn-proto, anyhow — ZK-only, but one `cargo update` away, and a fixable advisory left in place makes the real list harder to read.

## Rust: 8 → 2

Both survivors are confined to `treeship-zk-risc0` (pre-release, non-default `zk` feature), transitive through risc0's own chain, and unfixable here: `rsa` 0.9.10 has no fixed 0.9 release, `tracing-subscriber` 0.2.25 is pinned by arkworks.

Ignored in `.cargo/audit.toml` with **dependency path, reason, and the condition for removing the entry** — not inline in the CI command, because an ignore list buried in a shell line is how a scanner goes quiet without anyone deciding it should. The rule for adding one is written down: if `cargo tree -p treeship-cli -i <crate>` resolves, it's not a candidate.

## Go: the toolchain pin *was* the vulnerability

CI built the hub with **Go 1.22**, which stopped receiving security fixes — so the shipped binary was compiled by something that would never be patched. govulncheck reports GO-2026-5856 (`crypto/tls`) as **called** from hub code, fixed in 1.26.5.

Bumped the pin, and verified by installing 1.26.5 locally rather than assuming:

```
1.26.4:  Your code is affected by 1 vulnerability
1.26.5:  Your code is affected by 0 vulnerabilities
```

Builds, vets, and passes all 16 hub test packages under it. `go.mod` still says `go 1.22` — that's the minimum language version, a different claim from which compiler builds the release.

## JS: five packages, production deps only

`--omit=dev --audit-level=high`. A vulnerability in a test runner is not a vulnerability in anything a user installs, and auditing dev deps at the same severity is how these gates get switched off.

`docs/` is deliberately absent — its lockfile is gitignored, so there's nothing reproducible to audit. That's audit item 14; committing the lockfile is what closes it.

## Verification

All three jobs run locally and pass, including the Go one under a freshly installed 1.26.5. Two of the three CI failures on #283 were me treating a green local run as a green CI run, so this time the toolchain difference got checked rather than assumed.