### PR TITLE
fix(docs): remove conflict markers I committed to main in #308

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,12 @@ jobs:
         run: |
           cargo build --bin treeship --quiet
           python3 scripts/gen-capability-map.py --check
+      # PR #308 committed nine conflict markers into a published doc. Every
+      # other gate passed -- none of them read that file. This one is a grep
+      # that runs, which is the whole point: the markers were not hard to see,
+      # nothing looked.
+      - name: No committed conflict markers
+        run: python3 scripts/check-conflict-markers.py
       - name: Every protocol spec is indexed
         run: python3 scripts/check-specs-index.py
       - name: Published crates embed only files inside their own root

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,6 +1,5 @@
 # Treeship + Hermes Integration
 
-<<<<<<< Updated upstream
 Hermes integrates via the universal MCP bridge and a declarative skill file — there is **no Hermes-native in-process plugin** today. Coverage is skill-driven + MCP-routed; if you need hook-based bypass-proof capture, that lives in the Claude Code, Kimi Code, or OpenClaw plugins.
 
 The target outcome is a **provable Hermes session**: Hermes has its own Treeship agent identity, MCP-routed tool calls are signed as `agent://hermes`, important shell commands are wrapped, and the final session report verifies offline.
@@ -12,42 +11,17 @@ curl -fsSL https://treeship.dev/install | sh
 treeship init
 npm install -g @treeship/mcp
 ```
-=======
-## Quick install (recommended)
->>>>>>> Stashed changes
 
-From a project with `treeship init` already run:
+## Method 1: Skill file (instruction-based)
 
-<<<<<<< Updated upstream
 Copy this integration skill into Hermes:
-=======
-```bash
-treeship add hermes
-```
-
-That command installs the Treeship skill to `~/.hermes/skills/treeship/SKILL.md` and configures the Hermes MCP path. The actor URI is `agent://hermes` so receipts identify Hermes as the tool caller. Idempotent — safe to re-run.
-
-To instrument every detected agent on this machine at once:
-
-```bash
-treeship add
-```
-
-## Method 1: Manual skill install
-
-If `treeship add hermes` isn't available (older CLI) or you want to install by hand:
->>>>>>> Stashed changes
 
 ```bash
 mkdir -p ~/.hermes/skills/treeship
 cp integrations/hermes/treeship.skill/SKILL.md ~/.hermes/skills/treeship/SKILL.md
 ```
 
-<<<<<<< Updated upstream
 Or install from GitHub:
-=======
-Or from the repo:
->>>>>>> Stashed changes
 
 ```bash
 mkdir -p ~/.hermes/skills/treeship

--- a/scripts/check-conflict-markers.py
+++ b/scripts/check-conflict-markers.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Fail when a merge-conflict marker is committed.
+
+This exists because it happened. PR #308 committed nine markers into
+`integrations/hermes/README.md`, including the `Updated upstream` /
+`Stashed changes` pair a conflicted `git stash pop` leaves behind. A
+`git add -A` swept the conflicted file in, the diff was large and about
+something else, and every other gate passed -- none of them read that file.
+
+The document was published to the docs site in that state.
+
+Nothing here is clever. It is a grep that runs, which is the entire point:
+the failure mode was not that the markers were hard to see, it was that
+nothing looked.
+
+Markers are matched only at the start of a line and with the exact widths git
+writes, so prose *about* conflicts and any legitimate run of `=` in a table or
+underline does not trip it.
+"""
+
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# git writes exactly seven characters, at column zero.
+PATTERNS = [
+    r"^<<<<<<< ",
+    r"^>>>>>>> ",
+    r"^\|\|\|\|\|\|\| ",  # diff3 style base section
+]
+
+# `=======` alone is too common (markdown underlines, ASCII rules) to match on
+# its own. It is only a conflict when it sits between the other two, which the
+# patterns above already catch.
+
+SKIP_DIRS = {".git", "node_modules", "target", "dist", "build", ".next", "vendor"}
+
+
+def tracked_files():
+    out = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=REPO, capture_output=True, text=True, check=True
+    )
+    for path in out.stdout.split("\0"):
+        if not path:
+            continue
+        if any(part in SKIP_DIRS for part in path.split("/")):
+            continue
+        yield path
+
+
+def main():
+    import re
+
+    compiled = [re.compile(p) for p in PATTERNS]
+    hits = []
+    checked = 0
+
+    for rel in tracked_files():
+        full = os.path.join(REPO, rel)
+        try:
+            with open(full, encoding="utf-8") as f:
+                lines = f.readlines()
+        except (OSError, UnicodeDecodeError):
+            continue  # binary or unreadable; a marker cannot hide in a jpeg
+        checked += 1
+        # This file necessarily contains the patterns it searches for.
+        if rel == "scripts/check-conflict-markers.py":
+            continue
+        for n, line in enumerate(lines, 1):
+            if any(p.match(line) for p in compiled):
+                hits.append((rel, n, line.rstrip()[:70]))
+
+    if not checked:
+        # A sweep that examined nothing passes vacuously and reads as a pass.
+        print("  err   no tracked files were read; this check would pass vacuously")
+        return 1
+
+    if hits:
+        for rel, n, text in hits:
+            print(f"  err   {rel}:{n}: committed conflict marker")
+            print(f"        {text}")
+        print()
+        print(
+            f"{len(hits)} conflict marker(s) in tracked files. A conflicted "
+            "`git stash pop` or merge was committed, most likely by `git add -A`."
+        )
+        return 1
+
+    print(f"  ✓ no committed conflict markers ({checked} text files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`integrations/hermes/README.md` on `main` carries **nine merge-conflict markers**, including the `Updated upstream` / `Stashed changes` pair a conflicted `git stash pop` leaves behind.

It has been published to the docs site in that state.

## I did it

#308 was about labelling Hub metrics as claims. A `git add -A` swept in a conflicted file with nothing to do with that change, the diff was large and about something else, and **I didn't read it.**

Every gate passed. None of them read that file.

## Why a gate and not "be more careful"

This is the **second** time this session `git add -A` picked up something it shouldn't. The first was caught in review before merge; this one wasn't. "Be careful with `git add -A`" is what I'd have said after the first one, and it didn't hold.

`check-conflict-markers.py` greps every tracked text file for markers at column zero with the exact widths git writes — so prose about conflicts and markdown `=====` underlines don't trip it.

Verified in both directions:
- Against the **actual broken file from #308** → fails, naming both lines
- Against the restored file → passes
- Swept all 721 tracked text files → **this was the only one**

## The restore

Back to `5a01b00`, the last version before #308 touched it. The `Stashed changes` side held content belonging to **PR #170**, which is still open and will land it properly.