### PR TITLE
feat(grant): grants can be revoked, and verification honors it

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -1049,6 +1049,22 @@ treeship grant show [OPTIONS] <GRANT_ID>
 |---|---|
 | `<GRANT_ID>` | -- |
 
+### `treeship grant revoke`
+
+Withdraw a grant. Mints a signed grant_revocation.v1 receipt
+
+```
+treeship grant revoke [OPTIONS] <GRANT_ID>
+```
+
+| Argument | Description |
+|---|---|
+| `<GRANT_ID>` | -- |
+
+| Option | Description |
+|---|---|
+| `--reason <REASON>` | Why, e.g. compromised, task-complete, scope-error, key-rotation |
+
 ## `treeship doctor`
 
 Diagnostic check -- verify everything is working

--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -21,7 +21,8 @@
 use std::path::{Path, PathBuf};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use treeship_core::statements::{parse_rfc3339_to_unix, Grant};
+use treeship_core::statements::{parse_rfc3339_to_unix, payload_type, Grant, ReceiptStatement};
+use treeship_core::storage::Record;
 
 use crate::ctx;
 use crate::printer::{Format, Printer};
@@ -484,6 +485,139 @@ fn format_rfc3339(secs: u64) -> String {
     let y = if m <= 2 { y + 1 } else { y };
 
     format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+/// Withdraw a grant by minting a signed `grant_revocation.v1` receipt.
+///
+/// # Why a receipt and not a flag on the grant
+///
+/// A grant is content-addressed: its id is derived from its bytes. Editing it
+/// to add `revoked: true` would change the id, so every mandate naming the old
+/// id would stop resolving -- the grant would not be revoked, it would vanish,
+/// and receipts already signed under it would become unverifiable rather than
+/// correctly-authorized-then-withdrawn.
+///
+/// So revocation is a separate artifact that points at the grant, exactly as
+/// capability-card revocation already works.
+///
+/// # Who may revoke
+///
+/// Only the grantor. The receipt is signed with the ship's default key and
+/// records the grantor it claims to be; `LocalRevocationSource` honors it only
+/// when those match. A revocation anyone could mint is a denial of service
+/// against every grant whose id they know, and grant ids appear in published
+/// receipts.
+///
+/// # What revocation does not do
+///
+/// It does not invalidate what already happened. `verify_mandate` compares the
+/// revocation instant against the action's `signed_at`, so actions signed
+/// before this moment stay authorized. Withdrawing authority and unmaking the
+/// past are different operations, and only the first is available.
+pub fn revoke(
+    id: &str,
+    reason: Option<&str>,
+    config: Option<&str>,
+    printer: &Printer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = ctx::open(config)?;
+    let dir = grants_dir_for(&ctx.config_path);
+    let path = grant_path(&dir, id);
+    if !path.exists() {
+        return Err(format!("grant not found: {id}\n  run: treeship grant list").into());
+    }
+
+    // Checked, not unchecked: we are about to assert something about this
+    // grant's authority, and an inconsistent id means the bytes are not the
+    // grant that id names.
+    let grant = read_grant_unchecked(&path)?;
+    if !grant.id_is_consistent() {
+        return Err(format!(
+            "grant {id} has an inconsistent id -- its bytes do not derive it. Refusing to \
+             revoke a grant that is not what it claims to be; inspect it with:\n  \
+             treeship grant show {id}"
+        )
+        .into());
+    }
+
+    let signer = ctx.keys.default_signer()?;
+    let signer_pub = URL_SAFE_NO_PAD.encode(signer.public_key_bytes());
+
+    // Refuse up front rather than minting a receipt the resolver will ignore.
+    // A revocation that silently does nothing is worse than an error: the
+    // operator believes the grant is dead.
+    if signer_pub != grant.grantor {
+        return Err(format!(
+            "only the grantor can revoke this grant.\n  \
+             grant was issued by: {}\n  \
+             your default key is: {}\n\n\
+             A revocation signed by anyone else is ignored by verifiers, so minting one \
+             here would tell you the grant was withdrawn when it was not.",
+            grant.grantor, signer_pub
+        )
+        .into());
+    }
+
+    let revoked_at = crate::commands::verify::now_rfc3339();
+    let mut payload = serde_json::Map::new();
+    payload.insert("schema".into(), "grant_revocation.v1".into());
+    payload.insert("grant_id".into(), grant.grant_id.clone().into());
+    payload.insert("grantor".into(), grant.grantor.clone().into());
+    if let Some(r) = reason {
+        payload.insert("reason".into(), r.into());
+    }
+    payload.insert("revoked_at".into(), revoked_at.clone().into());
+    let payload = serde_json::Value::Object(payload);
+
+    treeship_core::predicates::validate("grant_revocation.v1", Some(&payload))
+        .map_err(|e| format!("invalid revocation: {e}"))?;
+
+    let mut stmt = ReceiptStatement::new(
+        format!("ship://{}", ctx.config.ship_id),
+        "grant_revocation.v1",
+    );
+    stmt.payload = Some(payload);
+
+    let signed = treeship_core::attestation::sign(&payload_type("receipt"), &stmt, &*signer)?;
+    ctx.storage.write(&Record {
+        artifact_id: signed.artifact_id.clone(),
+        digest: signed.digest.clone(),
+        payload_type: signed.envelope.payload_type.clone(),
+        key_id: signer.key_id().to_string(),
+        signed_at: revoked_at.clone(),
+        parent_id: None,
+        envelope: signed.envelope.clone(),
+        hub_url: None,
+        anchors: Vec::new(),
+    })?;
+
+    if printer.format == Format::Json {
+        printer.json(&serde_json::json!({
+            "status":     "revoked",
+            "grant_id":   grant.grant_id,
+            "revoked_at": revoked_at,
+            "reason":     reason,
+            "artifact":   signed.artifact_id,
+        }));
+        return Ok(());
+    }
+
+    printer.success(
+        "grant revoked",
+        &[
+            ("grant", grant.grant_id.as_str()),
+            ("revoked_at", revoked_at.as_str()),
+            ("reason", reason.unwrap_or("(none given)")),
+            ("receipt", signed.artifact_id.as_str()),
+        ],
+    );
+    printer.blank();
+    printer.hint(
+        "actions signed BEFORE this instant remain authorized -- revoking withdraws authority, \
+         it does not unmake what was already done under it. Verifiers on other machines honor \
+         this only once they have the revocation receipt; publish it with `treeship publish`.",
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub mod publish;
 pub mod quickstart;
 pub mod receipt;
 pub mod resolve;
+pub mod revocation_source;
 pub mod room;
 pub mod session;
 pub mod setup;

--- a/packages/cli/src/commands/revocation_source.rs
+++ b/packages/cli/src/commands/revocation_source.rs
@@ -1,0 +1,414 @@
+//! A [`RevocationSource`] backed by `grant_revocation.v1` receipts in the
+//! local artifact store.
+//!
+//! # Why this exists
+//!
+//! `Mandate.revocation.path` has always named a resolver (`hub://local/…`) and
+//! nothing implemented one, so every verification passed `NoRevocationSource`
+//! and every action/v2 mandate degraded to `Unverified`. That was the honest
+//! failure -- refusing to confirm rather than confirming falsely -- but it
+//! meant a withdrawn grant was indistinguishable from a live one, and
+//! `--require-authority` could never be satisfied by a real receipt.
+//!
+//! # What makes a revocation count
+//!
+//! **Signed by the grant's own grantor, and nothing else.** A revocation
+//! anyone could mint is a denial-of-service against every grant whose id they
+//! know: learn a `grn_…` from a published receipt, sign "revoked", and the
+//! grant dies. So the signer's key must equal the `grantor` the revocation
+//! names, and the reader is expected to have obtained that grantor from the
+//! grant itself.
+//!
+//! This is the same rule capability-card revocation already applies -- honored
+//! only from the card's own key or a trusted issuer -- stated for grants.
+//!
+//! # Time, and what revocation does not do
+//!
+//! Revocation is evaluated against the action's `signed_at`, not against now.
+//! An action signed before the revocation instant stays authorized: withdrawing
+//! authority is not the same as retroactively unmaking what was already done
+//! under it. `verify_mandate` owns that comparison; this type only reports
+//! *when* the grant was withdrawn.
+//!
+//! # Absence only means something for grants we issued
+//!
+//! This is the distinction that decides whether the resolver is sound.
+//!
+//! For a grant **this ship issued**, the local store is authoritative: we are
+//! the grantor, revoking is something we would have done, and finding no
+//! revocation is a real answer -- [`RevocationStatus::NotRevoked`].
+//!
+//! For a grant issued by **anyone else**, an empty local store says nothing.
+//! We may simply never have been told. Reporting `NotRevoked` there would let
+//! a stale or freshly-initialised store manufacture a passing verdict out of
+//! ignorance, which is the same defect as a boolean that reads true because
+//! nothing looked. Those resolve [`RevocationStatus::Unknown`], and the
+//! mandate degrades to `Unverified` exactly as it did before.
+//!
+//! Closing that needs a published, fetchable revocation list. The Hub's
+//! `/.well-known/treeship/revoked.json` is currently hardcoded empty and
+//! unsigned (audit item 6), so there is nothing to fetch yet.
+
+use treeship_core::statements::{RevocationSource, RevocationStatus};
+use treeship_core::storage::Store;
+
+use treeship_core::attestation::{verify_with_key, Envelope};
+use treeship_core::statements::ReceiptStatement;
+
+/// Resolves revocation from `grant_revocation.v1` receipts held locally.
+pub struct LocalRevocationSource {
+    entries: Vec<RevocationEntry>,
+    /// Public keys this ship holds, base64url-no-pad. A grant whose grantor is
+    /// one of these was issued here, which is what makes "no revocation found"
+    /// an answer rather than an absence of information.
+    own_keys: Vec<String>,
+    /// grant_id -> grantor, for grants held locally. Needed because `status`
+    /// receives only a grant id and has to decide whether we issued it.
+    known_grantors: std::collections::HashMap<String, String>,
+}
+
+struct RevocationEntry {
+    grant_id: String,
+    /// Kept for the error message when a revocation fails the grantor check --
+    /// naming the key that was expected is what makes that message actionable.
+    #[allow(dead_code)]
+    grantor: String,
+    revoked_at: String,
+    /// Whether the DSSE signature verifies under the `grantor` key the payload
+    /// names. Computed at load, because that is where the envelope is.
+    grantor_signed: bool,
+}
+
+impl LocalRevocationSource {
+    /// Scan the store once. Called before verification so a chain of N
+    /// mandates does not re-read the store N times.
+    pub fn load(
+        store: &Store,
+        own_keys: Vec<String>,
+        known_grantors: std::collections::HashMap<String, String>,
+    ) -> Self {
+        let mut entries = Vec::new();
+
+        for entry in store.list() {
+            let Ok(record) = store.read(&entry.id) else {
+                continue;
+            };
+            let Ok(stmt) = record.envelope.unmarshal_statement::<ReceiptStatement>() else {
+                continue;
+            };
+            if stmt.kind != "grant_revocation.v1" {
+                continue;
+            }
+            let Some(p) = stmt.payload else { continue };
+
+            // Every field is required by the schema, but this reads receipts
+            // that may predate it or come from elsewhere. A revocation missing
+            // any of them cannot be evaluated, and treating it as valid would
+            // let a malformed artifact kill a grant.
+            let (Some(grant_id), Some(grantor), Some(revoked_at)) = (
+                p.get("grant_id").and_then(|v| v.as_str()),
+                p.get("grantor").and_then(|v| v.as_str()),
+                p.get("revoked_at").and_then(|v| v.as_str()),
+            ) else {
+                continue;
+            };
+
+            entries.push(RevocationEntry {
+                grant_id: grant_id.to_string(),
+                grantor: grantor.to_string(),
+                revoked_at: revoked_at.to_string(),
+                grantor_signed: signed_by(&record.envelope, grantor),
+            });
+        }
+
+        Self {
+            entries,
+            own_keys,
+            known_grantors,
+        }
+    }
+
+    /// Whether this ship issued the grant, and so whether the absence of a
+    /// local revocation is informative.
+    fn we_issued(&self, grant_id: &str) -> bool {
+        self.known_grantors
+            .get(grant_id)
+            .map(|g| {
+                let g = g.strip_prefix("ed25519:").unwrap_or(g);
+                self.own_keys
+                    .iter()
+                    .any(|k| k.strip_prefix("ed25519:").unwrap_or(k) == g)
+            })
+            .unwrap_or(false)
+    }
+}
+
+impl RevocationSource for LocalRevocationSource {
+    fn status(&self, grant_id: &str, _path: &str) -> RevocationStatus {
+        let mut unauthorized = 0usize;
+
+        // Earliest revocation wins. Two revocations of one grant should not
+        // happen, but if they do, the earlier instant is the one that
+        // withdrew the authority -- taking the later would silently widen the
+        // window in which actions still count as authorized.
+        let mut earliest: Option<&RevocationEntry> = None;
+
+        for e in self.entries.iter().filter(|e| e.grant_id == grant_id) {
+            // The grantor check. Without it, anyone who learns a grant id from
+            // a published receipt can revoke it.
+            //
+            // `grantor` is the grant issuer's public key and `signer_keyid` is
+            // the DSSE key id, so this compares a key to its id: the match
+            // holds when the revocation was signed by the same key material
+            // the grant names. A mismatch is counted and reported rather than
+            // ignored, because a revocation someone tried and failed to make
+            // stick is worth a verifier seeing.
+            if !e.grantor_signed {
+                unauthorized += 1;
+                continue;
+            }
+            match earliest {
+                None => earliest = Some(e),
+                Some(cur) if e.revoked_at < cur.revoked_at => earliest = Some(e),
+                _ => {}
+            }
+        }
+
+        if let Some(e) = earliest {
+            return RevocationStatus::RevokedAt(e.revoked_at.clone());
+        }
+
+        if unauthorized > 0 {
+            // Not `NotRevoked`: something claimed to revoke this grant and was
+            // not authorized to. Saying "not revoked" would hide that, and
+            // saying "revoked" would let the forgery succeed.
+            return RevocationStatus::Unknown(format!(
+                "{unauthorized} revocation(s) exist for {grant_id} but none was signed by \
+                 the grant's grantor; treating the grant as neither confirmed live nor \
+                 revoked"
+            ));
+        }
+
+        // Nothing found locally. Whether that means anything depends on who
+        // issued the grant.
+        if self.we_issued(grant_id) {
+            // We are the grantor. Revoking is an act we would have performed,
+            // and we have no record of performing it.
+            RevocationStatus::NotRevoked
+        } else {
+            // Someone else's grant. An empty local store is ignorance, not
+            // evidence, and saying `NotRevoked` here would let a machine that
+            // has never synced produce a passing verdict out of not knowing.
+            RevocationStatus::Unknown(format!(
+                "no local revocation record for {grant_id}, and this ship did not issue it -- \
+                 a revocation published elsewhere would not be visible here"
+            ))
+        }
+    }
+}
+
+/// Whether this envelope's signature verifies under the key the payload names
+/// as `grantor`.
+///
+/// This is a cryptographic check, not a name comparison, and the distinction
+/// is the whole control. The first version of this compared the DSSE `keyid`
+/// (`key_<hex>`) against `grantor` (a base64url public key) as strings, on the
+/// assumption that the store carried both forms. It does not, so the check
+/// never matched and every revocation was rejected as unauthorized.
+///
+/// Comparing names would also have been the weaker test even if the forms had
+/// lined up: `grantor` is a field in a payload an attacker writes. Verifying
+/// the signature *against* that key is what makes the claim self-checking --
+/// a forger can name the victim's key, and then cannot produce a signature
+/// that verifies under it.
+fn signed_by(envelope: &Envelope, grantor: &str) -> bool {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use ed25519_dalek::VerifyingKey;
+
+    let raw = grantor.strip_prefix("ed25519:").unwrap_or(grantor);
+    let Ok(bytes) = URL_SAFE_NO_PAD.decode(raw) else {
+        return false;
+    };
+    let Ok(arr): Result<[u8; 32], _> = bytes.as_slice().try_into() else {
+        return false;
+    };
+    let Ok(vk) = VerifyingKey::from_bytes(&arr) else {
+        return false;
+    };
+
+    // `verify_with_key` needs a key id to index by; any label works, because
+    // the map holds exactly this one key and a signature that verifies under
+    // it is the only thing that can pass.
+    envelope
+        .signatures
+        .iter()
+        .any(|sig| verify_with_key(envelope, &sig.keyid, vk).is_ok())
+}
+
+/// Build a resolver for this context: the local revocations, plus the two
+/// things needed to know whether an absent revocation is informative -- which
+/// keys this ship holds, and which grants it issued.
+pub fn for_ctx(ctx: &crate::ctx::Ctx) -> LocalRevocationSource {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+
+    // Every key this ship holds, as a pinnable public key. A grant issued by
+    // any of them is one we could have revoked ourselves.
+    let own_keys: Vec<String> = ctx
+        .keys
+        .list()
+        .map(|infos| {
+            infos
+                .iter()
+                .map(|k| URL_SAFE_NO_PAD.encode(&k.public_key))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // grant_id -> grantor for grants on disk. Read unchecked: this only
+    // decides whether absence is informative, and a grant with an
+    // inconsistent id simply will not match a mandate's grant_id anyway.
+    let mut known_grantors = std::collections::HashMap::new();
+    let dir = crate::commands::grant::grants_dir_for(&ctx.config_path);
+    if dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for e in entries.flatten() {
+                let path = e.path();
+                if path.extension().and_then(|x| x.to_str()) != Some("json") {
+                    continue;
+                }
+                if let Ok(g) = crate::commands::grant::read_grant_unchecked(&path) {
+                    known_grantors.insert(g.grant_id.clone(), g.grantor.clone());
+                }
+            }
+        }
+    }
+
+    LocalRevocationSource::load(&ctx.storage, own_keys, known_grantors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(grant: &str, grantor: &str, at: &str, grantor_signed: bool) -> RevocationEntry {
+        RevocationEntry {
+            grant_id: grant.into(),
+            grantor: grantor.into(),
+            revoked_at: at.into(),
+            grantor_signed,
+        }
+    }
+
+    /// A source that did NOT issue the grants under test, so absence is
+    /// `Unknown`. `own()` below covers the other side.
+    fn src(entries: Vec<RevocationEntry>) -> LocalRevocationSource {
+        LocalRevocationSource {
+            entries,
+            own_keys: vec![],
+            known_grantors: Default::default(),
+        }
+    }
+
+    /// A source for a grant this ship issued, where absence is informative.
+    fn own(entries: Vec<RevocationEntry>) -> LocalRevocationSource {
+        LocalRevocationSource {
+            entries,
+            own_keys: vec!["pk1".into()],
+            known_grantors: [("grn_a".to_string(), "pk1".to_string())]
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn a_grantor_signed_revocation_is_honored() {
+        let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", true)]);
+        assert_eq!(
+            s.status("grn_a", "hub://local/revocations"),
+            RevocationStatus::RevokedAt("2026-08-14T10:00:00Z".into())
+        );
+    }
+
+    /// The denial-of-service this check exists to stop: learn a grant id from
+    /// a published receipt, sign "revoked", kill the grant.
+    #[test]
+    fn a_revocation_signed_by_a_stranger_does_not_revoke() {
+        let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", false)]);
+        match s.status("grn_a", "p") {
+            RevocationStatus::Unknown(r) => {
+                assert!(r.contains("none was signed by the grant's grantor"), "{r}")
+            }
+            other => panic!("a stranger's revocation must not decide the outcome: {other:?}"),
+        }
+    }
+
+    /// And it must not read as a clean bill of health either. Something tried
+    /// to revoke this grant; a verifier should see that.
+    #[test]
+    fn an_unauthorized_attempt_is_not_reported_as_not_revoked() {
+        let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", false)]);
+        assert_ne!(s.status("grn_a", "p"), RevocationStatus::NotRevoked);
+    }
+
+    #[test]
+    fn the_earliest_revocation_wins() {
+        let s = src(vec![
+            entry("grn_a", "pk1", "2026-08-14T12:00:00Z", true),
+            entry("grn_a", "pk1", "2026-08-14T09:00:00Z", true),
+        ]);
+        assert_eq!(
+            s.status("grn_a", "p"),
+            RevocationStatus::RevokedAt("2026-08-14T09:00:00Z".into()),
+            "taking the later instant would widen the window in which actions still count"
+        );
+    }
+
+    #[test]
+    fn other_grants_are_unaffected() {
+        let s = own(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", true)]);
+        // grn_b was not issued here, so we cannot speak to it either way.
+        assert!(matches!(
+            s.status("grn_b", "p"),
+            RevocationStatus::Unknown(_)
+        ));
+    }
+
+    /// The soundness rule. An empty store is an answer only about grants this
+    /// ship issued; for anyone else's it is ignorance, and reporting
+    /// `NotRevoked` would let a machine that has never synced manufacture a
+    /// pass out of not knowing.
+    #[test]
+    fn absence_is_an_answer_only_for_our_own_grants() {
+        assert_eq!(
+            own(vec![]).status("grn_a", "p"),
+            RevocationStatus::NotRevoked
+        );
+
+        match src(vec![]).status("grn_a", "p") {
+            RevocationStatus::Unknown(r) => assert!(r.contains("did not issue it"), "{r}"),
+            other => {
+                panic!("someone else's grant must not resolve from an empty store: {other:?}")
+            }
+        }
+    }
+
+    /// A revocation we DO hold decides the outcome regardless of issuer -- the
+    /// ignorance rule is about absence, not about evidence in hand.
+    #[test]
+    fn a_held_revocation_counts_even_for_someone_elses_grant() {
+        let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", true)]);
+        assert_eq!(
+            s.status("grn_a", "p"),
+            RevocationStatus::RevokedAt("2026-08-14T10:00:00Z".into())
+        );
+    }
+
+    #[test]
+    fn an_unsigned_revocation_is_not_authorized() {
+        let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", false)]);
+        assert!(matches!(
+            s.status("grn_a", "p"),
+            RevocationStatus::Unknown(_)
+        ));
+    }
+}

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -10,8 +10,8 @@ use treeship_core::{
         session_participant::{verify_participant_envelope, SessionParticipantStatement},
         verify_effect, verify_grant_chain, verify_mandate, ActionStatement, ActionStatementV2,
         ApprovalScope, ApprovalStatement, DeadlineEvent, DecisionStatement, EffectConfidence,
-        EffectFinality, EffectVerdict, HandoffStatement, MandateVerdict, NoRevocationSource,
-        NoWitnessAuthority, ReceiptStatement, ResolutionStatus,
+        EffectFinality, EffectVerdict, HandoffStatement, MandateVerdict, NoWitnessAuthority,
+        ReceiptStatement, ResolutionStatus,
     },
     storage::Store,
     trust::TrustRootStore,
@@ -153,16 +153,29 @@ fn v2_effect_verdict(env: &Envelope) -> Option<EffectVerdict> {
 }
 
 /// Reconciled mandate verdict for an envelope, if it is a treeship/action/v2
-/// receipt. `None` for anything else. Uses [`NoRevocationSource`]: the CLI
-/// wires no revocation resolver yet, so that layer resolves Unknown and the
-/// verdict degrades to Unverified -- claiming a grant is live because we never
-/// looked would be exactly the false pass this verifier exists to refuse.
-fn v2_mandate_summary(env: &Envelope, verifier: Option<&Verifier>) -> Option<MandateSummary> {
+/// receipt. `None` for anything else.
+///
+/// `revocation` is the resolver. It used to be hardcoded to
+/// [`NoRevocationSource`], so the layer always resolved Unknown and every
+/// verdict degraded to Unverified -- honest, and permanently so: a withdrawn
+/// grant was indistinguishable from a live one. Callers now pass
+/// `LocalRevocationSource`, which reads `grant_revocation.v1` receipts from
+/// the store.
+///
+/// Still fails toward Unverified when the resolver cannot answer. Claiming a
+/// grant is live because nobody looked is the false pass this verifier exists
+/// to refuse, and a local store that has never seen a revocation is not
+/// evidence that none was issued.
+fn v2_mandate_summary(
+    env: &Envelope,
+    verifier: Option<&Verifier>,
+    revocation: &dyn treeship_core::statements::RevocationSource,
+) -> Option<MandateSummary> {
     if env.payload_type != payload_type_v2("action") {
         return None;
     }
     let stmt = env.unmarshal_statement::<ActionStatementV2>().ok()?;
-    let mut verdict = match verify_mandate(&stmt, &NoRevocationSource) {
+    let mut verdict = match verify_mandate(&stmt, revocation) {
         MandateVerdict::Pass => MandateSummary::Pass,
         MandateVerdict::Unverified(r) => MandateSummary::Unverified(r),
         MandateVerdict::Fail(r) => MandateSummary::Fail(r),
@@ -400,6 +413,12 @@ pub fn run(
     // Local keys cover artifacts produced here; pinned roots cover artifacts
     // pulled or imported from trusted counterparties.
     let trust = TrustRootStore::open_default_or_empty()?;
+
+    // Loaded once. A chain of N mandates would otherwise rescan the store N
+    // times, and every mandate must be judged against the same revocation
+    // state -- reloading mid-chain could have two hops disagree about whether
+    // the same grant was live.
+    let revocation = crate::commands::revocation_source::for_ctx(&ctx);
     let verifier = crate::commands::verifier::from_local_and_trust(&ctx.keys, &trust)?
         .ok_or("no local or trusted verification keys are configured")?;
 
@@ -493,7 +512,7 @@ pub fn run(
         let authority_by_id: HashMap<String, serde_json::Value> = chain_envelopes
             .iter()
             .filter_map(|(id, env)| {
-                v2_mandate_summary(env, Some(&verifier))
+                v2_mandate_summary(env, Some(&verifier), &revocation)
                     .map(|m| (id.clone(), mandate_summary_json(&m)))
             })
             .collect();
@@ -532,7 +551,7 @@ pub fn run(
         // unverified, one gating a payment should not.
         let summaries: Vec<MandateSummary> = chain_envelopes
             .iter()
-            .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier)))
+            .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier), &revocation))
             .collect();
         let authority_ok = !summaries
             .iter()
@@ -676,7 +695,7 @@ pub fn run(
         {
             let summaries: Vec<MandateSummary> = chain_envelopes
                 .iter()
-                .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier)))
+                .filter_map(|(_, env)| v2_mandate_summary(env, Some(&verifier), &revocation))
                 .collect();
             let checked = summaries.len();
             let unverified = summaries
@@ -1443,7 +1462,11 @@ fn extract_step_info(
                 info.runtime_model = rt.model.clone();
             }
             // Surface the effect line only when there is an effect to judge.
-            info.mandate_verdict = v2_mandate_summary(env, verifier);
+            info.mandate_verdict = v2_mandate_summary(
+                env,
+                verifier,
+                &treeship_core::statements::NoRevocationSource,
+            );
             info.chain_summary = v2_chain_summary(env);
             if let Some(verdict) = v2_effect_verdict(env) {
                 info.effect_effective = Some(verdict.effective_confidence);
@@ -2614,7 +2637,12 @@ mod tests {
         .unwrap()
         .envelope;
         assert!(
-            v2_mandate_summary(&v1_env, None).is_none(),
+            v2_mandate_summary(
+                &v1_env,
+                None,
+                &treeship_core::statements::NoRevocationSource
+            )
+            .is_none(),
             "v1 receipts must not claim anything about authority"
         );
     }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1423,6 +1423,22 @@ enum GrantCommand {
     List,
     /// Show one grant, re-deriving its id and re-checking its signature.
     Show { grant_id: String },
+
+    /// Withdraw a grant. Mints a signed grant_revocation.v1 receipt.
+    ///
+    /// Only the grantor can revoke: a revocation anyone could mint would be a
+    /// denial of service against every grant whose id they know, and grant ids
+    /// appear in published receipts.
+    ///
+    /// Actions signed BEFORE the revocation instant remain authorized.
+    /// Revoking withdraws authority; it does not unmake what was already done
+    /// under it.
+    Revoke {
+        grant_id: String,
+        /// Why, e.g. compromised, task-complete, scope-error, key-rotation.
+        #[arg(long)]
+        reason: Option<String>,
+    },
 }
 
 // --- harness ---------------------------------------------------------------
@@ -3144,6 +3160,9 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                 printer,
             ),
             GrantCommand::List => commands::grant::list(cli.config.as_deref(), printer),
+            GrantCommand::Revoke { grant_id, reason } => {
+                commands::grant::revoke(grant_id, reason.as_deref(), cli.config.as_deref(), printer)
+            }
             GrantCommand::Show { grant_id } => {
                 commands::grant::show(grant_id, cli.config.as_deref(), printer)
             }

--- a/packages/cli/tests/action_v2_emit_e2e.rs
+++ b/packages/cli/tests/action_v2_emit_e2e.rs
@@ -158,10 +158,21 @@ fn cli_emits_action_v2_that_verify_reads() {
         "emitted v2 receipt must verify: {j}"
     );
 
-    // Authority is unverified without a revocation resolver — never a false pass.
+    // Authority passes, and the reason it may is narrow.
+    //
+    // This asserted `unverified` for as long as the CLI wired no revocation
+    // resolver: every mandate degraded, because claiming a grant was live when
+    // nobody had looked would be a false pass. There is a resolver now.
+    //
+    // It resolves `NotRevoked` here only because this ship ISSUED the grant --
+    // `grant issue` above wrote it to this workspace, so we are the grantor,
+    // revoking is an act we would have performed, and we have no record of it.
+    // For a grant issued by anyone else an empty local store is ignorance
+    // rather than evidence, and still resolves Unknown; the resolver's unit
+    // tests cover that side.
     assert_eq!(
-        check["authority"]["outcome"], "unverified",
-        "authority must be unverified without a revocation resolver: {j}"
+        check["authority"]["outcome"], "pass",
+        "a grant this ship issued, with no revocation on record, is not revoked: {j}"
     );
 
     // Effect claim reaches verify (kebab label on the machine surface).

--- a/packages/core/src/predicates/mod.rs
+++ b/packages/core/src/predicates/mod.rs
@@ -57,6 +57,10 @@ const REGISTRY: &[(&str, &str)] = &[
         "agent_card_revocation.v1",
         include_str!("schemas/agent_card_revocation.v1.json"),
     ),
+    (
+        "grant_revocation.v1",
+        include_str!("schemas/grant_revocation.v1.json"),
+    ),
     ("session.v1", include_str!("schemas/session.v1.json")),
     ("agent_cert.v1", include_str!("schemas/agent_cert.v1.json")),
     ("profile.v1", include_str!("schemas/profile.v1.json")),

--- a/packages/core/src/predicates/schemas/grant_revocation.v1.json
+++ b/packages/core/src/predicates/schemas/grant_revocation.v1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://treeship.dev/schemas/grant_revocation.v1.json",
+  "title": "grant_revocation.v1",
+  "description": "Withdraws a previously-issued capability grant. Carried as the payload of a Treeship receipt with kind=grant_revocation.v1. Honored only when the signer is the grant's own grantor: a revocation anyone could mint would be a denial-of-service against every grant whose id they knew. Revocation is evaluated at the action's signed_at, so an action signed BEFORE the revocation instant stays valid -- withdrawing authority is not the same as retroactively unmaking what was already done under it.",
+  "type": "object",
+  "required": ["schema", "grant_id", "grantor", "revoked_at"],
+  "properties": {
+    "schema": {
+      "description": "Schema identifier. Must be exactly this value.",
+      "const": "grant_revocation.v1"
+    },
+    "grant_id": {
+      "description": "Content-derived id (grn_...) of the grant being withdrawn.",
+      "type": "string"
+    },
+    "grantor": {
+      "description": "Ed25519 public key of the grant's issuer, base64url-no-pad. Recorded so a verifier can confirm the revocation was signed by the party that issued the grant, without re-resolving the grant itself.",
+      "type": "string"
+    },
+    "reason": {
+      "description": "Optional human-readable reason, e.g. compromised, task-complete, scope-error, key-rotation.",
+      "type": "string"
+    },
+    "revoked_at": {
+      "description": "RFC 3339 instant the grant was withdrawn. An action whose signed_at is at or after this instant is unauthorized; one signed strictly before it is not affected.",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Audit item 5. `Mandate.revocation.path` has named a resolver since v2 shipped and nothing implemented one — so every verification passed `NoRevocationSource`, every mandate degraded to `Unverified`, and **a withdrawn grant was indistinguishable from a live one.**

The gap was wider than "the resolver is unwired": `treeship grant` had issue, list and show, and no revoke. **Grants could not be withdrawn at all.**

## `treeship grant revoke <id> --reason <r>`

Mints a signed `grant_revocation.v1` receipt. A separate artifact rather than a flag on the grant, because a grant is content-addressed — editing it would move its id, so every mandate naming the old one would stop resolving. The grant wouldn't be revoked, it would *vanish*, and receipts already signed under it would become unverifiable rather than correctly-authorized-then-withdrawn.

Only the grantor may revoke, checked at mint time and again at verify time. Grant ids appear in published receipts, so a revocation anyone could sign is a denial of service against every grant whose id they know. `grant revoke` refuses up front when the default key isn't the grantor — minting a receipt the resolver will ignore would tell an operator the grant was dead when it wasn't.

## Verified end to end

```
signed BEFORE revoke   UNVERIFIED  (bearer grant — unrelated, pre-existing)
signed AFTER  revoke   FAIL        grant was revoked at '2026-08-14T15:15:44Z';
                                   signed_at is not before revocation
```

Withdrawing authority and unmaking the past are different operations, and only the first is available.

## Two things I got wrong, both caught by tests

**The authorization check was a string comparison** between the DSSE `keyid` (`key_<hex>`) and `grantor` (a base64url public key), on an assumption that the store carried both forms. It doesn't — so no revocation was ever honored.

It's now a signature verification against the key the payload names, which is also the *stronger* check: `grantor` is a field an attacker writes, and verifying **against** it means a forger can name the victim's key and then cannot produce a signature under it.

**Absence was reported as `NotRevoked` unconditionally.** An existing e2e test caught this by flipping from `unverified` to `pass`, which was the right alarm. An empty local store is not evidence that nothing was revoked — a machine that had never synced could manufacture a passing verdict out of ignorance. Same defect as a boolean that reads true because nothing looked.

Absence is now informative **only for grants this ship issued**: we're the grantor, revoking is an act we'd have performed, and having no record of it is an answer. For anyone else's grant an empty store resolves `Unknown` and the mandate degrades exactly as before.

Closing that needs a published, fetchable list — the Hub's endpoint is still hardcoded empty and unsigned (item 6).

8 resolver tests · clippy `-D warnings` clean across four crates · all docs gates pass.
