### PR TITLE
fix(hub): label the agent metrics as claims, because that is what they are

### DIFF
--- a/docs/content/docs/api/hub-openapi.yaml
+++ b/docs/content/docs/api/hub-openapi.yaml
@@ -758,7 +758,6 @@ paths:
                       basis: { type: string, description: "States plainly that these are self-reported." }
                       total: { type: integer, deprecated: true, description: "Same value as claimed_total. Removed at the next major." }
                       seen_last_7d: { type: integer, deprecated: true, description: "Same value as claimed_seen_last_7d." }
-                  agents:    { type: object, properties: { total: { type: integer }, seen_last_7d: { type: integer } } }
                   generated_at: { type: string, format: date-time }
         '500':
           description: Stats unavailable

--- a/docs/content/docs/api/hub-openapi.yaml
+++ b/docs/content/docs/api/hub-openapi.yaml
@@ -743,6 +743,21 @@ paths:
                   artifacts: { type: object, properties: { total: { type: integer }, last_7d: { type: integer } } }
                   docks:     { type: object, properties: { total: { type: integer }, attached_last_7d: { type: integer }, active_last_7d: { type: integer } } }
                   sessions:  { type: object, properties: { total: { type: integer }, receipts_uploaded: { type: integer }, uploaded_last_7d: { type: integer } } }
+                  agents:
+                    type: object
+                    description: >-
+                      Counts CLAIMS, unlike the blocks above. Populated from
+                      AgentGraph nodes in uploaded session receipts, which the
+                      hub does not cryptographically verify -- so an
+                      authenticated dock can inflate these. Artifact, dock and
+                      session counts are facts about the hub's own state and
+                      are unaffected.
+                    properties:
+                      claimed_total: { type: integer }
+                      claimed_seen_last_7d: { type: integer }
+                      basis: { type: string, description: "States plainly that these are self-reported." }
+                      total: { type: integer, deprecated: true, description: "Same value as claimed_total. Removed at the next major." }
+                      seen_last_7d: { type: integer, deprecated: true, description: "Same value as claimed_seen_last_7d." }
                   agents:    { type: object, properties: { total: { type: integer }, seen_last_7d: { type: integer } } }
                   generated_at: { type: string, format: date-time }
         '500':

--- a/integrations/agent-skills/README.md
+++ b/integrations/agent-skills/README.md
@@ -6,17 +6,25 @@ The skill covers the full Treeship surface: CLI commands (`treeship wrap`, `tree
 
 ## Quick Reference
 
-| Agent | Install Command | `--agent` flag | Skills Path |
-|---|---|---|---|
-| Kimi Code CLI | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` | `kimi-cli` | `~/.config/agents/skills/` |
-| Claude Code | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` | `claude-code` | `~/.claude/skills/` |
-| Codex | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` | `codex` | `~/.codex/skills/` |
-| Codex contributor | `npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y` | `codex` | `~/.codex/skills/` |
-| Cursor | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` | `cursor` | `~/.cursor/skills/` |
-| OpenClaw | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` | `openclaw` | `~/.openclaw/skills/` |
-| Hermes | Manual curl (see below) | — | `~/.hermes/skills/` |
+The canonical one-liner per agent is `treeship add <agent>` — it configures skill + MCP (and hook plugin where available) in one shot. The `npx skills add` alternative ships skill-only and is useful for non-Treeship-native discovery.
 
-The `-g` installs globally (one copy on the machine, every project sees it). `-y` skips the confirmation prompt — useful in CI and scripted setup. Drop both for an interactive install scoped to the current project.
+| Agent | Canonical (skill + MCP + plugin where available) | Skill-only alternative |
+|---|---|---|
+| Kimi Code CLI | `treeship add kimi-code` *(pending; use skill-only today)* | `npx skills add zerkerlabs/treeship --skill treeship --agent kimi-cli -g -y` |
+| Claude Code | `treeship add claude-code` | `npx skills add zerkerlabs/treeship --skill treeship --agent claude-code -g -y` |
+| Codex | `treeship add codex` | `npx skills add zerkerlabs/treeship --skill treeship --agent codex -g -y` |
+| Codex contributor | — | `npx skills add zerkerlabs/treeship --skill treeship-dev --agent codex -g -y` |
+| Cursor | `treeship add cursor` | `npx skills add zerkerlabs/treeship --skill treeship --agent cursor -g -y` |
+| OpenClaw | `treeship add openclaw` | `npx skills add zerkerlabs/treeship --skill treeship --agent openclaw -g -y` |
+| Hermes | `treeship add hermes` | (skill-only path is the same; treeship add is recommended) |
+
+Or instrument everything Treeship detects on this machine in one shot:
+
+```bash
+treeship add
+```
+
+The `-g` flag on `npx skills add` installs globally (one copy on the machine, every project sees it). `-y` skips the confirmation prompt — useful in CI and scripted setup. Drop both for an interactive install scoped to the current project.
 
 ## Per-Agent Setup
 

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,5 +1,6 @@
 # Treeship + Hermes Integration
 
+<<<<<<< Updated upstream
 Hermes integrates via the universal MCP bridge and a declarative skill file — there is **no Hermes-native in-process plugin** today. Coverage is skill-driven + MCP-routed; if you need hook-based bypass-proof capture, that lives in the Claude Code, Kimi Code, or OpenClaw plugins.
 
 The target outcome is a **provable Hermes session**: Hermes has its own Treeship agent identity, MCP-routed tool calls are signed as `agent://hermes`, important shell commands are wrapped, and the final session report verifies offline.
@@ -11,17 +12,42 @@ curl -fsSL https://treeship.dev/install | sh
 treeship init
 npm install -g @treeship/mcp
 ```
+=======
+## Quick install (recommended)
+>>>>>>> Stashed changes
 
-## Method 1: Skill file (instruction-based)
+From a project with `treeship init` already run:
 
+<<<<<<< Updated upstream
 Copy this integration skill into Hermes:
+=======
+```bash
+treeship add hermes
+```
+
+That command installs the Treeship skill to `~/.hermes/skills/treeship/SKILL.md` and configures the Hermes MCP path. The actor URI is `agent://hermes` so receipts identify Hermes as the tool caller. Idempotent — safe to re-run.
+
+To instrument every detected agent on this machine at once:
+
+```bash
+treeship add
+```
+
+## Method 1: Manual skill install
+
+If `treeship add hermes` isn't available (older CLI) or you want to install by hand:
+>>>>>>> Stashed changes
 
 ```bash
 mkdir -p ~/.hermes/skills/treeship
 cp integrations/hermes/treeship.skill/SKILL.md ~/.hermes/skills/treeship/SKILL.md
 ```
 
+<<<<<<< Updated upstream
 Or install from GitHub:
+=======
+Or from the repo:
+>>>>>>> Stashed changes
 
 ```bash
 mkdir -p ~/.hermes/skills/treeship

--- a/packages/hub/internal/stats/stats.go
+++ b/packages/hub/internal/stats/stats.go
@@ -49,9 +49,32 @@ type sessionStats struct {
 	UploadedLast7d   int64 `json:"uploaded_last_7d"`
 }
 
+// agentStats counts CLAIMS, unlike every other block on this endpoint.
+//
+// `ship_agents` is populated from `AgentGraph.Nodes` in receipts uploaded by
+// authenticated docks, and the hub does not cryptographically verify a receipt
+// before deriving from it -- verification is the client's job, by design. So a
+// dock can name as many agents as it likes in a receipt and this count follows.
+//
+// Artifacts, docks and sessions are different: those are facts about the hub's
+// own state (a row exists, a dock completed the DPoP flow, an upload landed).
+// Only this block is downstream of content the hub did not check, which is why
+// only this block is relabelled.
 type agentStats struct {
+	// The honest names. A reader who sees `claimed_total` cannot mistake it
+	// for a verified population count.
+	ClaimedTotal      int64 `json:"claimed_total"`
+	ClaimedSeenLast7d int64 `json:"claimed_seen_last_7d"`
+
+	// Deprecated, and duplicated rather than removed: this is a public
+	// endpoint and renaming a field is a breaking change for anyone reading
+	// it. They carry the same values and will go at the next major.
 	Total      int64 `json:"total"`
 	SeenLast7d int64 `json:"seen_last_7d"`
+
+	// Impossible to miss when reading the JSON, which is the point -- a
+	// caveat in documentation nobody opens is not a caveat.
+	Basis string `json:"basis"`
 }
 
 type response struct {
@@ -84,8 +107,8 @@ func (h *Handlers) Stats(w http.ResponseWriter, r *http.Request) {
 		{&resp.Sessions.Total, `SELECT COUNT(*) FROM sessions`, nil},
 		{&resp.Sessions.ReceiptsUploaded, `SELECT COUNT(*) FROM sessions WHERE receipt_json IS NOT NULL`, nil},
 		{&resp.Sessions.UploadedLast7d, `SELECT COUNT(*) FROM sessions WHERE uploaded_at IS NOT NULL AND uploaded_at >= ?`, []any{cutoff}},
-		{&resp.Agents.Total, `SELECT COUNT(DISTINCT agent_id) FROM ship_agents`, nil},
-		{&resp.Agents.SeenLast7d, `SELECT COUNT(DISTINCT agent_id) FROM ship_agents WHERE last_seen >= ?`, []any{cutoff}},
+		{&resp.Agents.ClaimedTotal, `SELECT COUNT(DISTINCT agent_id) FROM ship_agents`, nil},
+		{&resp.Agents.ClaimedSeenLast7d, `SELECT COUNT(DISTINCT agent_id) FROM ship_agents WHERE last_seen >= ?`, []any{cutoff}},
 	}
 	for _, item := range queries {
 		if err := h.DB.QueryRow(item.query, item.args...).Scan(item.dst); err != nil {
@@ -95,6 +118,15 @@ func (h *Handlers) Stats(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Mirror the honest names into the deprecated ones so both are correct
+	// for the release in which they coexist.
+	resp.Agents.Total = resp.Agents.ClaimedTotal
+	resp.Agents.SeenLast7d = resp.Agents.ClaimedSeenLast7d
+	resp.Agents.Basis = "self-reported: counted from AgentGraph nodes in uploaded " +
+		"session receipts, which the hub does not cryptographically verify. An " +
+		"authenticated dock can inflate this. Artifact, dock and session counts are " +
+		"facts about the hub's own state and are not affected."
+
 	resp.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
 
 	w.Header().Set("Content-Type", "application/json")

--- a/packages/hub/internal/stats/stats_test.go
+++ b/packages/hub/internal/stats/stats_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,5 +171,60 @@ func assertEq(t *testing.T, name string, got, want int64) {
 	t.Helper()
 	if got != want {
 		t.Errorf("%s = %d, want %d", name, got, want)
+	}
+}
+
+// Audit item 23. `ship_agents` is populated from AgentGraph nodes in uploaded
+// receipts that the hub never cryptographically verifies, so this count is a
+// sum of claims. `agents.total` read as a verified population figure, and a
+// public adoption metric that can be inflated by anyone with a dock should
+// not be phrased as a fact.
+func TestAgentCountsAreLabelledAsClaims(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	h := &Handlers{DB: database}
+	rec := httptest.NewRecorder()
+	h.Stats(rec, httptest.NewRequest(http.MethodGet, "/v1/stats", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+	agents, _ := body["agents"].(map[string]any)
+	if agents == nil {
+		t.Fatal("no agents block")
+	}
+
+	if _, ok := agents["claimed_total"]; !ok {
+		t.Error("the honest name must be present -- `total` alone reads as verified")
+	}
+	basis, _ := agents["basis"].(string)
+	if basis == "" {
+		t.Fatal("the agents block must state what its numbers are counted from")
+	}
+	if !strings.Contains(basis, "self-reported") {
+		t.Errorf("basis should say plainly that these are claims: %q", basis)
+	}
+
+	// The deprecated name stays for one release and must agree, or a consumer
+	// reading the old field gets a different number from one reading the new.
+	if agents["total"] != agents["claimed_total"] {
+		t.Errorf("deprecated `total` (%v) disagrees with `claimed_total` (%v)",
+			agents["total"], agents["claimed_total"])
+	}
+
+	// Facts must NOT be relabelled as claims. Artifact and dock counts are
+	// statements about the hub's own state; calling them self-reported would
+	// be its own inaccuracy in the opposite direction.
+	for _, block := range []string{"artifacts", "docks", "sessions"} {
+		b, _ := body[block].(map[string]any)
+		if _, ok := b["basis"]; ok {
+			t.Errorf("%s counts the hub's own rows and should not carry a claims caveat", block)
+		}
 	}
 }

--- a/scripts/check-hub-openapi.py
+++ b/scripts/check-hub-openapi.py
@@ -16,6 +16,8 @@ import os
 import re
 import sys
 
+import yaml
+
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MAIN_GO = os.path.join(REPO, "packages", "hub", "main.go")
 OPENAPI = os.path.join(REPO, "docs", "content", "docs", "api", "hub-openapi.yaml")
@@ -62,7 +64,53 @@ def routes_from_openapi():
     return routes
 
 
+class _NoDuplicatesLoader(yaml.SafeLoader):
+    """A loader that refuses duplicate mapping keys.
+
+    PyYAML silently keeps the last of a duplicated key. The JS YAML parser the
+    docs build uses rejects the file outright -- so a hand-edit that inserted a
+    block beside an existing one parsed fine here, passed this check, and then
+    failed the production build with an error pointing at an unrelated line.
+
+    Subclassing the loader rather than scanning lines because YAML sequences
+    legitimately repeat keys across items (`- name: / in: / required:`), and a
+    line-based scan flags every one of them.
+    """
+
+
+def _no_duplicates(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            mark = key_node.start_mark
+            raise yaml.constructor.ConstructorError(
+                None, None,
+                f"duplicate key {key!r} (line {mark.line + 1})", mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_NoDuplicatesLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates
+)
+
+
 def main():
+    try:
+        with open(OPENAPI) as f:
+            yaml.load(f, Loader=_NoDuplicatesLoader)
+    except yaml.YAMLError as e:
+        print(f"  err   {OPENAPI} is not valid YAML for the docs build: {e}")
+        print()
+        print(
+            "PyYAML keeps a duplicated key silently and the JS parser the docs "
+            "build uses rejects the file, so this passed here and failed there. "
+            "Caught before CI now."
+        )
+        return 1
+
     code = routes_from_router()
     spec = routes_from_openapi()
 


### PR DESCRIPTION
Audit item 23. `/v1/stats` reported `agents.total` as a plain number beside artifact, dock and session counts — and it isn't the same kind of number.

`ship_agents` is populated from `AgentGraph.Nodes` in session receipts uploaded by authenticated docks, and **the hub does not cryptographically verify a receipt before deriving from it** — verification is the client's job, deliberately. So a dock can name as many agents as it likes and this count follows.

A sum of claims presented as a fact, on a public adoption metric.

## Only that block is relabelled

The precision matters. **Artifacts, docks and sessions are facts about the hub's own state** — a row exists, a dock completed the DPoP flow, an upload landed. Calling those self-reported would be an inaccuracy in the opposite direction, and there's a test asserting they carry no claims caveat.

## The shape

```json
"agents": {
  "claimed_total": 12,
  "claimed_seen_last_7d": 4,
  "basis": "self-reported: counted from AgentGraph nodes in uploaded session
              receipts, which the hub does not cryptographically verify…",
  "total": 12,            // deprecated, same value, removed next major
  "seen_last_7d": 4       // deprecated
}
```

A reader seeing `claimed_total` can't mistake it for a verified population. Old keys stay one release because this is a public endpoint and renaming breaks anyone reading it — with a test asserting the two agree, or a consumer on the old name would get a different number from one on the new.

`basis` lives **in the payload**, not only in the OpenAPI description. A caveat in documentation nobody opens is not a caveat.