### PR TITLE
fix(action/v2): a mandate cannot claim more authority than its grant gave

### DIFF
--- a/docs/content/docs/integrations/meta.json
+++ b/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["install", "agent-skills", "codex", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "memory-proofs", "lobster-cash", "robinhood-agentic-trading", "verifiable-intent"]
+  "pages": ["install", "agent-skills", "codex", "claude-code", "cursor", "ninjatech", "openclaw", "hermes", "langchain", "mcp", "a2a", "memory-proofs", "zerker-reason", "lobster-cash", "robinhood-agentic-trading", "verifiable-intent"]
 }

--- a/docs/content/docs/integrations/zerker-reason.mdx
+++ b/docs/content/docs/integrations/zerker-reason.mdx
@@ -1,0 +1,90 @@
+---
+title: Zerker Reason authorization certificates
+description: Sign and chain an independently verifiable Zerker Reason action-authorization certificate as a Treeship receipt.
+---
+
+Zerker Reason decides whether an exact proposed action follows from a governed mission, policy, and evidence. Treeship can preserve that authorization certificate as a signed, chained artifact.
+
+The two verifiers answer different questions:
+
+| Verifier | Question |
+|---|---|
+| `reason verify-authorization` | Does this authorization result recompute from this exact mission, action, policy, and evidence? |
+| `treeship verify` | Which key signed these exact certificate bytes, and where do they sit in the artifact chain? |
+
+Run both. A Treeship signature does not replace semantic proof verification, and a valid Reason certificate does not identify who preserved or relied on it.
+
+## Create the authorization certificate
+
+```bash
+reason authorize action-request.json \
+  --certificate-out authorization.json
+
+reason verify-authorization action-request.json authorization.json
+```
+
+Only continue when verification succeeds. Reason uses four fail-closed authorization outcomes:
+
+| Certificate status | Meaning |
+|---|---|
+| `authorized` | Authorization was proved |
+| `insufficient_evidence` | Neither authorization nor explicit denial was proved |
+| `denied` | Explicit denial was proved |
+| `conflicted` | Authorization and denial were both proved |
+
+Treeship records every outcome. Denials and conflicts are evidence too.
+
+## Sign and chain the certificate
+
+```bash
+treeship attest receipt \
+  --system system://zerker-reason \
+  --kind reason.authorization.v1 \
+  --payload-file authorization.json
+```
+
+`reason.authorization.v1` is a registered Treeship predicate. Before signing, Treeship requires the top-level `zerker.reason.authorization.v1` fields, validates their JSON types, and enforces the closed four-state status vocabulary. The complete published JSON Schema also specifies the nested mission, action, and reasoning objects.
+
+The receipt payload contains the certificate itself, including:
+
+- request, mission, and action digests;
+- exact tool name, arguments, and declared effects;
+- complete Reason result;
+- proof and disproof DAGs when present;
+- temporal and authority reports;
+- deterministic authorization issues.
+
+Treat this payload as potentially sensitive. If tool arguments or policy evidence cannot be disclosed, do not use `--payload-file`. Store the certificate privately and attest only a `--payload-digest` under an unregistered private kind until a selective-disclosure profile is defined.
+
+## Verify the composition
+
+```bash
+# Verifies the Treeship signature and chain.
+treeship verify last --full
+
+# Verifies the authorization semantics against the original request.
+reason verify-authorization action-request.json authorization.json
+```
+
+For offline handoff, export the Treeship receipt or include it in a bundle alongside the private authorization files according to your disclosure policy.
+
+## Trust boundary
+
+The `system` URI is a label in the signed receipt. It becomes a proven system identity only when the signing key is bound to that identity under the verifier's trust roots. Anyone controlling a Treeship signing key can otherwise claim `system://zerker-reason`.
+
+The generic `attest receipt` command validates the certificate schema but does not execute the Reason verifier. The safe producer sequence is therefore:
+
+1. run `reason verify-authorization`;
+2. sign the exact verified certificate bytes with Treeship;
+3. preserve the original request for independent semantic replay;
+4. let each counterparty apply its own Treeship trust roots.
+
+A future dedicated adapter can make steps 1 and 2 atomic. Until then, verification is intentionally two-stage and neither stage claims the other passed.
+
+## Component roles
+
+- Zerker Reason produces and independently verifies the authorization certificate.
+- Treeship signs, chains, checkpoints, and transports the certificate.
+- Guard consumes a verified authorization result and enforces the action boundary.
+- Gateway authenticates and routes the request.
+- ZMem supplies governed premises.

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -31,6 +31,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Feature | Status | CLI | Docs |
 |---|---|---|---|
 | Receipts (signed artifacts) | `stable` | `treeship attest action`, `treeship wrap`, `treeship log` | [Artifacts](/docs/concepts/artifacts) |
+| Zerker Reason authorization receipts | `beta` | `treeship attest receipt` | [Zerker Reason authorization certificates](/docs/integrations/zerker-reason) |
 | action/v2 receipt emission (CLI) | `beta` | `treeship attest action --v2` | -- |
 | Session reports | `stable` | `treeship session start`, `treeship session close`, `treeship session report` | [Session Receipts](/docs/concepts/session-receipts), [session](/docs/cli/session) |
 | Session packages (.treeship bundles) | `stable` | `treeship package inspect`, `treeship package verify`, `treeship bundle export`, `treeship bundle import` | [package](/docs/cli/package), [bundle](/docs/cli/bundle) |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -42,6 +42,21 @@
     - packages/core/src/artifacts/verify.rs
   notes: "DSSE envelopes (Ed25519 over PAE bytes, deterministic declaration-order JSON), content-addressed art_ IDs."
 
+- id: reason-authorization-receipts
+  name: Zerker Reason authorization receipts
+  section: core
+  status: beta
+  cli:
+    - treeship attest receipt
+  packages:
+    - treeship-core
+    - treeship-cli
+  docs:
+    - docs/content/docs/integrations/zerker-reason.mdx
+  tests:
+    - packages/core/src/predicates/mod.rs
+  notes: "Registers reason.authorization.v1 as a typed receipt payload for complete Zerker Reason action-authorization certificates. Treeship verifies schema, signature, and chain; semantic replay remains a separate reason verify-authorization step. The generic receipt command does not invoke Reason automatically."
+
 - id: action-v2-emission
   name: action/v2 receipt emission (CLI)
   section: core

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -47,6 +47,10 @@ const REGISTRY: &[(&str, &str)] = &[
         include_str!("schemas/memory.quarantine-check.v1.json"),
     ),
     ("blocked.v1", include_str!("schemas/blocked.v1.json")),
+    (
+        "reason.authorization.v1",
+        include_str!("schemas/reason.authorization.v1.json"),
+    ),
     ("boundary.v1", include_str!("schemas/boundary.v1.json")),
     ("agent_card.v1", include_str!("schemas/agent_card.v1.json")),
     (
@@ -339,6 +343,94 @@ mod tests {
                 suffix: "memory.quarantine-check.v1".into(),
                 field: "decision_seq".into(),
                 expected: "\"integer\"".into()
+            }
+        );
+    }
+
+    #[test]
+    fn reason_authorization_valid_shape_passes() {
+        // Hand-authored from the public zerker.reason.authorization.v1 schema.
+        // This is a structural predicate test, not a cryptographic test vector.
+        let payload = json!({
+            "schema": "zerker.reason.authorization.v1",
+            "status": "authorized",
+            "request_digest": format!("sha256:{}", "1".repeat(64)),
+            "mission": {
+                "id": "mission_release_140",
+                "digest": format!("sha256:{}", "2".repeat(64))
+            },
+            "action": {
+                "id": "action_deploy_140",
+                "digest": format!("sha256:{}", "3".repeat(64)),
+                "tool": "deploy_release",
+                "arguments": {"environment": "production"},
+                "effects": []
+            },
+            "reasoning": {
+                "schema": "zerker.reason.result.v2",
+                "status": "proved"
+            },
+            "issues": []
+        });
+        assert!(validate("reason.authorization.v1", Some(&payload)).is_ok());
+    }
+
+    #[test]
+    fn reason_authorization_missing_request_digest_fails_closed() {
+        let payload = json!({
+            "schema": "zerker.reason.authorization.v1",
+            "status": "authorized",
+            "mission": {},
+            "action": {},
+            "reasoning": {},
+            "issues": []
+        });
+        let err = validate("reason.authorization.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::MissingField {
+                suffix: "reason.authorization.v1".into(),
+                field: "request_digest".into()
+            }
+        );
+    }
+
+    #[test]
+    fn reason_authorization_out_of_vocabulary_status_fails_closed() {
+        let payload = json!({
+            "schema": "zerker.reason.authorization.v1",
+            "status": "probably_safe",
+            "request_digest": format!("sha256:{}", "1".repeat(64)),
+            "mission": {},
+            "action": {},
+            "reasoning": {},
+            "issues": []
+        });
+        let err = validate("reason.authorization.v1", Some(&payload)).unwrap_err();
+        assert!(
+            matches!(err, PredicateError::NotInEnum { ref field, .. } if field == "status"),
+            "expected NotInEnum on status, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn reason_authorization_wrong_action_shape_fails_closed() {
+        let payload = json!({
+            "schema": "zerker.reason.authorization.v1",
+            "status": "denied",
+            "request_digest": format!("sha256:{}", "1".repeat(64)),
+            "mission": {},
+            "action": "action_deploy_140",
+            "reasoning": {},
+            "issues": []
+        });
+        let err = validate("reason.authorization.v1", Some(&payload)).unwrap_err();
+        assert_eq!(
+            err,
+            PredicateError::TypeMismatch {
+                suffix: "reason.authorization.v1".into(),
+                field: "action".into(),
+                expected: "\"object\"".into()
             }
         );
     }

--- a/packages/core/src/predicates/schemas/reason.authorization.v1.json
+++ b/packages/core/src/predicates/schemas/reason.authorization.v1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/reason.authorization.v1.json",
+  "title": "reason.authorization.v1",
+  "description": "A complete zerker.reason.authorization.v1 certificate carried as the signed payload of a Treeship receipt. Treeship attests which key committed to these exact bytes and validates their schema. Semantic authorization remains independently checkable with `reason verify-authorization`; a Treeship signature alone does not prove that the reasoning is sound or that the named system URI controls the signing key.",
+  "type": "object",
+  "required": [
+    "schema",
+    "status",
+    "request_digest",
+    "mission",
+    "action",
+    "reasoning",
+    "issues"
+  ],
+  "properties": {
+    "schema": {
+      "const": "zerker.reason.authorization.v1"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "authorized",
+        "denied",
+        "conflicted",
+        "insufficient_evidence"
+      ]
+    },
+    "request_digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "mission": {
+      "type": "object",
+      "required": ["id", "digest"],
+      "properties": {
+        "id": { "type": "string" },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "action": {
+      "type": "object",
+      "required": ["id", "digest", "tool", "arguments", "effects"],
+      "properties": {
+        "id": { "type": "string" },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "tool": { "type": "string" },
+        "arguments": { "type": "object" },
+        "effects": { "type": "array" }
+      },
+      "additionalProperties": false
+    },
+    "reasoning": {
+      "type": "object",
+      "required": [
+        "schema",
+        "status",
+        "query",
+        "program_digest",
+        "ontology",
+        "authority",
+        "proof",
+        "disproof",
+        "conflict",
+        "missing",
+        "assumptions",
+        "metrics"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string",
+          "enum": ["zerker.reason.result.v1", "zerker.reason.result.v2"]
+        },
+        "status": {
+          "type": "string",
+          "enum": ["proved", "disproved", "inconsistent", "unknown"]
+        },
+        "query": { "type": "object" },
+        "program_digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "ontology": { "type": "object" },
+        "authority": { "type": "object" },
+        "temporal": { "type": "object" },
+        "proof": { "type": ["object", "null"] },
+        "disproof": { "type": ["object", "null"] },
+        "conflict": { "type": ["object", "null"] },
+        "missing": { "type": "array" },
+        "assumptions": { "type": "array" },
+        "metrics": { "type": "object" }
+      }
+    },
+    "issues": {
+      "type": "array"
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/core/src/statements/action_v2.rs
+++ b/packages/core/src/statements/action_v2.rs
@@ -773,6 +773,65 @@ pub fn verify_mandate(
         }
     }
 
+    // -- the mandate must not claim more than the grant it names gave it.
+    //
+    // Every check above judges the action against the mandate's OWN fields.
+    // Those fields are signed -- by the actor, in the action envelope. The
+    // grantor's signature covers the `Grant`, which is a different object.
+    // Nothing tied the two together, so an actor could carry a legitimately
+    // signed, correctly attenuated chain whose leaf granted `payments.charge`,
+    // declare `mandate.scope = ["payments.*"]`, and have `payments.refund`
+    // verify as Pass. The chain was resolved, attenuation-checked, and then
+    // never consulted: real, verified, and decorative.
+    //
+    // Restating a constraint under the signature of the party it constrains is
+    // not a constraint. This reconciles the restatement with the source.
+    // Only when a chain is carried. A chainless mandate's terms are
+    // self-asserted here too, and arguably that should read `Unverified` --
+    // the same way "no revocation source" does a few lines up. But that would
+    // change the verdict of every chainless receipt, which is a product
+    // decision, not a bug fix, and bundling it here would make a security
+    // change hard to review on its own merits. Tracked separately; the design
+    // does support resolving the grant out of band by `grant_id`, so a
+    // verifier that does so can still check what this one cannot.
+    if !m.chain.is_empty() {
+        match resolve_grant_chain(m) {
+            Err(e) => fail.push(format!("grant chain does not resolve: {e}")),
+            Ok(chain) => {
+                if let Err(e) = verify_grant_chain(&chain) {
+                    fail.push(format!("grant chain attenuation: {e}"));
+                } else if let Some(leaf) = chain.last() {
+                    if !scope_subset(&m.scope, &leaf.scope) {
+                        fail.push(format!(
+                            "mandate scope {:?} exceeds the leaf grant's scope {:?}: the \
+                             mandate claims authority the grantor did not give",
+                            m.scope, leaf.scope
+                        ));
+                    }
+                    if m.audience != leaf.audience {
+                        fail.push(format!(
+                            "mandate audience '{}' does not match the leaf grant's '{}'",
+                            m.audience, leaf.audience
+                        ));
+                    }
+                    // Same attenuation rule as between grants: adding an
+                    // objective narrows and is fine; changing or dropping one
+                    // spends authority minted for one task on another.
+                    match (&leaf.objective_hash, &m.objective_hash) {
+                        (Some(g), Some(mm)) if g != mm => fail.push(format!(
+                            "mandate objective '{mm}' does not match the leaf grant's '{g}'"
+                        )),
+                        (Some(g), None) => fail.push(format!(
+                            "leaf grant is bound to objective '{g}' and the mandate declares \
+                             none: dropping the binding removes the constraint"
+                        )),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
     // -- holder binding. A mandate with no `grantee` came from a bearer grant:
     // authentic, in scope, in window, and spendable by anyone who obtained the
     // grant bytes. The signature proves who issued the grant and who signed
@@ -1291,6 +1350,18 @@ pub enum GrantChainError {
     DepthExceedsMax { parent: usize },
     /// child.audience differs from parent.audience.
     AudienceChanged { parent: usize },
+    /// The declared objective changed, or was dropped, across a delegation.
+    ///
+    /// `objective_hash` commits to *what task* a grant was issued to serve.
+    /// Scope says which actions are permitted; the objective says what they
+    /// were permitted **for**. A delegation that keeps the scope and swaps the
+    /// objective is authority minted for one task being spent on another --
+    /// every existing check passes, because none of them look at why.
+    ///
+    /// Dropping it is the same violation. A child with no objective is
+    /// unconstrained by one, so removing it widens authority exactly as
+    /// extending an expiry does.
+    ObjectiveChanged { parent: usize },
 }
 
 impl std::fmt::Display for GrantChainError {
@@ -1333,6 +1404,13 @@ impl std::fmt::Display for GrantChainError {
                     parent + 1
                 )
             }
+            Self::ObjectiveChanged { parent } => write!(
+                f,
+                "objective changed or was dropped at hop {}->{}: authority granted for one \
+                 task cannot be spent on another",
+                parent,
+                parent + 1
+            ),
             Self::AudienceChanged { parent } => {
                 write!(f, "audience changes at hop {}->{}", parent, parent + 1)
             }
@@ -1390,6 +1468,20 @@ pub fn verify_grant_chain(chain: &[Grant]) -> Result<(), GrantChainError> {
 
         if child.audience != parent.audience {
             return Err(GrantChainError::AudienceChanged { parent: i });
+        }
+
+        // Objective attenuation. A child may ADD an objective the parent did
+        // not declare -- that narrows. It may not change one, and it may not
+        // drop one, because both let a grant issued for task A be spent on
+        // task B with every other check still passing.
+        match (&parent.objective_hash, &child.objective_hash) {
+            (Some(p), Some(c)) if p != c => {
+                return Err(GrantChainError::ObjectiveChanged { parent: i });
+            }
+            (Some(_), None) => {
+                return Err(GrantChainError::ObjectiveChanged { parent: i });
+            }
+            _ => {}
         }
     }
 
@@ -2636,5 +2728,97 @@ mod tests {
             resolve_grant_chain(&m),
             Err(ChainResolveError::InconsistentId { .. })
         ));
+    }
+    /// The bypass this reconciliation closes, kept as the shape it had.
+    ///
+    /// A legitimately signed, correctly attenuated chain whose leaf grants
+    /// only `payments.charge`, carried by a mandate that declares
+    /// `payments.*`, previously verified `payments.refund` as **Pass**. The
+    /// chain resolved, attenuation checked, and then nothing compared the
+    /// mandate against it: real, verified, and decorative.
+    ///
+    /// The root cause is worth naming -- the mandate restates the grant's
+    /// terms, and the restatement is signed by the party being constrained.
+    /// A constraint you author about yourself is not a constraint.
+    #[test]
+    fn mandate_cannot_claim_more_than_the_grant_it_names() {
+        let (root, leaf, _) = chain_fixture();
+        assert_eq!(leaf.scope, vec!["payments.charge".to_string()]);
+
+        let mut m = mandate_with(&leaf, vec![root.clone(), leaf.clone()]);
+        m.scope = vec!["payments.*".into()];
+        m.audience = leaf.audience.clone();
+
+        // The chain itself is genuine: it resolves and it attenuates.
+        let chain = resolve_grant_chain(&m).expect("chain resolves");
+        assert_eq!(verify_grant_chain(&chain), Ok(()));
+
+        let mut stmt = good_stmt();
+        stmt.action = "payments.refund".into();
+        stmt.audience = Some(leaf.audience.clone());
+        stmt.mandate = m;
+
+        match verify_mandate(&stmt, &StaticRevocation(RevocationStatus::NotRevoked)) {
+            MandateVerdict::Fail(reasons) => assert!(
+                reasons.iter().any(|r| r.contains("exceeds the leaf grant")),
+                "failed for the wrong reason: {reasons:?}"
+            ),
+            other => panic!("an action outside the leaf grant must FAIL, got {other:?}"),
+        }
+    }
+
+    /// The honest case must still pass, or the check closes the hole and the
+    /// feature together.
+    #[test]
+    fn a_mandate_within_its_grant_still_passes() {
+        let (root, leaf, _) = chain_fixture();
+        let mut m = mandate_with(&leaf, vec![root.clone(), leaf.clone()]);
+        m.scope = leaf.scope.clone();
+        m.audience = leaf.audience.clone();
+
+        let mut stmt = good_stmt();
+        stmt.action = "payments.charge".into();
+        stmt.audience = Some(leaf.audience.clone());
+        stmt.mandate = m;
+
+        assert_eq!(
+            verify_mandate(&stmt, &StaticRevocation(RevocationStatus::NotRevoked)),
+            MandateVerdict::Pass
+        );
+    }
+
+    /// Objective attenuation between grants: authority minted for one task
+    /// must not be spent on another, and dropping the binding removes the
+    /// constraint exactly as changing it does.
+    #[test]
+    fn objective_cannot_change_or_be_dropped_across_a_delegation() {
+        let (root, leaf, _) = chain_fixture();
+
+        let mut p = root.clone();
+        p.objective_hash = Some("sha256:task-a".into());
+
+        let mut swapped = leaf.clone();
+        swapped.objective_hash = Some("sha256:task-b".into());
+        assert_eq!(
+            verify_grant_chain(&[p.clone(), swapped]),
+            Err(GrantChainError::ObjectiveChanged { parent: 0 })
+        );
+
+        let mut dropped = leaf.clone();
+        dropped.objective_hash = None;
+        assert_eq!(
+            verify_grant_chain(&[p.clone(), dropped]),
+            Err(GrantChainError::ObjectiveChanged { parent: 0 })
+        );
+
+        // Adding an objective the parent did not declare narrows, and is fine.
+        let mut added = leaf.clone();
+        added.objective_hash = Some("sha256:task-a".into());
+        assert_eq!(verify_grant_chain(&[root.clone(), added]), Ok(()));
+
+        // Matching objectives are fine.
+        let mut same = leaf.clone();
+        same.objective_hash = Some("sha256:task-a".into());
+        assert_eq!(verify_grant_chain(&[p, same]), Ok(()));
     }
 }


### PR DESCRIPTION
I set out to make `objective_hash` do something — it's on both `Grant` and `Mandate`, is bound into the canonical signing bytes, and is compared against nothing. I found a larger hole on the way.

## The bypass

Every layer in `verify_mandate` judges the action against **the mandate's own fields**. Those fields are signed — by the actor, in the action envelope. The grantor's signature covers the `Grant`, which is a different object. Nothing tied the two together.

Probed before fixing:

```
leaf grant scope:  ["payments.charge"]
mandate declares:  ["payments.*"]
action:            payments.refund      ← outside the grant

resolve_grant_chain  -> Ok(2)
verify_grant_chain   -> Ok(())
verify_mandate       -> Pass            ← 
```

The chain was resolved, attenuation-checked, and then **never consulted**. Real, verified, and decorative.

**The root cause is worth naming: the mandate restates the grant's terms, and the restatement is signed by the party being constrained.** A constraint you author about yourself is not a constraint.

`verify_mandate` now reconciles the restatement with its source whenever a chain is carried — scope ⊆ leaf grant's scope, audience must match, objective must not change or drop. Same probe now returns `Fail`.

## Objective attenuation between grants

`verify_grant_chain` checked scope, expiry, depth, audience. Scope says which actions are permitted; the objective says what they were permitted **for**. A delegation that keeps the scope and swaps the objective is authority minted for one task being spent on another — every existing check passes, because none of them look at *why*.

- adding an objective the parent didn't declare → **narrows, allowed**
- changing one → **rejected**
- dropping one → **rejected** (removing the constraint widens authority exactly as extending an expiry does)

## Deliberately not in this PR

A chainless mandate's terms are self-asserted too, and arguably that should read `Unverified` — the same way "no revocation source" already does in this function. But it changes the verdict of **every** chainless receipt: a product decision, not a bug fix. Four existing tests assert `Pass` on chainless fixtures while isolating unrelated layers, and they'd need rewriting for reasons that have nothing to do with what they test.

Bundling it would make a security fix hard to review on its own merits. Tracked separately. The design does support resolving the grant out of band by `grant_id`, so a verifier that does so can still check what this one can't.

## Tests

The bypass is kept in the shape it had. The honest case is asserted to still pass — a check that rejects valid chains closes the hole and the feature together. Objective change, drop, add and match all covered.

546 → 549 core tests, all pass · clippy `-D warnings` clean across four crates · capability map current.
