### PR TITLE
docs: refresh the audit tracker (37 closed, 3 declined, 13 open)

### DIFF
--- a/docs/quality/audit-2026-08.md
+++ b/docs/quality/audit-2026-08.md
@@ -9,7 +9,7 @@ nobody can look up is a finding that gets rediscovered, re-analyzed, and
 re-argued six weeks later — which is how Treeship ended up with four
 documented claims that had quietly gone false (see #281).
 
-**Status as of 2026-08-13:** 30 closed, 3 declined, 17 open.
+**Status as of 2026-08-14:** 37 closed, 3 declined, 13 open.
 
 Both confirmed P0s from the second audit round are fixed (#284, #285).
 
@@ -89,7 +89,7 @@ answer than fixing them, and 3–7 remain the top of the queue.
 | 16 | Broken public "Verify a receipt" URL | **Closed** | `public/home.html`, commit 86e71ff |
 | 17 | Workspace share tokens truly single-use | **Partly closed** | device flow is single-use (`db.go:275`); share tokens "single-use in practice" |
 | 18 | Workspace credentials in query strings | **Open** | |
-| 19 | Per-IP rate limiting on Hub | **Open** | no limiter in `internal/` |
+| 19 | Per-IP rate limiting on Hub | **Closed** | #288 -- httprate, 60/min on the public reads |
 | 20 | Bound public resolver scans | **Open** | |
 | 21 | Indexed actor / kind / card-reference columns | **Open** | |
 | 22 | Reject malformed timestamps | **Closed** | #280 — `parseSignedAt` now returns `(int64, bool)`, rejects with 400 |
@@ -159,7 +159,7 @@ Items 29, 30, 36, 39 and 40 remain open.
 | 46 | Linux ARM64 release binaries | **Open** | not in the release matrix |
 | 47 | Upstream the pi/Prime integration into the monorepo | **Declined for now** | see below |
 | 48 | Remove stale tracked Python artifacts | **Closed** | none tracked |
-| 49 | Hub graceful shutdown and readiness | **Open** | no signal handling or readiness endpoint |
+| 49 | Hub graceful shutdown and readiness | **Closed** | #288 -- 20s drain, `/healthz` + `/readyz` |
 | 50 | Reconcile live-site branding with `DESIGN.md` | **Open** | needs a design decision |
 
 ### On #47 — declined, with a reason
@@ -184,7 +184,9 @@ Both confirmed ones are fixed.
 |---|---|---|
 | P0-1: secrets recorded and auto-published | **Closed** | #284 |
 | P0-2: Hub does not enforce its content-addressed namespace | **Closed** | #285 |
-| P0-3: verify can exit 0 with authority unverified | **Open** | conditional on Treeship being used to gate |
+| P0-3: verify can exit 0 with authority unverified | **Closed** | #297 -- `--require-authority` |
+| P1-2: malicious Hub can write outside the artifact store | **Closed** | #289 -- proved, then fixed |
+| P1-7: URL verification helpers permit unrestricted fetches | **Closed** | #294 -- SSRF guard + shared vectors |
 
 ### P0-1 — worse than reported, in two ways
 
@@ -212,6 +214,45 @@ The detailed JSON is honest; the exit code is not, for an enforcement use.
 The fix is a `--require-authority` flag and making strict authority the
 default for protected actions. It depends on 5 and 6 (revocation), which is
 why it is not fixed here.
+
+---
+
+## Found while working the list, not in it
+
+Four defects surfaced from doing the work rather than from either audit. The
+pattern is worth naming: each was a control that ran and left no evidence, or
+a claim nobody had checked against the code.
+
+**An authorization bypass (#298).** Every layer in `verify_mandate` judged the
+action against the mandate's own fields, which are signed by the actor. The
+grantor's signature covers the `Grant`, a different object, and nothing tied
+them together -- so a legitimately signed, correctly attenuated chain whose
+leaf granted `payments.charge` could carry `mandate.scope = ["payments.*"]`
+and have `payments.refund` verify as **Pass**. The chain resolved,
+attenuation-checked, and was then never consulted. Found while trying to make
+`objective_hash` do something; it is on both `Grant` and `Mandate`, signed,
+and was compared against nothing.
+
+**Receipts auto-published from two more plugins (#299).** #284 gated the
+OpenClaw plugin behind `TREESHIP_AUTO_PUBLISH` after finding it uploading at
+session end with no operator in the loop. Claude Code and Kimi did the same
+thing and did not get the fix -- an incomplete fix, not a new bug. Claude
+Code's session-start message also told users the receipt "only leaves this
+machine when you run `treeship session report`", which was false because
+session-end ran it for them.
+
+**Onboarding taught the weaker trust model (#300).** `onboard` printed
+`trust add <AGENT key> --kind agent_cert` -- HTTP public-key pinning. The
+codebase implements CA-chain verification (`resolution.rs` requires the cert
+to be signed by a key pinned under `CertIssuer`), and a counterparty
+following the printed line never walked that chain. Found by an external
+TLS-handshake test.
+
+**main did not build (#296).** #291 added a struct field; #292 added a new
+initializer in a crate CI never compiled. Both green separately. The CI jobs
+enumerate packages by name, so adding a workspace member does not add it to
+the list -- and I had asserted the opposite in #292's description, which is
+what stopped me checking.
 
 ---
 


### PR DESCRIPTION
Was 30/3/17. Records #288, #289, #294 and #297 against their rows.

Adds a section for **four defects that surfaced from doing the work rather than from either audit** — the pattern repeats, so it's worth naming: each was a control that ran and left no evidence, or a claim nobody had checked against the code.

- **#298** — an authorization bypass. `verify_mandate` judged the action against the mandate's own fields, signed by the actor; the grantor's signature covers the `Grant`, and nothing tied them together. A properly signed, correctly attenuated chain could be carried beside a mandate claiming more than it, and the action verified `Pass`.
- **#299** — two more plugins auto-publishing receipts. #284 fixed the path the audit named; I never checked whether the others shared it.
- **#300** — onboarding printing the leaf pin, teaching HPKP instead of the CA-chain verification the codebase implements.
- **#296** — main not building, because CI enumerates packages by name and a new workspace member wasn't in the list. I'd asserted the opposite in the PR that added it.

Replaces #295, whose rebase produced a destructive diff (it had begun deleting `verify/authority_use.rs`, added on main after that branch was cut) and whose content predated six merges.