### PR TITLE
docs: AGENTS.md described v0.10.2 while the product shipped 0.24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,16 @@
 # TREESHIP --AGENT INSTRUCTIONS
 
 > **Read this file first. Every time. It is the single source of truth.**
-> Last updated: May 2026 · 257 core lib tests passing · CLI + Hub + SDK + MCP + Claude Code plugin shipped (v0.10.2).
+> Last updated: August 2026 · shipped at v0.24.0 · CLI + Hub + SDKs + MCP/A2A
+> bridges + Claude Code / OpenClaw / Kimi plugins + a Rig integration.
+>
+> **This file is orientation, not inventory.** It described v0.10.2 for four
+> months while the product reached 0.24, and the specific numbers in it were
+> the part that rotted: a test count, a cipher, a list of "not built yet" items
+> that had shipped. Counts are deliberately gone now -- `cargo test` answers
+> that question and cannot be out of date. For what exists today, the
+> CI-checked source is
+> [`docs/quality/capability-index.md`](docs/quality/capability-index.md).
 
 ---
 
@@ -33,7 +42,7 @@ Treeship is a portable trust layer for AI agent workflows. Every action, approva
 
 | Component | Location | Status |
 |-----------|----------|--------|
-| Rust core library | `packages/core/` | 257 tests passing |
+| Rust core library | `packages/core/` | signing, verification, keystore, Merkle |
 | Rust CLI binary | `packages/cli/` | 25+ commands |
 | TUI (Ratatui) | `packages/cli/` | Interactive terminal dashboard (`treeship ui`) |
 | OTel export | `packages/cli/` | OpenTelemetry span export (feature-flagged) |
@@ -42,7 +51,7 @@ Treeship is a portable trust layer for AI agent workflows. Every action, approva
 | TypeScript SDK | `packages/sdk-ts/` | @treeship/sdk, 6 tests |
 | Python SDK | `packages/sdk-python/` | treeship-sdk, parity-tested vs TS via cross-SDK suite |
 | Cross-SDK contract suite | `tests/cross-sdk/` | 4 vectors, runs in CI matrix (Ubuntu+macOS, Node 20/22, Python 3.11/3.12) |
-| MCP bridge | `bridges/mcp/` | @treeship/mcp, 3 tests |
+| MCP bridge | `bridges/mcp/` | @treeship/mcp |
 | Fumadocs site | `docs/` | 62 pages + 18 blog posts |
 | Website | (separate repo) | 8 pages |
 
@@ -50,9 +59,14 @@ Treeship is a portable trust layer for AI agent workflows. Every action, approva
 
 1. **ZK TLS (TLSNotary)** -- fully specced, feature-flagged, TLSNotary still alpha
 2. **`treeship attach claude/cursor`** -- agent process detection (the official Claude Code plugin at `integrations/claude-code-plugin/` covers Claude Code via PostToolUse hooks; standalone process attach for Cursor/Cline is still planned)
-3. **Hub Merkle Rekor anchoring** -- Rekor integration is best-effort, not yet live
-4. **Verifier-side enforcement of `valid_until` on rotated keys** -- the metadata is captured in v0.9.5 (`Store::rotate`) but verifiers do not yet refuse signatures from expired keys; slated for v0.10.0 behind an opt-in flag
-5. **Compromise-revocation primitive** -- `rotate` is graceful (predecessor stays valid through grace window); a separate revocation primitive for compromised keys is its own design
+3. **Hub Merkle Rekor anchoring** -- wired and best-effort: `rekor.Anchor` runs on push and a failure does not fail the push, so an artifact may have no `rekor_index`. Treat it as supplemental until end-to-end tests confirm it.
+4. **Certificate pinning to `api.treeship.dev`** -- hub writes are DPoP-authenticated (RFC 9449), which binds the request to a dock keypair, but the TLS connection itself is trusted on the system root store. A machine with a hostile root CA sees a hub it should not trust.
+5. **Selective disclosure of receipt fields** -- receipts are all-or-nothing today; `present --disclose` narrows a capability card, not a session receipt's contents.
+
+Two items previously listed here have since shipped and are removed rather
+than left as "not built": verifier-side `valid_until` enforcement (now in
+`verify/resolution.rs`) and the compromise-revocation primitive (`treeship
+grant revoke`, honored by `verify` locally and via a hub's published list).
 
 ---
 
@@ -65,11 +79,11 @@ treeship/                           # monorepo root
 ├── AGENTS.md                       # this file
 │
 ├── packages/
-│   ├── core/                       # Rust library (257 tests)
+│   ├── core/                       # Rust library
 │   │   └── src/
 │   │       ├── attestation/        # DSSE, PAE, Ed25519, content-addressed IDs
 │   │       ├── statements/         # 8 statement types (action, approval, handoff, endorsement, receipt, bundle, decision, declaration), nonce binding
-│   │       ├── keys/               # AES-256-CTR + HMAC encrypted keystore
+│   │       ├── keys/               # AES-256-GCM encrypted keystore
 │   │       ├── storage/            # local artifact store
 │   │       ├── bundle/             # pack/export/import .treeship files
 │   │       ├── merkle/             # tree, checkpoint, proof


### PR DESCRIPTION
Every specific number in `AGENTS.md` had rotted:

| It said | Actually |
|---|---|
| 257 core lib tests | **556** |
| AES-256-CTR + HMAC keystore | **AES-256-GCM** (CTR+HMAC is the legacy pre-0.10.3 read path) |
| shipped (v0.10.2) | **0.24.0** |
| MCP bridge, 3 tests | **12** |

And two entries under **"What is NOT built yet"** had been built: verifier-side `valid_until` enforcement (now in `verify/resolution.rs`) and the compromise-revocation primitive (`treeship grant revoke`, plus the hub's published list).

**A file that tells a reader something doesn't exist is worse than one that omits it** — the omission prompts a look, the denial prevents one. Both removed rather than left with a "shipped" note, and the removal is stated so the change is visible.

## Counts are gone, not corrected

`cargo test` answers that question and can't be out of date. A number typed into prose is only right on the day it was typed. Same reasoning as removing them from ONBOARDING.md.

The header now says outright that this file is **orientation, not inventory**, and points at `docs/quality/capability-index.md`, which CI keeps honest.

## Two real gaps added while removing the fake ones

**Rekor anchoring** was listed as "not yet live." It's wired and best-effort — runs on push, and a failure doesn't fail the push, so an artifact may simply have no `rekor_index`. Neither "not built" nor "done"; now described as what it is.

**No certificate pinning to `api.treeship.dev`.** Hub writes are DPoP-authenticated (RFC 9449), which binds a request to a dock keypair — but the TLS connection is trusted on the system root store. Verified: no pinning in the CLI or the Go client.

A machine with a hostile root CA sees a hub it should not trust, and **DPoP doesn't help, because it authenticates the client to the server, not the server to the client.** That distinction is why this belongs on the gap list rather than being covered by "hub writes are authenticated."
