### PR TITLE
feat(verify): gate on authority, and report what was granted but never used

### DIFF
--- a/docs/capability-map.json
+++ b/docs/capability-map.json
@@ -3,7 +3,7 @@
   "counts": {
     "cli_commands": 34,
     "hub_routes": 22,
-    "wire_types": 115
+    "wire_types": 116
   },
   "cli_commands": [
     "add",
@@ -302,6 +302,11 @@
       "name": "AuthoritySection",
       "kind": "struct",
       "source": "packages/core/src/session/receipt.rs"
+    },
+    {
+      "name": "AuthorityUse",
+      "kind": "struct",
+      "source": "packages/core/src/verify/authority_use.rs"
     },
     {
       "name": "BudgetUpdate",

--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -471,6 +471,7 @@ treeship verify [OPTIONS] <TARGET>
 | `--max-depth <N>` | Maximum chain depth to walk (default: 20). Only applies to the artifact-ID form [default: 20] |
 | `--full` | Show full chain timeline with box-drawn cards. Only applies to the artifact-ID form |
 | `--max-unwitnessed <DURATION>` | Fail unless every stretch of claimed work was externally witnessed within this long (e.g. 15m, 1h, 3600) |
+| `--require-authority` | Exit non-zero unless authority was actually checked and passed |
 
 ## `treeship hub`
 

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -375,6 +375,7 @@ pub fn run(
     max_depth: usize,
     full: bool,
     max_unwitnessed: Option<&str>,
+    require_authority: bool,
     config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -577,9 +578,25 @@ pub fn run(
             // nothing is wrong.
             "authority_checked": authority_checked,
             "authority_unverified": authority_unverified,
+            // Populated only under --require-authority: why the gate refused.
+            // Absent when the flag is off, so the field's presence is itself
+            // the signal that a policy was applied.
+            // Latent capability is not a defect, so it is reported rather
+            // than gated. `out_of_scope` is a defect, and the mandate verdict
+            // fails for it independently.
+            "capability_use": chain_authority_use(&chain_envelopes),
+            "authority_gate": authority_gate_failure(
+                require_authority, authority_checked, authority_unverified, authority_ok,
+            ),
             "checks": out,
         }));
-        if failed > 0 || !linkage_ok {
+        let authority_gate = authority_gate_failure(
+            require_authority,
+            authority_checked,
+            authority_unverified,
+            authority_ok,
+        );
+        if failed > 0 || !linkage_ok || authority_gate.is_some() {
             std::process::exit(1);
         }
         return Ok(());
@@ -648,6 +665,45 @@ pub fn run(
                         ),
                     ],
                 );
+                printer.blank();
+                std::process::exit(1);
+            }
+        }
+
+        // Authority gate. Same policy as the JSON path -- a flag that only
+        // worked in one output mode would be a trap for whichever caller
+        // picked the other.
+        {
+            let summaries: Vec<MandateSummary> = chain_envelopes
+                .iter()
+                .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier)))
+                .collect();
+            let checked = summaries.len();
+            let unverified = summaries
+                .iter()
+                .filter(|m| matches!(m, MandateSummary::Unverified(_)))
+                .count();
+            let ok = !summaries
+                .iter()
+                .any(|m| matches!(m, MandateSummary::Fail(_)));
+
+            if checked > 0 {
+                printer.dim_info(&format!(
+                    "  authority:  {checked} mandate(s) judged, {unverified} unverified"
+                ));
+                // Granted vs exercised. Verification already checks that every
+                // action fell inside its scope; the remainder -- capability
+                // granted and never used -- is computed by nobody and shown to
+                // nobody, and it is the difference between a chain that could
+                // only do what it did and one that was a defect away from
+                // doing more.
+                let use_ = chain_authority_use(&chain_envelopes);
+                printer.dim_info(&format!("  capability: {}", use_.summary()));
+            }
+            if let Some(reason) = authority_gate_failure(require_authority, checked, unverified, ok)
+            {
+                printer.blank();
+                printer.failure("AUTHORITY NOT ESTABLISHED", &[("reason", &reason)]);
                 printer.blank();
                 std::process::exit(1);
             }
@@ -2045,6 +2101,77 @@ fn extract_actor(envelope: &Envelope) -> String {
         return s.actor;
     }
     "\u{2014}".into()
+}
+
+/// Collect mandate scopes and performed actions across a verified chain.
+///
+/// Both sides come out of the signed bytes already -- this reads them, it does
+/// not derive anything new. An envelope that will not decode as action/v2 is
+/// skipped rather than defaulted: a missing scope counted as empty would
+/// invent dormant capability, and a missing action counted as absent would
+/// hide an out-of-scope one.
+fn chain_authority_use(
+    chain_envelopes: &[(String, Envelope)],
+) -> treeship_core::verify::authority_use::AuthorityUse {
+    use treeship_core::statements::ActionStatementV2;
+    use treeship_core::verify::authority_use::AuthorityUse;
+
+    let mut scopes: Vec<String> = Vec::new();
+    let mut actions: Vec<String> = Vec::new();
+    for (_, env) in chain_envelopes {
+        if let Ok(stmt) = env.unmarshal_statement::<ActionStatementV2>() {
+            scopes.extend(stmt.mandate.scope.iter().cloned());
+            actions.push(stmt.action.clone());
+        }
+    }
+    AuthorityUse::compute(&scopes, &actions)
+}
+
+/// Why `--require-authority` refuses, or `None` when it is satisfied (or off).
+///
+/// The flag exists because the default exit code answers "are the signatures
+/// valid", and a caller writing `treeship verify "$ART" && deploy` is asking a
+/// different question: "was this agent allowed to do it". Those come apart
+/// exactly when authority could not be checked -- `NoRevocationSource` means
+/// no revocation resolver is configured, so a mandate degrades to `Unverified`
+/// and `authority_ok` stays true. Nothing was caught because nothing looked.
+///
+/// Three ways to fail, deliberately including the third:
+///
+/// * a mandate outright failed;
+/// * a mandate could not be checked;
+/// * **there was no mandate at all.** Requiring authority and finding none is
+///   not a pass. An action/v1 receipt makes no authority claim, so a gate that
+///   accepted it would be satisfied by the absence of the thing it demanded.
+fn authority_gate_failure(
+    require: bool,
+    checked: usize,
+    unverified: usize,
+    ok: bool,
+) -> Option<String> {
+    if !require {
+        return None;
+    }
+    if checked == 0 {
+        return Some(
+            "--require-authority: this receipt carries no action/v2 mandate, so there is no \
+             authority to verify. Absence of a claim is not a passing check."
+                .to_string(),
+        );
+    }
+    if !ok {
+        return Some(format!(
+            "--require-authority: {checked} mandate(s) judged and at least one FAILED"
+        ));
+    }
+    if unverified > 0 {
+        return Some(format!(
+            "--require-authority: {unverified} of {checked} mandate(s) could not be fully \
+             verified (typically no revocation source configured, so a withdrawn grant would \
+             not be detected). Nothing was caught because nothing looked."
+        ));
+    }
+    None
 }
 
 #[cfg(test)]

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -2154,6 +2154,21 @@ struct VerifyArgs {
     /// itself evidence of anything.
     #[arg(long, value_name = "DURATION")]
     max_unwitnessed: Option<String>,
+
+    /// Exit non-zero unless authority was actually checked and passed.
+    ///
+    /// The default exit code answers "are the signatures valid". A caller
+    /// writing `treeship verify "$ART" && deploy` is asking something else --
+    /// "was this agent allowed to do it" -- and the two come apart exactly
+    /// when authority could not be checked: with no revocation source
+    /// configured a mandate degrades to `unverified` while `authority_ok`
+    /// stays true, because nothing was caught by nothing looking.
+    ///
+    /// Under this flag, a failed mandate, an unverifiable one, or **no
+    /// mandate at all** are each non-zero. The last one matters: requiring
+    /// authority and finding none is not a pass.
+    #[arg(long, default_value_t = false)]
+    require_authority: bool,
 }
 
 #[derive(Args)]
@@ -3377,6 +3392,7 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     a.max_depth,
                     a.full,
                     a.max_unwitnessed.as_deref(),
+                    a.require_authority,
                     cli.config.as_deref(),
                     printer,
                 )

--- a/packages/core/src/verify/authority_use.rs
+++ b/packages/core/src/verify/authority_use.rs
@@ -1,0 +1,222 @@
+//! Granted versus exercised: what a chain was authorized to do, next to what
+//! it actually did.
+//!
+//! # Why this exists
+//!
+//! Verification checks that every action fell *inside* its mandate's scope --
+//! `exercised ⊆ granted`. That is the safety property, and it is the only
+//! thing reported. The remainder, `granted \ exercised`, is computed by
+//! nobody and shown to nobody.
+//!
+//! That remainder is the difference between two rooms a reader currently
+//! cannot tell apart. An agent that could deploy to staging and deployed to
+//! staging, and an agent that could deploy to staging *and production* and
+//! deployed to staging, produce receipts that are identical in every
+//! reported field. The second was one defect away from a different run, and
+//! nothing in the log says so, because nothing happened.
+//!
+//! Latent authority is the thing that shows up in an incident review as "wait,
+//! it could do *what*?". It is free to report -- both sides are already in the
+//! signed bytes -- and it is reported nowhere.
+//!
+//! # What this is not
+//!
+//! Dormant capability is **not a finding**. A grant scoped to a family
+//! (`deploy.*`) will nearly always show dormant members, and narrowing every
+//! grant to exactly what was used is only possible in hindsight. This is a
+//! number for a reader to weigh, not a rule to fail.
+//!
+//! `out_of_scope` is different: an action outside every mandate that covered
+//! it is a real violation, and the mandate verdict already fails for it. It
+//! appears here so the two views cannot disagree silently.
+
+use serde::{Deserialize, Serialize};
+
+use crate::statements::action_in_scope;
+
+/// What a chain was permitted to do, set against what it did.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityUse {
+    /// Every distinct scope entry across the chain's mandates, sorted.
+    pub granted: Vec<String>,
+    /// Every distinct action actually performed, sorted.
+    pub exercised: Vec<String>,
+    /// Granted entries no action matched. Latent capability, not a defect.
+    pub dormant: Vec<String>,
+    /// Actions matching no granted entry. A violation; the mandate verdict
+    /// fails independently, and this makes the two views reconcilable.
+    pub out_of_scope: Vec<String>,
+}
+
+impl AuthorityUse {
+    /// Compute from the chain's mandate scopes and the actions performed.
+    ///
+    /// Matching uses [`action_in_scope`], the same predicate the verifier
+    /// judges with, so this cannot report an action as dormant-adjacent that
+    /// the verifier considered in scope, or vice versa. A separate
+    /// reimplementation here would eventually disagree, and the disagreement
+    /// would be invisible.
+    pub fn compute(scopes: &[String], actions: &[String]) -> Self {
+        let granted = sorted_unique(scopes);
+        let exercised = sorted_unique(actions);
+
+        let dormant = granted
+            .iter()
+            .filter(|entry| {
+                // A scope entry is dormant when no action it covers ran. For a
+                // glob this means the whole family went unused, which is the
+                // honest reading: `deploy.*` with only `deploy.staging` used
+                // is exercised, not dormant, because narrowing it would need
+                // hindsight about which members were reachable.
+                !exercised
+                    .iter()
+                    .any(|a| action_in_scope(a, std::slice::from_ref(*entry)))
+            })
+            .cloned()
+            .collect();
+
+        let out_of_scope = exercised
+            .iter()
+            .filter(|a| !action_in_scope(a, &granted))
+            .cloned()
+            .collect();
+
+        Self {
+            granted,
+            exercised,
+            dormant,
+            out_of_scope,
+        }
+    }
+
+    /// True when the chain used everything it was given. Rare, and not a goal
+    /// -- reported so a reader can see the unusual case rather than infer it.
+    pub fn fully_exercised(&self) -> bool {
+        !self.granted.is_empty() && self.dormant.is_empty()
+    }
+
+    /// One line for humans. Phrased so dormant capability reads as a fact to
+    /// weigh, not an accusation, while `out_of_scope` reads as the violation
+    /// it is.
+    pub fn summary(&self) -> String {
+        if self.granted.is_empty() {
+            return "no mandate scope on this chain".to_string();
+        }
+        let mut s = format!(
+            "{} of {} granted capabilit{} exercised",
+            self.granted.len() - self.dormant.len(),
+            self.granted.len(),
+            if self.granted.len() == 1 { "y" } else { "ies" }
+        );
+        if !self.dormant.is_empty() {
+            s.push_str(&format!("; dormant: {}", self.dormant.join(", ")));
+        }
+        if !self.out_of_scope.is_empty() {
+            s.push_str(&format!("; OUT OF SCOPE: {}", self.out_of_scope.join(", ")));
+        }
+        s
+    }
+}
+
+fn sorted_unique(v: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = v.to_vec();
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| x.to_string()).collect()
+    }
+
+    /// The case the whole module exists for: two chains whose every other
+    /// reported field is identical, distinguished only by what went unused.
+    #[test]
+    fn narrow_and_broad_grants_are_distinguishable() {
+        let narrow = AuthorityUse::compute(&s(&["deploy.staging"]), &s(&["deploy.staging"]));
+        let broad = AuthorityUse::compute(
+            &s(&["deploy.staging", "deploy.production"]),
+            &s(&["deploy.staging"]),
+        );
+
+        assert!(narrow.dormant.is_empty());
+        assert_eq!(broad.dormant, s(&["deploy.production"]));
+        assert_eq!(narrow.exercised, broad.exercised);
+        assert_ne!(
+            narrow, broad,
+            "identical actions under different grants must not compare equal"
+        );
+        assert!(broad.summary().contains("deploy.production"));
+    }
+
+    /// A glob whose family was used is exercised, not dormant. Calling it
+    /// dormant would demand hindsight about which members were reachable.
+    #[test]
+    fn a_used_glob_family_is_not_dormant() {
+        let u = AuthorityUse::compute(&s(&["payments.*"]), &s(&["payments.refund"]));
+        assert!(u.dormant.is_empty(), "{:?}", u.dormant);
+        assert!(u.out_of_scope.is_empty());
+    }
+
+    #[test]
+    fn an_entirely_unused_glob_family_is_dormant() {
+        let u = AuthorityUse::compute(&s(&["payments.*", "read.repo"]), &s(&["read.repo"]));
+        assert_eq!(u.dormant, s(&["payments.*"]));
+    }
+
+    /// Must agree with the verifier. Reporting an action as in-scope that the
+    /// mandate verdict failed -- or the reverse -- would leave two views of
+    /// the same chain disagreeing with nobody noticing.
+    #[test]
+    fn out_of_scope_matches_the_verifier_predicate() {
+        let u = AuthorityUse::compute(&s(&["read.*"]), &s(&["read.repo", "deploy.production"]));
+        assert_eq!(u.out_of_scope, s(&["deploy.production"]));
+        // And confirm directly against the shared predicate.
+        assert!(!action_in_scope("deploy.production", &s(&["read.*"])));
+        assert!(action_in_scope("read.repo", &s(&["read.*"])));
+    }
+
+    /// A bare `*` is deliberately not a wildcard in `action_in_scope`. If this
+    /// module treated it as one, it would report a chain as fully exercised
+    /// while the verifier rejected every action in it.
+    #[test]
+    fn bare_star_is_not_treated_as_a_wildcard() {
+        let u = AuthorityUse::compute(&s(&["*"]), &s(&["deploy.production"]));
+        assert_eq!(u.out_of_scope, s(&["deploy.production"]));
+        assert_eq!(u.dormant, s(&["*"]));
+    }
+
+    #[test]
+    fn duplicates_across_hops_collapse() {
+        let u = AuthorityUse::compute(
+            &s(&["read.repo", "read.repo", "edit.src"]),
+            &s(&["read.repo", "read.repo"]),
+        );
+        assert_eq!(u.granted, s(&["edit.src", "read.repo"]));
+        assert_eq!(u.exercised, s(&["read.repo"]));
+        assert_eq!(u.dormant, s(&["edit.src"]));
+    }
+
+    /// An empty scope authorizes nothing, so every action is out of scope --
+    /// and `fully_exercised` must not read true just because nothing is
+    /// dormant when nothing was granted.
+    #[test]
+    fn empty_scope_authorizes_nothing() {
+        let u = AuthorityUse::compute(&[], &s(&["read.repo"]));
+        assert!(u.granted.is_empty());
+        assert_eq!(u.out_of_scope, s(&["read.repo"]));
+        assert!(!u.fully_exercised());
+        assert!(u.summary().contains("no mandate scope"));
+    }
+
+    #[test]
+    fn a_chain_that_used_everything_says_so() {
+        let u = AuthorityUse::compute(&s(&["a.one", "b.two"]), &s(&["a.one", "b.two"]));
+        assert!(u.fully_exercised());
+        assert!(!u.summary().contains("dormant"));
+    }
+}

--- a/packages/core/src/verify/mod.rs
+++ b/packages/core/src/verify/mod.rs
@@ -17,6 +17,7 @@
 /// `resolve --hub` and `verify-presentation`). Lives in core so the CLI, the
 /// WASM verifier, and the SDKs run the same code path.
 pub mod anchoring;
+pub mod authority_use;
 pub mod resolution;
 
 /// Presentation verification primitives (the challenge-response canonical and


### PR DESCRIPTION
Tier-1 items 1 and 2 of the audit follow-through. Two changes, one gap.

## `--require-authority` (audit P0-3)

The default exit code answers *"are the signatures valid."* A caller writing `treeship verify "$ART" && deploy` is asking *"was this agent allowed to do it"* — and the two come apart exactly where it matters: with no revocation source configured a mandate degrades to `Unverified` while `authority_ok` stays **true**, because nothing was caught by nothing looking.

Here's today's behaviour on a v1 receipt, which is the whole problem in one line:

```
authority_ok: true   authority_checked: 0
```

Under the flag, three things exit non-zero — a failed mandate, an unverifiable one, and **no mandate at all**:

```
✗ AUTHORITY NOT ESTABLISHED
  reason: --require-authority: this receipt carries no action/v2 mandate,
          so there is no authority to verify. Absence of a claim is not a
          passing check.
```

The third is the one worth arguing about, and it's deliberate. An action/v1 receipt makes no authority claim, so a gate that accepted it would be satisfied by the absence of the thing it demanded.

Applied in **both** the JSON and human paths — a flag that worked in only one output mode is a trap for whichever caller picked the other.

## Granted versus exercised

Verification checks `exercised ⊆ granted` and reports nothing about the remainder. So these two chains are identical in every reported field:

| granted | exercised |
|---|---|
| `deploy.staging` | `deploy.staging` |
| `deploy.staging`, `deploy.production` | `deploy.staging` |

The second was one defect away from a different run. Nothing said so, because nothing happened.

```
capability: 1 of 2 granted capabilities exercised; dormant: deploy.production
```

**Dormant capability is reported, never gated.** A grant scoped to a family will nearly always show dormant members, and narrowing every grant to exactly what was used is only possible in hindsight — a number for a reader to weigh, not a rule to fail. `out_of_scope` is different and is a real violation; the mandate verdict already fails for it, and it appears here so the two views can't disagree silently.

Matching reuses `action_in_scope` — the predicate the verifier judges with — rather than reimplementing it. A second implementation would eventually disagree and the disagreement would be invisible. There's a test asserting a bare `*` isn't treated as a wildcard, because treating it as one would report a chain as fully exercised while the verifier rejected every action in it.

This closes the point raised on the public build log. It generalises further than it was put: the gap isn't specific to binaries, it's every capability the authority model grants.

16 new tests · clippy `-D warnings` clean across all four crates · all docs gates pass.
