### PR TITLE
docs: record the second audit round and the P0 fixes

### DIFF
--- a/docs/quality/audit-2026-08.md
+++ b/docs/quality/audit-2026-08.md
@@ -9,7 +9,9 @@ nobody can look up is a finding that gets rediscovered, re-analyzed, and
 re-argued six weeks later — which is how Treeship ended up with four
 documented claims that had quietly gone false (see #281).
 
-**Status as of v0.24.0 (2026-08-11):** 26 closed, 3 declined, 21 open.
+**Status as of 2026-08-13:** 30 closed, 3 declined, 17 open.
+
+Both confirmed P0s from the second audit round are fixed (#284, #285).
 
 Verify any "closed" row before trusting it — each cites the PR or the file
 that makes it true.
@@ -22,8 +24,8 @@ that makes it true.
 |---|---|---|---|
 | 1 | Duplicate `sequence_no` under burst contention (#275) | **Closed** | #279; issue auto-closed |
 | 2 | Lock `EventLog::open()` with the append lock | **Closed, differently** | #279 — see below |
-| 3 | Prevent Hub artifact-ID squatting | **Open** | needs a product decision |
-| 4 | Reject conflicting artifact re-uploads | **Open** | same decision as #3 |
+| 3 | Prevent Hub artifact-ID squatting | **Closed** | #285 -- `internal/contentaddress` re-derives at ingestion |
+| 4 | Reject conflicting artifact re-uploads | **Closed** | #285 -- 409, and no Rekor anchor on a duplicate |
 | 5 | Real grant revocation resolution | **Open** | `NoRevocationSource` in `commands/verify.rs`, `session.rs` |
 | 6 | Replace the unsigned, empty Hub revocation endpoint | **Open** | documented honestly in #281 |
 | 7 | Enforce Trusted Room invitation authority | **Open** | nothing in `verify/` reads it |
@@ -39,6 +41,16 @@ serialize.
 This matters because the recommended fix would have put an exclusive flock in
 the path of every handle construction, and would have preserved a write that
 has no reason to exist during `open`.
+
+### Correction: #3 and #4 were not a product decision
+
+I recorded them as needing one. They did not -- the fix is mechanical:
+re-derive `art_` and the digest from the DSSE envelope at ingestion, reject
+disagreement, 409 on differing bytes at the same id. #285 does exactly that.
+
+Filing a bug as a design question is how it stays open. Worth noting because
+the mis-filing, not the difficulty, is what kept these two at the top of the
+list for two days.
 
 ### On #8 — we tagged with 3–7 open. That was a judgment call.
 
@@ -73,7 +85,7 @@ answer than fixing them, and 3–7 remain the top of the queue.
 | 12 | Bind agent namespaces to publishers | **Open** | |
 | 13 | Six production vulns in the MCP package | **Closed** | #283 -- now zero |
 | 14 | Twelve high-severity vulns in the docs site | **Open** | `npm audit fix` exceeded 10min; still 12 high |
-| 15 | Dependency audits in CI | **Open** | no `cargo audit` / `npm audit` / dependabot |
+| 15 | Dependency audits in CI | **Closed** | #286 -- cargo audit, govulncheck, npm audit x5 |
 | 16 | Broken public "Verify a receipt" URL | **Closed** | `public/home.html`, commit 86e71ff |
 | 17 | Workspace share tokens truly single-use | **Partly closed** | device flow is single-use (`db.go:275`); share tokens "single-use in practice" |
 | 18 | Workspace credentials in query strings | **Open** | |
@@ -160,6 +172,46 @@ upstreams' `types.ts` and fails when either drops an event we use.
 Folding it into the monorepo would couple Treeship's release cadence to two
 third-party harnesses. The test is the better guarantee, and it fails at build
 time rather than on a user's machine.
+
+---
+
+## Second audit round (2026-08-13)
+
+A later review of `main` at f178124 confirmed two P0s and one conditional P0.
+Both confirmed ones are fixed.
+
+| Finding | Status | Evidence |
+|---|---|---|
+| P0-1: secrets recorded and auto-published | **Closed** | #284 |
+| P0-2: Hub does not enforce its content-addressed namespace | **Closed** | #285 |
+| P0-3: verify can exit 0 with authority unverified | **Open** | conditional on Treeship being used to gate |
+
+### P0-1 — worse than reported, in two ways
+
+The audit said the sanitizer missed common credential forms. It did: every
+pattern ended in `=`, so `--token secret123` split into two tokens that
+matched nothing. Two things it did not catch:
+
+- **The same broken function existed twice**, in `wrap.rs` and `hook.rs`.
+- **`argv` was worse than `command`.** The redactor was applied per element,
+  so it received the bare string `"secret123"`. No per-element function can
+  catch that -- knowing the previous argument was `--token` is the only thing
+  that makes the value recognisable. `capture` now takes the whole sequence.
+
+Program output is now a digest by default. `output_digest` already sat beside
+`output_summary`, so the raw line was disclosure with no verification value.
+
+### P0-3 — still open, and the disagreement is worth recording
+
+The audit rates this P0 *if* Treeship gates deployments or payments, P1 if it
+stays evidence-only. `treeship verify` can exit 0 while reporting
+`authority_unverified: 1`, so `treeship verify "$ART" && deploy` proceeds
+without knowing whether the authority was revoked.
+
+The detailed JSON is honest; the exit code is not, for an enforcement use.
+The fix is a `--require-authority` flag and making strict authority the
+default for protected actions. It depends on 5 and 6 (revocation), which is
+why it is not fixed here.
 
 ---
 


### PR DESCRIPTION
**30 closed, 3 declined, 17 open** (was 26/3/21).

Both confirmed P0s from the 2026-08-13 review are fixed — #284 (credential leakage) and #285 (Hub content addressing) — and dependency audits are gated in CI (#286).

**Corrects my own mis-filing.** I recorded items 3 and 4 as "needs a product decision." They didn't — the fix is mechanical, and #285 is it. Filing a bug as a design question is how it stays open, and that's what kept these two at the top of the list, not difficulty.

**Records P0-3 as open with the disagreement intact.** `treeship verify` can exit 0 while reporting `authority_unverified: 1`, so `treeship verify "$ART" && deploy` proceeds without knowing whether the authority was revoked. The detailed JSON is honest; the exit code isn't, for an enforcement use. It depends on revocation (items 5 and 6), which is why it isn't fixed alongside the other two.