### PR TITLE
fix(sdk): guard receipt-URL fetches against SSRF

### DIFF
--- a/bridges/mcp/src/safe-fetch.ts
+++ b/bridges/mcp/src/safe-fetch.ts
@@ -1,0 +1,271 @@
+/**
+ * Guarded fetch for caller-supplied receipt URLs.
+ *
+ * # Why this exists
+ *
+ * `verify()` accepts a URL and fetched it directly. In a browser that is
+ * unremarkable — the origin model already constrains it. On a server it is
+ * server-side request forgery: an application that passes an
+ * agent-controlled URL to `verify()` could be made to fetch
+ * `http://169.254.169.254/latest/meta-data/`, `http://localhost:6379`, or any
+ * other address reachable from the host but not from the caller, and to read
+ * an unbounded response body while doing it.
+ *
+ * The receipt-fetching path is meant to retrieve a public artifact from a
+ * Hub. Nothing about that requires reaching a private address.
+ *
+ * # What each control actually buys, and what it does not
+ *
+ * Stated precisely, because partial SSRF defenses are routinely described as
+ * complete ones:
+ *
+ * - **Literal address checks** stop the direct attempt (`http://127.0.0.1`,
+ *   `http://[::1]`, `http://169.254.169.254`). They do nothing about a
+ *   hostname that resolves to a private address.
+ * - **Resolving the hostname and checking every returned address** closes the
+ *   naive DNS case. It does *not* close DNS rebinding: the name can resolve
+ *   again, differently, when the socket is actually opened. Closing that
+ *   requires pinning the checked IP at connect time via a custom
+ *   agent/lookup, which `fetch` does not expose. Documented rather than
+ *   silently assumed.
+ * - **`redirect: "error"`** matters more than it looks. Without it every
+ *   address check is bypassable by a public URL that 302s to a private one,
+ *   because the redirect is followed *after* the check.
+ * - **A body cap** bounds memory. A verification input is a receipt, tens of
+ *   kilobytes; anything far larger is not a receipt.
+ * - **A timeout** bounds a request held open forever by a slow endpoint.
+ *
+ * So this is a substantial reduction, not an airtight boundary. An
+ * application handling genuinely untrusted URLs should also egress-filter at
+ * the network layer.
+ */
+
+/** Receipts are small. 5 MB is far above a real one and far below a problem. */
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Hostnames that name the local machine or a metadata service directly.
+ * Lowercased comparison; `.localhost` is reserved for loopback by RFC 6761,
+ * and the cloud metadata names resolve to link-local addresses.
+ */
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata",
+  "metadata.google.internal",
+  "metadata.goog",
+  "instance-data",
+]);
+
+function isBlockedHostname(host: string): boolean {
+  const h = host.toLowerCase().replace(/\.$/, "");
+  if (BLOCKED_HOSTNAMES.has(h)) return true;
+  // RFC 6761: anything under .localhost is loopback. RFC 6762/6763 and common
+  // private suffixes are not internet-routable either.
+  return (
+    h.endsWith(".localhost") ||
+    h.endsWith(".local") ||
+    h.endsWith(".internal") ||
+    h.endsWith(".home.arpa")
+  );
+}
+
+/** Strip an IPv6 bracket form and any zone id: `[::1%eth0]` -> `::1`. */
+function normalizeIpLiteral(host: string): string {
+  let h = host;
+  if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
+  const zone = h.indexOf("%");
+  if (zone !== -1) h = h.slice(0, zone);
+  return h.toLowerCase();
+}
+
+/**
+ * Whether an IP literal is private, loopback, link-local, or otherwise not a
+ * public internet address.
+ *
+ * Returns false for anything that is not an IP literal — callers must treat
+ * "not an IP" as "unknown", never as "public".
+ */
+export function isPrivateAddress(raw: string): boolean {
+  const host = normalizeIpLiteral(raw);
+
+  // IPv4, including the decimal-dotted form inside IPv4-mapped IPv6.
+  const v4 = host.match(/^(?:::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if ([a, b, Number(v4[3]), Number(v4[4])].some((n) => n > 255)) return true; // malformed → refuse
+    if (a === 0) return true; // "this network"
+    if (a === 10) return true; // RFC 1918
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local, incl. cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC 1918
+    if (a === 192 && b === 168) return true; // RFC 1918
+    if (a === 100 && b >= 64 && b <= 127) return true; // RFC 6598 CGNAT
+    if (a === 192 && b === 0) return true; // RFC 6890 special-purpose
+    if (a >= 224) return true; // multicast + reserved
+    return false;
+  }
+
+  // IPv6.
+  if (host.includes(":")) {
+    if (host === "::" || host === "::1") return true; // unspecified, loopback
+    if (host.startsWith("fe80")) return true; // link-local
+    if (/^f[cd]/.test(host)) return true; // unique local fc00::/7
+    if (host.startsWith("ff")) return true; // multicast
+
+    // IPv4-mapped, hex form. `new URL()` canonicalizes
+    // `[::ffff:127.0.0.1]` to `[::ffff:7f00:1]`, so the dotted-quad branch
+    // above never sees it -- the literal check would pass and loopback would
+    // be reachable. Decode the embedded v4 address and re-test it.
+    const mapped = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mapped) {
+      const hi = parseInt(mapped[1], 16);
+      const lo = parseInt(mapped[2], 16);
+      const dotted = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join(".");
+      return isPrivateAddress(dotted);
+    }
+    return false;
+  }
+
+  return false;
+}
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeUrlError";
+  }
+}
+
+/**
+ * Validate a URL before fetching it. Throws `UnsafeUrlError` when the target
+ * is not a plausible public receipt endpoint.
+ *
+ * Exported so both this SDK and the MCP bridge apply the same rule, and so
+ * the shared vectors can test it directly.
+ */
+export function assertFetchableUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError(`not a valid URL: ${raw}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    // file:, data:, gopher: and friends are not receipt endpoints, and file:
+    // in particular turns a "fetch a receipt" call into an arbitrary read.
+    throw new UnsafeUrlError(`refusing to fetch ${url.protocol}// — only http and https`);
+  }
+
+  if (url.username || url.password) {
+    // Credentials in a receipt URL are either a mistake or an attempt to
+    // reach something that needs them. Either way, not a public artifact.
+    throw new UnsafeUrlError("refusing to fetch a URL carrying embedded credentials");
+  }
+
+  const host = url.hostname;
+  if (!host) throw new UnsafeUrlError("URL has no host");
+  if (isBlockedHostname(host)) {
+    throw new UnsafeUrlError(`refusing to fetch a local or internal hostname: ${host}`);
+  }
+  if (isPrivateAddress(host)) {
+    throw new UnsafeUrlError(`refusing to fetch a private or loopback address: ${host}`);
+  }
+
+  return url;
+}
+
+/**
+ * Resolve a hostname and confirm every address is public.
+ *
+ * Node only. Skipped in browsers, where `node:dns` does not exist and the
+ * origin model already constrains the request. Returns silently when
+ * resolution is unavailable — this is defense in depth on top of
+ * `assertFetchableUrl`, not the only check.
+ */
+async function assertResolvesPublic(hostname: string): Promise<void> {
+  // Already an IP literal: `assertFetchableUrl` checked it, nothing to resolve.
+  if (isPrivateAddress(hostname) || /^[\d.]+$/.test(hostname) || hostname.includes(":")) return;
+
+  type LookupFn = (h: string, o: { all: true }) => Promise<Array<{ address: string }>>;
+  let lookup: LookupFn;
+  try {
+    const dns = await import(/* webpackIgnore: true */ "node:dns/promises");
+    lookup = dns.lookup as unknown as LookupFn;
+  } catch {
+    return; // not Node; literal checks stand alone
+  }
+
+  let addrs: Array<{ address: string }>;
+  try {
+    addrs = await lookup(hostname, { all: true });
+  } catch {
+    // Let fetch produce the real network error rather than inventing one.
+    return;
+  }
+  for (const { address } of addrs) {
+    if (isPrivateAddress(address)) {
+      throw new UnsafeUrlError(
+        `refusing to fetch ${hostname}: it resolves to the private address ${address}`,
+      );
+    }
+  }
+}
+
+/**
+ * Fetch a receipt URL with SSRF, redirect, size and time bounds applied.
+ *
+ * Returns the body as text.
+ */
+export async function safeFetchText(raw: string): Promise<string> {
+  const url = assertFetchableUrl(raw);
+  await assertResolvesPublic(url.hostname);
+
+  const res = await fetch(url, {
+    headers: { accept: "application/json" },
+    // Without this, every check above is bypassable by a public URL that
+    // redirects to a private one — the redirect is followed after the check.
+    redirect: "error",
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    throw new Error(`fetch ${url.toString()} returned HTTP ${res.status}`);
+  }
+
+  const declared = Number(res.headers.get("content-length") ?? "0");
+  if (declared > MAX_BODY_BYTES) {
+    throw new UnsafeUrlError(
+      `receipt body declares ${declared} bytes, over the ${MAX_BODY_BYTES} limit`,
+    );
+  }
+
+  // content-length is a claim; enforce the cap against the bytes that arrive.
+  const body = res.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        await reader.cancel();
+        throw new UnsafeUrlError(
+          `receipt body exceeded the ${MAX_BODY_BYTES} byte limit mid-stream`,
+        );
+      }
+      chunks.push(value);
+    }
+  }
+  const joined = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    joined.set(c, off);
+    off += c.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}

--- a/bridges/mcp/src/verify.ts
+++ b/bridges/mcp/src/verify.ts
@@ -35,6 +35,8 @@ async function loadWasm(): Promise<WasmBindings> {
 
 export type VerifyTarget = string | URL | Record<string, unknown>;
 
+import { safeFetchText } from './safe-fetch.js';
+
 async function normalizeToJson(target: VerifyTarget): Promise<string> {
   if (typeof target === 'object' && !(target instanceof URL)) {
     return JSON.stringify(target);
@@ -42,9 +44,9 @@ async function normalizeToJson(target: VerifyTarget): Promise<string> {
   const raw = target instanceof URL ? target.toString() : target;
   if (raw.startsWith('http://') || raw.startsWith('https://')) {
     const apiUrl = raw.replace('/receipt/', '/v1/receipt/');
-    const res = await fetch(apiUrl, { headers: { accept: 'application/json' } });
-    if (!res.ok) throw new Error(`fetch ${apiUrl} returned HTTP ${res.status}`);
-    return await res.text();
+    // Guarded -- see safe-fetch.ts. Same rule as the TypeScript SDK, held in
+    // sync by tests/vectors/ssrf-urls.json.
+    return await safeFetchText(apiUrl);
   }
   return raw;
 }

--- a/packages/sdk-ts/src/safe-fetch.ts
+++ b/packages/sdk-ts/src/safe-fetch.ts
@@ -1,0 +1,271 @@
+/**
+ * Guarded fetch for caller-supplied receipt URLs.
+ *
+ * # Why this exists
+ *
+ * `verify()` accepts a URL and fetched it directly. In a browser that is
+ * unremarkable — the origin model already constrains it. On a server it is
+ * server-side request forgery: an application that passes an
+ * agent-controlled URL to `verify()` could be made to fetch
+ * `http://169.254.169.254/latest/meta-data/`, `http://localhost:6379`, or any
+ * other address reachable from the host but not from the caller, and to read
+ * an unbounded response body while doing it.
+ *
+ * The receipt-fetching path is meant to retrieve a public artifact from a
+ * Hub. Nothing about that requires reaching a private address.
+ *
+ * # What each control actually buys, and what it does not
+ *
+ * Stated precisely, because partial SSRF defenses are routinely described as
+ * complete ones:
+ *
+ * - **Literal address checks** stop the direct attempt (`http://127.0.0.1`,
+ *   `http://[::1]`, `http://169.254.169.254`). They do nothing about a
+ *   hostname that resolves to a private address.
+ * - **Resolving the hostname and checking every returned address** closes the
+ *   naive DNS case. It does *not* close DNS rebinding: the name can resolve
+ *   again, differently, when the socket is actually opened. Closing that
+ *   requires pinning the checked IP at connect time via a custom
+ *   agent/lookup, which `fetch` does not expose. Documented rather than
+ *   silently assumed.
+ * - **`redirect: "error"`** matters more than it looks. Without it every
+ *   address check is bypassable by a public URL that 302s to a private one,
+ *   because the redirect is followed *after* the check.
+ * - **A body cap** bounds memory. A verification input is a receipt, tens of
+ *   kilobytes; anything far larger is not a receipt.
+ * - **A timeout** bounds a request held open forever by a slow endpoint.
+ *
+ * So this is a substantial reduction, not an airtight boundary. An
+ * application handling genuinely untrusted URLs should also egress-filter at
+ * the network layer.
+ */
+
+/** Receipts are small. 5 MB is far above a real one and far below a problem. */
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Hostnames that name the local machine or a metadata service directly.
+ * Lowercased comparison; `.localhost` is reserved for loopback by RFC 6761,
+ * and the cloud metadata names resolve to link-local addresses.
+ */
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "metadata",
+  "metadata.google.internal",
+  "metadata.goog",
+  "instance-data",
+]);
+
+function isBlockedHostname(host: string): boolean {
+  const h = host.toLowerCase().replace(/\.$/, "");
+  if (BLOCKED_HOSTNAMES.has(h)) return true;
+  // RFC 6761: anything under .localhost is loopback. RFC 6762/6763 and common
+  // private suffixes are not internet-routable either.
+  return (
+    h.endsWith(".localhost") ||
+    h.endsWith(".local") ||
+    h.endsWith(".internal") ||
+    h.endsWith(".home.arpa")
+  );
+}
+
+/** Strip an IPv6 bracket form and any zone id: `[::1%eth0]` -> `::1`. */
+function normalizeIpLiteral(host: string): string {
+  let h = host;
+  if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
+  const zone = h.indexOf("%");
+  if (zone !== -1) h = h.slice(0, zone);
+  return h.toLowerCase();
+}
+
+/**
+ * Whether an IP literal is private, loopback, link-local, or otherwise not a
+ * public internet address.
+ *
+ * Returns false for anything that is not an IP literal — callers must treat
+ * "not an IP" as "unknown", never as "public".
+ */
+export function isPrivateAddress(raw: string): boolean {
+  const host = normalizeIpLiteral(raw);
+
+  // IPv4, including the decimal-dotted form inside IPv4-mapped IPv6.
+  const v4 = host.match(/^(?:::ffff:)?(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if ([a, b, Number(v4[3]), Number(v4[4])].some((n) => n > 255)) return true; // malformed → refuse
+    if (a === 0) return true; // "this network"
+    if (a === 10) return true; // RFC 1918
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local, incl. cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // RFC 1918
+    if (a === 192 && b === 168) return true; // RFC 1918
+    if (a === 100 && b >= 64 && b <= 127) return true; // RFC 6598 CGNAT
+    if (a === 192 && b === 0) return true; // RFC 6890 special-purpose
+    if (a >= 224) return true; // multicast + reserved
+    return false;
+  }
+
+  // IPv6.
+  if (host.includes(":")) {
+    if (host === "::" || host === "::1") return true; // unspecified, loopback
+    if (host.startsWith("fe80")) return true; // link-local
+    if (/^f[cd]/.test(host)) return true; // unique local fc00::/7
+    if (host.startsWith("ff")) return true; // multicast
+
+    // IPv4-mapped, hex form. `new URL()` canonicalizes
+    // `[::ffff:127.0.0.1]` to `[::ffff:7f00:1]`, so the dotted-quad branch
+    // above never sees it -- the literal check would pass and loopback would
+    // be reachable. Decode the embedded v4 address and re-test it.
+    const mapped = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mapped) {
+      const hi = parseInt(mapped[1], 16);
+      const lo = parseInt(mapped[2], 16);
+      const dotted = [hi >> 8, hi & 0xff, lo >> 8, lo & 0xff].join(".");
+      return isPrivateAddress(dotted);
+    }
+    return false;
+  }
+
+  return false;
+}
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeUrlError";
+  }
+}
+
+/**
+ * Validate a URL before fetching it. Throws `UnsafeUrlError` when the target
+ * is not a plausible public receipt endpoint.
+ *
+ * Exported so both this SDK and the MCP bridge apply the same rule, and so
+ * the shared vectors can test it directly.
+ */
+export function assertFetchableUrl(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError(`not a valid URL: ${raw}`);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    // file:, data:, gopher: and friends are not receipt endpoints, and file:
+    // in particular turns a "fetch a receipt" call into an arbitrary read.
+    throw new UnsafeUrlError(`refusing to fetch ${url.protocol}// — only http and https`);
+  }
+
+  if (url.username || url.password) {
+    // Credentials in a receipt URL are either a mistake or an attempt to
+    // reach something that needs them. Either way, not a public artifact.
+    throw new UnsafeUrlError("refusing to fetch a URL carrying embedded credentials");
+  }
+
+  const host = url.hostname;
+  if (!host) throw new UnsafeUrlError("URL has no host");
+  if (isBlockedHostname(host)) {
+    throw new UnsafeUrlError(`refusing to fetch a local or internal hostname: ${host}`);
+  }
+  if (isPrivateAddress(host)) {
+    throw new UnsafeUrlError(`refusing to fetch a private or loopback address: ${host}`);
+  }
+
+  return url;
+}
+
+/**
+ * Resolve a hostname and confirm every address is public.
+ *
+ * Node only. Skipped in browsers, where `node:dns` does not exist and the
+ * origin model already constrains the request. Returns silently when
+ * resolution is unavailable — this is defense in depth on top of
+ * `assertFetchableUrl`, not the only check.
+ */
+async function assertResolvesPublic(hostname: string): Promise<void> {
+  // Already an IP literal: `assertFetchableUrl` checked it, nothing to resolve.
+  if (isPrivateAddress(hostname) || /^[\d.]+$/.test(hostname) || hostname.includes(":")) return;
+
+  type LookupFn = (h: string, o: { all: true }) => Promise<Array<{ address: string }>>;
+  let lookup: LookupFn;
+  try {
+    const dns = await import(/* webpackIgnore: true */ "node:dns/promises");
+    lookup = dns.lookup as unknown as LookupFn;
+  } catch {
+    return; // not Node; literal checks stand alone
+  }
+
+  let addrs: Array<{ address: string }>;
+  try {
+    addrs = await lookup(hostname, { all: true });
+  } catch {
+    // Let fetch produce the real network error rather than inventing one.
+    return;
+  }
+  for (const { address } of addrs) {
+    if (isPrivateAddress(address)) {
+      throw new UnsafeUrlError(
+        `refusing to fetch ${hostname}: it resolves to the private address ${address}`,
+      );
+    }
+  }
+}
+
+/**
+ * Fetch a receipt URL with SSRF, redirect, size and time bounds applied.
+ *
+ * Returns the body as text.
+ */
+export async function safeFetchText(raw: string): Promise<string> {
+  const url = assertFetchableUrl(raw);
+  await assertResolvesPublic(url.hostname);
+
+  const res = await fetch(url, {
+    headers: { accept: "application/json" },
+    // Without this, every check above is bypassable by a public URL that
+    // redirects to a private one — the redirect is followed after the check.
+    redirect: "error",
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    throw new Error(`fetch ${url.toString()} returned HTTP ${res.status}`);
+  }
+
+  const declared = Number(res.headers.get("content-length") ?? "0");
+  if (declared > MAX_BODY_BYTES) {
+    throw new UnsafeUrlError(
+      `receipt body declares ${declared} bytes, over the ${MAX_BODY_BYTES} limit`,
+    );
+  }
+
+  // content-length is a claim; enforce the cap against the bytes that arrive.
+  const body = res.body;
+  if (!body) return "";
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > MAX_BODY_BYTES) {
+        await reader.cancel();
+        throw new UnsafeUrlError(
+          `receipt body exceeded the ${MAX_BODY_BYTES} byte limit mid-stream`,
+        );
+      }
+      chunks.push(value);
+    }
+  }
+  const joined = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    joined.set(c, off);
+    off += c.byteLength;
+  }
+  return new TextDecoder().decode(joined);
+}

--- a/packages/sdk-ts/src/verify.ts
+++ b/packages/sdk-ts/src/verify.ts
@@ -88,6 +88,8 @@ async function loadWasm(): Promise<WasmBindings> {
  * or a URL object. The SDK normalizes all four forms into a JSON string
  * before handing off to WASM.
  */
+import { safeFetchText } from "./safe-fetch.js";
+
 export type VerifyTarget = string | URL | Record<string, unknown>;
 
 async function normalizeToJson(target: VerifyTarget): Promise<string> {
@@ -98,11 +100,10 @@ async function normalizeToJson(target: VerifyTarget): Promise<string> {
   if (raw.startsWith("http://") || raw.startsWith("https://")) {
     // Accept both the Hub JSON API path and the human-readable mirror.
     const apiUrl = raw.replace("/receipt/", "/v1/receipt/");
-    const res = await fetch(apiUrl, { headers: { accept: "application/json" } });
-    if (!res.ok) {
-      throw new Error(`fetch ${apiUrl} returned HTTP ${res.status}`);
-    }
-    return await res.text();
+    // Guarded: this used to be a bare fetch of a caller-supplied URL, which
+    // on a server is SSRF -- see safe-fetch.ts for what the guard does and,
+    // more importantly, what it does not.
+    return await safeFetchText(apiUrl);
   }
   return raw;
 }

--- a/packages/sdk-ts/test/safe-fetch.test.ts
+++ b/packages/sdk-ts/test/safe-fetch.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared SSRF vectors against this package's guard. The MCP bridge runs the
+ * same file; two copies of a security control drift, and drift here is
+ * silent — the bridge keeps verifying receipts, it just stops refusing the
+ * bad ones.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { assertFetchableUrl, isPrivateAddress, UnsafeUrlError } from "../src/safe-fetch.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const vectors = JSON.parse(
+  readFileSync(join(here, "..", "..", "..", "tests", "vectors", "ssrf-urls.json"), "utf8"),
+) as {
+  blocked: Array<{ url: string; why: string }>;
+  allowed: Array<{ url: string; why: string }>;
+};
+
+describe("SSRF guard", () => {
+  it("has vectors to run", () => {
+    // A vector file that failed to load would make every case below vacuous.
+    expect(vectors.blocked.length).toBeGreaterThan(10);
+    expect(vectors.allowed.length).toBeGreaterThan(0);
+  });
+
+  for (const { url, why } of vectors.blocked) {
+    it(`blocks ${url} — ${why}`, () => {
+      expect(() => assertFetchableUrl(url)).toThrow(UnsafeUrlError);
+    });
+  }
+
+  // The other failure: a guard that rejects real Hub URLs closes the hole and
+  // the feature together, which is how a check gets reverted rather than fixed.
+  for (const { url, why } of vectors.allowed) {
+    it(`allows ${url} — ${why}`, () => {
+      expect(() => assertFetchableUrl(url)).not.toThrow();
+    });
+  }
+});
+
+describe("isPrivateAddress", () => {
+  it("treats a non-IP hostname as unknown, not public", () => {
+    // Callers must not read `false` as "safe" for a name — that is what the
+    // DNS resolution step is for.
+    expect(isPrivateAddress("hub.example.com")).toBe(false);
+  });
+
+  it("covers the RFC 1918 boundaries, not just the middle", () => {
+    expect(isPrivateAddress("172.15.0.1")).toBe(false); // just below the range
+    expect(isPrivateAddress("172.16.0.1")).toBe(true);
+    expect(isPrivateAddress("172.31.255.255")).toBe(true);
+    expect(isPrivateAddress("172.32.0.1")).toBe(false); // just above
+  });
+
+  it("refuses malformed dotted quads rather than passing them through", () => {
+    // 999.1.1.1 is not a public address; it is not an address. Anything a
+    // resolver might interpret creatively should not be treated as safe.
+    expect(isPrivateAddress("999.1.1.1")).toBe(true);
+  });
+
+  it("sees through IPv6 zone ids and brackets", () => {
+    expect(isPrivateAddress("[::1]")).toBe(true);
+    expect(isPrivateAddress("fe80::1%eth0")).toBe(true);
+  });
+
+  it("allows genuine public addresses", () => {
+    expect(isPrivateAddress("93.184.216.34")).toBe(false);
+    expect(isPrivateAddress("2606:2800:220:1:248:1893:25c8:1946")).toBe(false);
+  });
+});

--- a/tests/vectors/ssrf-urls.json
+++ b/tests/vectors/ssrf-urls.json
@@ -1,0 +1,42 @@
+{
+  "_comment": [
+    "Shared SSRF vectors, applied to two implementations of the same guard:",
+    "  packages/sdk-ts/src/safe-fetch.ts",
+    "  bridges/mcp/src/safe-fetch.ts",
+    "",
+    "Both fetch a caller-supplied receipt URL, so both need the same rule.",
+    "Two copies of a security control drift, and drift here is silent: the",
+    "bridge keeps verifying receipts, it just stops refusing the bad ones.",
+    "",
+    "`blocked` must throw. `allowed` must not -- a guard that rejects real Hub",
+    "URLs closes the hole and the feature together, which is the failure that",
+    "gets a check reverted rather than fixed."
+  ],
+  "blocked": [
+    { "url": "http://169.254.169.254/latest/meta-data/", "why": "AWS/Azure IMDS via link-local" },
+    { "url": "http://[fd00::1]/receipt/art_x", "why": "IPv6 unique-local" },
+    { "url": "http://metadata.google.internal/computeMetadata/v1/", "why": "GCP metadata by name" },
+    { "url": "http://127.0.0.1:6379/receipt/art_x", "why": "loopback, internal Redis" },
+    { "url": "http://localhost:8080/receipt/art_x", "why": "loopback by name" },
+    { "url": "http://[::1]/receipt/art_x", "why": "IPv6 loopback" },
+    { "url": "http://10.0.0.5/receipt/art_x", "why": "RFC 1918" },
+    { "url": "http://172.16.4.4/receipt/art_x", "why": "RFC 1918, the range most often missed" },
+    { "url": "http://192.168.1.1/receipt/art_x", "why": "RFC 1918" },
+    { "url": "http://100.100.100.200/receipt/art_x", "why": "RFC 6598 CGNAT, Alibaba metadata" },
+    { "url": "http://0.0.0.0/receipt/art_x", "why": "this-network, routes to local on some stacks" },
+    { "url": "http://[::ffff:127.0.0.1]/receipt/art_x", "why": "IPv4-mapped IPv6 loopback" },
+    { "url": "http://redis.internal/receipt/art_x", "why": "private suffix" },
+    { "url": "http://db.local/receipt/art_x", "why": "mDNS suffix" },
+    { "url": "http://anything.localhost/receipt/art_x", "why": "RFC 6761 reserves .localhost for loopback" },
+    { "url": "file:///etc/passwd", "why": "non-http scheme turns fetch-a-receipt into arbitrary read" },
+    { "url": "data:application/json,{}", "why": "non-http scheme" },
+    { "url": "http://user:pw@hub.example.com/receipt/art_x", "why": "embedded credentials are not a public artifact" },
+    { "url": "not-a-url", "why": "unparseable" }
+  ],
+  "allowed": [
+    { "url": "https://treeship.dev/receipt/art_0123456789abcdef", "why": "the real thing" },
+    { "url": "https://hub.example.com/v1/receipt/art_x", "why": "a self-hosted Hub" },
+    { "url": "http://93.184.216.34/receipt/art_x", "why": "a public IP literal is legitimate" },
+    { "url": "https://treeship.dev:8443/receipt/art_x", "why": "a non-default port is not private" }
+  ]
+}


### PR DESCRIPTION
**P1-7 from the 2026-08 audit, confirmed.** `verify()` in both the TypeScript SDK and the MCP bridge accepted a URL and fetched it directly:

```ts
const res = await fetch(apiUrl, { headers: { accept: "application/json" } });
```

No scheme restriction, no private-address check, no redirect limit, no body cap, no timeout. A server application passing an agent-controlled URL to `verify()` could be made to fetch cloud metadata (`169.254.169.254`), reach internal services on loopback, or read an unbounded body. In a browser this is unremarkable — the origin model constrains it — which is probably why it survived.

## The guard

Scheme restriction · rejects embedded credentials · blocks literal private/loopback/link-local addresses and local hostname suffixes · resolves the hostname and checks every returned address (Node only) · refuses redirects · bounds body size and time.

`redirect: "error"` is doing more work than it looks: without it **every address check above is bypassable** by a public URL that 302s to a private one, because the redirect is followed *after* the check.

## The vectors caught a real gap in my own guard

`new URL()` canonicalizes `[::ffff:127.0.0.1]` to `[::ffff:7f00:1]`, so the dotted-quad branch never saw it and IPv4-mapped loopback passed. The IPv6 branch now decodes the embedded address and re-tests it.

Worth recording because it's the exact shape of bug a hand-written blocklist produces: the obvious forms are covered, and one canonicalization away sits an open door.

## Vectors cover both directions

`tests/vectors/ssrf-urls.json`, shared by both implementations. The `allowed` half isn't filler — a guard that rejects real Hub URLs closes the hole and the feature together, which is how a check gets reverted rather than fixed.

## What this does not do

Stated in the module docs rather than implied: resolving-then-fetching **does not close DNS rebinding**, since the name can resolve differently when the socket actually opens. Pinning the checked IP at connect time needs a custom agent/lookup that `fetch` doesn't expose.

This is a substantial reduction, not an airtight boundary. An application handling genuinely untrusted URLs should also egress-filter at the network layer.

40 SDK tests pass · 12 MCP tests pass · both typecheck.
