### PR TITLE
fix(profile,history): an empty result is not a zero

### DIFF
--- a/packages/cli/src/commands/history.rs
+++ b/packages/cli/src/commands/history.rs
@@ -202,7 +202,20 @@ pub fn history(
 
     if rows.is_empty() {
         printer.warn("no work history", &[("agent", agent.as_str())]);
-        printer.hint("session.v1 records are minted on `treeship session close` (0.16.0+); publish them with `treeship publish` + `merkle publish` to serve history from a hub.");
+        // The common way to land here is not "this agent has done nothing".
+        // It is having attested actions AS the agent while the session was
+        // opened by the ship -- so no session.v1 record names the agent and
+        // this reads empty. Say that first; the publishing mechanics are
+        // secondary and were the only thing this hint used to cover.
+        printer.hint(
+            "history reads session.v1 records, not raw actions. If you attested actions as \
+             this agent but the session was opened in the ship's name, no record names the \
+             agent and this is empty -- which is not the same as the agent having done \
+             nothing. Open the session as the agent:\n  \
+             treeship session start --actor <agent>\n\n\
+             session.v1 records are minted on `treeship session close` (0.16.0+); publish \
+             them with `treeship publish` + `merkle publish` to serve history from a hub.",
+        );
         printer.blank();
         return Ok(());
     }

--- a/packages/cli/src/commands/profile.rs
+++ b/packages/cli/src/commands/profile.rs
@@ -241,12 +241,75 @@ pub fn profile(agent: &str, attest: bool, config: Option<&str>, printer: &Printe
     }
 
     if printer.format == crate::printer::Format::Json {
-        let mut body = payload;
+        let mut body = payload.clone();
         if let Some(id) = &attested_id {
             body["attested_artifact_id"] = serde_json::json!(id);
         }
+        // Outside the signed payload deliberately: `payload` is what gets
+        // attested and validated against `profile.v1`, and adding a field
+        // there would change the schema and the signed bytes. This is a note
+        // to the reader of THIS invocation, not part of the claim.
+        //
+        // A machine consumer has the same problem a human does -- zero
+        // sessions and zero actions are indistinguishable from an agent that
+        // did nothing -- and is likelier to branch on the number.
+        if sessions.is_empty() {
+            body["_note"] = serde_json::json!({
+                "sessions_found": 0,
+                "meaning": format!(
+                    "no session.v1 receipt within checkpoint #{} names {agent} as actor. \
+                     Zero counts here do NOT mean the agent performed no actions -- a \
+                     profile aggregates sessions, and actions attested outside a session \
+                     (or inside one opened in the ship's name) are not counted.",
+                    checkpoint.index
+                ),
+                // `log` has no actor filter and `history` reads the same
+                // session.v1 records, so neither is a drop-in answer.
+                "see_instead": "treeship log (unfiltered receipt log; there is no --actor filter)",
+                "history_has_the_same_blind_spot": true,
+            });
+        }
         printer.json(&body);
         return Ok(());
+    }
+
+    // An empty result and a genuine zero are different answers, and printing
+    // `actions: 0` for both makes the first one read as the second.
+    //
+    // A profile aggregates `session.v1` receipts whose payload names this
+    // agent as `actor`. Actions attested directly -- `treeship attest action
+    // --actor agent://x` outside a session, or inside a session the ship
+    // opened in its own name -- are never counted, because no session receipt
+    // names the agent. So an agent that demonstrably attested a dozen actions
+    // reports zero, and nothing in the output says why.
+    if sessions.is_empty() {
+        printer.warn(
+            &format!(
+                "no session receipts name {agent} as actor within checkpoint #{}",
+                checkpoint.index
+            ),
+            &[],
+        );
+        printer.blank();
+        printer
+            .info("  A profile aggregates session.v1 receipts, not raw actions. Zero here means");
+        printer.info("  no session named this agent -- NOT that the agent did nothing. Actions");
+        printer.info("  attested outside a session, or inside one the ship opened in its own");
+        printer.info("  name, are invisible to this command.");
+        printer.blank();
+        // `treeship log` has no --actor filter, and `history` is session.v1
+        // filtered too, so it has exactly this same blind spot. Pointing at
+        // either as though it answered the question would just move the
+        // confusion one command along.
+        printer.hint(&format!(
+            "raw attestations are in the receipt log (no actor filter yet):\n  \
+             treeship log\n\n\
+             `treeship history {agent}` reads the same session.v1 records as this \
+             command, so it will also be empty.\n\n\
+             to give this agent a session history, open the session as the agent:\n  \
+             treeship session start --actor {agent}"
+        ));
+        printer.blank();
     }
 
     printer.success(


### PR DESCRIPTION
An external E2E run onboarded an agent, attested `deploy.production` several times, and got:

```
actions: 0
```

The agent had done the work. The command was answering a different question and printing the answer as a number.

`profile` aggregates `session.v1` receipts whose payload names the agent as `actor`. Actions attested outside a session — **or inside one the ship opened in its own name, which is the default** — are never counted. So no session names the agent, every total is zero, and nothing in the output distinguished that from an agent that had done nothing.

A zero meaning *"did nothing"* and a zero meaning *"asked the wrong index"* are different claims, and a reader gating on the number can't tell them apart.

```
⚠ no session receipts name agent://e2e-deployer as actor within checkpoint #5

  A profile aggregates session.v1 receipts, not raw actions. Zero here means
  no session named this agent -- NOT that the agent did nothing.
```

Both human and JSON paths. The JSON note sits **outside** `payload` deliberately — that's what gets signed and validated against `profile.v1`, and this is a remark about the invocation, not part of the claim.

## history had the same blind spot

It reported it better — already warning rather than printing zeros — but its hint only covered publishing mechanics, when the usual reason for landing there is attesting as an agent while the ship holds the session. That's now what it says first.

## The hint text is checked, not plausible

`treeship log` has no `--actor` filter, so my first version pointed at a flag that doesn't exist. It now points at the unfiltered log and states outright that `history` shares the blind spot, rather than moving the confusion one command along.