### PR TITLE
fix(session): `event --format json` exited 0 and printed nothing

### DIFF
--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1789,7 +1789,19 @@ pub fn event(
         "sequence_no": evt.sequence_no,
     });
 
-    printer.info(&serde_json::to_string(&output).unwrap_or_default());
+    // `printer.info` returns early in JSON mode, so this command built its
+    // response and then discarded it: `session event --format json` exited 0
+    // and printed nothing. Every SDK wrapper reading `event_id` off the
+    // result got `undefined` from an empty document.
+    //
+    // `printer.json` is the emitter that actually writes in JSON mode. In
+    // human mode the id is not what a reader wants, so it stays a one-line
+    // confirmation.
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&output);
+    } else {
+        printer.info(&serde_json::to_string(&output).unwrap_or_default());
+    }
 
     Ok(())
 }

--- a/packages/cli/tests/session_cli.rs
+++ b/packages/cli/tests/session_cli.rs
@@ -84,3 +84,86 @@ fn session_close_json_is_one_parseable_document() {
     assert!(json["session_id"].as_str().is_some());
     assert!(json["package"].as_str().is_some());
 }
+
+/// `session event --format json` exited 0 and printed nothing.
+///
+/// It built the response and passed it to `printer.info`, which returns early
+/// in JSON mode -- so the document was constructed and discarded. Every SDK
+/// wrapper reading `event_id` off the result got `undefined` from an empty
+/// stdout, and the command's exit code said success.
+///
+/// Found reviewing an external contributor's SDK PR (#203). The PR was right;
+/// the CLI it wrapped was not.
+#[test]
+fn session_event_json_actually_emits_the_event_id() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+
+    let command = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = command(&[
+        "init",
+        "--config",
+        config.to_str().unwrap(),
+        "--name",
+        "event-json-test",
+    ]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let start = command(&[
+        "session",
+        "start",
+        "--config",
+        config.to_str().unwrap(),
+        "--name",
+        "json-event",
+    ]);
+    assert!(
+        start.status.success(),
+        "start: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+
+    let event = command(&[
+        "session",
+        "event",
+        "--config",
+        config.to_str().unwrap(),
+        "--type",
+        "agent.called_tool",
+        "--tool",
+        "bash",
+        "--format",
+        "json",
+    ]);
+    assert!(
+        event.status.success(),
+        "event: {}",
+        String::from_utf8_lossy(&event.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&event.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "`--format json` produced no output; exit code 0 with an empty document \
+         is the shape that made this bug invisible"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout must be one parseable JSON document");
+    assert!(
+        json["event_id"].as_str().is_some_and(|s| !s.is_empty()),
+        "event_id is what an SDK reads off this call: {json}"
+    );
+    assert!(json["session_id"].as_str().is_some(), "{json}");
+    assert!(json["sequence_no"].as_u64().is_some(), "{json}");
+}


### PR DESCRIPTION
It built the response document and passed it to `printer.info`, **which returns early when the format is JSON.** So the JSON was constructed and discarded: exit code 0, empty stdout.

```
$ treeship session event --type agent.called_tool --tool bash --format json
$ echo $?
0
```

That's the shape that kept it invisible. A command that fails loudly gets fixed; one that **succeeds silently** gets worked around. Every SDK wrapper reading `event_id` off this call received `undefined` from an empty document, with no signal anything was wrong.

## How it surfaced

Reviewing **#203** — an external contributor's SDK PR adding `ship.session.event()`, open five weeks.

I checked all 14 flags it passes: every one exists. Then I checked the return shape it reads, and found the CLI never emits it. **The PR is correct; the CLI it wraps was not.**

## The fix

`printer.json` is the emitter that actually writes in JSON mode. Human mode keeps the one-line confirmation — an event id isn't what a person reading a terminal wants.

Swept for the same pattern: no other command passes a serialized document to `printer.info`.

## On the test

It asserts stdout is **non-empty before parsing**, because "exit 0 with nothing on stdout" is exactly what this looked like — a parse-only assertion would have failed with a confusing serde error instead of the real problem.

This unblocks #203, which I'd merge next.