### PR TITLE
feat(hub): index on fields derived from the envelope, not from the caller

### DIFF
--- a/packages/hub/internal/artifacts/artifacts.go
+++ b/packages/hub/internal/artifacts/artifacts.go
@@ -126,7 +126,14 @@ func (h *Handlers) Push(w http.ResponseWriter, r *http.Request) {
 
 	hubURL := "https://treeship.dev/verify/" + derived.ArtifactID
 
+	// Indexed fields come from the envelope, not the request. See
+	// contentaddress.DeriveIndexable: an index built from caller-supplied
+	// metadata lets an uploader choose how their artifact is found.
+	idx := contentaddress.DeriveIndexable(req.EnvelopeJSON)
+
 	artifact := &db.Artifact{
+		Kind:         idx.Kind,
+		Actor:        idx.Actor,
 		ArtifactID:   req.ArtifactID,
 		PayloadType:  req.PayloadType,
 		EnvelopeJSON: req.EnvelopeJSON,

--- a/packages/hub/internal/contentaddress/contentaddress.go
+++ b/packages/hub/internal/contentaddress/contentaddress.go
@@ -151,3 +151,75 @@ func Check(envelopeJSON, claimedID, claimedDigest, claimedPayloadType string) (*
 func SameBytes(a, b string) bool {
 	return a == b
 }
+
+// Indexable is the metadata the hub indexes on, derived from the envelope's
+// own signed bytes.
+//
+// Derived, never accepted. An index built from caller-supplied fields lets an
+// uploader choose how their artifact is found -- and a resolver filtering on
+// it is filtering on the uploader's claim about itself, not on the content.
+// That is audit item 11, and it is the same reason `Check` above re-derives
+// the artifact id rather than trusting the one submitted.
+//
+// Both fields are optional. A statement without a `kind`, or one that is not a
+// receipt, indexes as NULL rather than as a guess, and queries must treat NULL
+// as "not derived" rather than "does not match".
+type Indexable struct {
+	Kind  *string
+	Actor *string
+}
+
+// DeriveIndexable extracts the indexable fields from an envelope.
+//
+// Never errors: an envelope that will not decode simply has nothing to index,
+// and refusing the whole ingestion over an unindexable artifact would reject
+// content the store is otherwise happy to hold.
+func DeriveIndexable(envelopeJSON string) Indexable {
+	var env Envelope
+	if json.Unmarshal([]byte(envelopeJSON), &env) != nil {
+		return Indexable{}
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(env.Payload, "="))
+	if err != nil {
+		return Indexable{}
+	}
+
+	// Receipts carry `kind` plus a payload that may name an actor; action
+	// statements name the actor at the top level. Read both shapes rather than
+	// assuming one, since the store holds both.
+	var stmt struct {
+		Kind    string          `json:"kind"`
+		Actor   string          `json:"actor"`
+		Payload json.RawMessage `json:"payload"`
+	}
+	if json.Unmarshal(payload, &stmt) != nil {
+		return Indexable{}
+	}
+
+	out := Indexable{}
+	if stmt.Kind != "" {
+		k := stmt.Kind
+		out.Kind = &k
+	}
+	actor := stmt.Actor
+	if actor == "" && len(stmt.Payload) > 0 {
+		var inner struct {
+			Actor string `json:"actor"`
+			Agent string `json:"agent"`
+		}
+		if json.Unmarshal(stmt.Payload, &inner) == nil {
+			// `agent` is the agent_card/cert spelling of the same idea. Folding
+			// them into one column is what lets a single index answer "this
+			// agent's records" across receipt kinds.
+			if inner.Actor != "" {
+				actor = inner.Actor
+			} else if inner.Agent != "" {
+				actor = inner.Agent
+			}
+		}
+	}
+	if actor != "" {
+		out.Actor = &actor
+	}
+	return out
+}

--- a/packages/hub/internal/db/db.go
+++ b/packages/hub/internal/db/db.go
@@ -28,7 +28,12 @@ CREATE TABLE IF NOT EXISTS artifacts (
   parent_id     TEXT,
   hub_url       TEXT NOT NULL,
   rekor_index   INTEGER,
-  dock_id       TEXT REFERENCES ships(dock_id)
+  dock_id       TEXT REFERENCES ships(dock_id),
+  -- Derived from the envelope at ingestion, never from the request. Present
+  -- here for fresh databases; migrate() ALTERs them onto existing ones, and
+  -- tolerates the resulting "duplicate column" on a fresh one.
+  kind          TEXT,
+  actor         TEXT
 );
 
 CREATE TABLE IF NOT EXISTS dock_challenges (
@@ -121,6 +126,11 @@ CREATE TABLE IF NOT EXISTS sessions (
 );
 CREATE INDEX IF NOT EXISTS idx_artifacts_payload_type ON artifacts(payload_type, signed_at);
 CREATE INDEX IF NOT EXISTS idx_artifacts_dock_id ON artifacts(dock_id);
+-- Derived-column indices. A kind-only lookup answers "every revocation"; the
+-- composite answers "this agent's receipts" without loading the table and
+-- JSON-parsing every envelope, which is what made the public reads expensive.
+CREATE INDEX IF NOT EXISTS idx_artifacts_kind ON artifacts(kind, signed_at);
+CREATE INDEX IF NOT EXISTS idx_artifacts_actor_kind ON artifacts(actor, kind, signed_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_dock_id ON sessions(dock_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_uploaded_at ON sessions(uploaded_at);
 
@@ -198,6 +208,20 @@ func Open() (*sql.DB, error) {
 func migrate(db *sql.DB) error {
 	addColumns := []string{
 		`ALTER TABLE dock_challenges ADD COLUMN dock_id TEXT`,
+		// Derived indexing columns (audit items 11, 20, 21).
+		//
+		// Both are computed from the envelope's own signed bytes at
+		// ingestion, never taken from the request. That distinction is the
+		// whole point of item 11: an index built from caller-supplied
+		// metadata lets an uploader decide how their artifact is found, and
+		// a resolver filtering on it is filtering on the uploader's claim.
+		//
+		// Nullable, because rows written before this migration have neither
+		// and a backfill cannot invent them for an envelope that will not
+		// decode. A NULL here means "not derived", which is why queries must
+		// not treat it as "does not match".
+		`ALTER TABLE artifacts ADD COLUMN kind TEXT`,
+		`ALTER TABLE artifacts ADD COLUMN actor TEXT`,
 	}
 	for _, stmt := range addColumns {
 		if _, err := db.Exec(stmt); err != nil {
@@ -208,6 +232,57 @@ func migrate(db *sql.DB) error {
 		}
 	}
 	return nil
+}
+
+// BackfillDerivedIndex populates `kind`/`actor` for rows written before those
+// columns existed.
+//
+// Only touches rows where both are NULL, so it is a no-op on an up-to-date
+// database and does not re-examine rows a previous run found unindexable.
+//
+// Errors are returned rather than logged and ignored: a half-populated index
+// answers queries with a subset, which looks like an empty result rather than
+// a failure.
+func BackfillDerivedIndex(db *sql.DB, derive func(string) (kind, actor *string)) (int, error) {
+	rows, err := db.Query(
+		`SELECT artifact_id, envelope_json FROM artifacts
+		 WHERE kind IS NULL AND actor IS NULL`)
+	if err != nil {
+		return 0, err
+	}
+	type row struct{ id, env string }
+	var pending []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.env); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		pending = append(pending, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	n := 0
+	for _, r := range pending {
+		kind, actor := derive(r.env)
+		if kind == nil && actor == nil {
+			// Nothing derivable. Left NULL rather than written as empty
+			// strings, so "not derived" stays distinguishable from "derived
+			// to nothing".
+			continue
+		}
+		if _, err := db.Exec(
+			`UPDATE artifacts SET kind = ?, actor = ? WHERE artifact_id = ?`,
+			kind, actor, r.id,
+		); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
 }
 
 // --- dock_challenges ---
@@ -353,6 +428,9 @@ type Artifact struct {
 	HubURL       string  `json:"hub_url"`
 	RekorIndex   *int64  `json:"rekor_index"`
 	DockID       *string `json:"dock_id"`
+	// Derived at ingestion from the envelope, not accepted from the caller.
+	Kind  *string `json:"kind"`
+	Actor *string `json:"actor"`
 }
 
 // InsertArtifact stores an artifact, idempotently on artifact_id.
@@ -374,10 +452,10 @@ func InsertArtifact(db *sql.DB, a *Artifact) (inserted bool, err error) {
 	// DO NOTHING rather than DO UPDATE: stored bytes are never overwritten,
 	// so even a derivation bug cannot change what an existing id serves.
 	res, err := db.Exec(
-		`INSERT INTO artifacts (artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO artifacts (artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id, kind, actor)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(artifact_id) DO NOTHING`,
-		a.ArtifactID, a.PayloadType, a.EnvelopeJSON, a.Digest, a.SignedAt, a.ParentID, a.HubURL, a.RekorIndex, a.DockID,
+		a.ArtifactID, a.PayloadType, a.EnvelopeJSON, a.Digest, a.SignedAt, a.ParentID, a.HubURL, a.RekorIndex, a.DockID, a.Kind, a.Actor,
 	)
 	if err != nil {
 		return false, err
@@ -452,6 +530,48 @@ func ListArtifactsByDock(db *sql.DB, dockID string) ([]Artifact, error) {
 // ListArtifactsByPayloadType returns every artifact of a given payload type,
 // newest first. Used by the agent resolver to scan receipts. Bounded scans are
 // acceptable for now; an agent-indexed lookup is a later optimization.
+// ListArtifactsByKind returns artifacts of one derived kind, newest first,
+// bounded, reporting whether more exist.
+//
+// This is the point of the derived columns. The alternative -- and what the
+// revocation endpoint did before -- is to select every receipt, JSON-decode
+// each envelope, base64-decode each payload, and discard the 99% that are not
+// the kind you wanted. That cost is per-request and unauthenticated.
+//
+// Rows with a NULL kind are not returned. They are not "no match", they are
+// "never derived" (written before the column existed and not backfillable), so
+// a caller that needs completeness has to say so rather than assume this is
+// exhaustive.
+func ListArtifactsByKind(db *sql.DB, kind string, limit int) ([]Artifact, bool, error) {
+	rows, err := db.Query(
+		`SELECT artifact_id, payload_type, envelope_json, digest, signed_at, parent_id, hub_url, rekor_index, dock_id, kind, actor
+		 FROM artifacts WHERE kind = ? ORDER BY signed_at DESC LIMIT ?`,
+		kind, limit+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	var out []Artifact
+	for rows.Next() {
+		var a Artifact
+		if err := rows.Scan(&a.ArtifactID, &a.PayloadType, &a.EnvelopeJSON, &a.Digest,
+			&a.SignedAt, &a.ParentID, &a.HubURL, &a.RekorIndex, &a.DockID, &a.Kind, &a.Actor); err != nil {
+			return nil, false, err
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+
+	truncated := len(out) > limit
+	if truncated {
+		out = out[:limit]
+	}
+	return out, truncated, nil
+}
+
 // ListArtifactsByPayloadTypeLimit is the bounded form. Takes newest-first up
 // to `limit`, and reports whether more exist.
 //

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-chi/httprate"
 	"github.com/treeship/hub/internal/agents"
 	"github.com/treeship/hub/internal/artifacts"
+	"github.com/treeship/hub/internal/contentaddress"
 	"github.com/treeship/hub/internal/db"
 	"github.com/treeship/hub/internal/dock"
 	"github.com/treeship/hub/internal/merkle"
@@ -36,6 +37,25 @@ func main() {
 		log.Fatalf("failed to open database: %v", err)
 	}
 	defer database.Close()
+
+	// Populate the derived index for rows written before those columns
+	// existed. Without this, every indexed query silently returns only
+	// artifacts ingested after the upgrade -- an empty revocation list on a
+	// hub that holds revocations, which is the worst shape of wrong answer.
+	//
+	// Fatal on error rather than logged and continued: serving from a
+	// half-populated index answers queries with a subset that looks exactly
+	// like a complete result.
+	backfilled, err := db.BackfillDerivedIndex(database, func(env string) (*string, *string) {
+		idx := contentaddress.DeriveIndexable(env)
+		return idx.Kind, idx.Actor
+	})
+	if err != nil {
+		log.Fatalf("derived-index backfill failed: %v", err)
+	}
+	if backfilled > 0 {
+		log.Printf("backfilled derived index for %d artifact(s)", backfilled)
+	}
 
 	dockHandlers := &dock.Handlers{DB: database}
 	artifactHandlers := &artifacts.Handlers{DB: database}
@@ -358,8 +378,11 @@ func revokedHandler(database *sql.DB) http.HandlerFunc {
 		// holds the revoked grant.
 		w.Header().Set("Cache-Control", "max-age=300")
 
-		artifacts, truncated, err := db.ListArtifactsByPayloadTypeLimit(
-			database, receiptPayloadType, revocationListLimit)
+		// Indexed lookup. This used to select every receipt and decode each
+		// envelope to find the few that were revocations -- per request, on an
+		// unauthenticated endpoint.
+		artifacts, truncated, err := db.ListArtifactsByKind(
+			database, "grant_revocation.v1", revocationListLimit)
 		if err != nil {
 			log.Printf("revocation list query failed: %v", err)
 			// 503, not an empty 200. An empty list is indistinguishable from

--- a/packages/hub/revoked_test.go
+++ b/packages/hub/revoked_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/treeship/hub/internal/contentaddress"
 	"github.com/treeship/hub/internal/db"
 )
 
@@ -63,9 +64,14 @@ func getRevoked(t *testing.T, mux *http.ServeMux) (map[string]any, *httptest.Res
 	return body, rec
 }
 
+// Mirrors what Push does: the indexed fields are derived from the envelope.
+// A fixture that set them by hand would test the query and not the derivation.
 func artifact(id, env string) *db.Artifact {
 	dock := "dock_a"
+	idx := contentaddress.DeriveIndexable(env)
 	return &db.Artifact{
+		Kind:         idx.Kind,
+		Actor:        idx.Actor,
 		ArtifactID:   id,
 		PayloadType:  receiptPayloadType,
 		EnvelopeJSON: env,
@@ -169,5 +175,81 @@ func TestTruncationIsReported(t *testing.T) {
 	body, _ := getRevoked(t, hubWith(t))
 	if _, present := body["truncated"]; !present {
 		t.Error("`truncated` must always be present, so its absence is never ambiguous")
+	}
+}
+
+// A hub upgraded in place holds artifacts written before `kind` existed. If
+// the backfill does not run, every indexed query returns only what was
+// ingested after the upgrade -- an empty revocation list on a hub that holds
+// revocations, which is the worst shape of wrong answer: confident and wrong.
+//
+// This writes a row the way a pre-upgrade hub would (no derived fields), then
+// asserts it is invisible until backfilled and present afterwards.
+func TestBackfillMakesPreUpgradeRowsVisible(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if _, err := database.Exec(
+		`INSERT INTO ships (dock_id, ship_public_key, dock_public_key, created_at)
+		 VALUES (?, ?, ?, ?)`, "dock_a", []byte("s"), []byte("d"), 1,
+	); err != nil {
+		t.Fatalf("register dock: %v", err)
+	}
+
+	env := receiptEnvelope(t, "grant_revocation.v1", map[string]any{
+		"grant_id": "grn_old", "grantor": "pk1", "revoked_at": "2026-08-01T10:00:00Z",
+	})
+	// Deliberately NULL kind/actor -- exactly what a pre-migration row looks like.
+	if _, err := database.Exec(
+		`INSERT INTO artifacts
+		 (artifact_id, payload_type, envelope_json, digest, signed_at, hub_url, dock_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"art_old", receiptPayloadType, env, "sha256:00", 100, "https://x/art_old", "dock_a",
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/treeship/revoked.json", revokedHandler(database))
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/treeship/revoked.json", nil))
+	var before map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &before)
+	if list, _ := before["revoked"].([]any); len(list) != 0 {
+		t.Fatalf("a row with no derived kind should not be found by an indexed query; got %d", len(list))
+	}
+
+	n, err := db.BackfillDerivedIndex(database, func(e string) (*string, *string) {
+		idx := contentaddress.DeriveIndexable(e)
+		return idx.Kind, idx.Actor
+	})
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("backfill should have updated 1 row, updated %d", n)
+	}
+
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/treeship/revoked.json", nil))
+	var after map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &after)
+	list, _ := after["revoked"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("after backfill the legacy revocation must appear; got %d", len(list))
+	}
+
+	// Idempotent: a second run must not re-touch rows it already decided.
+	n2, err := db.BackfillDerivedIndex(database, func(e string) (*string, *string) {
+		idx := contentaddress.DeriveIndexable(e)
+		return idx.Kind, idx.Actor
+	})
+	if err != nil || n2 != 0 {
+		t.Fatalf("second backfill should be a no-op, got n=%d err=%v", n2, err)
 	}
 }


### PR DESCRIPTION
Audit items **11, 20 and 21**. `artifacts` gains `kind` and `actor`, both computed from the envelope's own signed bytes at ingestion.

## Derived, never accepted

That distinction *is* item 11. An index built from caller-supplied metadata lets an uploader choose how their artifact is found — and a resolver filtering on it is filtering on the uploader's claim about itself rather than on content. Same reason #285 re-derives the artifact id instead of trusting the submitted one.

## What it buys

The revocation endpoint selected **every receipt**, JSON-decoded each envelope, base64-decoded each payload, and discarded the ones that weren't revocations — per request, on an unauthenticated endpoint. It now does an indexed lookup on `kind`.

#288 rate-limited that path. This makes it *cheap* rather than merely throttled.

`ListArtifactsByKind` is bounded and reports truncation, because a silently-truncated revocation list drops revocations a client needed and looks identical to their not existing.

## The bug I nearly shipped

**I wrote `BackfillDerivedIndex` and didn't call it.**

On a hub upgraded in place, every pre-existing row has a NULL kind — so every indexed query would have returned only artifacts ingested *after* the upgrade. An empty revocation list on a hub that holds revocations. Confident and wrong, which is the worst shape of answer for this endpoint specifically.

It now runs at startup and is **fatal on error**: serving from a half-populated index answers queries with a subset that looks exactly like a complete result.

There's a test that writes a row the way a pre-upgrade hub would (NULL derived fields), asserts it's invisible to the indexed query, runs the backfill, asserts it appears, then runs it again to confirm the second pass is a no-op.

## NULL is not empty

A row whose envelope won't decode indexes as NULL — meaning *"not derived"*, never *"derived to nothing"*. Queries must not read the two as the same, and `ListArtifactsByKind` documents that it excludes them.

`go vet` clean · all hub tests pass · govulncheck 0 · OpenAPI drift gate passes.
