### PR TITLE
feat(hub): publish real revocations, and stop implying the list is signed

### DIFF
--- a/docs/content/docs/api/hub-openapi.yaml
+++ b/docs/content/docs/api/hub-openapi.yaml
@@ -836,15 +836,25 @@ paths:
     get:
       summary: Revocation list
       description: >-
-        Revoked artifact IDs and key fingerprints. Currently a hardcoded empty
-        list, and unsigned, despite carrying a fresh signed_at. Served with
-        Cache-Control max-age=86400, so a verifier that trusted it would cache
-        "nothing is revoked" for a day. The CLI does not consult it: verify and
-        session both pass NoRevocationSource, so revocation resolves Unknown and
-        an action/v2 mandate degrades to Unverified. Do not treat as
-        authoritative until it is populated and signed.
-      operationId: revocationList
-      security: []
+        Grant revocations published by this hub. Each entry carries the
+        grantor-signed `grant_revocation.v1` DSSE envelope.
+
+        The hub does NOT sign this list and holds no signing key. That is
+        deliberate: the entries are already signed by the grantor who issued
+        the grant, so a client verifies each envelope against that key -- the
+        same check it runs on a locally-held revocation. A hub signature would
+        add a party to trust and prove less, attesting that the hub said this
+        rather than that the grantor did. The timestamp field is therefore
+        `generated_at`, not `signed_at`.
+
+        A hostile hub can WITHHOLD revocations, which is why absence from this
+        list is never proof that a grant is live. It cannot manufacture one.
+
+        Cache-Control is max-age=300. Longer would turn a revocation into a
+        grace period of the same length for whoever holds the revoked grant.
+
+        `truncated` is always present; when true the list is incomplete and
+        must not be treated as exhaustive.
       responses:
         '200':
           description: Revocation list

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -452,6 +452,43 @@ func ListArtifactsByDock(db *sql.DB, dockID string) ([]Artifact, error) {
 // ListArtifactsByPayloadType returns every artifact of a given payload type,
 // newest first. Used by the agent resolver to scan receipts. Bounded scans are
 // acceptable for now; an agent-indexed lookup is a later optimization.
+// ListArtifactsByPayloadTypeLimit is the bounded form. Takes newest-first up
+// to `limit`, and reports whether more exist.
+//
+// The unbounded sibling below loads every matching row and JSON-parses each
+// envelope, which is what makes the public read endpoints expensive (audit
+// items 20/21). New callers should use this one; the caller is expected to say
+// something honest about truncation rather than silently serving a prefix.
+func ListArtifactsByPayloadTypeLimit(db *sql.DB, payloadType string, limit int) ([]Artifact, bool, error) {
+	// Fetch one extra to learn whether more exist without a second COUNT.
+	rows, err := db.Query(
+		`SELECT artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id
+		 FROM artifacts WHERE payload_type = ? ORDER BY signed_at DESC LIMIT ?`,
+		payloadType, limit+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	var out []Artifact
+	for rows.Next() {
+		var a Artifact
+		if err := rows.Scan(&a.ArtifactID, &a.PayloadType, &a.EnvelopeJSON, &a.Digest, &a.SignedAt, &a.ParentID, &a.HubURL, &a.RekorIndex, &a.DockID); err != nil {
+			return nil, false, err
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	truncated := len(out) > limit
+	if truncated {
+		out = out[:limit]
+	}
+	return out, truncated, nil
+}
+
 func ListArtifactsByPayloadType(db *sql.DB, payloadType string) ([]Artifact, error) {
 	rows, err := db.Query(
 		`SELECT artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"log"
@@ -147,7 +149,7 @@ func main() {
 	})
 
 	// Well-known revocation list.
-	r.Get("/.well-known/treeship/revoked.json", revokedHandler)
+	r.Get("/.well-known/treeship/revoked.json", revokedHandler(database))
 
 	// Liveness and readiness are different questions and need different
 	// answers. /healthz says the process is up; a load balancer uses it to
@@ -314,13 +316,126 @@ func redactPath(u *url.URL) string {
 	return u.Path + "?" + q.Encode()
 }
 
+// Revocation entries are small; this bounds the scan and the response. A
+// deployment that outgrows it needs the derived `kind` column (audit item 21),
+// not a bigger number here.
+// receiptPayloadType is the MIME type of treeship receipt envelopes; grant
+// revocations are receipts.
+const receiptPayloadType = "application/vnd.treeship.receipt.v1+json"
+
+const revocationListLimit = 1000
+
 // revokedHandler serves GET /.well-known/treeship/revoked.json
-func revokedHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "max-age=86400")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"revoked":   []interface{}{},
-		"signed_at": time.Now().UTC().Format(time.RFC3339),
-		"version":   "1",
-	})
+//
+// # What changed, and why there is still no Hub signature
+//
+// This used to return a hardcoded empty list carrying a fresh `signed_at`,
+// with `Cache-Control: max-age=86400`. Three problems in nine lines: the list
+// was always empty regardless of what had been revoked, `signed_at` named a
+// signature that did not exist, and a verifier that trusted it would cache
+// "nothing is revoked" for a day.
+//
+// It now serves real revocations, and it still does not sign them -- because
+// it does not need to and cannot honestly. The Hub holds no signing key, and
+// `grant_revocation.v1` receipts are **already DSSE-signed by the grantor**.
+// Serving the envelopes lets a client verify each one against the key the
+// grant names, which is the same check the local resolver runs. A Hub
+// signature over a summary would add a party to trust and prove strictly
+// less: it would attest that the Hub said this, not that the grantor did.
+//
+// That is also the Hub's stated role -- it "stores immutable bytes, serves
+// lookup indices and proofs, and never supplies trust verdicts".
+//
+// So the field is `generated_at`, not `signed_at`. The list is not signed; the
+// entries are, individually, and a client that skips verifying them has
+// learned nothing.
+func revokedHandler(database *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Short, and deliberately not 24h. A stale revocation list is a
+		// withdrawn grant still reading as live, so caching it for a day
+		// converts a revocation into a day-long grace period for whoever
+		// holds the revoked grant.
+		w.Header().Set("Cache-Control", "max-age=300")
+
+		artifacts, truncated, err := db.ListArtifactsByPayloadTypeLimit(
+			database, receiptPayloadType, revocationListLimit)
+		if err != nil {
+			log.Printf("revocation list query failed: %v", err)
+			// 503, not an empty 200. An empty list is indistinguishable from
+			// "nothing is revoked", and answering a revocation query with a
+			// confident wrong answer is worse than failing.
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": "revocation list temporarily unavailable",
+			})
+			return
+		}
+
+		revoked := make([]map[string]any, 0, len(artifacts))
+		for _, a := range artifacts {
+			kind, payload, ok := receiptKindAndPayload(a.EnvelopeJSON)
+			if !ok || kind != "grant_revocation.v1" {
+				continue
+			}
+			grantID, _ := payload["grant_id"].(string)
+			if grantID == "" {
+				continue
+			}
+			revoked = append(revoked, map[string]any{
+				"grant_id":   grantID,
+				"grantor":    payload["grantor"],
+				"revoked_at": payload["revoked_at"],
+				"reason":     payload["reason"],
+				// The signed bytes. A client MUST verify this against the
+				// grantor rather than trusting the fields above, which this
+				// server could have written.
+				"envelope":    json.RawMessage(a.EnvelopeJSON),
+				"artifact_id": a.ArtifactID,
+			})
+		}
+
+		body := map[string]any{
+			"version":      "2",
+			"generated_at": time.Now().UTC().Format(time.RFC3339),
+			"revoked":      revoked,
+			// Silent truncation on a revocation list would drop revocations a
+			// client needed and look identical to their not existing.
+			"truncated": truncated,
+			"note": "Entries are individually DSSE-signed by the grantor. This list is " +
+				"NOT signed by the hub -- verify each envelope against the grantor key " +
+				"before honoring it. Absence from this list is not proof a grant is live.",
+		}
+		if truncated {
+			body["truncation_warning"] = "more revocations exist than were returned; " +
+				"this list is incomplete and must not be treated as exhaustive"
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// receiptKindAndPayload pulls `kind` and `payload` out of a receipt envelope.
+//
+// Returns ok=false rather than partial data: a revocation whose envelope will
+// not decode cannot be evaluated, and emitting it with missing fields would
+// put an entry on the list that no client can verify.
+func receiptKindAndPayload(envelopeJSON string) (string, map[string]any, bool) {
+	var env struct {
+		Payload string `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(envelopeJSON), &env); err != nil {
+		return "", nil, false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(env.Payload, "="))
+	if err != nil {
+		return "", nil, false
+	}
+	var stmt struct {
+		Kind    string         `json:"kind"`
+		Payload map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal(raw, &stmt); err != nil {
+		return "", nil, false
+	}
+	return stmt.Kind, stmt.Payload, true
 }

--- a/packages/hub/revoked_test.go
+++ b/packages/hub/revoked_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/treeship/hub/internal/db"
+)
+
+// The endpoint this replaces returned a hardcoded empty list carrying a fresh
+// `signed_at`, cached for 24 hours. These assert the three properties that
+// made it wrong, rather than only that the new code runs.
+
+func receiptEnvelope(t *testing.T, kind string, payload map[string]any) string {
+	t.Helper()
+	stmt, _ := json.Marshal(map[string]any{"kind": kind, "payload": payload})
+	env, _ := json.Marshal(map[string]any{
+		"payload":     base64.RawURLEncoding.EncodeToString(stmt),
+		"payloadType": receiptPayloadType,
+		"signatures":  []map[string]string{{"keyid": "k1", "sig": "AAAA"}},
+	})
+	return string(env)
+}
+
+func hubWith(t *testing.T, artifacts ...*db.Artifact) *http.ServeMux {
+	t.Helper()
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	if _, err := database.Exec(
+		`INSERT INTO ships (dock_id, ship_public_key, dock_public_key, created_at)
+		 VALUES (?, ?, ?, ?)`, "dock_a", []byte("s"), []byte("d"), 1,
+	); err != nil {
+		t.Fatalf("register dock: %v", err)
+	}
+	for _, a := range artifacts {
+		if _, err := db.InsertArtifact(database, a); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/treeship/revoked.json", revokedHandler(database))
+	return mux
+}
+
+func getRevoked(t *testing.T, mux *http.ServeMux) (map[string]any, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/treeship/revoked.json", nil))
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	return body, rec
+}
+
+func artifact(id, env string) *db.Artifact {
+	dock := "dock_a"
+	return &db.Artifact{
+		ArtifactID:   id,
+		PayloadType:  receiptPayloadType,
+		EnvelopeJSON: env,
+		Digest:       "sha256:00",
+		SignedAt:     100,
+		HubURL:       "https://treeship.dev/verify/" + id,
+		DockID:       &dock,
+	}
+}
+
+// The headline defect: the list was empty no matter what had been revoked.
+func TestRevocationsActuallyAppear(t *testing.T) {
+	env := receiptEnvelope(t, "grant_revocation.v1", map[string]any{
+		"schema":     "grant_revocation.v1",
+		"grant_id":   "grn_abc",
+		"grantor":    "pk1",
+		"revoked_at": "2026-08-14T10:00:00Z",
+		"reason":     "compromised",
+	})
+	body, rec := getRevoked(t, hubWith(t, artifact("art_r1", env)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	list, _ := body["revoked"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("a revoked grant must appear in the list; got %d entries", len(list))
+	}
+	entry := list[0].(map[string]any)
+	if entry["grant_id"] != "grn_abc" {
+		t.Errorf("wrong grant_id: %v", entry["grant_id"])
+	}
+	// The evidence, not just the summary. A client that trusts the sibling
+	// fields is trusting the hub; the envelope is what it verifies.
+	if entry["envelope"] == nil {
+		t.Error("entry carries no signed envelope, so a client has nothing to verify")
+	}
+}
+
+// `signed_at` named a signature that did not exist. The hub holds no key and
+// does not sign this list; saying otherwise invited clients to trust it.
+func TestListDoesNotClaimToBeSigned(t *testing.T) {
+	body, _ := getRevoked(t, hubWith(t))
+
+	if _, present := body["signed_at"]; present {
+		t.Error("`signed_at` implies a signature the hub cannot produce -- it holds no key")
+	}
+	if _, present := body["generated_at"]; !present {
+		t.Error("the list should still say when it was produced")
+	}
+	note, _ := body["note"].(string)
+	if note == "" {
+		t.Error("the response must state that entries are individually signed and the list is not")
+	}
+}
+
+// A day-long cache on a revocation list converts a revocation into a day-long
+// grace period for whoever holds the revoked grant.
+func TestCacheIsShortEnoughForRevocationToMeanSomething(t *testing.T) {
+	_, rec := getRevoked(t, hubWith(t))
+	cc := rec.Header().Get("Cache-Control")
+	if cc == "max-age=86400" {
+		t.Fatal("24h cache on a revocation list: a withdrawn grant reads as live for a day")
+	}
+	if cc == "" {
+		t.Error("no Cache-Control at all leaves the window to whatever a proxy decides")
+	}
+}
+
+// Only revocations. A hub serving every receipt here would leak unrelated
+// records and bury the entries a client came for.
+func TestOnlyGrantRevocationsAreListed(t *testing.T) {
+	rev := receiptEnvelope(t, "grant_revocation.v1", map[string]any{
+		"grant_id": "grn_abc", "grantor": "pk1", "revoked_at": "2026-08-14T10:00:00Z",
+	})
+	other := receiptEnvelope(t, "session.v1", map[string]any{"actor": "agent://x"})
+	body, _ := getRevoked(t, hubWith(t, artifact("art_r1", rev), artifact("art_s1", other)))
+
+	list, _ := body["revoked"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("only grant_revocation.v1 belongs here; got %d entries", len(list))
+	}
+}
+
+// An entry whose envelope will not decode cannot be verified by anyone.
+// Emitting it with missing fields would put an unusable row on the list.
+func TestUndecodableEnvelopesAreSkippedNotEmitted(t *testing.T) {
+	body, rec := getRevoked(t, hubWith(t, artifact("art_bad", "{not json")))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("one bad artifact must not fail the whole list: %d", rec.Code)
+	}
+	list, _ := body["revoked"].([]any)
+	if len(list) != 0 {
+		t.Fatalf("an undecodable envelope must not be listed; got %d", len(list))
+	}
+}
+
+// Truncation has to be visible: a client that received a prefix and thought it
+// had everything would honor fewer revocations than exist.
+func TestTruncationIsReported(t *testing.T) {
+	body, _ := getRevoked(t, hubWith(t))
+	if _, present := body["truncated"]; !present {
+		t.Error("`truncated` must always be present, so its absence is never ambiguous")
+	}
+}


### PR DESCRIPTION
Audit item 6. The endpoint was nine lines and wrong three ways:

```go
"revoked":   []interface{}{},        // always empty
"signed_at": time.Now()...,          // no signature exists
Cache-Control: max-age=86400         // cached for a day
```

Empty regardless of what had been revoked; `signed_at` naming a signature that didn't exist; and a verifier trusting it would cache *"nothing is revoked"* for 24 hours — turning a revocation into a day-long grace period for whoever holds the revoked grant.

## It serves real revocations now — and still doesn't sign them

That's the design, not a shortcut. **The hub holds no signing key**, and `grant_revocation.v1` entries are already DSSE-signed by the grantor who issued the grant.

Serving the envelopes lets a client verify each one against the key the grant names — the same check the local resolver runs. A hub signature over a summary would **add a party to trust and prove strictly less**: that the hub said this, not that the grantor did.

So the field is `generated_at`, and the response says so in a `note`.

This also matches the hub's stated role: it *"stores immutable bytes, serves lookup indices and proofs, and never supplies trust verdicts."*

## The honest limit, in the response itself

A hostile hub can **withhold** revocations. It cannot manufacture one. Absence from this list is therefore never proof a grant is live — the same rule the local resolver applies to an empty store.

## Three details that carry weight

- **A query failure returns 503, not an empty 200.** An empty list is indistinguishable from "nothing is revoked", and answering a revocation query with a confident wrong answer is worse than failing.
- **`truncated` is always present**, so its absence is never ambiguous. The scan is bounded via a new `ListArtifactsByPayloadTypeLimit`. Silently serving a prefix would drop revocations a client needed and look identical to their not existing.
- **An undecodable envelope is skipped, not emitted with holes.** A row no client can verify doesn't belong on the list.

## Not in this PR

Client-side consumption needs the `grant_revocation.v1` type from #303. Stacking an unmerged dependency would make both harder to review, so the fetcher lands on top of that.

6 new tests, each asserting one of the properties that made the old endpoint wrong rather than just that the new code runs · `go vet` clean · govulncheck 0 · OpenAPI updated and the drift gate passes.
