### PR TITLE
fix(storage): reject artifact ids that escape the store directory

### DIFF
--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -552,10 +552,39 @@ pub fn pull(
 
     let envelope: treeship_core::attestation::Envelope = serde_json::from_str(envelope_json_str)?;
 
+    // Re-derive identity from the bytes we were handed, and trust that rather
+    // than the fields alongside them. `artifact_id` used to be taken from the
+    // response and written straight to disk, so a hostile Hub controlled a
+    // filesystem path (fixed in `Store::artifact_path` too -- both halves are
+    // needed: one stops the write, this stops the wrong file being stored
+    // under a name that lies about its contents).
+    //
+    // Deriving also makes `art_x` mean the same bytes on both sides. The Hub
+    // performs the identical derivation at ingestion; a mismatch here means
+    // the bytes are not the artifact that was asked for, whatever the
+    // response says.
+    let payload_bytes = URL_SAFE_NO_PAD
+        .decode(envelope.payload.trim_end_matches('='))
+        .map_err(|e| format!("hub returned an envelope whose payload is not base64url: {e}"))?;
+    let pae = treeship_core::attestation::pae(&envelope.payload_type, &payload_bytes);
+    let derived_id = treeship_core::attestation::artifact_id_from_pae(&pae);
+    let derived_digest = treeship_core::attestation::digest_from_pae(&pae);
+
+    if derived_id != id {
+        return Err(format!(
+            "hub returned the wrong artifact: asked for {id}, \
+             the returned bytes derive {derived_id}"
+        )
+        .into());
+    }
+
     let record = treeship_core::storage::Record {
-        artifact_id: resp["artifact_id"].as_str().unwrap_or(id).to_string(),
-        digest: resp["digest"].as_str().unwrap_or("").to_string(),
-        payload_type: resp["payload_type"].as_str().unwrap_or("").to_string(),
+        artifact_id: derived_id,
+        digest: derived_digest,
+        // payload_type is bound into the PAE above, so the derived id already
+        // proves this value; taking it from the envelope rather than the
+        // response body keeps every stored field sourced from signed bytes.
+        payload_type: envelope.payload_type.clone(),
         key_id: envelope
             .signatures
             .first()

--- a/packages/core/src/attestation/mod.rs
+++ b/packages/core/src/attestation/mod.rs
@@ -7,7 +7,7 @@ pub mod verify;
 
 // Re-exports for ergonomic use: `use treeship_core::attestation::*`
 pub use envelope::{Envelope, Signature};
-pub use id::{artifact_id_from_pae, digest_from_pae, ArtifactId};
+pub use id::{artifact_id_from_pae, digest_from_pae, parse_artifact_id, ArtifactId};
 pub use pae::pae;
 pub use sign::{sign, SignError, SignResult};
 pub use signer::{Ed25519Signer, Signer, SignerError};

--- a/packages/core/src/storage/mod.rs
+++ b/packages/core/src/storage/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::attestation::{ArtifactId, Envelope};
+use crate::attestation::{parse_artifact_id, ArtifactId, Envelope};
 
 /// The on-disk record for one stored artifact.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,6 +46,10 @@ pub enum StorageError {
     Io(io::Error),
     Json(serde_json::Error),
     EmptyId,
+    /// The id is not a well-formed `art_<32 hex>`. Returned instead of
+    /// touching the filesystem: an id reaches here from a Hub response, and
+    /// one containing `../` used to resolve to a path outside the store.
+    InvalidId(String),
     NotFound(ArtifactId),
 }
 
@@ -55,6 +59,7 @@ impl std::fmt::Display for StorageError {
             Self::Io(e) => write!(f, "storage io: {}", e),
             Self::Json(e) => write!(f, "storage json: {}", e),
             Self::EmptyId => write!(f, "artifact_id must not be empty"),
+            Self::InvalidId(e) => write!(f, "storage: {}", e),
             Self::NotFound(id) => write!(f, "artifact not found: {}", id),
         }
     }
@@ -103,7 +108,7 @@ impl Store {
         }
 
         let json = serde_json::to_vec_pretty(record)?;
-        write_600(&self.artifact_path(&record.artifact_id), &json)?;
+        write_600(&self.artifact_path(&record.artifact_id)?, &json)?;
 
         let mut idx = self.index.write().unwrap();
         let entry = IndexEntry {
@@ -123,7 +128,7 @@ impl Store {
 
     /// Reads an artifact by ID.
     pub fn read(&self, id: &str) -> Result<Record, StorageError> {
-        let path = self.artifact_path(id);
+        let path = self.artifact_path(id)?;
         if !path.exists() {
             return Err(StorageError::NotFound(id.to_string()));
         }
@@ -133,7 +138,9 @@ impl Store {
 
     /// Returns true if an artifact with this ID is stored locally.
     pub fn exists(&self, id: &str) -> bool {
-        self.artifact_path(id).exists()
+        // A malformed id cannot name a stored artifact, so it does not exist.
+        // Deliberately not a filesystem probe on an unvalidated path.
+        self.artifact_path(id).is_ok_and(|p| p.exists())
     }
 
     /// Lists index entries, most recent first.
@@ -162,8 +169,17 @@ impl Store {
         self.index.read().unwrap().entries.last().cloned()
     }
 
-    fn artifact_path(&self, id: &str) -> PathBuf {
-        self.dir.join(format!("{}.json", id))
+    /// Resolve an artifact id to its on-disk path.
+    ///
+    /// Validates the id first. `join` on an attacker-influenced string is a
+    /// path-traversal primitive: `../../x` resolved to a file outside the
+    /// store, and `hub pull` writes whatever `artifact_id` the server sends
+    /// back. `parse_artifact_id` already existed and enforces
+    /// `art_<32 hex>` -- which cannot contain a separator or a dot -- it was
+    /// simply never called on this path.
+    fn artifact_path(&self, id: &str) -> Result<PathBuf, StorageError> {
+        let id = parse_artifact_id(id).map_err(StorageError::InvalidId)?;
+        Ok(self.dir.join(format!("{}.json", id)))
     }
 }
 
@@ -358,5 +374,84 @@ mod tests {
             Some("https://treeship.dev/verify/art_aabbccdd11223344aabbccdd11223344")
         );
         rm(dir);
+    }
+}
+
+#[cfg(test)]
+mod path_traversal_tests {
+    use super::*;
+
+    fn record_with_id(id: &str) -> Record {
+        Record {
+            artifact_id: id.to_string(),
+            digest: "sha256:00".into(),
+            payload_type: "application/vnd.in-toto+json".into(),
+            key_id: "k".into(),
+            signed_at: "2026-01-01T00:00:00Z".into(),
+            parent_id: None,
+            envelope: Envelope {
+                payload: "e30".into(),
+                payload_type: "application/vnd.in-toto+json".into(),
+                signatures: vec![],
+            },
+            hub_url: None,
+        }
+    }
+
+    /// The vulnerability, as it actually behaved.
+    ///
+    /// `hub pull` writes the `artifact_id` the *server* returned, and
+    /// `artifact_path` used to `join` it unvalidated. A malicious or
+    /// compromised Hub could therefore write an attacker-chosen `.json` file
+    /// anywhere the process could write. Before the fix this test's escaped
+    /// file existed.
+    #[test]
+    fn write_cannot_escape_the_store_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store_dir = tmp.path().join("a").join("b").join("store");
+        let store = Store::open(&store_dir).unwrap();
+
+        for id in [
+            "../../escaped",
+            "../../../etc/cron.d/x",
+            "art_/../../escaped",
+            "/tmp/absolute",
+            "..",
+        ] {
+            let err = store.write(&record_with_id(id)).unwrap_err();
+            assert!(
+                matches!(err, StorageError::InvalidId(_)),
+                "id {id:?} should be rejected as malformed, got {err:?}"
+            );
+        }
+
+        let escaped = tmp.path().join("a").join("escaped.json");
+        assert!(!escaped.exists(), "a file was written outside the store");
+        assert!(!tmp.path().join("absolute.json").exists());
+    }
+
+    /// The check must not be so strict it rejects real ids -- a validator that
+    /// blocks everything closes the hole and the feature together.
+    #[test]
+    fn well_formed_ids_still_write_and_read() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+
+        let id = "art_0123456789abcdef0123456789abcdef";
+        store.write(&record_with_id(id)).expect("write a valid id");
+        assert!(store.exists(id));
+        assert_eq!(store.read(id).unwrap().artifact_id, id);
+    }
+
+    /// `exists` took an unvalidated path to the filesystem. It now answers
+    /// false rather than probing, which is also the honest answer: a malformed
+    /// id cannot name a stored artifact.
+    #[test]
+    fn exists_reports_false_for_malformed_ids_without_probing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        assert!(!store.exists("../../../etc/passwd"));
+        assert!(!store.exists(""));
+        assert!(!store.exists("art_nothex0000000000000000000000zz"));
     }
 }


### PR DESCRIPTION
**P1-2 from the 2026-08 audit.** Confirmed by test *before* fixing — an id of `../../escaped` wrote a file outside the store:

```
write result: true
ESCAPED FILE EXISTS: true      <- before
ESCAPED FILE EXISTS: false     <- after
```

```rust
Store::artifact_path -> self.dir.join(format!("{}.json", id))
```

`join` on an attacker-influenced string is a path-traversal primitive, and the string reaches it from a Hub response: `hub pull` took `resp["artifact_id"]` verbatim into the record it writes. A malicious or compromised Hub could write an attacker-chosen `.json` file anywhere the process could write.

## The validator already existed and was unreachable

`parse_artifact_id` enforces `art_<32 hex>` — which cannot contain a separator or a dot — and it was correct. It just wasn't in `attestation/mod.rs`'s public re-exports, so **nothing outside its own file could call it.** Zero callers before this commit. That's the whole reason the audit could write "without calling the existing `parse_artifact_id()`".

Exported, and wired into `artifact_path`, which is now fallible. `exists` also took an unvalidated path to the filesystem; it now answers false rather than probing — the honest answer anyway, since a malformed id cannot name a stored artifact.

## Both halves are needed, and they stop different things

- **Validation** stops the write landing outside the directory.
- **Client-side derivation** stops the *right* directory being filled with the wrong bytes under a name that lies about them.

So `hub pull` now re-derives `artifact_id` and `digest` from the envelope's own PAE and refuses when the result isn't what was asked for:

```
hub returned the wrong artifact: asked for art_a…, the returned bytes derive art_b…
```

`payload_type` likewise comes from the envelope, not the response body, so every stored field is sourced from signed bytes.

This is the **client half of "enforce content addressing at every boundary"** (audit improvement #2). The Hub does the identical derivation at ingestion since #285; matching them is what makes `art_x` mean the same bytes on both sides.

## Tests

Traversal closed (five id shapes incl. absolute paths and `art_/../`), well-formed ids still write and read — a validator that rejects everything closes the hole and the feature together — and `exists` reports false without probing.

clippy `-D warnings` clean, 577 Rust tests pass.