### PR TITLE
docs: refresh the audit tracker, and record where it converges with product

### DIFF
--- a/docs/quality/audit-2026-08.md
+++ b/docs/quality/audit-2026-08.md
@@ -9,7 +9,7 @@ nobody can look up is a finding that gets rediscovered, re-analyzed, and
 re-argued six weeks later — which is how Treeship ended up with four
 documented claims that had quietly gone false (see #281).
 
-**Status as of 2026-08-13:** 30 closed, 3 declined, 17 open.
+**Status as of 2026-08-14:** 35 closed, 3 declined, 15 open.
 
 Both confirmed P0s from the second audit round are fixed (#284, #285).
 
@@ -89,7 +89,7 @@ answer than fixing them, and 3–7 remain the top of the queue.
 | 16 | Broken public "Verify a receipt" URL | **Closed** | `public/home.html`, commit 86e71ff |
 | 17 | Workspace share tokens truly single-use | **Partly closed** | device flow is single-use (`db.go:275`); share tokens "single-use in practice" |
 | 18 | Workspace credentials in query strings | **Open** | |
-| 19 | Per-IP rate limiting on Hub | **Open** | no limiter in `internal/` |
+| 19 | Per-IP rate limiting on Hub | **Closed** | #288 -- httprate, 60/min on the public reads |
 | 20 | Bound public resolver scans | **Open** | |
 | 21 | Indexed actor / kind / card-reference columns | **Open** | |
 | 22 | Reject malformed timestamps | **Closed** | #280 — `parseSignedAt` now returns `(int64, bool)`, rejects with 400 |
@@ -159,7 +159,7 @@ Items 29, 30, 36, 39 and 40 remain open.
 | 46 | Linux ARM64 release binaries | **Open** | not in the release matrix |
 | 47 | Upstream the pi/Prime integration into the monorepo | **Declined for now** | see below |
 | 48 | Remove stale tracked Python artifacts | **Closed** | none tracked |
-| 49 | Hub graceful shutdown and readiness | **Open** | no signal handling or readiness endpoint |
+| 49 | Hub graceful shutdown and readiness | **Closed** | #288 -- 20s drain, `/healthz` + `/readyz` |
 | 50 | Reconcile live-site branding with `DESIGN.md` | **Open** | needs a design decision |
 
 ### On #47 — declined, with a reason
@@ -185,6 +185,8 @@ Both confirmed ones are fixed.
 | P0-1: secrets recorded and auto-published | **Closed** | #284 |
 | P0-2: Hub does not enforce its content-addressed namespace | **Closed** | #285 |
 | P0-3: verify can exit 0 with authority unverified | **Open** | conditional on Treeship being used to gate |
+| P1-2: malicious Hub can write outside the artifact store | **Closed** | #289 -- proved, then fixed |
+| P1-7: URL verification helpers permit unrestricted fetches | **Closed** | #294 -- SSRF guard + shared vectors |
 
 ### P0-1 — worse than reported, in two ways
 
@@ -212,6 +214,34 @@ The detailed JSON is honest; the exit code is not, for an enforcement use.
 The fix is a `--require-authority` flag and making strict authority the
 default for protected actions. It depends on 5 and 6 (revocation), which is
 why it is not fixed here.
+
+---
+
+## Beyond the audit: the product analysis converges on it
+
+The same pi session carried ~140k characters of product and strategy analysis
+that the pasted excerpts never included. Read against the security findings,
+four separate observations turn out to be one gap:
+
+| Source | Wording |
+|---|---|
+| Audit P0-3 | `verify` exits 0 while authority is unverified |
+| Product doc #5 | "authority *before* action, not observability after" |
+| Product doc #7 | capability leases -- `refund: maximum: 100 USD` |
+| Public build-log comment | granted-minus-exercised is never reported |
+
+All four say: **Treeship records what happened; it does not gate what may
+happen, and it never reports the gap between what was permitted and what was
+used.** That is what the audit means by "authority runtime rather than
+primarily an evidence recorder" -- not a feature request, the same defect
+surfacing in four places.
+
+It also explains a public claim that did not match the code. A build-log reply
+stated "we closed this for spend (could have spent 10k, spent 3)". No spend
+limit exists; `Grant` carries scope, expiry and delegation depth. The
+`maximum: 100 USD` example is from the product *recommendation* in that
+session. A roadmap item was read as a shipped feature -- the same failure mode
+as the stale docs this file tracks, pointed forward instead of backward.
 
 ---
 


### PR DESCRIPTION
35 closed, 3 declined, 15 open (was 30/3/17).

**Items 19 and 49 shipped in #288 and the tracker still said Open** — the exact drift this file exists to prevent, so worth naming rather than quietly correcting. Also records P1-2 (#289) and P1-7 (#294), which were in the second-round findings but never had rows.

## Where the product analysis converges

The pasted audit excerpts only ever carried the security half. The same pi session export holds ~140k characters of product and strategy analysis. Read against the findings, four separate observations turn out to be one gap:

| Source | Wording |
|---|---|
| Audit P0-3 | `verify` exits 0 while authority is unverified |
| Product doc #5 | "authority *before* action, not observability after" |
| Product doc #7 | capability leases — `refund: maximum: 100 USD` |
| Build-log comment | granted-minus-exercised is never reported |

**Treeship records what happened; it does not gate what may happen, and it never reports the gap between permitted and used.** That's what the audit means by "authority runtime rather than primarily an evidence recorder" — not a feature request, one defect surfacing in four places.

## And it explains a public claim that didn't match the code

A build-log reply stated *"we closed this for spend (could have spent 10k, spent 3)."* No spend limit exists — `Grant` carries scope, expiry, delegation depth. The `maximum: 100 USD` example is from the product **recommendation** in that session. A roadmap item was read as a shipped feature: the same failure mode as the stale docs this file tracks, pointed forward instead of backward.