### PR TITLE
feat(rig): move rig-treeship into the monorepo, publish from the same pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,6 +476,36 @@ jobs:
       - name: Verify treeship-core on crates.io
         run: .github/scripts/wait-for-crates-version.sh treeship-core "${GITHUB_REF_NAME#v}"
 
+      # rig-treeship depends on treeship-core, so it must go second: crates.io
+      # rejects a publish whose dependency version does not yet exist, and the
+      # verify step above is what guarantees it does.
+      - name: Publish rig-treeship
+        run: |
+          set -e
+          VERSION="${GITHUB_REF_NAME#v}"
+          CRATE="rig-treeship"
+
+          if cargo search "$CRATE" --limit 1 | grep -Fq "$CRATE = \"$VERSION\""; then
+            echo "  ✓ $CRATE $VERSION already live on crates.io; skipping publish"
+            exit 0
+          fi
+
+          if PUBLISH_OUTPUT="$(cargo publish -p "$CRATE" 2>&1)"; then
+            echo "$PUBLISH_OUTPUT"
+            exit 0
+          fi
+          echo "$PUBLISH_OUTPUT"
+          if echo "$PUBLISH_OUTPUT" | grep -qE "already (exists|uploaded)"; then
+            echo "  ✓ $CRATE $VERSION publish race: registry reports already exists; treating as success"
+            exit 0
+          fi
+          exit 1
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Verify rig-treeship on crates.io
+        run: .github/scripts/wait-for-crates-version.sh rig-treeship "${GITHUB_REF_NAME#v}"
+
       # treeship-cli is NOT published to crates.io.
       # It's a binary tool with ZK deps that can't satisfy crates.io requirements.
       # Install via: npm install -g treeship (prebuilt binary)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +658,7 @@ checksum = "a381a5f681e536070483826412fcfcd6f6637921717c6aa0a3759926899ee9c2"
 dependencies = [
  "duplicate",
  "maybe-async",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -1410,6 +1438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,10 +1545,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.32"
+name = "futures"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1517,45 +1571,67 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1629,6 +1705,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1983,12 +2077,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2250,6 +2344,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,6 +2392,16 @@ name = "no_std_strings"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2394,6 +2520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2583,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2924,9 +3079,44 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -2937,6 +3127,54 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f5520515ae8f6851adcbc6fde9eea8e96f657418c062e16c82cd81cce44e8e"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64",
+ "bytes",
+ "eventsource-stream",
+ "fastrand",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http",
+ "indexmap 2.14.0",
+ "mime",
+ "mime_guess",
+ "ordered-float",
+ "pin-project-lite",
+ "reqwest 0.13.4",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "rig-treeship"
+version = "0.24.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "rig-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "treeship-core",
 ]
 
 [[package]]
@@ -3347,8 +3585,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3381,6 +3632,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3424,10 +3681,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
+name = "serde_derive_internals"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3467,7 +3735,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -3494,7 +3762,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3713,6 +3981,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,16 +4122,28 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3914,7 +4205,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3928,7 +4219,7 @@ version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -4025,6 +4316,18 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -4167,6 +4470,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4388,7 +4697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4407,6 +4716,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,7 +4736,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4665,7 +4987,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4696,7 +5018,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4715,7 +5037,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["packages/core", "packages/cli", "packages/core-wasm", "packages/zk-circom", "packages/zk-risc0", "packages/zk-risc0/methods", "packages/vi"]
+members = ["packages/core", "packages/cli", "packages/core-wasm", "packages/zk-circom", "packages/zk-risc0", "packages/zk-risc0/methods", "packages/vi", "packages/rig"]
 default-members = ["packages/core", "packages/cli"]
 resolver = "2"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,17 +4,12 @@
 # suggesting new-version syntax that would break the build on older
 # toolchains.
 #
-# CI does NOT currently run `cargo clippy`; the project relies on
-# CONTRIBUTING.md asking contributors to run `cargo clippy --all-targets`
-# locally before commit. A pre-existing ~40-warning clippy debt against
-# `-D warnings` (mostly `clippy::manual_map`, `clippy::doc_overindented_list_items`,
-# and similar style nits in `packages/core` and `packages/cli`) is
-# documented in the v0.10.4 audit lane G PR; this file does not add
-# `deny`/`allow` lists so merging it does not change the workspace lint
-# surface. Once the debt is paid, a follow-up PR can enable
-# `cargo clippy --workspace -- -D warnings` in ci.yml and tighten this
-# config accordingly.
-
+# CI runs `cargo clippy -p treeship-core -p treeship-cli -p treeship-core-wasm
+# --all-targets -- -D warnings` (added in #283, which also cleared the ~149
+# warnings the workspace had accumulated while nothing enforced it). Anything
+# allowed is allowed in `[workspace.lints.clippy]` in Cargo.toml, in writing,
+# with a reason -- this file carries configuration, not exceptions.
+#
 # MSRV: matches the `channel` pin in rust-toolchain.toml. Keep these two
 # in lockstep when bumping; out-of-sync values silently disable lints
 # that would have caught real bugs.

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "rig-treeship"
+# Versioned in lockstep with the rest of the workspace, because the release
+# pipeline derives every crate's version from the git tag. This crate exists to
+# wrap `treeship-core`, so "which treeship does this match" is the most useful
+# thing its version can say.
+version = "0.24.0"
+edition = "2021"
+# Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
+# standalone repo, where a dedicated CI job built against it. In the workspace
+# nothing does, and an MSRV nobody builds is a guess -- so this states the
+# version that is actually verified on every commit.
+rust-version = "1.94"
+description = "Ed25519-signed Treeship attestations for every Rig tool call: wrap any PortableTool and get a tamper-evident, offline-verifiable receipt chain."
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords = ["treeship", "rig", "attestation", "agents", "provenance"]
+categories = ["cryptography", "development-tools"]
+
+[dependencies]
+# Rig's context-free tool contract (PortableTool). Providers/HTTP not needed here.
+rig = { package = "rig-core", version = "0.41", default-features = false }
+
+# Path + version: the path keeps the workspace building against the core in
+# this tree (so a breaking change here fails CI in the same commit that makes
+# it), and the version is what `cargo publish` puts in the released manifest.
+treeship-core = { version = "0.24.0", path = "../core" }
+
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+hex = "0.4"
+thiserror = "2"
+ed25519-dalek = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/packages/rig/README.md
+++ b/packages/rig/README.md
@@ -1,0 +1,68 @@
+# rig-treeship
+
+Signed, chained, offline-verifiable receipts for every tool call a [Rig](https://crates.io/crates/rig-core) agent makes — built natively on [`treeship-core`](https://crates.io/crates/treeship-core).
+
+Both stacks are Rust, so this is a type-level integration: no CLI subprocess, no shell wrapping. Signing happens in-process with Ed25519 over DSSE envelopes, and the compiler checks the seam — if `rig-core` or `treeship-core` changes shape, the build fails instead of your audit trail.
+
+## What it does
+
+Wrap any Rig `PortableTool`:
+
+```rust
+use std::sync::Arc;
+use rig_treeship::{AttestedExt, TreeshipLedger};
+
+let ledger = Arc::new(TreeshipLedger::open_default("agent://my-agent")?);
+let tool = MyTool.attested(ledger.clone());
+// register `tool` with your runtime exactly like the bare tool
+```
+
+Every call then:
+
+1. hashes the deserialized arguments (SHA-256, compact JSON),
+2. runs the inner tool,
+3. hashes the output — or records the failure (`outcome: "error"`),
+4. signs a `treeship/action/v1` statement carrying both hashes, chained to the previous receipt via `parentId`,
+5. returns the result **only after** the receipt is stored (fail-closed: an unattested action is treated as no action).
+
+The wrapper is transparent to the model — same `NAME`, description, and JSON schema — so it changes what your agent can *prove*, not what it can do.
+
+## Verifying
+
+```rust
+let head = ledger.head().unwrap();
+let verified = ledger.verify_chain(&head)?;   // walks parentId back to genesis
+println!("{} receipts verified", verified.length);
+```
+
+`verify_chain` re-derives every artifact ID from its PAE bytes, checks each Ed25519 signature, and confirms the stored parent pointer matches the *signed* `parentId` — so neither payloads nor chain structure can be rewritten. Flip one byte anywhere and verification fails (see the `tampering_breaks_verification` test).
+
+Receipts are standard Treeship artifacts on disk, so the CLI workflow still applies: `treeship verify <id>`, `treeship hub push <id>` for a public `treeship.dev/verify/...` URL.
+
+## Design notes
+
+- **Hashes, not content.** Receipts carry `args_hash` / `output_hash`, never raw arguments — sensitive tool inputs don't leak into the audit trail.
+- **Linear chain under concurrency.** The ledger holds its head lock across sign+store, so parallel tool calls serialize into one chain rather than forking.
+- **Failed calls are attested.** A chain with gaps proves nothing; errors get receipts too.
+- **Ledger modes.** `open_default()` uses `$TREESHIP_HOME` or `~/.treeship`; `open(dir)` for project-local ships; `ephemeral()` for tests (signed + chained, not persisted).
+
+## Layout
+
+```
+src/
+  lib.rs        crate docs, re-exports, integration tests
+  ledger.rs     TreeshipLedger: keystore, artifact store, chain head, verify_chain
+  attested.rs   Attested<T>: PortableTool impl + .attested() extension
+  error.rs      AttestError / AttestedError (tool vs attestation failure)
+examples/
+  attested_agent.rs   end-to-end: 3 calls (one failing) → verified chain
+```
+
+## Run it
+
+```
+cargo test
+cargo run --example attested_agent
+```
+
+Built and tested against `rig-core 0.41.0` and `treeship-core 0.23.0` on Rust 1.91.

--- a/packages/rig/examples/attested_agent.rs
+++ b/packages/rig/examples/attested_agent.rs
@@ -1,0 +1,111 @@
+//! End-to-end demo: a Rig `PortableTool` wrapped with Treeship attestation.
+//!
+//! Run with: `cargo run --example attested_agent`
+//!
+//! Uses a temp directory so it never touches your real `~/.treeship`.
+
+use std::sync::Arc;
+
+use rig::tool::PortableTool;
+use rig_treeship::{AttestedExt, TreeshipLedger};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+#[error("unknown city: {0}")]
+struct UnknownCity(String);
+
+#[derive(Serialize, Deserialize)]
+struct WeatherArgs {
+    city: String,
+}
+
+#[derive(Serialize)]
+struct Weather {
+    city: String,
+    temp_c: f32,
+}
+
+/// A stand-in for a real tool (API call, shell command, DB write...).
+struct GetWeather;
+
+impl PortableTool for GetWeather {
+    const NAME: &'static str = "get_weather";
+    type Args = WeatherArgs;
+    type Output = Weather;
+    type Error = UnknownCity;
+
+    fn description(&self) -> String {
+        "Get the current temperature for a city".into()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "city": { "type": "string" } },
+            "required": ["city"]
+        })
+    }
+
+    async fn call(&self, args: WeatherArgs) -> Result<Weather, UnknownCity> {
+        match args.city.as_str() {
+            "Brooklyn" => Ok(Weather {
+                city: args.city,
+                temp_c: 27.0,
+            }),
+            "Tbilisi" => Ok(Weather {
+                city: args.city,
+                temp_c: 31.5,
+            }),
+            other => Err(UnknownCity(other.to_string())),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let ledger = Arc::new(TreeshipLedger::open(dir.path(), "agent://weather-bot")?);
+
+    // One line turns a bare Rig tool into an attested one.
+    let tool = GetWeather.attested(ledger.clone());
+
+    // Simulate an agent loop making tool calls.
+    let w1 = tool
+        .call(WeatherArgs {
+            city: "Brooklyn".into(),
+        })
+        .await?;
+    println!("call 1  -> {} is {}°C", w1.city, w1.temp_c);
+    println!("receipt -> {}\n", ledger.head().unwrap());
+
+    let w2 = tool
+        .call(WeatherArgs {
+            city: "Tbilisi".into(),
+        })
+        .await?;
+    println!("call 2  -> {} is {}°C", w2.city, w2.temp_c);
+    println!("receipt -> {}\n", ledger.head().unwrap());
+
+    // A failing call still leaves a signed receipt (outcome: "error").
+    let _ = tool
+        .call(WeatherArgs {
+            city: "Atlantis".into(),
+        })
+        .await;
+    println!("call 3  -> failed (attested anyway)");
+    println!("receipt -> {}\n", ledger.head().unwrap());
+
+    // Walk and verify the whole chain, newest to genesis.
+    let head = ledger.head().unwrap();
+    let verified = ledger.verify_chain(&head)?;
+    println!("chain verified: {} receipts", verified.length);
+    for id in &verified.artifact_ids {
+        println!("  {id}");
+    }
+    println!(
+        "\npublic key (share for independent verification): {}",
+        hex::encode(ledger.public_key_bytes())
+    );
+
+    Ok(())
+}

--- a/packages/rig/examples/interop.rs
+++ b/packages/rig/examples/interop.rs
@@ -1,0 +1,39 @@
+//! Proves the two claims the README makes about interoperability:
+//!
+//!   1. `open_default` resolves the same store the `treeship` CLI would, so
+//!      an agent run inside a project writes into that project's ship.
+//!   2. The receipts it writes are ordinary Treeship artifacts, so
+//!      `treeship verify` accepts them with no special flags.
+//!
+//! Run from a directory containing `.treeship/config.json`:
+//!
+//! ```text
+//! cargo run --example interop
+//! treeship verify <printed id>
+//! ```
+use rig_treeship::TreeshipLedger;
+
+fn main() {
+    let ledger = TreeshipLedger::open_default("agent://rig-interop").expect("open ledger");
+
+    let a = ledger
+        .attest_action(
+            "tool.call.calculator",
+            serde_json::json!({
+                "args_hash": "sha256:aa", "output_hash": "sha256:bb", "outcome": "success"
+            }),
+        )
+        .expect("attest a");
+
+    let b = ledger
+        .attest_action(
+            "tool.call.search",
+            serde_json::json!({
+                "args_hash": "sha256:cc", "output_hash": "sha256:dd", "outcome": "success"
+            }),
+        )
+        .expect("attest b");
+
+    println!("{}", a.artifact_id);
+    println!("{}", b.artifact_id);
+}

--- a/packages/rig/src/attested.rs
+++ b/packages/rig/src/attested.rs
@@ -1,0 +1,124 @@
+//! `Attested<T>` — wrap any Rig [`PortableTool`] so every call produces a
+//! signed, chained Treeship receipt before the result is returned to the
+//! model.
+
+use std::sync::Arc;
+
+use rig::tool::PortableTool;
+use rig::wasm_compat::WasmCompatSend;
+use serde::Serialize;
+
+use crate::error::{AttestError, AttestedError};
+use crate::ledger::{sha256_json, tool_call_meta, TreeshipLedger};
+
+/// A Rig tool whose every invocation is attested on a [`TreeshipLedger`].
+///
+/// The wrapper is transparent to the model: same name, description, and
+/// parameter schema as the inner tool. On each call it:
+///
+/// 1. hashes the deserialized arguments (SHA-256 over compact JSON),
+/// 2. runs the inner tool,
+/// 3. hashes the output (or records the failure),
+/// 4. signs a `treeship/action/v1` statement carrying both hashes,
+///    chained to the previous attestation, and
+/// 5. returns the inner result only after the receipt is stored.
+///
+/// **Fail-closed:** if signing or storage fails, the call errors even when
+/// the tool succeeded. Failed tool calls are attested too (`outcome:
+/// "error"`) — a receipt chain with gaps proves nothing.
+pub struct Attested<T> {
+    inner: T,
+    ledger: Arc<TreeshipLedger>,
+}
+
+impl<T> Attested<T> {
+    pub fn new(inner: T, ledger: Arc<TreeshipLedger>) -> Self {
+        Self { inner, ledger }
+    }
+
+    pub fn ledger(&self) -> &Arc<TreeshipLedger> {
+        &self.ledger
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> PortableTool for Attested<T>
+where
+    T: PortableTool,
+    T::Args: Serialize,
+    T::Output: Serialize,
+{
+    const NAME: &'static str = T::NAME;
+    type Args = T::Args;
+    type Output = T::Output;
+    type Error = AttestedError<T::Error>;
+
+    fn description(&self) -> String {
+        self.inner.description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.inner.parameters()
+    }
+
+    // clippy suggests `async fn` here, and it is wrong: `async fn` desugars to
+    // a bare `impl Future` with no way to add the `+ WasmCompatSend` bound
+    // that `PortableTool::call` requires. Taking the suggestion would drop the
+    // bound and break the wasm targets Rig supports.
+    #[allow(clippy::manual_async_fn)]
+    fn call(
+        &self,
+        arguments: Self::Args,
+    ) -> impl std::future::Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend {
+        async move {
+            let args_hash = sha256_json(&arguments).map_err(AttestedError::Attest)?;
+            let action = format!("tool.call.{}", T::NAME);
+
+            match self.inner.call(arguments).await {
+                Ok(output) => {
+                    let output_hash = sha256_json(&output).map_err(AttestedError::Attest)?;
+                    self.attest(&action, &args_hash, Some(&output_hash), "success")?;
+                    Ok(output)
+                }
+                Err(tool_err) => {
+                    self.attest(&action, &args_hash, None, "error")?;
+                    Err(AttestedError::Tool(tool_err))
+                }
+            }
+        }
+    }
+}
+
+impl<T> Attested<T>
+where
+    T: PortableTool,
+{
+    fn attest(
+        &self,
+        action: &str,
+        args_hash: &str,
+        output_hash: Option<&str>,
+        outcome: &str,
+    ) -> Result<(), AttestedError<T::Error>> {
+        self.ledger
+            .attest_action(
+                action,
+                tool_call_meta(T::NAME, args_hash, output_hash, outcome),
+            )
+            .map(|_| ())
+            .map_err(|e: AttestError| AttestedError::Attest(e))
+    }
+}
+
+/// Extension method so wrapping reads left-to-right at the call site:
+/// `Calculator.attested(ledger.clone())`.
+pub trait AttestedExt: PortableTool + Sized {
+    fn attested(self, ledger: Arc<TreeshipLedger>) -> Attested<Self> {
+        Attested::new(self, ledger)
+    }
+}
+
+impl<T: PortableTool> AttestedExt for T {}

--- a/packages/rig/src/error.rs
+++ b/packages/rig/src/error.rs
@@ -1,0 +1,35 @@
+use thiserror::Error;
+
+/// Errors produced by the Treeship side of the integration.
+#[derive(Debug, Error)]
+pub enum AttestError {
+    #[error("keystore: {0}")]
+    Keys(String),
+
+    #[error("signing: {0}")]
+    Sign(String),
+
+    #[error("artifact store: {0}")]
+    Storage(String),
+
+    #[error("verification failed for {artifact_id}: {reason}")]
+    Verify { artifact_id: String, reason: String },
+
+    #[error("serialization: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Error type surfaced by an [`crate::Attested`] tool.
+///
+/// Distinguishes the wrapped tool's own failure from a failure to produce
+/// the attestation. The wrapper is **fail-closed**: if the receipt cannot
+/// be signed and stored, the call fails even when the underlying tool
+/// succeeded — an unattested action is treated as no action.
+#[derive(Debug, Error)]
+pub enum AttestedError<E: std::error::Error + 'static> {
+    #[error("tool: {0}")]
+    Tool(#[source] E),
+
+    #[error("attestation: {0}")]
+    Attest(#[source] AttestError),
+}

--- a/packages/rig/src/ledger.rs
+++ b/packages/rig/src/ledger.rs
@@ -1,0 +1,529 @@
+//! The ledger owns the signing key, the local artifact store, and the
+//! chain head. Every attestation links to the previous one by artifact ID,
+//! so the sequence of tool calls forms a tamper-evident hash chain.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use ed25519_dalek::VerifyingKey;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use treeship_core::attestation::{sign, Ed25519Signer, Envelope, Signer, Verifier};
+use treeship_core::keys;
+use treeship_core::statements::{payload_type, ActionStatement};
+use treeship_core::storage::{Record, Store as ArtifactStore};
+
+use crate::error::AttestError;
+
+/// A signed, stored attestation for one action.
+#[derive(Debug, Clone)]
+pub struct Attestation {
+    /// Content-addressed ID (`art_...`). Recomputed at verify time; any
+    /// tampering changes it.
+    pub artifact_id: String,
+    /// `sha256:<hex>` digest of the signed PAE bytes.
+    pub digest: String,
+    /// Parent artifact this one chains to, if any.
+    pub parent_id: Option<String>,
+}
+
+/// Outcome of verifying a chain of attestations.
+#[derive(Debug, Clone)]
+pub struct ChainVerification {
+    /// Number of artifacts verified, newest to oldest.
+    pub length: usize,
+    /// Artifact IDs in verification order (newest first).
+    pub artifact_ids: Vec<String>,
+}
+
+/// Signing + storage context shared by all attested tools of one agent.
+///
+/// Thread-safe: hold it in an `Arc` and hand clones of the `Arc` to every
+/// [`crate::Attested`] wrapper. Calls are serialized through an internal
+/// mutex so chain links never race.
+pub struct TreeshipLedger {
+    signer: Box<dyn Signer>,
+    store: Option<ArtifactStore>,
+    actor: String,
+    /// Chain head: the artifact ID of the most recent attestation.
+    head: Mutex<Option<String>>,
+}
+
+impl TreeshipLedger {
+    /// In-memory ledger with a freshly generated Ed25519 key and no disk
+    /// store. Receipts are signed and chained but not persisted — useful
+    /// for tests and short-lived agents. For durable receipts use
+    /// [`TreeshipLedger::open`] or [`TreeshipLedger::open_default`].
+    pub fn ephemeral(actor: impl Into<String>) -> Result<Self, AttestError> {
+        let signer = Ed25519Signer::generate("key_ephemeral")
+            .map_err(|e| AttestError::Sign(e.to_string()))?;
+        Ok(Self {
+            signer: Box::new(signer),
+            store: None,
+            actor: actor.into(),
+            head: Mutex::new(None),
+        })
+    }
+
+    /// Opens (or creates) a ledger rooted at `base`, using `base/keys` for
+    /// the encrypted keystore and `base/artifacts` for the receipt store.
+    /// Generates a default key on first use.
+    pub fn open(base: impl AsRef<Path>, actor: impl Into<String>) -> Result<Self, AttestError> {
+        let base = base.as_ref();
+        let key_store =
+            keys::Store::open(base.join("keys")).map_err(|e| AttestError::Keys(e.to_string()))?;
+
+        let signer = match key_store.default_signer() {
+            Ok(s) => s,
+            Err(_) => {
+                // First run: create a default key, then load its signer.
+                key_store
+                    .generate(true)
+                    .map_err(|e| AttestError::Keys(e.to_string()))?;
+                key_store
+                    .default_signer()
+                    .map_err(|e| AttestError::Keys(e.to_string()))?
+            }
+        };
+
+        let store = ArtifactStore::open(base.join("artifacts"))
+            .map_err(|e| AttestError::Storage(e.to_string()))?;
+
+        Ok(Self {
+            signer,
+            store: Some(store),
+            actor: actor.into(),
+            head: Mutex::new(None),
+        })
+    }
+
+    /// Opens the ledger the same way the `treeship` CLI would, so receipts
+    /// written by a Rig agent land in the store the operator actually uses
+    /// and `treeship verify` finds them without extra flags.
+    ///
+    /// Resolution order, matching the CLI:
+    ///   1. `$TREESHIP_HOME` — explicit override, used as a bare base dir
+    ///   2. `$TREESHIP_CONFIG` — path to a `config.json`
+    ///   3. `.treeship/config.json` found by walking up from the cwd
+    ///      (project-local stores)
+    ///   4. `$HOME/.treeship/config.json`
+    ///
+    /// When a config file is found, its `storage_dir` / `keys_dir` are
+    /// honored, including relative paths (resolved against the config's own
+    /// directory) and one level of `extends`. Falling back to `base/keys`
+    /// and `base/artifacts` only when there is no config to read.
+    ///
+    /// Hardcoding `~/.treeship` here — the previous behavior — meant a Rig
+    /// agent silently wrote into a different ship than the operator's CLI
+    /// whenever a project-local store or `TREESHIP_CONFIG` was in play.
+    pub fn open_default(actor: impl Into<String>) -> Result<Self, AttestError> {
+        match resolve_store_dirs() {
+            Some((keys_dir, artifacts_dir)) => Self::open_dirs(keys_dir, artifacts_dir, actor),
+            None => Self::open(default_base(), actor),
+        }
+    }
+
+    /// Opens a ledger against an explicit `config.json`, the crate-level
+    /// equivalent of `treeship --config <path>`.
+    pub fn open_config(
+        config_path: impl AsRef<Path>,
+        actor: impl Into<String>,
+    ) -> Result<Self, AttestError> {
+        let (keys_dir, artifacts_dir) =
+            read_config_dirs(config_path.as_ref(), 0).ok_or_else(|| {
+                AttestError::Keys(format!(
+                    "could not read treeship config at {}",
+                    config_path.as_ref().display()
+                ))
+            })?;
+        Self::open_dirs(keys_dir, artifacts_dir, actor)
+    }
+
+    /// Opens a ledger from explicit key and artifact directories.
+    pub fn open_dirs(
+        keys_dir: impl AsRef<Path>,
+        artifacts_dir: impl AsRef<Path>,
+        actor: impl Into<String>,
+    ) -> Result<Self, AttestError> {
+        let key_store =
+            keys::Store::open(keys_dir.as_ref()).map_err(|e| AttestError::Keys(e.to_string()))?;
+
+        let signer = match key_store.default_signer() {
+            Ok(s) => s,
+            Err(_) => {
+                key_store
+                    .generate(true)
+                    .map_err(|e| AttestError::Keys(e.to_string()))?;
+                key_store
+                    .default_signer()
+                    .map_err(|e| AttestError::Keys(e.to_string()))?
+            }
+        };
+
+        let store = ArtifactStore::open(artifacts_dir.as_ref())
+            .map_err(|e| AttestError::Storage(e.to_string()))?;
+
+        Ok(Self {
+            signer,
+            store: Some(store),
+            actor: actor.into(),
+            head: Mutex::new(None),
+        })
+    }
+
+    /// The actor URI attached to every attestation (e.g. `agent://researcher`).
+    pub fn actor(&self) -> &str {
+        &self.actor
+    }
+
+    /// The current chain head, if any attestation has been made.
+    pub fn head(&self) -> Option<String> {
+        self.head.lock().unwrap().clone()
+    }
+
+    /// The signer's public key bytes (32 bytes, Ed25519) — hand these to a
+    /// counterparty so they can verify your receipts independently.
+    pub fn public_key_bytes(&self) -> Vec<u8> {
+        self.signer.public_key_bytes()
+    }
+
+    /// Signs a `treeship/action/v1` statement, links it to the current
+    /// chain head, persists it (when a store is attached), and advances
+    /// the head.
+    ///
+    /// `meta` carries whatever evidence you want in the receipt. The
+    /// [`crate::Attested`] wrapper puts `args_hash`, `output_hash`, and
+    /// `outcome` here — hashes, never raw content.
+    pub fn attest_action(
+        &self,
+        action: &str,
+        meta: serde_json::Value,
+    ) -> Result<Attestation, AttestError> {
+        // Hold the head lock across sign+store so concurrent tool calls
+        // produce a linear chain instead of two children of one parent.
+        let mut head = self.head.lock().unwrap();
+
+        let mut stmt = ActionStatement::new(self.actor.clone(), action);
+        stmt.parent_id = head.clone();
+        stmt.meta = Some(meta);
+
+        let signed = sign(&payload_type("action"), &stmt, self.signer.as_ref())
+            .map_err(|e| AttestError::Sign(e.to_string()))?;
+
+        if let Some(store) = &self.store {
+            let record = Record {
+                artifact_id: signed.artifact_id.clone(),
+                digest: signed.digest.clone(),
+                payload_type: payload_type("action"),
+                key_id: self.signer.key_id().to_string(),
+                signed_at: stmt.timestamp.clone(),
+                parent_id: stmt.parent_id.clone(),
+                envelope: signed.envelope.clone(),
+                hub_url: None,
+            };
+            store
+                .write(&record)
+                .map_err(|e| AttestError::Storage(e.to_string()))?;
+        }
+
+        let attestation = Attestation {
+            artifact_id: signed.artifact_id.clone(),
+            digest: signed.digest,
+            parent_id: stmt.parent_id,
+        };
+        *head = Some(signed.artifact_id);
+        Ok(attestation)
+    }
+
+    /// Verifies the chain ending at `artifact_id`: every envelope's
+    /// signature checks out against this ledger's key, and every
+    /// `parentId` resolves, back to the genesis attestation.
+    ///
+    /// Requires a disk store (receipts must be readable back).
+    pub fn verify_chain(&self, artifact_id: &str) -> Result<ChainVerification, AttestError> {
+        let store = self.store.as_ref().ok_or_else(|| AttestError::Verify {
+            artifact_id: artifact_id.to_string(),
+            reason: "ephemeral ledger has no artifact store to verify against".into(),
+        })?;
+
+        let verifier = self.verifier()?;
+        let mut ids = Vec::new();
+        let mut cursor = Some(artifact_id.to_string());
+
+        while let Some(id) = cursor {
+            let record = store.read(&id).map_err(|e| AttestError::Verify {
+                artifact_id: id.clone(),
+                reason: format!("read: {e}"),
+            })?;
+
+            verify_envelope(&verifier, &record.envelope, &id)?;
+
+            // The stored parent pointer must match the signed payload's
+            // parentId — otherwise the index was tampered with even though
+            // the envelope itself verifies.
+            let stmt: ActionStatement =
+                record
+                    .envelope
+                    .unmarshal_statement()
+                    .map_err(|e| AttestError::Verify {
+                        artifact_id: id.clone(),
+                        reason: format!("payload: {e}"),
+                    })?;
+            if stmt.parent_id != record.parent_id {
+                return Err(AttestError::Verify {
+                    artifact_id: id.clone(),
+                    reason: "index parent_id does not match signed parentId".into(),
+                });
+            }
+
+            ids.push(id);
+            cursor = stmt.parent_id;
+        }
+
+        Ok(ChainVerification {
+            length: ids.len(),
+            artifact_ids: ids,
+        })
+    }
+
+    fn verifier(&self) -> Result<Verifier, AttestError> {
+        let bytes = self.signer.public_key_bytes();
+        let arr: [u8; 32] = bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| AttestError::Keys("public key is not 32 bytes".into()))?;
+        let key = VerifyingKey::from_bytes(&arr)
+            .map_err(|e| AttestError::Keys(format!("verifying key: {e}")))?;
+        let mut map = HashMap::new();
+        map.insert(self.signer.key_id().to_string(), key);
+        Ok(Verifier::new(map))
+    }
+}
+
+fn verify_envelope(verifier: &Verifier, envelope: &Envelope, id: &str) -> Result<(), AttestError> {
+    verifier
+        .verify(envelope)
+        .map_err(|e| AttestError::Verify {
+            artifact_id: id.to_string(),
+            reason: e.to_string(),
+        })
+        .map(|_| ())
+}
+
+fn default_base() -> PathBuf {
+    if let Ok(dir) = std::env::var("TREESHIP_HOME") {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    Path::new(&home).join(".treeship")
+}
+
+/// Locate the config the CLI would use and read its store directories.
+/// Returns `None` when there is no readable config, leaving the caller to
+/// fall back to a bare base directory.
+fn resolve_store_dirs() -> Option<(PathBuf, PathBuf)> {
+    // 1. TREESHIP_HOME wins outright and is a base dir, not a config path.
+    if std::env::var("TREESHIP_HOME").is_ok() {
+        return None;
+    }
+    // 2. Explicit config path.
+    if let Ok(p) = std::env::var("TREESHIP_CONFIG") {
+        return read_config_dirs(Path::new(&p), 0);
+    }
+    // 3. Project-local: nearest .treeship/config.json walking up from cwd.
+    if let Ok(cwd) = std::env::current_dir() {
+        let mut dir = Some(cwd.as_path());
+        while let Some(d) = dir {
+            let candidate = d.join(".treeship").join("config.json");
+            if candidate.is_file() {
+                return read_config_dirs(&candidate, 0);
+            }
+            dir = d.parent();
+        }
+    }
+    // 4. Global.
+    let home = std::env::var("HOME").ok()?;
+    let global = Path::new(&home).join(".treeship").join("config.json");
+    if global.is_file() {
+        return read_config_dirs(&global, 0);
+    }
+    None
+}
+
+/// Depth cap on `extends`. The CLI allows a deeper chain; two levels covers
+/// the project-stub-extends-global shape and refuses to loop.
+const EXTENDS_MAX_DEPTH: u8 = 2;
+
+/// Read `storage_dir` / `keys_dir` out of a config, following `extends` and
+/// resolving relative paths against the directory holding the config that
+/// declared them -- the same rule the CLI applies.
+fn read_config_dirs(config_path: &Path, depth: u8) -> Option<(PathBuf, PathBuf)> {
+    if depth > EXTENDS_MAX_DEPTH {
+        return None;
+    }
+    let raw: serde_json::Value = serde_json::from_slice(&std::fs::read(config_path).ok()?).ok()?;
+    let base = config_path.parent().unwrap_or_else(|| Path::new("."));
+
+    // Project stubs carry only {"extends": "...", "project": true}.
+    if let Some(parent) = raw.get("extends").and_then(|v| v.as_str()) {
+        let p = Path::new(parent);
+        let resolved = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            base.join(p)
+        };
+        return read_config_dirs(&resolved, depth + 1);
+    }
+
+    let join = |key: &str, default: &str| -> PathBuf {
+        let raw_val = raw.get(key).and_then(|v| v.as_str()).unwrap_or(default);
+        let p = Path::new(raw_val);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            base.join(p)
+        }
+    };
+    Some((join("keys_dir", "keys"), join("storage_dir", "artifacts")))
+}
+
+/// `sha256:<hex>` over a value's compact JSON encoding. Used for
+/// `args_hash` / `output_hash` so receipts carry evidence without leaking
+/// raw content.
+pub fn sha256_json<T: serde::Serialize>(value: &T) -> Result<String, AttestError> {
+    let bytes = serde_json::to_vec(value)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    Ok(format!("sha256:{}", hex::encode(hasher.finalize())))
+}
+
+/// Convenience: the standard meta object the [`crate::Attested`] wrapper
+/// records for a tool call.
+pub fn tool_call_meta(
+    tool: &str,
+    args_hash: &str,
+    output_hash: Option<&str>,
+    outcome: &str,
+) -> serde_json::Value {
+    let mut meta = json!({
+        "tool": tool,
+        "args_hash": args_hash,
+        "outcome": outcome,
+    });
+    if let Some(h) = output_hash {
+        meta["output_hash"] = json!(h);
+    }
+    meta
+}
+
+#[cfg(test)]
+mod config_resolution_tests {
+    use super::read_config_dirs;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    fn tmp(name: &str) -> PathBuf {
+        let d =
+            std::env::temp_dir().join(format!("rig-treeship-cfg-{name}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write(dir: &Path, body: serde_json::Value) -> PathBuf {
+        let p = dir.join("config.json");
+        fs::write(&p, serde_json::to_vec_pretty(&body).unwrap()).unwrap();
+        p
+    }
+
+    /// A portable config -- the shape this crate itself writes -- must
+    /// resolve against the config's directory, not the process cwd. This is
+    /// the bug that made a relative store invisible to the CLI.
+    #[test]
+    fn relative_dirs_resolve_against_the_config_not_cwd() {
+        let d = tmp("relative");
+        let cfg = write(
+            &d,
+            serde_json::json!({
+                "ship_id": "ship_x", "storage_dir": "artifacts", "keys_dir": "keys",
+                "default_key_id": "key_a"
+            }),
+        );
+        let (keys, artifacts) = read_config_dirs(&cfg, 0).expect("config reads");
+        assert_eq!(keys, d.join("keys"));
+        assert_eq!(artifacts, d.join("artifacts"));
+    }
+
+    #[test]
+    fn absolute_dirs_are_used_verbatim() {
+        let d = tmp("absolute");
+        let cfg = write(
+            &d,
+            serde_json::json!({
+                "ship_id": "ship_x",
+                "storage_dir": "/opt/ship/artifacts", "keys_dir": "/opt/ship/keys",
+                "default_key_id": "key_a"
+            }),
+        );
+        let (keys, artifacts) = read_config_dirs(&cfg, 0).unwrap();
+        assert_eq!(keys, PathBuf::from("/opt/ship/keys"));
+        assert_eq!(artifacts, PathBuf::from("/opt/ship/artifacts"));
+    }
+
+    /// Project-local stubs `extends` a global config. An agent run from a
+    /// project directory must sign into the ship that config points at.
+    #[test]
+    fn extends_follows_through_to_the_parent_store() {
+        let global = tmp("extends-global");
+        write(
+            &global,
+            serde_json::json!({
+                "ship_id": "ship_parent", "storage_dir": "artifacts", "keys_dir": "keys",
+                "default_key_id": "key_a"
+            }),
+        );
+        let proj = tmp("extends-project");
+        let stub = write(
+            &proj,
+            serde_json::json!({
+                "extends": global.join("config.json").to_string_lossy(), "project": true
+            }),
+        );
+        let (keys, artifacts) = read_config_dirs(&stub, 0).expect("stub resolves");
+        assert_eq!(keys, global.join("keys"), "must use the parent's keystore");
+        assert_eq!(artifacts, global.join("artifacts"));
+    }
+
+    /// An `extends` loop must terminate rather than recurse forever.
+    #[test]
+    fn extends_cycle_terminates() {
+        let d = tmp("cycle");
+        let p = d.join("config.json");
+        fs::write(
+            &p,
+            serde_json::to_vec(&serde_json::json!({
+                "extends": p.to_string_lossy()
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            read_config_dirs(&p, 0).is_none(),
+            "a self-referencing config must not hang"
+        );
+    }
+
+    /// Missing keys fall back to the conventional layout rather than erroring.
+    #[test]
+    fn missing_dir_fields_default_to_the_standard_layout() {
+        let d = tmp("defaults");
+        let cfg = write(
+            &d,
+            serde_json::json!({ "ship_id": "ship_x", "default_key_id": "key_a" }),
+        );
+        let (keys, artifacts) = read_config_dirs(&cfg, 0).unwrap();
+        assert_eq!(keys, d.join("keys"));
+        assert_eq!(artifacts, d.join("artifacts"));
+    }
+}

--- a/packages/rig/src/lib.rs
+++ b/packages/rig/src/lib.rs
@@ -1,0 +1,131 @@
+//! # rig-treeship
+//!
+//! Signed, chained, offline-verifiable receipts for every tool call a
+//! [Rig](https://crates.io/crates/rig-core) agent makes — built natively on
+//! [`treeship-core`](https://crates.io/crates/treeship-core). No CLI
+//! subprocess, no wrapper scripts: signing happens in-process, the compiler
+//! checks the seam, and receipts carry SHA-256 hashes of arguments and
+//! outputs rather than raw content.
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use rig_treeship::{AttestedExt, TreeshipLedger};
+//! # use rig::tool::PortableTool;
+//! # #[derive(serde::Deserialize, serde::Serialize)] struct Args { x: i64 }
+//! # struct MyTool;
+//! # impl PortableTool for MyTool {
+//! #     const NAME: &'static str = "my_tool";
+//! #     type Args = Args; type Output = i64; type Error = std::io::Error;
+//! #     fn description(&self) -> String { "".into() }
+//! #     fn parameters(&self) -> serde_json::Value { serde_json::json!({}) }
+//! #     async fn call(&self, a: Args) -> Result<i64, std::io::Error> { Ok(a.x) }
+//! # }
+//!
+//! # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
+//! let ledger = Arc::new(TreeshipLedger::open_default("agent://my-agent")?);
+//! let tool = MyTool.attested(ledger.clone());
+//! // register `tool` with your Rig runtime exactly like the bare tool —
+//! // same NAME, description, and JSON schema; every call now signs a
+//! // treeship/action/v1 receipt chained to the previous one.
+//! # Ok(()) }
+//! ```
+
+mod attested;
+mod error;
+mod ledger;
+
+pub use attested::{Attested, AttestedExt};
+pub use error::{AttestError, AttestedError};
+pub use ledger::{sha256_json, tool_call_meta, Attestation, ChainVerification, TreeshipLedger};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::tool::PortableTool;
+    use serde::{Deserialize, Serialize};
+    use std::sync::Arc;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("division by zero")]
+    struct DivByZero;
+
+    #[derive(Serialize, Deserialize)]
+    struct DivArgs {
+        a: i64,
+        b: i64,
+    }
+
+    struct Divide;
+
+    impl PortableTool for Divide {
+        const NAME: &'static str = "divide";
+        type Args = DivArgs;
+        type Output = i64;
+        type Error = DivByZero;
+
+        fn description(&self) -> String {
+            "Divide a by b".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "a": { "type": "integer" },
+                    "b": { "type": "integer" }
+                },
+                "required": ["a", "b"]
+            })
+        }
+
+        async fn call(&self, args: DivArgs) -> Result<i64, DivByZero> {
+            if args.b == 0 {
+                return Err(DivByZero);
+            }
+            Ok(args.a / args.b)
+        }
+    }
+
+    #[tokio::test]
+    async fn attests_and_chains_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(TreeshipLedger::open(dir.path(), "agent://test").unwrap());
+        let tool = Divide.attested(ledger.clone());
+
+        assert_eq!(tool.call(DivArgs { a: 10, b: 2 }).await.unwrap(), 5);
+        assert_eq!(tool.call(DivArgs { a: 9, b: 3 }).await.unwrap(), 3);
+        // A failing call is attested too.
+        assert!(tool.call(DivArgs { a: 1, b: 0 }).await.is_err());
+
+        let head = ledger.head().expect("chain head after three calls");
+        let verified = ledger.verify_chain(&head).unwrap();
+        assert_eq!(verified.length, 3);
+    }
+
+    #[tokio::test]
+    async fn wrapper_is_transparent_to_the_model() {
+        let ledger = Arc::new(TreeshipLedger::ephemeral("agent://test").unwrap());
+        let tool = Divide.attested(ledger);
+        assert_eq!(<Attested<Divide> as PortableTool>::NAME, "divide");
+        assert_eq!(tool.description(), Divide.description());
+        assert_eq!(tool.parameters(), Divide.parameters());
+    }
+
+    #[tokio::test]
+    async fn tampering_breaks_verification() {
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Arc::new(TreeshipLedger::open(dir.path(), "agent://test").unwrap());
+        let tool = Divide.attested(ledger.clone());
+        tool.call(DivArgs { a: 8, b: 2 }).await.unwrap();
+        let head = ledger.head().unwrap();
+
+        // Flip bytes in the stored artifact's payload.
+        let path = dir.path().join("artifacts").join(format!("{head}.json"));
+        let mut record: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        record["envelope"]["payload"] = serde_json::json!("dGFtcGVyZWQ");
+        std::fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
+
+        assert!(ledger.verify_chain(&head).is_err());
+    }
+}

--- a/scripts/check-release-versions.py
+++ b/scripts/check-release-versions.py
@@ -373,6 +373,7 @@ def collect_sites() -> list[Site]:
         ("packages/core/Cargo.toml", "rust crate treeship-core"),
         ("packages/cli/Cargo.toml", "rust crate treeship-cli"),
         ("packages/core-wasm/Cargo.toml", "rust crate treeship-core-wasm"),
+        ("packages/rig/Cargo.toml", "rust crate rig-treeship"),
     ]:
         sites.append(
             Site(
@@ -383,15 +384,19 @@ def collect_sites() -> list[Site]:
             )
         )
 
-    # Workspace-internal Cargo pin: cli depends on core at the same version.
-    sites.append(
-        Site(
-            "packages/cli/Cargo.toml",
-            "cargo dep treeship-core (in cli)",
-            cargo_dep_version("packages/cli/Cargo.toml", "treeship-core"),
-            lambda v: set_cargo_dep_version("packages/cli/Cargo.toml", "treeship-core", v),
+    # Workspace-internal Cargo pins: crates that depend on core must name the
+    # same version. `cargo publish` puts this literal in the released manifest,
+    # so a stale pin publishes a crate depending on a version that may not
+    # exist yet -- which fails at the registry, after the tag is already cut.
+    for rel in ["packages/cli/Cargo.toml", "packages/rig/Cargo.toml"]:
+        sites.append(
+            Site(
+                rel,
+                f"cargo dep treeship-core (in {rel.split('/')[1]})",
+                cargo_dep_version(rel, "treeship-core"),
+                lambda v, rel=rel: set_cargo_dep_version(rel, "treeship-core", v),
+            )
         )
-    )
 
     # All published npm packages.
     for rel, label in [


### PR DESCRIPTION
You asked why rig can't just use the same key and pipeline. It can — but not by copying a secret, because **GitHub cannot share a repo secret across repos.** I checked `/repos/{repo}/actions/organization-secrets` for both: empty. There's no org-level secret to inherit either, so the token genuinely exists only on `treeship`.

Setting the same token a second time was the wrong answer to a right complaint: the key is already configured, and a second copy is a second thing to rotate and a second thing to leak.

**So the crate moves in.** Same repo, same pipeline, same key, nothing new configured.

It also inherits CI that already exists — clippy at `-D warnings`, the dependency audits from #286, the version-consistency gate — none of which the standalone repo had until I hand-built them this week.

## The one visible decision: lockstep versioning, 0.1.0 → 0.24.0

The release pipeline derives every crate's version from the git tag, so a crate at 0.1.0 inside a `v0.24.0` tag simply wouldn't match. Lockstep is also the more useful claim — this crate exists to wrap `treeship-core`, so *"which treeship does this match"* is the most informative thing its version can say.

**Nothing is published yet, so this is fully reversible until the tag is pushed.** Say the word if you'd rather it kept an independent version and I'll special-case the publish step instead.

## Ordering matters

`treeship-core` is a **path + version** dependency: the path keeps the workspace building against the core in this tree (a breaking change fails CI in the commit that makes it), the version is what lands in the published manifest. `rig-treeship` publishes *after* `treeship-core`'s verify step — crates.io rejects a publish whose dependency version isn't live yet.

## Registered in the version gate

It checked 39 sites and knew nothing about rig, so both the crate version and the `treeship-core` pin could drift from the tag silently. That's exactly the failure the gate exists for — and exactly what happened to the npm lockfiles before #283. Now 41 sites.

## Two things found on the way in

- **rig declared `rust-version = "1.88"`** — the only crate in the workspace declaring one. That MSRV was tested in the standalone repo by a job I added for it. Here nothing builds at 1.88 (toolchain pinned to 1.94.1), so the claim went untested the moment it moved. Now states 1.94, the version actually verified every commit.
- **`clippy.toml` still said "CI does NOT currently run `cargo clippy`"** and described a ~40-warning debt to pay off later. #283 made clippy a gate and cleared it to zero.

## Verified

Builds · 9 rig tests pass · clippy clean under workspace lints · `cargo publish --dry-run` packages · 41/41 version sites consistent · capability map and CLI reference current.

## After merge

The standalone `zerkerlabs/rig-treeship` repo is redundant and should be **archived**, not left to drift — two copies of a crate is how the two get different. Happy to do that once this lands.