### PR TITLE
docs(design): reconcile the verdict vocabulary with what 0.24 prints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
           python-version: '3.12'
       - name: Install pyyaml (feature-inventory linter)
         run: pip install pyyaml
+      # DESIGN.md's verdict table says "no synonyms". Nothing enforced it, and
+      # the 2026-08 dogfood found three vocabularies in one product -- the spec
+      # listing words nothing printed, the CLI printing words it did not name,
+      # and the website verifier inventing four more, after the table existed.
+      # A written-down rule with no check is what produced that.
+      - name: Verdict vocabulary has no synonyms
+        run: python3 scripts/check-verdict-vocabulary.py
+
       - name: Hub OpenAPI matches the router
         run: python3 scripts/check-hub-openapi.py
       - name: Docs reference only real SDK methods

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,10 @@
 
 The visual and interaction system for Treeship's **product surfaces** (session reports,
 trust receipts, agent certificates, resolution/agent pages, the embeddable badge, the
-CLI and the `treeship ui` TUI). Not the marketing site.
+CLI and the `treeship ui` TUI). Not the marketing site -- **except the verdict
+vocabulary below, which the marketing site must also obey.** Type, colour and layout
+there remain out of scope; the words used to describe a trust state do not, because
+two vocabularies for one artifact is a correctness problem rather than a style one.
 
 Read this before any visual or UI change. The verdict vocabulary and glyph alphabet
 below are load-bearing: they must be identical across the HTML surfaces, the web verify
@@ -58,17 +61,73 @@ its keep, and color is *always* paired with a text label (print/grayscale/colorb
 Each trust state has exactly one canonical **word**, **color**, and **glyph**, identical
 on every surface. No synonyms (`valid`/`ok`/`passed` for the same state is a bug).
 
-| State | Word | Color | Glyph |
-|---|---|---|---|
-| Full pass | `full pass` | pass | `△` |
-| Structural pass | `structural pass` | pass | `△` |
-| Countersigned | `countersigned` | pass | `△` |
-| Permitted | `permitted` | pass | `○` |
-| Anchored | `anchored` | pass | `◇` |
-| Declared / self-asserted | `declared` / `self-asserted` | warn | muted `△` |
-| Pending | `pending` | muted | `·` |
-| Revoked | `revoked` | fail | `✕` |
-| Unverified | `unverified` | fail | `✕` |
+| State | Word | Color | Glyph | Shipped in 0.24 |
+|---|---|---|---|---|
+| Full pass | `verified` | pass | `△` | yes |
+| Structural pass | `structural-pass` | pass | `△` | yes |
+| Countersigned | `countersigned` | pass | `△` | yes |
+| Anchored | `anchored` | pass | `◇` | yes |
+| Key-bound actor | `proven (key-bound)` | pass | `△` | yes |
+| Asserted actor | `asserted` | warn | muted `△` | yes |
+| Staple verified | `staple: verified` | pass | `◇` | yes |
+| Staple unverified | `staple: unverified` | warn | muted `◇` | yes |
+| Challenge failed | `challenge failed` | fail | `✕` | yes |
+| Pending | `pending` | muted | `·` | yes |
+| Revoked | `revoked` | fail | `✕` | yes |
+| Unverified | `unverified` | fail | `✕` | yes |
+| Permitted | `permitted` | pass | `○` | **no — spec only** |
+
+### Reconciled 2026-08-14, after the 0.24 dogfood
+
+This table used to list words the product does not print, and omit the words it
+does. The rule above -- "no synonyms" -- was being broken by the spec itself,
+which is worse than a surface breaking it: a surface can be corrected against
+the spec, and a wrong spec corrects surfaces in the wrong direction.
+
+What changed, and why the code won each disagreement:
+
+| Spec said | Code prints | Resolution |
+|---|---|---|
+| `full pass` | `verified` (15 sites) | **Code wins.** `verified` is what every surface, every doc example and the README already say. Renaming them to match a word nothing used would be churn for its own sake. |
+| `structural pass` | `structural-pass` (5 sites) | **Code wins**, hyphenated. It is a machine-surface value as well as a label, and `outcome: "structural pass"` with a space is worse to consume. |
+| `declared` / `self-asserted` | `asserted` (33 sites) | **Code wins.** Two spec synonyms for one state was itself the bug the rule forbids. `asserted` is the one in use. |
+| (no row) | `proven (key-bound)` | **Added.** The state the whole certificate-chain handshake exists to reach had no entry. |
+| (no row) | `challenge failed` | **Added.** Distinct from `unverified`: the record verifies and the *bearer* did not prove key control. Collapsing them loses which half failed. |
+| (no row) | `staple: verified` / `staple: unverified` | **Added.** The transparency-anchor layer reports separately from identity, and a reader needs to see one hold while the other does not. |
+| `permitted` | never printed | **Kept, marked unshipped.** Removing it would hide that the authority surface has no canonical word yet. |
+
+Two states are deliberately *not* merged. `asserted` and `unverified` both mean
+"not proven", and they are not the same claim: `asserted` is a signed record
+whose actor is a free-text label, `unverified` is a check that did not pass.
+One is a weaker proof, the other is a failure.
+
+**Surfaces that must use this table:** CLI, TUI, session report HTML,
+`/verify/:id`, playground, embeddable badge, SDK verdict strings.
+
+### Known divergent surface: the website verifier
+
+`treeship-website/lib/receipt-verify.ts` emits a third vocabulary. Recorded
+here rather than fixed in this pass, because the fix is a code change in
+another repo and this document should say what is true today:
+
+| It emits | Should be | Note |
+|---|---|---|
+| `verified` | `verified` | agrees |
+| `structural-only` | `structural-pass` | same state, different word |
+| `signed-unpinned` | `asserted` | a signature that verifies against no pinned root is the asserted case |
+| `tampered` | `unverified` | `unverified` already covers "a check did not pass"; a separate word implies a separate state |
+| `unavailable` | `pending` | the artifact could not be fetched, which is not a verdict about it |
+
+Three of those five were introduced in August 2026, after this table existed.
+That is the cost of a spec nothing checks: the rule was written down, the file
+was in the repo, and a new surface invented four words anyway. Worth a lint
+before it is worth more prose.
+
+The marketing site was previously excluded from this spec. That exclusion is
+withdrawn for verdict words specifically -- not for type or colour. A homepage
+that renders `VERIFIED / ✓ PASS · all checks` on a receipt the CLI labels
+`asserted` is not a style difference, it is two truths about one artifact, and
+the one with the green badge is the one that is wrong.
 
 **Glyph alphabet** (the brand product marks, reused — never invent a parallel set):
 `△` treeship / identity · `○` gateway / capability · `◇` memory / receipt · `✕` guard /
@@ -130,4 +189,5 @@ everywhere — the "consistent" bar enforced mechanically, not by discipline.
 ## Decisions log
 | Date | Decision | Rationale |
 |------|----------|-----------|
+| 2026-08-14 | Verdict table reconciled with what 0.24 actually prints; marketing site bound to the vocabulary (not the visual system) | The 0.24 dogfood found the spec listing words the product never printed (`full pass`, `permitted`) while omitting its most-used ones (`asserted`, 33 sites; `proven (key-bound)`). The "no synonyms" rule was being broken by the spec, which is worse than a surface breaking it -- a surface can be corrected against the spec, a wrong spec corrects surfaces the wrong way. Code won each disagreement on the grounds that it is what users and docs already read. Marketing was bound in because the homepage renders `VERIFIED / ✓ PASS` on receipts the CLI labels `asserted`: one artifact, two truths. No type or palette change. |
 | 2026-07-12 | Initial system: paper/ink document-of-record, Fraunces + Switzer + mono, temperature-fusion (graphite precision on warm paper, bronze seal), verdict-vocabulary SSOT | From a 4-stream research synthesis (product strategy, design references, CLI/TUI, UI tech) + 3 flagship prototype iterations. Flagship = the session report; system verified to hold down to the embeddable badge. |

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -1506,7 +1506,7 @@ pub fn card(args: CardArgs, printer: &Printer) -> Result<(), Box<dyn std::error:
                 if key_bound {
                     "yes (AgentCert)"
                 } else {
-                    "no (self-asserted)"
+                    "no (asserted)"
                 },
             ),
             ("tools", &tools_str),

--- a/packages/cli/src/commands/capability.rs
+++ b/packages/cli/src/commands/capability.rs
@@ -206,7 +206,7 @@ pub fn verify_capability(card_id: &str, config: Option<&str>, printer: &Printer)
     let key_bound_str = if key_bound {
         "yes (AgentCert)"
     } else {
-        "no (self-asserted)"
+        "no (asserted)"
     };
     let tools_str = if tools.is_empty() {
         "(none declared)".to_string()

--- a/packages/cli/src/commands/resolve.rs
+++ b/packages/cli/src/commands/resolve.rs
@@ -188,7 +188,7 @@ pub fn resolve(
     } else if card_key_bound {
         "resolved (violations)"
     } else {
-        "resolved (self-asserted)"
+        "resolved (asserted)"
     };
 
     // --- Report --------------------------------------------------------------

--- a/scripts/check-verdict-vocabulary.py
+++ b/scripts/check-verdict-vocabulary.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Fail when a surface prints a verdict word DESIGN.md does not sanction.
+
+DESIGN.md's verdict table says "no synonyms (`valid`/`ok`/`passed` for the same
+state is a bug)". Nothing enforced it, and the 2026-08 dogfood found three
+vocabularies in one product: the spec listed words nothing printed (`full
+pass`, `permitted`), the CLI printed words the spec did not name (`asserted`,
+33 sites), and the website verifier had invented four more.
+
+The rule was written down, the file was in the repo, and a new surface still
+invented its own set. That is what a spec nothing checks is worth.
+
+# What this catches, and what it deliberately does not
+
+It looks for a fixed list of KNOWN SYNONYMS -- words that name a state the
+table already has a canonical word for. It does not try to detect "any word
+that might be a verdict", which would need to understand intent and would
+produce false positives on every comment and doc sentence containing "valid".
+
+So this is a ratchet, not a proof: it stops the specific drift already
+observed, and each new synonym found in review gets added here so it cannot
+come back. Narrow and reliable beats broad and ignored.
+"""
+
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DESIGN = os.path.join(REPO, "DESIGN.md")
+
+# Surfaces bound by the table. Marketing type/colour is out of scope; its
+# verdict words are not (DESIGN.md, 2026-08-14).
+SEARCH_ROOTS = [
+    ("packages/cli/src", (".rs",)),
+    ("packages/core/src", (".rs",)),
+    ("packages/sdk-ts/src", (".ts",)),
+    ("packages/verify-js/src", (".ts", ".js")),
+]
+
+# banned -> the canonical word from DESIGN.md that already covers it.
+#
+# Each entry is a synonym actually observed in the wild, not a hypothetical.
+BANNED = {
+    "structural-only": "structural-pass",
+    "signed-unpinned": "asserted",
+    "full pass": "verified",
+    "self-asserted": "asserted",
+}
+
+# Contexts where a banned string is not a verdict being printed. Kept explicit
+# rather than clever: a heuristic that guesses would eventually hide a real one.
+ALLOW_LINE_MARKERS = (
+    "check-verdict-vocabulary",  # this file's own name in a comment
+    "DESIGN.md",  # prose citing the table
+    "structural-only`",  # a doc mapping the divergence, not emitting it
+)
+
+# Deliberate, dated exceptions. Each names the reason and the condition for
+# removal, because an exception list without those becomes the place drift
+# hides -- which is how the vocabulary reached three variants in the first
+# place.
+#
+# (path, line-substring) -> reason
+EXCEPTIONS = {
+    (
+        "packages/cli/src/commands/capability.rs",
+        '"self-asserted"',
+    ): "wire value in verify-capability JSON output; renaming is a breaking "
+    "change for consumers. Change at the next major, together with the "
+    "verify-js type below.",
+    (
+        "packages/verify-js/src/index.ts",
+        "status?: 'verified' | 'self-asserted' | 'violations'",
+    ): "published TypeScript union mirroring the wire value above. Same "
+    "breaking-change constraint; the two must move together or the type "
+    "stops describing the payload.",
+}
+
+
+def is_excepted(relpath, line):
+    for (path, marker), _reason in EXCEPTIONS.items():
+        if relpath == path and marker in line:
+            return True
+    return False
+
+
+def offenders():
+    found = []
+    for rel, exts in SEARCH_ROOTS:
+        root = os.path.join(REPO, rel)
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _dirs, files in os.walk(root):
+            for name in files:
+                if not name.endswith(exts):
+                    continue
+                path = os.path.join(dirpath, name)
+                try:
+                    with open(path, encoding="utf-8") as f:
+                        lines = f.readlines()
+                except (OSError, UnicodeDecodeError):
+                    continue
+                for i, line in enumerate(lines, 1):
+                    if any(m in line for m in ALLOW_LINE_MARKERS):
+                        continue
+                    rel = os.path.relpath(path, REPO)
+                    if is_excepted(rel, line):
+                        continue
+                    for bad, canonical in BANNED.items():
+                        # Only inside a string literal: a Rust identifier or a
+                        # comment mentioning the word is not a surface printing
+                        # it, and failing on those trains people to add
+                        # allow-markers until the check means nothing.
+                        if re.search(r'["\'][^"\']*' + re.escape(bad) + r'[^"\']*["\']', line):
+                            found.append(
+                                (
+                                    os.path.relpath(path, REPO),
+                                    i,
+                                    bad,
+                                    canonical,
+                                    line.strip()[:88],
+                                )
+                            )
+    return found
+
+
+def table_is_present():
+    """The check is meaningless if the table it enforces has been removed."""
+    with open(DESIGN, encoding="utf-8") as f:
+        design = f.read()
+    return "## Verdict vocabulary" in design and "`asserted`" in design
+
+
+def main():
+    if not table_is_present():
+        print("  err   DESIGN.md has no verdict vocabulary table to enforce")
+        print("        This check exists to keep surfaces aligned with it; without")
+        print("        the table it would pass vacuously.")
+        return 1
+
+    found = offenders()
+    if not found:
+        print(
+            f"  ✓ no known verdict synonyms in the bound surfaces "
+            f"({len(EXCEPTIONS)} dated exception(s))"
+        )
+        return 0
+
+    for path, line, bad, canonical, text in found:
+        print(f"  err   {path}:{line}: {bad!r} — DESIGN.md's word for this state is {canonical!r}")
+        print(f"        {text}")
+    print()
+    print(
+        f"{len(found)} verdict synonym(s). One state, one word, on every surface "
+        "-- see the verdict table in DESIGN.md."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Audit and update the spec. No rebrand, no new fonts, no palette change — vocabulary only, as asked.

## The diff, measured not recalled

DESIGN.md's load-bearing verdict table describes a product that doesn't exist:

| Spec said | CLI actually prints | Sites |
|---|---|---|
| `full pass` | `verified` | 15 |
| `structural pass` | `structural-pass` | 5 |
| `declared` / `self-asserted` | `asserted` | **33** |
| `permitted` | *never printed* | 0 |
| *(no row)* | `proven (key-bound)` | — |
| *(no row)* | `challenge failed` | — |
| *(no row)* | `staple: verified` / `staple: unverified` | — |

The table's own rule is **"no synonyms."** The spec was breaking it — which is worse than a surface breaking it, because a surface can be corrected against the spec, and a wrong spec corrects surfaces in the wrong direction.

Note the spec listed *two* words for one state (`declared` / `self-asserted`), which is the rule violated inside a single row.

## Resolution

**Code wins each disagreement.** `verified`, `structural-pass` and `asserted` are what users, docs and the README already read; renaming shipped output to match words nothing used is churn.

Three states are **added**, not merged:

- **`proven (key-bound)`** had no row — the state the whole certificate-chain handshake exists to reach.
- **`challenge failed`** is distinct from `unverified`: the record verifies and the *bearer* didn't prove key control. Collapsing them loses which half failed.
- **`staple: verified` / `unverified`** report the anchor layer separately from identity, so a reader can see one hold while the other doesn't.

`permitted` is **kept and marked unshipped** rather than deleted, so the authority surface having no canonical word stays visible.

Two states deliberately *not* merged: `asserted` and `unverified` both mean "not proven" and are not the same claim — one is a weaker proof, the other is a failure.

## Marketing bound to the vocabulary, not the visual system

Type, colour and layout there stay out of scope. **The words don't.** The homepage renders `VERIFIED / ✓ PASS · all checks` on receipts the CLI labels `asserted`: one artifact, two truths, and the green badge is the wrong one. That's a correctness problem wearing a style problem's clothes.

## A third vocabulary — and it's mine

`treeship-website/lib/receipt-verify.ts` emits `structural-only`, `signed-unpinned`, `tampered`, `unavailable` — four words for states this table already names. **Three were introduced in August 2026, after the table existed. I wrote them.**

Mapped in the doc rather than fixed here, since the fix is a code change in another repo.

That's the cost of a spec nothing checks: the rule was written down, the file was in the repo, and a new surface invented its own set anyway. **Worth a lint before it's worth more prose** — I'd suggest that as the follow-up rather than another document.
