### PR TITLE
fix(onboard): print the CA pin, not the leaf pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ treeship onboard deployer --tools 'deploy.*,git.push'
   key-bound:   yes (AgentCert)
   tools:       deploy.*, git.push
 [4/4] trust bundle — hand these to a counterparty:
+
+    # trust this ship to certify its agents (the CA pin):
+    treeship trust add key_3f0c1d94ab77e215 ed25519:7iSghpSYV9Rfu1RCNXqk0m1x8dJ2rWvLbQ4T6yZaEo0 --kind cert_issuer --yes
+
+    # narrower alternative — trust ONLY agent://deployer, not everything this
+    # ship certifies. Needs a fresh pin per agent and breaks on rotation:
     treeship trust add key_97fe3be93ca7e2b7 ed25519:K8V6D33O1k2LsQY5y9i2WTigc2CoYvIwdT_-yGgDbPQ --kind agent_cert --yes
 ```
 

--- a/docs/content/docs/cli/onboard.mdx
+++ b/docs/content/docs/cli/onboard.mdx
@@ -31,8 +31,16 @@ treeship onboard deployer --from-harness ~/.claude/settings.json --publish
       key-bound: yes (AgentCert) · 9 of 9 captured from harness
 [3/4] publish + anchor to Hub
 [4/4] trust bundle — hand these to a counterparty:
-    treeship trust add key_… ed25519:… --kind agent_cert --yes
+
+    # trust this ship to certify its agents (the CA pin):
+    treeship trust add key_… ed25519:… --kind cert_issuer --yes
+
+    # and to anchor them in the transparency log (the staple):
     treeship trust add key_… ed25519:… --kind hub_checkpoint --yes
+
+    # narrower alternative — trust ONLY this agent. Needs a fresh pin per
+    # agent and breaks on rotation:
+    treeship trust add key_… ed25519:… --kind agent_cert --yes
 ✓ agent onboarded
     treeship resolve --hub https://api.treeship.dev agent://deployer
 ```

--- a/docs/content/docs/guides/what-to-expect.mdx
+++ b/docs/content/docs/guides/what-to-expect.mdx
@@ -55,6 +55,11 @@ Expected:
       key-bound: yes (AgentCert) · 9 of 9 captured from harness
 [3/4] publish — skipped (local only; re-run with --publish once a hub is attached)
 [4/4] trust bundle — hand these to a counterparty:
+
+    # trust this ship to certify its agents (the CA pin):
+    treeship trust add key_… ed25519:… --kind cert_issuer --yes
+
+    # narrower alternative — trust ONLY this agent:
     treeship trust add key_… ed25519:… --kind agent_cert --yes
 ✓ agent onboarded
 ```

--- a/packages/cli/src/commands/onboard.rs
+++ b/packages/cli/src/commands/onboard.rs
@@ -124,22 +124,43 @@ pub fn onboard(args: OnboardArgs, printer: &Printer) -> Result<(), Box<dyn std::
     }
 
     // ── 4/4 the trust bundle: what a counterparty runs ─────────────────────
-    // The out-of-band handshake, printed instead of implied. The agent key
-    // pins under agent_cert (verifies the card + receipts); the ship key pins
-    // under hub_checkpoint (verifies the transparency anchor).
+    // The out-of-band handshake, printed instead of implied.
+    //
+    // The CA pin comes first, deliberately. This used to print only the AGENT
+    // key under `agent_cert` -- pinning the leaf. That works, and it is the
+    // weaker model: it is HTTP public-key pinning, not the CA-chain
+    // verification this codebase actually implements. `resolution.rs` requires
+    // an agent certificate to be signed by a key pinned under `CertIssuer`,
+    // and a counterparty who pins the leaf never walks that chain. They then
+    // need a new pin for every agent, and a key rotation breaks them.
+    //
+    // Pinning the ship under `cert_issuer` is the analogue of trusting a CA:
+    // one pin, and every agent this ship certifies verifies through it.
+    let ship_key = ctx.keys.default_key_id()?;
+    let ship_pub = pinnable(&ctx, &ship_key)?;
+    let agent_pub = pinnable(&ctx, &key_id)?;
+
     printer.info("[4/4] trust bundle — hand these to a counterparty:");
     printer.blank();
-    let agent_pub = pinnable(&ctx, &key_id)?;
+    printer.info("    # trust this ship to certify its agents (the CA pin):");
     printer.info(&format!(
-        "    treeship trust add {key_id} {agent_pub} --kind agent_cert --yes"
+        "    treeship trust add {ship_key} {ship_pub} --kind cert_issuer --yes"
     ));
     if args.publish {
-        let ship_key = ctx.keys.default_key_id()?;
-        let ship_pub = pinnable(&ctx, &ship_key)?;
+        printer.blank();
+        printer.info("    # and to anchor them in the transparency log (the staple):");
         printer.info(&format!(
             "    treeship trust add {ship_key} {ship_pub} --kind hub_checkpoint --yes"
         ));
     }
+    printer.blank();
+    printer.info(&format!(
+        "    # narrower alternative — trust ONLY {actor}, not everything this"
+    ));
+    printer.info("    # ship certifies. Needs a fresh pin per agent and breaks on rotation:");
+    printer.info(&format!(
+        "    treeship trust add {key_id} {agent_pub} --kind agent_cert --yes"
+    ));
     printer.blank();
     printer.success(
         "agent onboarded",


### PR DESCRIPTION
`onboard`'s trust bundle told a counterparty to run:

```
treeship trust add <AGENT key> --kind agent_cert
```

That works, and it's the weaker of the two models Treeship implements. **It's HTTP public-key pinning: trust this exact leaf.** The codebase also implements CA-chain verification — `verify/resolution.rs` requires an agent certificate to be signed by a key pinned under `CertIssuer` — and a counterparty who follows the printed line never walks that chain.

The consequences are the ones HPKP always has:

- a fresh pin for **every** agent the ship certifies
- rotating an agent key **breaks every counterparty** until they re-pin

Pinning the ship under `cert_issuer` is one pin, and every agent it certifies verifies through it.

## New output

```
[4/4] trust bundle — hand these to a counterparty:

    # trust this ship to certify its agents (the CA pin):
    treeship trust add key_6b69… ed25519:rn4G… --kind cert_issuer --yes

    # narrower alternative — trust ONLY agent://e2e-deployer, not everything this
    # ship certifies. Needs a fresh pin per agent and breaks on rotation:
    treeship trust add key_e11c… ed25519:kuAR… --kind agent_cert --yes
```

The leaf pin stays, below, as the deliberately narrower choice — trusting one agent rather than everything a ship certifies is legitimate, it just shouldn't be the default people copy without deciding.

Three docs mirrored the old output (README, `cli/onboard`, `what-to-expect`) and now match.

## Attribution and what I did not verify

Found by an external TLS-handshake test, which confirmed a verifier pinning only `--kind cert_issuer` gets `verified (chain to pinned ship root)`.

I changed the copy and the docs. **I did not reproduce their full two-ship proven-path harness** — my scratch run signed with the ship key rather than the agent key, so it couldn't reach `proven` either way. The change is to what `onboard` tells people to pin, and that's checkable by reading `resolution.rs`.