### PR TITLE
fix(present): panicked instead of reporting a checkpoint/store mismatch

### DIFF
--- a/packages/cli/src/commands/present.rs
+++ b/packages/cli/src/commands/present.rs
@@ -211,6 +211,26 @@ pub fn present(
             )
             .into());
         }
+        // The checkpoint can legitimately describe a larger tree than this
+        // store holds: `load_latest_checkpoint` reads
+        // ~/.treeship/merkle/checkpoints unconditionally, while `build_tree`
+        // reads the artifacts for THIS context -- so `--config`, a second
+        // workspace, or a pruned store all produce tree_size > len.
+        //
+        // Slicing on that panicked with "range end index N out of range",
+        // which is a crash where the honest answer is "these two stores do
+        // not describe the same history". The guard above only checked that
+        // the card is not newer than the checkpoint; it never checked the
+        // other direction.
+        if checkpoint.tree_size > artifact_ids.len() {
+            return Err(format!(
+                "checkpoint #{} describes {} artifact(s) but this store holds {}.\n\n  Checkpoints live in ~/.treeship/merkle/checkpoints and are NOT scoped by --config, so a checkpoint written from another workspace does not describe this one.\n\n  Fix: treeship checkpoint  (write one for this store)",
+                checkpoint.index,
+                checkpoint.tree_size,
+                artifact_ids.len()
+            )
+            .into());
+        }
         let mut cp_tree = MerkleTree::new();
         for id in &artifact_ids[..checkpoint.tree_size] {
             cp_tree.append(id);

--- a/packages/cli/tests/present_cli.rs
+++ b/packages/cli/tests/present_cli.rs
@@ -1,0 +1,88 @@
+use std::process::Command;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+/// `present` panicked with "range end index 3 out of range for slice of
+/// length 2" on a fresh onboard.
+///
+/// `load_latest_checkpoint` reads ~/.treeship/merkle/checkpoints
+/// unconditionally, while `build_tree` reads the artifacts for the current
+/// context. `--config`, a second workspace, or a pruned store all give a
+/// checkpoint describing more leaves than the store holds, and the slice
+/// panicked.
+///
+/// A panic is the wrong answer here twice over: it is a crash where the
+/// honest result is a diagnosis, and the message named an index rather than
+/// the actual problem, which is that two stores do not describe the same
+/// history.
+#[test]
+fn present_reports_a_checkpoint_store_mismatch_instead_of_panicking() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+
+    let command = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        // HOME is redirected so the checkpoint store is this test's, not the
+        // developer's -- the bug itself is that those can differ.
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = command(&[
+        "init",
+        "--config",
+        config.to_str().unwrap(),
+        "--name",
+        "present-test",
+    ]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let onboard = command(&[
+        "onboard",
+        "agent://deployer",
+        "--config",
+        config.to_str().unwrap(),
+        "--tools",
+        "deploy.*",
+    ]);
+    assert!(
+        onboard.status.success(),
+        "onboard: {}",
+        String::from_utf8_lossy(&onboard.stderr)
+    );
+
+    let out = root.join("d.presentation.json");
+    let present = command(&[
+        "present",
+        "agent://deployer",
+        "--config",
+        config.to_str().unwrap(),
+        "--out",
+        out.to_str().unwrap(),
+    ]);
+
+    let stderr = String::from_utf8_lossy(&present.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "present must not panic; it did:\n{stderr}"
+    );
+
+    // Either it succeeds (checkpoint and store agree) or it explains itself.
+    // Both are acceptable; a panic is not.
+    if !present.status.success() {
+        let combined = format!("{}{}", String::from_utf8_lossy(&present.stdout), stderr);
+        assert!(
+            combined.contains("checkpoint") && combined.contains("treeship checkpoint"),
+            "a failure must name the mismatch and the fix, got:\n{combined}"
+        );
+    } else {
+        assert!(out.exists(), "reported success but wrote no presentation");
+    }
+}


### PR DESCRIPTION
`treeship present` **crashed** on a fresh onboard:

```
range end index 3 out of range for slice of length 2
```

That's the documented happy path for the command the entire hand-your-proof-to-a-counterparty story rests on.

## Cause

`load_latest_checkpoint()` reads `~/.treeship/merkle/checkpoints` **unconditionally** — `merkle_dir()` resolves `home::home_dir()` and takes no context. `build_tree(&ctx)` reads artifacts for the **current** context.

So `--config`, a second workspace, or a pruned store all produce a checkpoint describing more leaves than the store holds, and `artifact_ids[..checkpoint.tree_size]` panics.

The guard immediately above checked one direction — the card must not be newer than the checkpoint — and never the other.

## The fix

A typed error naming both sizes, stating that checkpoints aren't scoped by `--config`, and giving the remedy.

A panic is the wrong answer twice over: it's a crash where the honest result is a diagnosis, and *"range end index 3"* names the symptom rather than the cause — that two stores don't describe the same history.

## On the test

It redirects `HOME` so the checkpoint store is the test's own — the bug is precisely that those can differ. It accepts success **or** a self-explaining failure, and fails only on a panic. Pinning the exact outcome would make it a test of which store the developer happened to have.

## Deliberately not fixed

`merkle_dir()` ignoring `--config` at all. Same shape as trust roots living in `~/.treeship` regardless of `--config`; it may well be deliberate (checkpoints as machine-global), and changing it moves where every existing checkpoint is read from.

Worth deciding explicitly rather than as a side effect of a crash fix.