### PR TITLE
feat(hub): give clients what they need to check the revocation list themselves

### DIFF
--- a/docs/content/docs/api/hub-openapi.yaml
+++ b/docs/content/docs/api/hub-openapi.yaml
@@ -869,6 +869,15 @@ paths:
 
         `truncated` is always present; when true the list is incomplete and
         must not be treated as exhaustive.
+
+        Each entry carries `dock_id` and `rekor_index` so a client can act on
+        the withholding caveat above rather than only be warned about it:
+        `dock_id` names the log the artifact belongs to, so inclusion can be
+        checked against that dock's checkpoint and a forked log detected via
+        /v1/merkle/consistency. `rekor_index` is null when the best-effort
+        anchor did not land -- null means "not anchored", never "anchored and
+        fine". The response also carries a `completeness` field stating in the
+        document itself that absence proves nothing.
       responses:
         '200':
           description: Revocation list

--- a/packages/hub/main.go
+++ b/packages/hub/main.go
@@ -415,13 +415,45 @@ func revokedHandler(database *sql.DB) http.HandlerFunc {
 				// server could have written.
 				"envelope":    json.RawMessage(a.EnvelopeJSON),
 				"artifact_id": a.ArtifactID,
+				// Where to check this entry against the log.
+				//
+				// The entries are individually DSSE-signed, so this server
+				// cannot forge one. What it CAN do is omit one, and an omitted
+				// revocation is indistinguishable from a grant that was never
+				// revoked -- the same failure Certificate Transparency exists
+				// to make detectable.
+				//
+				// Nothing here proves the list is complete; completeness
+				// cannot be proven from a list. These fields are what a client
+				// needs to start checking: `dock_id` names the log this
+				// artifact belongs to, so a client can fetch that dock's
+				// checkpoint (/v1/merkle/checkpoint/latest) and request an
+				// inclusion proof, and can run /v1/merkle/consistency across
+				// checkpoints to detect a forked log. Without them a client
+				// cannot even ask.
+				//
+				// `rekor_index` is null when the best-effort Rekor anchor did
+				// not land; null means "not anchored", never "anchoring
+				// failed silently and this is fine".
+				"dock_id":     a.DockID,
+				"rekor_index": a.RekorIndex,
 			})
 		}
 
 		body := map[string]any{
-			"version":      "2",
+			"version":      "3",
 			"generated_at": time.Now().UTC().Format(time.RFC3339),
 			"revoked":      revoked,
+			// Say what this document does not prove, in the document.
+			//
+			// A client that treats an absent grant as "not revoked" is making
+			// an inference this endpoint cannot support: the entries are
+			// signed, so nothing here is forged, but a withheld entry looks
+			// exactly like a grant nobody revoked. Callers that need better
+			// than that must verify inclusion against the per-entry dock log.
+			"completeness": "unproven: entries are individually signed and cannot be " +
+				"forged, but absence from this list is not evidence a grant was not " +
+				"revoked. Check inclusion per entry via its dock_id checkpoint.",
 			// Silent truncation on a revocation list would drop revocations a
 			// client needed and look identical to their not existing.
 			"truncated": truncated,

--- a/packages/hub/revoked_test.go
+++ b/packages/hub/revoked_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/treeship/hub/internal/contentaddress"
@@ -251,5 +252,72 @@ func TestBackfillMakesPreUpgradeRowsVisible(t *testing.T) {
 	})
 	if err != nil || n2 != 0 {
 		t.Fatalf("second backfill should be a no-op, got n=%d err=%v", n2, err)
+	}
+}
+
+// The entries are individually signed, so this server cannot forge one. It
+// CAN omit one, and an omitted revocation is indistinguishable from a grant
+// nobody revoked -- the failure Certificate Transparency exists to detect.
+//
+// Completeness cannot be proven from a list. What the response must do is
+// carry what a client needs to check inclusion for itself, and say plainly
+// that absence proves nothing. A response that stayed silent on both would
+// invite exactly the inference it cannot support.
+func TestRevocationListShipsAnchorRefsAndDisclaimsCompleteness(t *testing.T) {
+	t.Setenv("TREESHIP_HUB_DB", filepath.Join(t.TempDir(), "hub.db"))
+	database, err := db.Open()
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+
+	if _, err := database.Exec(
+		`INSERT INTO ships (dock_id, ship_public_key, dock_public_key, created_at)
+		 VALUES (?, ?, ?, ?)`, "dock_a", []byte("s"), []byte("d"), 1,
+	); err != nil {
+		t.Fatalf("register dock: %v", err)
+	}
+
+	env := receiptEnvelope(t, "grant_revocation.v1", map[string]any{
+		"grant_id": "grn_anchored", "grantor": "pk1", "revoked_at": "2026-08-01T10:00:00Z",
+	})
+	if _, err := db.InsertArtifact(database, artifact("art_anchored", env)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/treeship/revoked.json", revokedHandler(database))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/.well-known/treeship/revoked.json", nil))
+
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("not JSON: %v", err)
+	}
+
+	note, _ := body["completeness"].(string)
+	if !strings.Contains(note, "unproven") {
+		t.Errorf("the response must say absence proves nothing; got %q", note)
+	}
+
+	list, _ := body["revoked"].([]any)
+	if len(list) != 1 {
+		t.Fatalf("expected the revocation, got %d", len(list))
+	}
+	entry, _ := list[0].(map[string]any)
+
+	// dock_id names the log to check inclusion against. Without it a client
+	// cannot even form the request.
+	if entry["dock_id"] != "dock_a" {
+		t.Errorf("entry must name its dock log, got %v", entry["dock_id"])
+	}
+	// Present-and-null is the point: null means "not anchored", which a client
+	// must be able to tell apart from the field being missing.
+	if _, present := entry["rekor_index"]; !present {
+		t.Error("rekor_index must be present even when null -- null means not anchored")
+	}
+	// And the signed bytes must still travel, or none of the above matters.
+	if _, ok := entry["envelope"]; !ok {
+		t.Error("the DSSE envelope is what makes an entry unforgeable; it must ship")
 	}
 }


### PR DESCRIPTION
You asked me to sign the revocation list. **I was wrong to propose that** — the endpoint's own comment already explains why, and I wrote it in #305:

> A hub signature would add a party to trust and prove strictly less: it would attest that the hub *said* this, not that the grantor *did*.

Entries are individually DSSE-signed by the grantor. Forgery is already impossible.

## The real gap is omission

The docs already warned about it:

> A hostile hub can WITHHOLD revocations, which is why absence from this list is never proof that a grant is live.

It warned, and left the client **no way to act on it**. An omitted revocation is indistinguishable from a grant nobody revoked — precisely the failure Certificate Transparency exists to detect.

Completeness cannot be proven from a list. What *can* be done is hand the client the references to check inclusion itself. The response carried none.

## What's added

| field | why |
|---|---|
| `dock_id` | names the log this artifact belongs to — a client can now fetch that dock's checkpoint, request an inclusion proof, and run `/v1/merkle/consistency` to detect a forked log. **Without it a client can't even form the request.** |
| `rekor_index` | present-and-null when the best-effort anchor didn't land. Present matters: null means *"not anchored"*, which must be distinguishable from the field being absent. |
| `completeness` | states in the document that absence is not evidence. The OpenAPI said so already — a client parsing JSON doesn't read OpenAPI descriptions. |

Both `dock_id` and `rekor_index` were already on the row and simply never exposed.

Version 2 → 3, additive only.

## Not attempted

**Proving completeness.** It isn't provable from a list, and claiming otherwise would be the overclaim this endpoint has spent three PRs removing.

## Note

The duplicate-YAML gate from #308 caught me adding a second `description` key to the OpenAPI — the check working on its author. Docs build compiles, hub tests pass, govulncheck 0 on the pinned 1.26.6 toolchain.