### PR TITLE
feat(verify): report how much of a timeline nobody witnessed

### DIFF
--- a/docs/capability-map.json
+++ b/docs/capability-map.json
@@ -3,7 +3,7 @@
   "counts": {
     "cli_commands": 34,
     "hub_routes": 22,
-    "wire_types": 109
+    "wire_types": 113
   },
   "cli_commands": [
     "add",
@@ -229,6 +229,16 @@
       "source": "packages/core/src/session/graph.rs"
     },
     {
+      "name": "Anchor",
+      "kind": "struct",
+      "source": "packages/core/src/verify/anchoring.rs"
+    },
+    {
+      "name": "AnchorCoverage",
+      "kind": "struct",
+      "source": "packages/core/src/verify/anchoring.rs"
+    },
+    {
       "name": "ApprovalConfig",
       "kind": "struct",
       "source": "packages/core/src/rules.rs"
@@ -332,6 +342,11 @@
       "name": "Cost",
       "kind": "struct",
       "source": "packages/core/src/statements/action_v2.rs"
+    },
+    {
+      "name": "Coverage",
+      "kind": "enum",
+      "source": "packages/core/src/verify/anchoring.rs"
     },
     {
       "name": "Custody",
@@ -565,6 +580,11 @@
     },
     {
       "name": "Record",
+      "kind": "struct",
+      "source": "packages/core/src/storage/mod.rs"
+    },
+    {
+      "name": "RecordAnchor",
       "kind": "struct",
       "source": "packages/core/src/storage/mod.rs"
     },

--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -469,6 +469,7 @@ treeship verify [OPTIONS] <TARGET>
 | `--no-chain` | Verify only this artifact, do not walk the parent chain. Only applies to the artifact-ID form |
 | `--max-depth <N>` | Maximum chain depth to walk (default: 20). Only applies to the artifact-ID form [default: 20] |
 | `--full` | Show full chain timeline with box-drawn cards. Only applies to the artifact-ID form |
+| `--max-unwitnessed <DURATION>` | Fail unless every stretch of claimed work was externally witnessed within this long (e.g. 15m, 1h, 3600) |
 
 ## `treeship hub`
 

--- a/packages/cli/src/commands/agent.rs
+++ b/packages/cli/src/commands/agent.rs
@@ -154,6 +154,7 @@ fn mint_cert_receipt(
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     Ok(())
 }

--- a/packages/cli/src/commands/approve.rs
+++ b/packages/cli/src/commands/approve.rs
@@ -339,6 +339,7 @@ pub fn approve(
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // Mark the pending file as approved with the nonce
@@ -414,6 +415,7 @@ pub fn deny(
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // Remove the pending file

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -249,6 +249,7 @@ fn action_v1(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std:
         parent_id: args.parent_id.clone(),
         envelope: result.envelope.clone(),
         hub_url: None,
+        anchors: Vec::new(),
     };
     ctx.storage.write(&record)?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
@@ -416,6 +417,7 @@ fn action_v2(args: ActionArgs, printer: &Printer) -> Result<String, Box<dyn std:
         parent_id: args.parent_id.clone(),
         envelope: result.envelope.clone(),
         hub_url: None,
+        anchors: Vec::new(),
     };
     ctx.storage.write(&record)?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
@@ -807,6 +809,7 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
@@ -899,6 +902,7 @@ fn record_approval_refusal(
             parent_id: None,
             envelope: result.envelope,
             hub_url: None,
+            anchors: Vec::new(),
         })
         .ok()?;
     Some(result.artifact_id)
@@ -1010,6 +1014,7 @@ pub fn handoff(args: HandoffArgs, printer: &Printer) -> Result<(), Box<dyn std::
         parent_id: args.artifacts.first().cloned(),
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
@@ -1109,6 +1114,7 @@ pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::
         parent_id: args.subject_id.clone(),
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
@@ -1471,6 +1477,7 @@ pub fn card(args: CardArgs, printer: &Printer) -> Result<(), Box<dyn std::error:
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
@@ -1561,6 +1568,7 @@ pub fn decision(args: DecisionArgs, printer: &Printer) -> Result<(), Box<dyn std
         parent_id: parent,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // Write .last for auto-chaining
@@ -1721,6 +1729,7 @@ pub fn endorsement(
         parent_id: parent,
         envelope: result.envelope.clone(),
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // Write .last for auto-chaining

--- a/packages/cli/src/commands/bundle.rs
+++ b/packages/cli/src/commands/bundle.rs
@@ -194,6 +194,7 @@ mod tests {
                 parent_id: None,
                 envelope: signed.envelope,
                 hub_url: None,
+                anchors: Vec::new(),
             })
             .unwrap();
 

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -394,6 +394,7 @@ pub fn revoke_capability(
         parent_id: Some(card_id.to_string()),
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     let self_revoke = signer.key_id() == card_keyid;

--- a/packages/cli/src/commands/daemon.rs
+++ b/packages/cli/src/commands/daemon.rs
@@ -465,6 +465,7 @@ fn attest_file_change(
         parent_id,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     write_last(&ctx.config.storage_dir, &result.artifact_id);

--- a/packages/cli/src/commands/hook.rs
+++ b/packages/cli/src/commands/hook.rs
@@ -188,6 +188,7 @@ pub fn post(
         parent_id,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // Write .last for auto-chaining

--- a/packages/cli/src/commands/hub.rs
+++ b/packages/cli/src/commands/hub.rs
@@ -594,6 +594,7 @@ pub fn pull(
         parent_id: resp["parent_id"].as_str().map(|s| s.to_string()),
         envelope,
         hub_url: resp["hub_url"].as_str().map(|s| s.to_string()),
+        anchors: Vec::new(),
     };
 
     ctx.storage.write(&record)?;
@@ -779,6 +780,40 @@ fn push_artifact_to_hub(
     // 4. Update local record with hub_url
     if !hub_url.is_empty() {
         ctx.storage.set_hub_url(id, &hub_url)?;
+    }
+
+    // 5. Record the witnesses, with the time we observed them.
+    //
+    // `hub_url` alone says *that* this was pushed, never *when* -- and when is
+    // the whole value of an anchor. A receipt's own timestamp is the signer's
+    // claim about itself; this is a record that somebody else saw these bytes,
+    // which is what makes a timeline expensive to fabricate afterwards. Until
+    // this existed there was no local data from which anchoring coverage could
+    // be computed at all.
+    //
+    // Hub and Rekor are recorded separately because they fail differently: a
+    // Hub anchor requires trusting the Hub, a Rekor entry is independently
+    // checkable in a public log. Collapsing them would throw that away.
+    let observed_at = now_rfc3339();
+    if !hub_url.is_empty() {
+        ctx.storage.add_anchor(
+            id,
+            treeship_core::storage::RecordAnchor {
+                mechanism: "hub".to_string(),
+                observed_at: observed_at.clone(),
+                reference: Some(hub_url.clone()),
+            },
+        )?;
+    }
+    if let Some(idx) = rekor_index {
+        ctx.storage.add_anchor(
+            id,
+            treeship_core::storage::RecordAnchor {
+                mechanism: "rekor".to_string(),
+                observed_at,
+                reference: Some(idx.to_string()),
+            },
+        )?;
     }
 
     Ok(PushResult {
@@ -973,6 +1008,20 @@ fn format_device_code(code: &str) -> String {
     } else {
         code.to_string()
     }
+}
+
+/// Local wall-clock now, RFC 3339. Used to stamp when a witness responded.
+///
+/// Still our own clock, deliberately: this defends against a timeline
+/// fabricated *after* the work, not against a machine whose clock is wrong in
+/// real time. Getting the witness's own signed time is time-anchoring.md
+/// slices 3-5.
+fn now_rfc3339() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    treeship_core::statements::unix_to_rfc3339(secs)
 }
 
 #[cfg(test)]

--- a/packages/cli/src/commands/invitation.rs
+++ b/packages/cli/src/commands/invitation.rs
@@ -400,6 +400,7 @@ pub fn invite(
         parent_id: None,
         envelope: sign_result.envelope.clone(),
         hub_url: None,
+        anchors: Vec::new(),
     };
     c.storage.write(&record)?;
 
@@ -673,6 +674,7 @@ pub fn join(
         parent_id: Some(bundle.invitation_id.clone()),
         envelope: pending_env.clone(),
         hub_url: None,
+        anchors: Vec::new(),
     };
     c.storage.write(&record)?;
 

--- a/packages/cli/src/commands/profile.rs
+++ b/packages/cli/src/commands/profile.rs
@@ -235,6 +235,7 @@ pub fn profile(agent: &str, attest: bool, config: Option<&str>, printer: &Printe
             parent_id: None,
             envelope: result.envelope,
             hub_url: None,
+            anchors: Vec::new(),
         })?;
         attested_id = Some(result.artifact_id);
     }

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -356,6 +356,7 @@ pub fn start(
         parent_id,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     write_last(&ctx.config.storage_dir, &result.artifact_id);
@@ -1092,6 +1093,7 @@ fn mint_session_record(
         parent_id: Some(close_artifact_id.to_string()),
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
     write_last(&ctx.config.storage_dir, &result.artifact_id);
 
@@ -1193,6 +1195,7 @@ pub fn close(
         parent_id,
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     write_last(&ctx.config.storage_dir, &result.artifact_id);

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -374,9 +374,14 @@ pub fn run(
     no_chain: bool,
     max_depth: usize,
     full: bool,
+    max_unwitnessed: Option<&str>,
     config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let max_unwitnessed_secs = match max_unwitnessed {
+        Some(raw) => Some(parse_duration_secs(raw)?),
+        None => None,
+    };
     let ctx = ctx::open(config)?;
 
     // Resolve "last" keyword to the most recent artifact ID.
@@ -615,6 +620,38 @@ pub fn run(
             if chain_count == 1 { "" } else { "s" }
         );
         printer.success(&header, &[]);
+
+        // Anchoring coverage. Reported on every verify, gating only when the
+        // caller asked -- unanchored work is normal (offline machines, network
+        // failures) and is not by itself evidence of anything. What would be
+        // wrong is staying silent: a reader has no other way to tell a
+        // continuously witnessed timeline from an entirely self-asserted one,
+        // and the receipts look identical either way.
+        let coverage = compute_chain_coverage(&ctx, &chain_ids);
+        printer.dim_info(&format!("  anchoring: {}", coverage.summary()));
+
+        if let Some(limit) = max_unwitnessed_secs {
+            if !coverage.within(limit) {
+                printer.blank();
+                printer.failure(
+                    "UNWITNESSED WORK EXCEEDS POLICY",
+                    &[
+                        (
+                            "longest_unwitnessed",
+                            &human_secs(coverage.unwitnessed_span_seconds),
+                        ),
+                        ("allowed", &human_secs(limit)),
+                        (
+                            "meaning",
+                            "the signatures are valid; nobody outside this machine \
+                             witnessed that stretch of the timeline",
+                        ),
+                    ],
+                );
+                printer.blank();
+                std::process::exit(1);
+            }
+        }
 
         // Show info about the target artifact.
         if let Some((_id, env)) = chain_envelopes.last() {
@@ -2759,5 +2796,107 @@ mod tests {
             "must name the violated invariant: {gs}"
         );
         assert!(!gs.contains('{'), "must not be Debug-formatted: {gs}");
+    }
+}
+
+/// Parse `15m`, `2h`, `90s`, or a bare number of seconds.
+fn parse_duration_secs(raw: &str) -> Result<i64, String> {
+    let t = raw.trim();
+    let (digits, mult) = match t.chars().last() {
+        Some('s') => (&t[..t.len() - 1], 1),
+        Some('m') => (&t[..t.len() - 1], 60),
+        Some('h') => (&t[..t.len() - 1], 3600),
+        Some('d') => (&t[..t.len() - 1], 86_400),
+        _ => (t, 1),
+    };
+    let n: i64 = digits
+        .parse()
+        .map_err(|_| format!("invalid duration {raw:?}: expected e.g. 15m, 2h, 3600"))?;
+    if n < 0 {
+        return Err(format!("invalid duration {raw:?}: must not be negative"));
+    }
+    Ok(n * mult)
+}
+
+fn human_secs(s: i64) -> String {
+    match s {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s => format!("{}h{:02}m", s / 3600, (s % 3600) / 60),
+    }
+}
+
+/// Gather the claimed timeline and its witnesses across a verified chain.
+///
+/// Claimed times come from each artifact's `signed_at` -- the signer's own
+/// assertion, which is exactly what anchoring exists to constrain. Anchors
+/// come from `Record.anchors`, written when a push was acknowledged.
+///
+/// An artifact whose `signed_at` will not parse is skipped rather than
+/// defaulted: inventing a timestamp for it would shrink or stretch the
+/// computed span with a value nobody asserted.
+fn compute_chain_coverage(
+    ctx: &ctx::Ctx,
+    chain_ids: &[String],
+) -> treeship_core::verify::anchoring::AnchorCoverage {
+    use treeship_core::statements::parse_rfc3339_to_unix;
+    use treeship_core::verify::anchoring::{Anchor, AnchorCoverage};
+
+    let mut event_times: Vec<i64> = Vec::new();
+    let mut anchors: Vec<Anchor> = Vec::new();
+
+    for id in chain_ids {
+        let Ok(record) = ctx.storage.read(id) else {
+            continue;
+        };
+        if let Some(t) = parse_rfc3339_to_unix(&record.signed_at) {
+            event_times.push(t as i64);
+        }
+        for a in &record.anchors {
+            if let Some(t) = parse_rfc3339_to_unix(&a.observed_at) {
+                anchors.push(Anchor {
+                    at: t as i64,
+                    mechanism: a.mechanism.clone(),
+                });
+            }
+        }
+    }
+
+    AnchorCoverage::compute(&event_times, &anchors)
+}
+
+#[cfg(test)]
+mod anchoring_gate_tests {
+    use super::*;
+
+    #[test]
+    fn duration_units_parse() {
+        assert_eq!(parse_duration_secs("90s").unwrap(), 90);
+        assert_eq!(parse_duration_secs("15m").unwrap(), 900);
+        assert_eq!(parse_duration_secs("2h").unwrap(), 7200);
+        assert_eq!(parse_duration_secs("1d").unwrap(), 86_400);
+        // A bare number is seconds, so a caller who passes a raw count of
+        // seconds gets what they meant rather than a parse error.
+        assert_eq!(parse_duration_secs("3600").unwrap(), 3600);
+        assert_eq!(parse_duration_secs("  30m ").unwrap(), 1800);
+    }
+
+    /// A silently-misparsed duration is worse than a rejected one: it would
+    /// gate on a bound the caller never asked for.
+    #[test]
+    fn malformed_durations_are_rejected_not_guessed() {
+        for bad in ["bogus", "", "15x", "m", "1.5h", "-5m", "--"] {
+            assert!(
+                parse_duration_secs(bad).is_err(),
+                "{bad:?} should not parse"
+            );
+        }
+    }
+
+    #[test]
+    fn human_secs_is_readable_at_each_scale() {
+        assert_eq!(human_secs(45), "45s");
+        assert_eq!(human_secs(900), "15m");
+        assert_eq!(human_secs(39_600), "11h00m");
     }
 }

--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -269,6 +269,7 @@ pub fn run(
         parent_id: parent_id.clone(),
         envelope: result.envelope,
         hub_url: None,
+        anchors: Vec::new(),
     })?;
 
     // ── 2. Auto-chaining: write .last ──────────────────────────────────

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -2127,6 +2127,21 @@ struct VerifyArgs {
     /// Only applies to the artifact-ID form.
     #[arg(long, default_value_t = false)]
     full: bool,
+
+    /// Fail unless every stretch of claimed work was externally witnessed
+    /// within this long (e.g. 15m, 1h, 3600).
+    ///
+    /// A receipt's timestamp is the signer's own clock, signed with the
+    /// signer's own key, so it proves what was claimed and not when it
+    /// happened. An anchor -- a Hub checkpoint or Rekor entry -- is somebody
+    /// else's record that the bytes existed by then, and cannot be obtained
+    /// retroactively. This bounds how long the timeline goes unwitnessed.
+    ///
+    /// Without this flag, coverage is reported and never gates: unanchored
+    /// work is normal (offline machines, network failures) and is not by
+    /// itself evidence of anything.
+    #[arg(long, value_name = "DURATION")]
+    max_unwitnessed: Option<String>,
 }
 
 #[derive(Args)]
@@ -3348,6 +3363,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     a.no_chain,
                     a.max_depth,
                     a.full,
+                    a.max_unwitnessed.as_deref(),
                     cli.config.as_deref(),
                     printer,
                 )

--- a/packages/cli/tests/action_v2_verify_e2e.rs
+++ b/packages/cli/tests/action_v2_verify_e2e.rs
@@ -90,6 +90,7 @@ impl Workspace {
             parent_id: None,
             envelope: signed.envelope.clone(),
             hub_url: None,
+            anchors: Vec::new(),
         };
         store.write(&record).expect("write record");
         signed.artifact_id.to_string()

--- a/packages/core/src/bundle/mod.rs
+++ b/packages/core/src/bundle/mod.rs
@@ -153,6 +153,8 @@ pub fn create(
         parent_id: None,
         envelope: result.envelope,
         hub_url: None,
+        // Just signed locally; nothing external has witnessed it yet.
+        anchors: Vec::new(),
     };
 
     storage.write(&record)?;
@@ -326,6 +328,9 @@ fn record_from_envelope(
         parent_id,
         envelope: envelope.clone(),
         hub_url: None,
+        // Imported from a bundle. Any anchors the exporter held are their
+        // evidence, not ours -- we record what we witness.
+        anchors: Vec::new(),
     })
 }
 
@@ -379,6 +384,7 @@ mod tests {
                 parent_id: None,
                 envelope: result.envelope,
                 hub_url: None,
+                anchors: Vec::new(),
             })
             .unwrap();
         result.artifact_id

--- a/packages/core/src/storage/mod.rs
+++ b/packages/core/src/storage/mod.rs
@@ -22,6 +22,42 @@ pub struct Record {
     pub envelope: Envelope,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hub_url: Option<String>,
+    /// External witnesses to this artifact's existence, in the order they
+    /// were obtained.
+    ///
+    /// Separate from `hub_url` because a URL records *that* something was
+    /// pushed and not *when* -- and when is the whole value. A receipt's own
+    /// timestamp is the signer's claim about itself; an anchor is somebody
+    /// else's record that these bytes existed by a given moment, which is
+    /// what makes a timeline hard to fabricate after the fact.
+    ///
+    /// `#[serde(default)]` so receipts written before this field parse
+    /// unchanged: an old artifact has no anchors recorded, which is exactly
+    /// what an empty list means.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub anchors: Vec<RecordAnchor>,
+}
+
+/// One external witness to an artifact, as observed locally.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecordAnchor {
+    /// Which mechanism witnessed it: "hub", "rekor", "ots", "tsa".
+    pub mechanism: String,
+    /// RFC 3339, from the *local* clock at the moment the witness responded.
+    ///
+    /// Honest caveat, and the reason this is not the end of the story: this
+    /// is still our own clock. It records when we observed the witness, not
+    /// when the witness says it saw us. It is trustworthy against an actor
+    /// who fabricates a timeline afterwards -- you cannot obtain a Hub or
+    /// Rekor response for bytes you have not written yet -- and not
+    /// trustworthy against one who sets the system clock and anchors in real
+    /// time. Closing that needs the witness's own signed time, which is
+    /// `time-anchoring.md` slices 3-5.
+    pub observed_at: String,
+    /// Witness-side identifier where one exists: a Rekor log index, a Hub
+    /// artifact URL. Lets a verifier go and check independently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference: Option<String>,
 }
 
 /// A lightweight index entry — stored in index.json for fast listing
@@ -164,6 +200,18 @@ impl Store {
         self.write(&record)
     }
 
+    /// Record that an external witness saw this artifact.
+    ///
+    /// Appends rather than replaces: two witnesses are strictly better
+    /// evidence than one, and they fail differently -- a Hub anchor requires
+    /// trusting the Hub, an OpenTimestamps anchor does not. Collapsing them
+    /// would discard that difference.
+    pub fn add_anchor(&self, id: &str, anchor: RecordAnchor) -> Result<(), StorageError> {
+        let mut record = self.read(id)?;
+        record.anchors.push(anchor);
+        self.write(&record)
+    }
+
     /// Returns the most recently stored artifact, if any.
     pub fn latest(&self) -> Option<IndexEntry> {
         self.index.read().unwrap().entries.last().cloned()
@@ -236,6 +284,7 @@ mod tests {
                 }],
             },
             hub_url: None,
+            anchors: Vec::new(),
         }
     }
 
@@ -395,6 +444,7 @@ mod path_traversal_tests {
                 signatures: vec![],
             },
             hub_url: None,
+            anchors: Vec::new(),
         }
     }
 

--- a/packages/core/src/verify/anchoring.rs
+++ b/packages/core/src/verify/anchoring.rs
@@ -1,0 +1,334 @@
+//! Anchoring coverage: how much of a claimed timeline had an external witness.
+//!
+//! # Why this exists
+//!
+//! A receipt's timestamp comes from `SystemTime::now()` on the signing machine
+//! and is signed with that machine's own key. It proves *"this key asserted
+//! this"*, never *"this happened then"*. An actor holding its own key and
+//! controlling its own clock can emit a chain claiming any timeline it likes.
+//!
+//! What constrains a timeline is an **anchor**: a record, held by someone
+//! other than the actor, that a given digest existed at a given time. A Hub
+//! checkpoint, a Rekor entry, an OpenTimestamps attestation. Anchors cannot be
+//! obtained retroactively, so work that happened between two anchors is
+//! bracketed by them.
+//!
+//! # What this reports, and why it is not a boolean
+//!
+//! `anchored: true` would flatten three materially different situations into
+//! one word: a session witnessed every few minutes, a session witnessed once
+//! at close, and a session witnessed never. Only the first constrains the
+//! timeline. That flattening is the same defect as revocation resolving
+//! `Unknown` and still reaching a passing exit code -- the honest detail
+//! exists and the summary discards it.
+//!
+//! So the output carries [`AnchorCoverage::unwitnessed_span_seconds`]: the
+//! longest stretch of claimed work with no external witness. For an
+//! 11-hour session honestly anchored every 15 minutes that number is small.
+//! For an 11-hour session fabricated at the end and anchored once, it is the
+//! whole session -- whatever the receipts themselves claim.
+//!
+//! # What this does NOT prove
+//!
+//! Anchoring bounds *when a claim was made*, never whether the claim is true.
+//! A receipt describing work that never happened, anchored punctually, is a
+//! punctual lie. And a low coverage score is not evidence of wrongdoing:
+//! offline work, air-gapped machines and network failures all produce
+//! unanchored sessions. This reports the fact; the policy belongs to the
+//! caller.
+//!
+//! Nor does it detect **omission** -- an actor presenting a shortened chain
+//! and discarding the rest. That chain is honestly signed and honestly
+//! anchored; catching it requires anchors discoverable by identity, which is
+//! the transparency log's property. See `docs/specs/time-anchoring.md`.
+
+use serde::{Deserialize, Serialize};
+
+/// How a claimed timeline relates to its external witnesses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Coverage {
+    /// No anchors at all. The timeline rests entirely on the actor's own
+    /// clock and key. Not an accusation -- offline work looks like this.
+    None,
+    /// Anchors exist, but none of them falls inside the work. Everything
+    /// before the first anchor is unconstrained, which for a
+    /// single-anchor-at-close session is the entire timeline.
+    EndpointOnly,
+    /// Anchors interleave with the work, so stretches between them are
+    /// bracketed. `unwitnessed_span_seconds` says how coarsely.
+    Periodic,
+}
+
+/// One external witness: someone other than the actor recorded that a digest
+/// existed at a time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Anchor {
+    /// Unix seconds at which the witness recorded the digest. This is the
+    /// witness's clock, not the actor's -- that is the entire point.
+    pub at: i64,
+    /// Which mechanism produced it: "hub", "rekor", "ots", "tsa".
+    pub mechanism: String,
+}
+
+/// The anchoring picture for one session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnchorCoverage {
+    pub coverage: Coverage,
+    /// The longest stretch of claimed work with no external witness. The
+    /// number a caller gating on time should read.
+    pub unwitnessed_span_seconds: i64,
+    /// Total claimed duration, for context: an unwitnessed span of 600s means
+    /// something different across a 10-minute session than a 10-hour one.
+    pub claimed_span_seconds: i64,
+    pub anchor_count: usize,
+    /// Distinct mechanisms, sorted. Mechanisms fail differently -- a Hub
+    /// anchor needs the Hub trusted, an OTS anchor does not -- so which ones
+    /// were used is part of the answer.
+    pub mechanisms: Vec<String>,
+}
+
+impl AnchorCoverage {
+    /// Compute coverage from claimed event times and the anchors witnessing
+    /// them. Both are unix seconds; `event_times` need not be sorted.
+    ///
+    /// The unwitnessed span is the widest gap in the sequence
+    /// `[work_start, ..anchors inside the work.., work_end]`. So:
+    ///
+    /// * no anchors -> the whole session is one unwitnessed span;
+    /// * one anchor at close -> everything before it is unwitnessed, which is
+    ///   the correct reading: an anchor at the end says nothing about when the
+    ///   middle was written;
+    /// * anchors every N seconds -> roughly N.
+    ///
+    /// Anchors outside the work window are counted (they are real witnesses)
+    /// but cannot shrink an interior gap, which is why a close-time anchor
+    /// does not rescue an unwitnessed session.
+    pub fn compute(event_times: &[i64], anchors: &[Anchor]) -> Self {
+        let mut mechanisms: Vec<String> = anchors.iter().map(|a| a.mechanism.clone()).collect();
+        mechanisms.sort();
+        mechanisms.dedup();
+
+        // No events means no claimed timeline to witness. Reporting a
+        // confident zero here would be a vacuous pass -- there is nothing to
+        // be confident about.
+        let (Some(&start), Some(&end)) = (event_times.iter().min(), event_times.iter().max())
+        else {
+            return Self {
+                coverage: Coverage::None,
+                unwitnessed_span_seconds: 0,
+                claimed_span_seconds: 0,
+                anchor_count: anchors.len(),
+                mechanisms,
+            };
+        };
+
+        let claimed = (end - start).max(0);
+
+        if anchors.is_empty() {
+            return Self {
+                coverage: Coverage::None,
+                unwitnessed_span_seconds: claimed,
+                claimed_span_seconds: claimed,
+                anchor_count: 0,
+                mechanisms,
+            };
+        }
+
+        // Only anchors strictly inside the work window subdivide it. One at or
+        // before the start, or at or after the end, brackets the session
+        // without constraining anything within it.
+        let mut interior: Vec<i64> = anchors
+            .iter()
+            .map(|a| a.at)
+            .filter(|&t| t > start && t < end)
+            .collect();
+        interior.sort_unstable();
+
+        let coverage = if interior.is_empty() {
+            Coverage::EndpointOnly
+        } else {
+            Coverage::Periodic
+        };
+
+        let mut widest = 0i64;
+        let mut prev = start;
+        for t in &interior {
+            widest = widest.max(t - prev);
+            prev = *t;
+        }
+        widest = widest.max(end - prev);
+
+        Self {
+            coverage,
+            unwitnessed_span_seconds: widest,
+            claimed_span_seconds: claimed,
+            anchor_count: anchors.len(),
+            mechanisms,
+        }
+    }
+
+    /// Whether this satisfies a caller's maximum tolerated unwitnessed span.
+    ///
+    /// A session with no claimed work cannot violate a bound -- there is no
+    /// timeline to have fabricated.
+    pub fn within(&self, max_unwitnessed_seconds: i64) -> bool {
+        self.claimed_span_seconds == 0 || self.unwitnessed_span_seconds <= max_unwitnessed_seconds
+    }
+
+    /// One line for humans, phrased so it cannot be misread as a guarantee.
+    pub fn summary(&self) -> String {
+        match self.coverage {
+            Coverage::None if self.claimed_span_seconds == 0 => "no timeline to anchor".to_string(),
+            Coverage::None => format!(
+                "UNWITNESSED — {} of claimed work with no external anchor; \
+                 the timeline rests on the signer's own clock",
+                human(self.claimed_span_seconds)
+            ),
+            Coverage::EndpointOnly => format!(
+                "endpoint-only — {} anchor(s), none during the work; \
+                 {} unwitnessed",
+                self.anchor_count,
+                human(self.unwitnessed_span_seconds)
+            ),
+            Coverage::Periodic => format!(
+                "anchored — {} anchor(s) via {}; longest unwitnessed span {}",
+                self.anchor_count,
+                self.mechanisms.join("+"),
+                human(self.unwitnessed_span_seconds)
+            ),
+        }
+    }
+}
+
+fn human(secs: i64) -> String {
+    match secs {
+        s if s < 60 => format!("{s}s"),
+        s if s < 3600 => format!("{}m", s / 60),
+        s => format!("{}h{:02}m", s / 3600, (s % 3600) / 60),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anchor(at: i64) -> Anchor {
+        Anchor {
+            at,
+            mechanism: "hub".into(),
+        }
+    }
+
+    const H: i64 = 3600;
+
+    /// The scenario the spec is written around: 11 hours of work presented as
+    /// 4. Whichever way it is told, coverage is what distinguishes the honest
+    /// session from the fabricated one -- not the receipts, which are equally
+    /// well signed in both.
+    #[test]
+    fn fabricated_session_reports_the_whole_span_unwitnessed() {
+        // Eleven hours of claimed work, one anchor when it was all over.
+        let events: Vec<i64> = (0..=11).map(|h| h * H).collect();
+        let c = AnchorCoverage::compute(&events, &[anchor(11 * H)]);
+
+        assert_eq!(c.coverage, Coverage::EndpointOnly);
+        assert_eq!(c.unwitnessed_span_seconds, 11 * H);
+        assert!(!c.within(H), "an 11h unwitnessed span must fail a 1h bound");
+    }
+
+    #[test]
+    fn honest_session_anchored_throughout_reports_the_interval() {
+        let events: Vec<i64> = (0..=11).map(|h| h * H).collect();
+        // Anchored every hour, including one after close.
+        let anchors: Vec<Anchor> = (1..=11).map(|h| anchor(h * H)).collect();
+        let c = AnchorCoverage::compute(&events, &anchors);
+
+        assert_eq!(c.coverage, Coverage::Periodic);
+        assert_eq!(c.unwitnessed_span_seconds, H);
+        assert!(c.within(2 * H));
+        assert!(!c.within(H / 2));
+    }
+
+    /// An anchor at close must not rescue the session. This is the case a
+    /// boolean `anchored: true` would get wrong, and the reason this module
+    /// reports a span instead.
+    #[test]
+    fn closing_anchor_does_not_shrink_the_interior_gap() {
+        let events = vec![0, 4 * H];
+        let with = AnchorCoverage::compute(&events, &[anchor(4 * H)]);
+        let without = AnchorCoverage::compute(&events, &[]);
+
+        assert_eq!(
+            with.unwitnessed_span_seconds, without.unwitnessed_span_seconds,
+            "an anchor at close constrains nothing inside the session"
+        );
+        // It is still a real witness, so it is still counted and still
+        // changes the classification.
+        assert_eq!(with.anchor_count, 1);
+        assert_eq!(with.coverage, Coverage::EndpointOnly);
+        assert_eq!(without.coverage, Coverage::None);
+    }
+
+    #[test]
+    fn no_anchors_reports_the_entire_claimed_span() {
+        let c = AnchorCoverage::compute(&[0, 4 * H], &[]);
+        assert_eq!(c.coverage, Coverage::None);
+        assert_eq!(c.unwitnessed_span_seconds, 4 * H);
+        assert!(c.summary().contains("UNWITNESSED"));
+    }
+
+    /// An empty timeline has nothing to fabricate, so it must not be reported
+    /// as a violation -- but it must not be reported as *proven* either.
+    #[test]
+    fn empty_timeline_is_neither_a_pass_nor_a_violation() {
+        let c = AnchorCoverage::compute(&[], &[]);
+        assert_eq!(c.claimed_span_seconds, 0);
+        assert!(c.within(0));
+        assert_eq!(c.coverage, Coverage::None);
+        assert!(!c.summary().contains("UNWITNESSED"));
+    }
+
+    #[test]
+    fn unsorted_events_are_handled() {
+        let jumbled = vec![3 * H, 0, 2 * H, H];
+        let ordered = vec![0, H, 2 * H, 3 * H];
+        assert_eq!(
+            AnchorCoverage::compute(&jumbled, &[anchor(90 * 60)]),
+            AnchorCoverage::compute(&ordered, &[anchor(90 * 60)]),
+        );
+    }
+
+    #[test]
+    fn mechanisms_are_deduped_and_sorted() {
+        let events = vec![0, 4 * H];
+        let anchors = vec![
+            Anchor {
+                at: H,
+                mechanism: "rekor".into(),
+            },
+            Anchor {
+                at: 2 * H,
+                mechanism: "hub".into(),
+            },
+            Anchor {
+                at: 3 * H,
+                mechanism: "rekor".into(),
+            },
+        ];
+        let c = AnchorCoverage::compute(&events, &anchors);
+        assert_eq!(c.mechanisms, vec!["hub", "rekor"]);
+        assert_eq!(c.anchor_count, 3);
+    }
+
+    /// A single instant of work is a degenerate timeline, not a fabricated
+    /// one. Reporting a negative or nonsense span here would be worse than
+    /// reporting zero.
+    #[test]
+    fn single_event_has_no_span_to_fabricate() {
+        let c = AnchorCoverage::compute(&[1000], &[]);
+        assert_eq!(c.claimed_span_seconds, 0);
+        assert_eq!(c.unwitnessed_span_seconds, 0);
+        assert!(c.within(0));
+    }
+}

--- a/packages/core/src/verify/mod.rs
+++ b/packages/core/src/verify/mod.rs
@@ -16,6 +16,7 @@
 /// Card resolution verification (the certificate-chain walk behind
 /// `resolve --hub` and `verify-presentation`). Lives in core so the CLI, the
 /// WASM verifier, and the SDKs run the same code path.
+pub mod anchoring;
 pub mod resolution;
 
 /// Presentation verification primitives (the challenge-response canonical and


### PR DESCRIPTION
Slice 2 of `docs/specs/time-anchoring.md`.

A receipt's timestamp comes from `SystemTime::now()` on the signing machine, signed with that machine's own key. It proves *"this key asserted this"*, never *"this happened then"*. Verification never said so — and a reader had no way to tell a continuously witnessed timeline from an entirely self-asserted one, because **the receipts look identical**.

```
anchoring: UNWITNESSED — 11h00m of claimed work with no external anchor;
           the timeline rests on the signer's own clock
```

`--max-unwitnessed 15m` turns that into a gate for callers who need one. Without the flag it reports and never fails: unanchored work is normal (offline machines, network failures) and isn't by itself evidence of anything. **Staying silent is what was wrong.**

## The number is a span, not a boolean

`anchored: true` would flatten three different situations into one word — witnessed every few minutes, witnessed once at close, witnessed never. Only the first constrains a timeline.

So the output is `unwitnessed_span_seconds`, and **an anchor at close explicitly does not shrink it** — an anchor at the end says nothing about when the middle was written. There's a test for exactly that, since it's the case a boolean gets wrong.

Same shape as `NoRevocationSource` resolving `Unknown` and still reaching a passing exit code: the honest detail exists and the summary discards it.

## Building the report first turned up why it couldn't work

**Nothing recorded when an anchor was obtained.** `set_hub_url` stored a URL and no timestamp — and a URL says *that* something was pushed, not *when*, which is the entire value.

So `Record` gains `anchors: Vec<RecordAnchor>`, appended on successful push, one per mechanism. Hub and Rekor stay separate deliberately: they fail differently (a Hub anchor needs the Hub trusted; a Rekor entry is independently checkable), and collapsing them discards that. `#[serde(default)]` so older receipts parse unchanged — no anchors recorded is exactly what an empty list means.

This is the argument for reporting-before-fixing that the spec makes: the gap only became visible when something tried to compute the number.

## Honest limits, in the module docs rather than implied

- `observed_at` is still **our own clock** — this defends against a timeline fabricated *after* the work, not against a machine whose clock is wrong in real time.
- It does **not** detect omission. A shortened chain is honestly signed and honestly anchored; catching that needs anchors discoverable by identity.

Both need slices 3–5.

## Verified end to end

Against a simulated 11-hour session:

```
exceeds policy (--max-unwitnessed 1h)  -> exit 1
within policy  (--max-unwitnessed 24h) -> exit 0
no gate                                -> exit 0
--max-unwitnessed bogus                -> rejected, not guessed
```

clippy `-D warnings` clean · 534 core + 208 CLI tests pass · CLI reference regenerated · all docs gates pass.