### PR TITLE
fix(grant): show and list put a clean checkmark on revoked grants

### DIFF
--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -21,7 +21,10 @@
 use std::path::{Path, PathBuf};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use treeship_core::statements::{parse_rfc3339_to_unix, payload_type, Grant, ReceiptStatement};
+use treeship_core::statements::{
+    parse_rfc3339_to_unix, payload_type, Grant, ReceiptStatement, RevocationSource,
+    RevocationStatus,
+};
 use treeship_core::storage::Record;
 
 use crate::ctx;
@@ -360,6 +363,12 @@ pub fn list(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::
     }
     grants.sort_by(|a, b| a.issued_at.cmp(&b.issued_at));
 
+    // Listing grants without their revocation state showed a withdrawn grant
+    // exactly like a live one. Built once and reused across every row rather
+    // than per-grant, since it reads the whole receipt store.
+    let revocations = crate::commands::revocation_source::for_ctx(&ctx);
+    let state_of = |g: &Grant| revocations.status(&g.grant_id, "");
+
     if printer.format == Format::Json {
         let out: Vec<_> = grants
             .iter()
@@ -371,6 +380,15 @@ pub fn list(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::
                     "expiry": g.expiry,
                     "delegation_depth": g.delegation_depth,
                     "parent_grant_id": g.parent_grant_id,
+                    "revocation": match state_of(g) {
+                        RevocationStatus::NotRevoked => serde_json::json!({ "state": "not_revoked" }),
+                        RevocationStatus::RevokedAt(at) => {
+                            serde_json::json!({ "state": "revoked", "revoked_at": at })
+                        }
+                        RevocationStatus::Unknown(why) => {
+                            serde_json::json!({ "state": "unknown", "reason": why })
+                        }
+                    },
                 })
             })
             .collect();
@@ -384,8 +402,16 @@ pub fn list(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::
         return Ok(());
     }
     for g in &grants {
+        // The marker goes first: scanning a list, the thing that changes
+        // whether a row means anything should not be at the end of the line.
+        let mark = match state_of(g) {
+            RevocationStatus::NotRevoked => "",
+            RevocationStatus::RevokedAt(_) => "REVOKED  ",
+            RevocationStatus::Unknown(_) => "revocation unknown  ",
+        };
         printer.info(&format!(
-            "{}  depth {}  {}  expires {}",
+            "{}{}  depth {}  {}  expires {}",
+            mark,
             g.grant_id,
             g.delegation_depth,
             g.scope.join(", "),
@@ -423,11 +449,38 @@ pub fn show(
         .map(|s| g.verify_canonical(s))
         .unwrap_or(false);
 
+    // A grant's signature stays valid forever; revocation is what makes it
+    // stop counting. `show` reported the signature and never the revocation,
+    // so a grant revoked seconds earlier printed a clean success -- the
+    // command whose whole job is "tell me about this grant" was the one
+    // surface that never looked.
+    //
+    // `for_ctx` is the same resolver `verify` uses: it reads local
+    // `grant_revocation.v1` receipts and verifies their signatures rather
+    // than trusting a filename.
+    let revocation = crate::commands::revocation_source::for_ctx(&ctx).status(&g.grant_id, "");
+    let revocation_str = match &revocation {
+        RevocationStatus::NotRevoked => "not revoked".to_string(),
+        RevocationStatus::RevokedAt(at) => format!("REVOKED at {at}"),
+        // Unknown is not "fine". It says the question could not be answered,
+        // which is the honest output when no resolver could be consulted.
+        RevocationStatus::Unknown(why) => format!("unknown -- {why}"),
+    };
+
     if printer.format == Format::Json {
         printer.json(&serde_json::json!({
             "grant": g,
             "id_consistent": id_ok,
             "signature_valid": sig_ok,
+            "revocation": match &revocation {
+                RevocationStatus::NotRevoked => serde_json::json!({ "state": "not_revoked" }),
+                RevocationStatus::RevokedAt(at) => {
+                    serde_json::json!({ "state": "revoked", "revoked_at": at })
+                }
+                RevocationStatus::Unknown(why) => {
+                    serde_json::json!({ "state": "unknown", "reason": why })
+                }
+            },
         }));
         return Ok(());
     }
@@ -452,6 +505,7 @@ pub fn show(
             ("parent", &parent_str),
             ("id matches content", &id_str),
             ("issuer signature", &sig_str),
+            ("revocation", &revocation_str),
         ],
     );
     Ok(())

--- a/packages/cli/src/commands/verify.rs
+++ b/packages/cli/src/commands/verify.rs
@@ -11,7 +11,7 @@ use treeship_core::{
         verify_effect, verify_grant_chain, verify_mandate, ActionStatement, ActionStatementV2,
         ApprovalScope, ApprovalStatement, DeadlineEvent, DecisionStatement, EffectConfidence,
         EffectFinality, EffectVerdict, HandoffStatement, MandateVerdict, NoWitnessAuthority,
-        ReceiptStatement, ResolutionStatus,
+        ReceiptStatement, ResolutionStatus, RevocationSource,
     },
     storage::Store,
     trust::TrustRootStore,
@@ -632,6 +632,7 @@ pub fn run(
             target,
             linkage_ok,
             &linkage_detail,
+            &revocation,
         );
         if failed > 0 || !chain_ok {
             std::process::exit(1);
@@ -903,6 +904,11 @@ fn print_full_timeline(
     target: &str,
     linkage_ok: bool,
     linkage_detail: &str,
+    // Threaded through rather than defaulted: this display previously passed
+    // `NoRevocationSource`, so the mandate line on a full timeline always
+    // resolved Unknown even when the caller had a working resolver in scope
+    // two hundred lines up.
+    revocation: &dyn RevocationSource,
 ) -> bool {
     // Returns whether the CHAIN is intact (no gaps + signed linkage). The
     // caller must exit nonzero when this is false, even if every individual
@@ -914,7 +920,9 @@ fn print_full_timeline(
     let steps: Vec<StepInfo> = chain
         .iter()
         .enumerate()
-        .map(|(i, (id, env))| extract_step_info(i + 1, id, env, storage, Some(verifier)))
+        .map(|(i, (id, env))| {
+            extract_step_info(i + 1, id, env, storage, Some(verifier), revocation)
+        })
         .collect();
 
     // Header
@@ -1412,6 +1420,7 @@ fn extract_step_info(
     env: &Envelope,
     storage: &Store,
     verifier: Option<&Verifier>,
+    revocation: &dyn RevocationSource,
 ) -> StepInfo {
     let mut info = StepInfo {
         index,
@@ -1462,11 +1471,7 @@ fn extract_step_info(
                 info.runtime_model = rt.model.clone();
             }
             // Surface the effect line only when there is an effect to judge.
-            info.mandate_verdict = v2_mandate_summary(
-                env,
-                verifier,
-                &treeship_core::statements::NoRevocationSource,
-            );
+            info.mandate_verdict = v2_mandate_summary(env, verifier, revocation);
             info.chain_summary = v2_chain_summary(env);
             if let Some(verdict) = v2_effect_verdict(env) {
                 info.effect_effective = Some(verdict.effective_confidence);
@@ -2200,7 +2205,9 @@ fn authority_gate_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use treeship_core::statements::{ActionStatement, ApprovalScope, SubjectRef};
+    use treeship_core::statements::{
+        ActionStatement, ApprovalScope, NoRevocationSource, SubjectRef,
+    };
 
     // ── signed chain linkage: receipt.v1 subject edge ──────────────────
     //
@@ -2310,7 +2317,7 @@ mod tests {
         // effect verdict rather than silently taking the v1 branch.
         let dir = std::env::temp_dir().join("ts_verify_v2_effect_test");
         let store = Store::open(&dir).unwrap();
-        let info = extract_step_info(0, "art_test", &env, &store, None);
+        let info = extract_step_info(0, "art_test", &env, &store, None, &NoRevocationSource);
 
         assert_eq!(info.actor, "agent://worker");
         assert_eq!(
@@ -2590,7 +2597,7 @@ mod tests {
         let ok_env = sign(&payload_type_v2("action"), &ok, &signer)
             .unwrap()
             .envelope;
-        let info = extract_step_info(0, "art_ok", &ok_env, &store, None);
+        let info = extract_step_info(0, "art_ok", &ok_env, &store, None, &NoRevocationSource);
         match info.mandate_verdict {
             Some(MandateSummary::Unverified(ref r)) => {
                 assert!(
@@ -2616,7 +2623,7 @@ mod tests {
         let bad_env = sign(&payload_type_v2("action"), &bad, &signer)
             .unwrap()
             .envelope;
-        let bad_info = extract_step_info(1, "art_bad", &bad_env, &store, None);
+        let bad_info = extract_step_info(1, "art_bad", &bad_env, &store, None, &NoRevocationSource);
         match bad_info.mandate_verdict {
             Some(MandateSummary::Fail(ref r)) => {
                 assert!(
@@ -2864,7 +2871,7 @@ mod tests {
             .unwrap()
             .envelope;
 
-        let info = extract_step_info(0, "art_pending", &env, &store, None);
+        let info = extract_step_info(0, "art_pending", &env, &store, None, &NoRevocationSource);
         assert_eq!(
             info.effect_finality,
             Some(EffectFinality::Initiated),

--- a/packages/cli/tests/grant_revocation_display.rs
+++ b/packages/cli/tests/grant_revocation_display.rs
@@ -1,0 +1,133 @@
+use std::process::Command;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+/// `grant show` printed a clean success for a grant revoked seconds earlier,
+/// and `grant list` rendered it identically to a live one.
+///
+/// A signature stays valid forever; revocation is what makes a grant stop
+/// counting. Both commands reported the signature and neither consulted the
+/// revocation receipt they had just written -- so the two commands whose whole
+/// job is "tell me about this grant" were the surfaces that never looked.
+///
+/// This asserts the marker appears in both, and that a *live* grant is not
+/// marked, because a check that fires on everything is not a check.
+#[test]
+fn revoked_grants_are_marked_in_show_and_list() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let command = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = command(&["init", "--config", cfg, "--name", "revocation-display"]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let issue = |scope: &str| {
+        let out = command(&[
+            "grant",
+            "issue",
+            "--config",
+            cfg,
+            "--scope",
+            scope,
+            "--audience",
+            "agent://worker",
+            "--expiry",
+            "2030-12-31T23:59:59Z",
+        ]);
+        assert!(
+            out.status.success(),
+            "issue: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let text = String::from_utf8_lossy(&out.stdout);
+        text.split_whitespace()
+            .find(|t| t.starts_with("grn_"))
+            .map(|t| {
+                t.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_')
+                    .to_string()
+            })
+            .unwrap_or_else(|| panic!("no grant id in: {text}"))
+    };
+
+    let revoked = issue("deploy.*");
+    let live = issue("build.*");
+
+    let rev = command(&[
+        "grant",
+        "revoke",
+        &revoked,
+        "--config",
+        cfg,
+        "--reason",
+        "compromised",
+    ]);
+    assert!(
+        rev.status.success(),
+        "revoke: {}",
+        String::from_utf8_lossy(&rev.stderr)
+    );
+
+    // ── show ──
+    let show = command(&["grant", "show", &revoked, "--config", cfg]);
+    let shown = String::from_utf8_lossy(&show.stdout);
+    assert!(
+        shown.to_lowercase().contains("revoked"),
+        "`grant show` must report the revocation it just wrote, got:\n{shown}"
+    );
+
+    // A live grant must NOT be marked, or the marker means nothing.
+    let show_live = command(&["grant", "show", &live, "--config", cfg]);
+    let shown_live = String::from_utf8_lossy(&show_live.stdout);
+    assert!(
+        !shown_live.contains("REVOKED"),
+        "a live grant must not be marked revoked, got:\n{shown_live}"
+    );
+
+    // ── list ──
+    let list = command(&["grant", "list", "--config", cfg]);
+    let listed = String::from_utf8_lossy(&list.stdout);
+    let revoked_line = listed
+        .lines()
+        .find(|l| l.contains(&revoked))
+        .unwrap_or_else(|| panic!("revoked grant missing from list:\n{listed}"));
+    assert!(
+        revoked_line.contains("REVOKED"),
+        "the revoked row must be marked, got: {revoked_line}"
+    );
+    let live_line = listed
+        .lines()
+        .find(|l| l.contains(&live))
+        .unwrap_or_else(|| panic!("live grant missing from list:\n{listed}"));
+    assert!(
+        !live_line.contains("REVOKED"),
+        "the live row must not be marked, got: {live_line}"
+    );
+
+    // ── json carries the same fact, structured ──
+    let json = command(&[
+        "grant", "show", &revoked, "--config", cfg, "--format", "json",
+    ]);
+    let v: serde_json::Value =
+        serde_json::from_slice(&json.stdout).expect("show --format json must be one document");
+    assert_eq!(
+        v["revocation"]["state"], "revoked",
+        "json must carry the state too: {v}"
+    );
+    assert!(
+        v["revocation"]["revoked_at"].as_str().is_some(),
+        "a revoked state must carry when: {v}"
+    );
+}


### PR DESCRIPTION
`treeship grant revoke` mints a signed `grant_revocation.v1` receipt. `treeship grant show` then printed:

```
✓ grn_4c46626114013cda
  issuer signature:  yes
```

for a grant revoked **seconds earlier**. `grant list` rendered it identically to a live one.

A signature stays valid forever; **revocation is what makes a grant stop counting.** Both commands reported the signature and neither consulted the receipt the CLI had just written — so the two commands whose entire job is *"tell me about this grant"* were the surfaces that never looked.

## Now

```
$ treeship grant list
REVOKED  grn_3ae6fc9256b325e8  depth 0  deploy.*  expires 2026-12-31

$ treeship grant show grn_41146c…
  issuer signature:    yes
  revocation:          REVOKED at 2026-08-17T21:08:45Z
```

Both use `revocation_source::for_ctx` — the same resolver `verify` uses, which **verifies revocation signatures** rather than trusting a filename.

`list` puts the marker first: when scanning rows, the thing that decides whether a row means anything shouldn't be at the end of the line.

`Unknown` renders as `unknown -- <reason>`, never as clean. It means the question couldn't be answered — a third state, not a quiet pass.

## Two `NoRevocationSource` call sites wired

`extract_step_info` hardcoded it, so the mandate line on `verify --full` **always** resolved Unknown — even though the caller had a working resolver in scope two hundred lines above. Threaded through `print_full_timeline` rather than defaulted, so a future caller has to pass one.

## Deliberately left

`session.rs:2918`. Its comment says revocation has no resolver — true when written, stale now. But that path runs during `session close`, where reading the whole receipt store per mandate is a different cost question. Worth doing, not as a rider on this.

## On the test

It asserts a **live grant is not marked** as well as a revoked one being marked. A check that fires on everything is not a check. Covers human output and JSON.

556 core tests green, clippy clean.