### PR TITLE
feat(revocation): report whether a revocation is anchored in a log

### DIFF
--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -458,10 +458,22 @@ pub fn show(
     // `for_ctx` is the same resolver `verify` uses: it reads local
     // `grant_revocation.v1` receipts and verifies their signatures rather
     // than trusting a filename.
-    let revocation = crate::commands::revocation_source::for_ctx(&ctx).status(&g.grant_id, "");
+    let revocations = crate::commands::revocation_source::for_ctx(&ctx);
+    let revocation = revocations.status(&g.grant_id, "");
+    // Whether the revocation is in an append-only log, which is what stops a
+    // hub quietly ceasing to serve it. Not part of the verdict -- a revoked
+    // grant is revoked either way -- but it is the difference between a record
+    // that can be withdrawn and one that cannot.
+    let anchor_note = match revocations.anchor_for(&g.grant_id) {
+        Some(a) => match a.rekor_index {
+            Some(idx) => format!(" (log {}, rekor #{idx})", a.dock_id),
+            None => format!(" (log {}, not rekor-anchored)", a.dock_id),
+        },
+        None => String::new(),
+    };
     let revocation_str = match &revocation {
         RevocationStatus::NotRevoked => "not revoked".to_string(),
-        RevocationStatus::RevokedAt(at) => format!("REVOKED at {at}"),
+        RevocationStatus::RevokedAt(at) => format!("REVOKED at {at}{anchor_note}"),
         // Unknown is not "fine". It says the question could not be answered,
         // which is the honest output when no resolver could be consulted.
         RevocationStatus::Unknown(why) => format!("unknown -- {why}"),

--- a/packages/cli/src/commands/revocation_source.rs
+++ b/packages/cli/src/commands/revocation_source.rs
@@ -84,6 +84,26 @@ pub struct RevocationEntry {
     /// Whether the DSSE signature verifies under the `grantor` key the payload
     /// names. Computed at load, because that is where the envelope is.
     grantor_signed: bool,
+    /// Where this revocation sits in an append-only log, when it does.
+    ///
+    /// A grantor-signed revocation is unforgeable on its own, so this is not
+    /// about validity. It is about durability: a revocation recorded in a
+    /// checkpointed log cannot later be un-served without the log forking,
+    /// which /v1/merkle/consistency detects. One a hub asserts and never
+    /// anchored can simply stop being served tomorrow.
+    ///
+    /// `None` means not anchored -- never "anchored and we did not check".
+    anchor: Option<RevocationAnchor>,
+}
+
+/// Log references a client can use to check a revocation for itself.
+#[derive(Debug, Clone)]
+pub struct RevocationAnchor {
+    /// The dock whose Merkle log holds this artifact. Names which checkpoint
+    /// to fetch; without it a client cannot form the inclusion request.
+    pub dock_id: String,
+    /// Rekor index, when the hub's best-effort anchor landed.
+    pub rekor_index: Option<i64>,
 }
 
 impl LocalRevocationSource {
@@ -125,6 +145,10 @@ impl LocalRevocationSource {
                 grantor: grantor.to_string(),
                 revoked_at: revoked_at.to_string(),
                 grantor_signed: signed_by(&record.envelope, grantor),
+                // Held locally in our own store. A hub log reference would be
+                // meaningless here, and inventing one would imply a check that
+                // did not happen.
+                anchor: None,
             });
         }
 
@@ -155,6 +179,27 @@ impl LocalRevocationSource {
                     .any(|k| k.strip_prefix("ed25519:").unwrap_or(k) == g)
             })
             .unwrap_or(false)
+    }
+}
+
+impl LocalRevocationSource {
+    /// Where the authorized revocation for `grant_id` is anchored, if anywhere.
+    ///
+    /// Deliberately separate from `status()` rather than folded into
+    /// `RevocationStatus::RevokedAt`. That enum is the verdict, shared with
+    /// core and matched in twenty-odd places; anchoring is provenance about
+    /// how durable the verdict is, not part of the verdict itself. A revoked
+    /// grant is revoked whether or not the record is in a log.
+    ///
+    /// Applies the same grantor check as `status`, so this never reports an
+    /// anchor for a revocation that failed authorization -- that would dress
+    /// up an unauthorized entry with log provenance.
+    pub fn anchor_for(&self, grant_id: &str) -> Option<&RevocationAnchor> {
+        self.entries
+            .iter()
+            .filter(|e| e.grant_id == grant_id && e.grantor_signed)
+            .min_by(|a, b| a.revoked_at.cmp(&b.revoked_at))
+            .and_then(|e| e.anchor.as_ref())
     }
 }
 
@@ -330,8 +375,19 @@ pub fn fetch_hub_revocations(endpoint: &str) -> Vec<RevocationEntry> {
             continue;
         };
 
+        // Present-and-null is meaningful: the hub distinguishes "not anchored"
+        // from "field absent", and so must this.
+        let anchor = item
+            .get("dock_id")
+            .and_then(|v| v.as_str())
+            .map(|dock| RevocationAnchor {
+                dock_id: dock.to_string(),
+                rekor_index: item.get("rekor_index").and_then(|v| v.as_i64()),
+            });
+
         out.push(RevocationEntry {
             grant_id: grant_id.to_string(),
+            anchor,
             grantor: grantor.to_string(),
             revoked_at: revoked_at.to_string(),
             grantor_signed: signed_by(&envelope, grantor),
@@ -417,6 +473,7 @@ mod tests {
             grantor: grantor.into(),
             revoked_at: at.into(),
             grantor_signed,
+            anchor: None,
         }
     }
 
@@ -581,6 +638,72 @@ mod tests {
         let s = src(vec![entry("grn_a", "pk1", "2026-08-14T10:00:00Z", false)]);
         assert!(matches!(
             s.status("grn_a", "p"),
+            RevocationStatus::Unknown(_)
+        ));
+    }
+
+    fn anchored(
+        grant: &str,
+        grantor: &str,
+        at: &str,
+        dock: &str,
+        rekor: Option<i64>,
+    ) -> RevocationEntry {
+        RevocationEntry {
+            grant_id: grant.into(),
+            grantor: grantor.into(),
+            revoked_at: at.into(),
+            grantor_signed: true,
+            anchor: Some(RevocationAnchor {
+                dock_id: dock.into(),
+                rekor_index: rekor,
+            }),
+        }
+    }
+
+    /// A revocation held only by a hub can stop being served tomorrow. One
+    /// recorded in a checkpointed log cannot, without the log forking. The
+    /// verdict is the same either way; the durability is not, and a caller
+    /// that wants to check inclusion needs to know which log to ask.
+    #[test]
+    fn anchor_is_reported_for_an_authorized_revocation() {
+        let src = src(vec![anchored(
+            "grn_a",
+            "pk1",
+            "2026-08-01T00:00:00Z",
+            "dock_x",
+            Some(42),
+        )]);
+        let a = src
+            .anchor_for("grn_a")
+            .expect("anchored entry must report its log");
+        assert_eq!(a.dock_id, "dock_x");
+        assert_eq!(a.rekor_index, Some(42));
+    }
+
+    /// None means "not anchored", and must not be confused with "anchored but
+    /// we did not look".
+    #[test]
+    fn an_unanchored_revocation_reports_no_anchor() {
+        let src = src(vec![entry("grn_b", "pk1", "2026-08-01T00:00:00Z", true)]);
+        assert!(src.anchor_for("grn_b").is_none());
+    }
+
+    /// An entry that failed the grantor check must not be dressed up with log
+    /// provenance -- that would make a forgery attempt look better sourced
+    /// than an honest unanchored revocation.
+    #[test]
+    fn an_unauthorized_revocation_never_reports_an_anchor() {
+        let mut bad = anchored("grn_c", "pk1", "2026-08-01T00:00:00Z", "dock_x", Some(7));
+        bad.grantor_signed = false;
+        let src = src(vec![bad]);
+        assert!(
+            src.anchor_for("grn_c").is_none(),
+            "an unauthorized revocation must not carry an anchor"
+        );
+        // And the verdict itself stays Unknown, not NotRevoked.
+        assert!(matches!(
+            src.status("grn_c", ""),
             RevocationStatus::Unknown(_)
         ));
     }


### PR DESCRIPTION
#315 made the hub publish `dock_id` and `rekor_index` per entry. This is the client half: the CLI reads them and can say **which log holds a revocation**.

```
revocation:  REVOKED at 2026-08-17T21:08:45Z (log dock_x, rekor #42)
revocation:  REVOKED at 2026-08-17T21:08:45Z (log dock_x, not rekor-anchored)
revocation:  REVOKED at 2026-08-17T21:08:45Z
```

## Durability, not validity

A grantor-signed revocation is unforgeable either way — that's what the signature buys.

But one a hub **merely asserts** can stop being served tomorrow and nothing detects it. One recorded in a **checkpointed log** can't disappear without the log forking, which `/v1/merkle/consistency` catches.

Same verdict. Different answer to *"can this record be withdrawn?"*

## Why it's not in the verdict enum

`RevocationStatus::RevokedAt` is shared with core and matched in twenty-odd places. Anchoring is **provenance about** the verdict, not part of it — threading it through would make every match site care about something only the display needs.

## Two guards

**`anchor_for` applies the same grantor check as `status`.** An entry that failed authorization never reports an anchor — otherwise a forgery attempt would render as *better-sourced* than an honest unanchored revocation, inverting the exact signal this adds.

**`None` means not anchored**, never "anchored and we didn't check." Local receipts from our own store report `None` rather than an invented reference, because implying a log check that didn't happen is the failure this whole line of work has been removing.

556 core tests green, clippy clean, 3 new tests covering anchored / unanchored / unauthorized.