### PR TITLE
fix(plugins): stop auto-publishing receipts from Claude Code and Kimi

### DIFF
--- a/integrations/claude-code-plugin/scripts/session-end.sh
+++ b/integrations/claude-code-plugin/scripts/session-end.sh
@@ -29,11 +29,26 @@ fi
 HEADLINE="Claude Code session"
 
 if treeship session close --headline "$HEADLINE" >/dev/null 2>&1; then
-  # `treeship session report` prints the report URL on stdout by default.
-  # Capture it; fall back to a local-only message if reporting fails (no hub
-  # configured, offline, etc.).
-  REPORT_OUT=$(treeship session report 2>/dev/null || true)
-  REPORT_URL=$(printf '%s\n' "$REPORT_OUT" | grep -oE 'https?://[^[:space:]]+' | head -1)
+  # Publishing is opt-in.
+  #
+  # This used to run unconditionally, so ending a session uploaded its receipt
+  # to the configured Hub with no operator in the loop. A receipt is immutable
+  # and the upload is not undoable, so anything the capture path got wrong
+  # became public before anyone could look at it. The OpenClaw plugin was
+  # gated behind this same variable when that was found; this path and the
+  # Kimi one were missed, which is why they are being fixed now rather than
+  # then.
+  #
+  # The local receipt is written either way. `treeship session report`
+  # publishes it whenever the operator chooses to.
+  REPORT_URL=""
+  case "${TREESHIP_AUTO_PUBLISH:-}" in
+    1|true)
+      # `treeship session report` prints the report URL on stdout by default.
+      REPORT_OUT=$(treeship session report 2>/dev/null || true)
+      REPORT_URL=$(printf '%s\n' "$REPORT_OUT" | grep -oE 'https?://[^[:space:]]+' | head -1)
+      ;;
+  esac
 
   if [ -n "$REPORT_URL" ]; then
     cat <<EOF

--- a/integrations/kimi-code-plugin/scripts/session-end.sh
+++ b/integrations/kimi-code-plugin/scripts/session-end.sh
@@ -15,8 +15,15 @@ if ! treeship session status --check >/dev/null 2>&1; then exit 0; fi
 
 HEADLINE="Kimi Code session"
 if treeship session close --headline "$HEADLINE" >/dev/null 2>&1; then
-  REPORT_OUT=$(treeship session report 2>/dev/null || true)
-  REPORT_URL=$(printf '%s\n' "$REPORT_OUT" | grep -oE 'https?://[^[:space:]]+' | head -1)
+  # Opt-in, same as the Claude Code and OpenClaw plugins. Uploading a receipt
+  # is not undoable, so it needs a deliberate decision rather than a default.
+  REPORT_URL=""
+  case "${TREESHIP_AUTO_PUBLISH:-}" in
+    1|true)
+      REPORT_OUT=$(treeship session report 2>/dev/null || true)
+      REPORT_URL=$(printf '%s\n' "$REPORT_OUT" | grep -oE 'https?://[^[:space:]]+' | head -1)
+      ;;
+  esac
   if [ -n "$REPORT_URL" ]; then
     cat <<EOF
 {"additionalContext": "Treeship session sealed. Receipt: .treeship/sessions/. Report: $REPORT_URL"}


### PR DESCRIPTION
#284 found the OpenClaw plugin uploading a session receipt at SessionEnd with no operator in the loop, and gated it behind `TREESHIP_AUTO_PUBLISH`. **The Claude Code and Kimi plugins do the same thing and never got the fix.**

That's an incomplete fix, not a new bug — I patched the path the audit named and never checked whether the others shared it. They did.

Both ran `treeship session report` unconditionally on session close. Publishing isn't undoable and a receipt is immutable, so anything the capture path got wrong became public before anyone could look at it. That's the reason the behaviour needs a deliberate decision behind it rather than a default.

## The Claude Code plugin also told users otherwise

Its session-start message reads:

> "The receipt is yours — it stays in `.treeship/sessions/` and only leaves this machine when you run `treeship session report`."

Which was false, because session-end ran it for them. **The sentence is true now.**

Both paths still write the local receipt; only the upload is gated. Swept the remaining hook scripts — `session-start` and both `post-tool-use` scripts mention `session report` in guidance text and don't invoke it.

Found by an inventory pass over the integrations, not by the audit.