### PR TITLE
feat(revocation): actually check the log, instead of only naming it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,16 @@
 
 ## Unreleased
 
+### Fixed
+- **Cyclic agent-parent events no longer overflow the stack during session close.**
+  `AgentGraph` depth calculation recursively followed untrusted
+  `parent_agent_instance_id` links and only cached a node after visiting its
+  parent. A self-parent or `A -> B -> A` cycle therefore recursed until the
+  process crashed while composing the receipt. Depth calculation is now
+  iterative, malformed cycles are recorded in `invalid_parent_cycles`, and
+  cyclic nodes retain depth 0 instead of being presented with a fabricated
+  hierarchy.
+
 ### Added
 - **`RoomInfo` on `SessionManifest`.** Optional `room` field (`room_id`,
   `host_pubkey`, `invitation_authority`, `workflow_ref`, `checkpoint_cadence`,
@@ -90,6 +100,14 @@
   remains informational-only in this PR — nothing gates any authority
   decision on it yet. There is no `room close`: plain `treeship session
   close` already works on a room since a room is just a session.
+
+### Documentation
+- **Workflow conformance now has an executable design contract.** Added the
+  missing `docs/specs/workflow-declarations.md` referenced by commitments,
+  rooms, vision, and the v0.11 changelog. Seven golden reports pin valid runs, undeclared
+  edges, missing terminals, loop-cap breaches, asserted edge evidence,
+  declaration pre-existence, and out-of-scope tools before a reducer or CLI
+  surface is built. `workflow.v1` remains roadmap, not shipped behavior.
 
 ## 0.23.0 (2026-08-05)
 

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -78,6 +78,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+### Fixed
+- **Cyclic agent-parent events no longer overflow the stack during session close.**
+  `AgentGraph` depth calculation recursively followed untrusted
+  `parent_agent_instance_id` links and only cached a node after visiting its
+  parent. A self-parent or `A -> B -> A` cycle therefore recursed until the
+  process crashed while composing the receipt. Depth calculation is now
+  iterative, malformed cycles are recorded in `invalid_parent_cycles`, and
+  cyclic nodes retain depth 0 instead of being presented with a fabricated
+  hierarchy.
+
 ### Added
 - **`RoomInfo` on `SessionManifest`.** Optional `room` field (`room_id`,
   `host_pubkey`, `invitation_authority`, `workflow_ref`, `checkpoint_cadence`,
@@ -100,6 +110,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
   remains informational-only in this PR — nothing gates any authority
   decision on it yet. There is no `room close`: plain `treeship session
   close` already works on a room since a room is just a session.
+
+### Documentation
+- **Workflow conformance now has an executable design contract.** Added the
+  missing `docs/specs/workflow-declarations.md` referenced by commitments,
+  rooms, vision, and the v0.11 changelog. Seven golden reports pin valid runs, undeclared
+  edges, missing terminals, loop-cap breaches, asserted edge evidence,
+  declaration pre-existence, and out-of-scope tools before a reducer or CLI
+  surface is built. `workflow.v1` remains roadmap, not shipped behavior.
 
 ## 0.23.0 (2026-08-05)
 

--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -1049,6 +1049,10 @@ treeship grant show [OPTIONS] <GRANT_ID>
 |---|---|
 | `<GRANT_ID>` | -- |
 
+| Option | Description |
+|---|---|
+| `--check-log` | Verify the log holding this grant's revocation, against the hub |
+
 ### `treeship grant revoke`
 
 Withdraw a grant. Mints a signed grant_revocation.v1 receipt

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -42,6 +42,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Hub-checkpoint consumer verifier | `stable` | -- | [Merkle Checkpoints](/docs/api/merkle-checkpoint) |
 | Hub transport (attach, push, pull, DPoP) | `stable` | `treeship hub attach`, `treeship hub push`, `treeship hub pull`, `treeship hub status` | [Hub API Overview](/docs/api/overview), [hub](/docs/cli/hub) |
 | Trust roots (split kinds) | `stable` | `treeship trust list`, `treeship trust add`, `treeship trust remove`, `treeship keys export` | [trust](/docs/cli/trust), [Trust model](/docs/concepts/trust-model) |
+| Workflow declarations and conformance | `roadmap` | -- | [/docs/specs/workflow-declarations.md](/docs/specs/workflow-declarations.md) |
 
 ## Identity, approval, attribution
 

--- a/docs/content/docs/reference/specs.mdx
+++ b/docs/content/docs/reference/specs.mdx
@@ -38,5 +38,6 @@ The `Status:` headers inside some spec files lag behind the shipped product (sev
 | [trusted-rooms](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/trusted-rooms.md) | Draft | Product spec building on invitations/rooms |
 | [token-capture](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/token-capture.md) | Draft | Working notes |
 | [local-dashboard](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/local-dashboard.md) | Draft | A dashboard ships behind a hidden command; the spec is ahead of it |
+| [workflow-declarations](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/workflow-declarations.md) | Design, slice 1 | Golden conformance reports plus the minimal signed authorization graph. Reducer, minting, and CLI are not implemented |
 | [cyberlogic-trust-model](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/cyberlogic-trust-model.md) | Theory, first draft | A first-principles account of Treeship's trust model |
 | [vision](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/vision.md) | Living document | The roadmap source of truth |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -652,6 +652,14 @@
     - docs/content/docs/integrations/agent-skills.mdx
   notes: "One skills/treeship/SKILL.md taught to every supported agent (Claude Code, Codex, Cursor, OpenClaw, Hermes, Kimi Code CLI). Kimi is a SKILL consumer, not a detected surface."
 
+- id: workflow-conformance
+  name: Workflow declarations and conformance
+  section: core
+  status: roadmap
+  docs:
+    - docs/specs/workflow-declarations.md
+  notes: "Slice 1 only: minimal workflow.v1 design and golden report fixtures. No predicate registration, reducer, mint command, or verifier surface ships yet."
+
 - id: zk-circom-cli
   name: ZK -- Circom Groth16 (snarkjs shell-out)
   section: zk

--- a/docs/specs/commitments.md
+++ b/docs/specs/commitments.md
@@ -1,7 +1,9 @@
 # Commitments: proving what an agent promised, and whether it kept it
 
-**Status:** draft. Two pieces have since shipped independently -- see
-"What changed since this was written" below. Slices 1-4 are unbuilt.
+**Status:** draft. Two pieces have since shipped independently, and
+`blocked.v1` is emitted for refused approval mints only. See "What changed
+since this was written" below. The general out-of-scope action refusal path and
+slices 2-4 are unbuilt.
 **Pairs with:** [workflow-declarations](./workflow-declarations.md) (#107, the authorization graph), `boundary.v1`, per-actor signing, the transparency log
 **Last updated:** 2026-06-29
 
@@ -44,13 +46,13 @@ This is a container over primitives Treeship ships, not new crypto:
 | `action_in_scope` (`capability/mod.rs`, `statements/action_v2.rs`) | already detects when an action falls outside an approval scope, the refusal trigger. Note: this spec originally named it `check_scope_violation`, which does not exist under that name -- there are two `action_in_scope` functions, one per scope model. |
 | Per-actor signing (0.13+) | the runtime signs the refusal/consequence; the agent cannot forge what it never held. |
 | Predicate registry | the commitment is a typed predicate (`commitment.v1`), validated at attest time. |
-| **`blocked.v1` predicate** | **already exists**, with nine fields (`reason_class`, `refused_kind`, `approver`, `actor`, `irreversibility`, `description`, `quarantine_receipt`, `evidence_digest`, `reevaluate_when`) and a `scope_violation` reason class. Nothing in the product emits it -- only the validation tests reference it. Slice 1 is therefore *wiring an existing predicate*, not designing a new one, which makes it considerably cheaper than this spec assumed when it proposed `refusal.v1`. |
+| **`blocked.v1` predicate** | **already exists**, with nine fields (`reason_class`, `refused_kind`, `approver`, `actor`, `irreversibility`, `description`, `quarantine_receipt`, `evidence_digest`, `reevaluate_when`) and a `scope_violation` reason class. `packages/cli/src/commands/attest.rs::record_approval_refusal` emits it when a gate refuses an approval mint. No general runtime path emits it for an attempted out-of-scope action. Slice 1 is therefore *extending the existing emit wiring*, not designing a new predicate. |
 | Transparency log + checkpoints | the commitment is checkpoint-anchored, so a verifier can prove it existed **before** the execution trace. |
 | Approval Use Journal | a commitment can require approval-use-bound actions; the nonce binding already works. |
 
 ## Slices
 
-1. **Signed refusal receipts (the "no-send predicate").** The cheapest, most self-contained slice, and the clearest demonstration of a property nobody else has: *honest proof of what did not happen*. When an action would violate an approval scope (`action_in_scope` returns false), the runtime emits a signed `blocked.v1` recording the attempted action, the policy/scope that denied it, the reason, and a null consequence. `verify` surfaces refusals as a distinct, attested outcome, *attempted X, denied by policy Y*, neither a pass nor a fail. One predicate + one emit path + one verify row.
+1. **Signed refusal receipts (the "no-send predicate").** The predicate and one narrow emit path already exist: refused approval mints produce `blocked.v1`. The remaining slice wires the action boundary. When an action would violate an approval scope (`action_in_scope` returns false), the runtime emits a signed `blocked.v1` recording the attempted action, the policy/scope that denied it, the reason, and a null consequence. `verify` surfaces refusals as a distinct, attested outcome, *attempted X, denied by policy Y*, neither a pass nor a fail.
 2. **Commitment receipt + satisfaction check.** `treeship commit` signs a `commitment.v1` before execution: `{ goal, allowed_actions, expected_outcome, failure_condition, expires_at, authority }`. After execution, `verify` cross-checks the action receipts against it and reports **satisfied** (the expected outcome is present and in scope), **violated** (an action outside `allowed_actions`, or the failure condition tripped), or **unfulfilled** (the commitment expired or the expected outcome never appeared). The commitment is checkpoint-anchored so its pre-existence is provable.
 3. **Commitment/policy hash in the session header.** Hash the active commitment (and policy) set at session start and reference it in every receipt, so an auditor can answer *which version of the rule governed this action*. Small; builds on `policy_ref`.
 4. **Compose with the #107 authorization graph.** The commitment names the *obligation* (promised outcome); #107's workflow names the *allowed path* (authorized action set, with `deviation`/`gap`). Together they answer the full question: *was every authorized action taken, the promise kept, and nothing unauthorized done?*
@@ -78,6 +80,7 @@ Slice 1, signed refusal receipts. It reuses `action_in_scope` and the existing `
 Written 2026-06-29 and reviewed 2026-08-15. Two of its ideas arrived from other
 directions, which is worth recording so nobody builds them twice:
 
+- **A narrow `blocked.v1` emit path** shipped for approval-mint gates. `record_approval_refusal` records a signed refusal when the CLI declines to mint an approval. It does not yet cover an attempted action rejected by `action_in_scope`, so slice 1 remains partial rather than absent.
 - **"A high Boundary with a null Consequence"** -- the case this spec calls out
   as *"the agent was allowed to do X and did nothing"*, distinct from both
   success and failure -- shipped as `AuthorityUse` (#297). It reports `granted`,

--- a/docs/specs/fixtures/workflow-conformance/README.md
+++ b/docs/specs/fixtures/workflow-conformance/README.md
@@ -1,0 +1,10 @@
+# Workflow conformance golden reports
+
+These fixtures pin the first `workflow.v1` conformance report before implementation.
+
+- `declaration.json` is the shared minimal declaration.
+- Each other file contains an abstract observed run and its expected report.
+- IDs such as `art_inspect` and `chk_10` are readable placeholders. They are not signatures, hashes, or cryptographic test vectors.
+- Reducer unit tests may deserialize these files. End-to-end verification tests must create real signed envelopes, inclusion proofs, and consistency proofs independently of the reducer under test.
+
+The expected reports deliberately keep path, authority, loop limits, and declaration pre-existence as separate axes. An implementation must not collapse them into one score or upgrade adapter assertions to checked evidence.

--- a/docs/specs/fixtures/workflow-conformance/asserted-edge.json
+++ b/docs/specs/fixtures/workflow-conformance/asserted-edge.json
@@ -1,0 +1,38 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_asserted_edge",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_20"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_change"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "asserted", "evidence": ["evt_adapter_claim"] },
+      { "node_id": "finish", "iteration": 0, "actor": "agent://claude-code", "tools": [], "outcome": "completed", "grade": "checked", "evidence": ["art_finish"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_asserted_edge",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": {
+      "grade": "asserted",
+      "deviations": [],
+      "gaps": [],
+      "asserted_edges": [
+        { "from": "change", "to": "qa", "evidence": ["art_change", "evt_adapter_claim"] },
+        { "from": "qa", "to": "finish", "evidence": ["evt_adapter_claim", "art_finish"] }
+      ]
+    },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/authority-deviation.json
+++ b/docs/specs/fixtures/workflow-conformance/authority-deviation.json
@@ -1,0 +1,34 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_authority_deviation",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_20"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit", "Bash"], "outcome": "completed", "grade": "checked", "evidence": ["art_change", "art_bash"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "checked", "evidence": ["art_qa"] },
+      { "node_id": "finish", "iteration": 0, "actor": "agent://claude-code", "tools": [], "outcome": "completed", "grade": "checked", "evidence": ["art_finish"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_authority_deviation",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": { "grade": "checked", "deviations": [], "gaps": [] },
+    "authority": {
+      "deviations": [
+        { "node_id": "change", "kind": "tool_out_of_scope", "value": "Bash", "evidence": ["art_bash"] }
+      ]
+    },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/declaration.json
+++ b/docs/specs/fixtures/workflow-conformance/declaration.json
@@ -1,0 +1,44 @@
+{
+  "kind": "workflow.v1",
+  "schema_version": "1",
+  "workflow_id": "claude-gstack-qa",
+  "authority": "human://operator",
+  "entry_node": "inspect",
+  "terminal_nodes": ["finish"],
+  "nodes": [
+    {
+      "id": "inspect",
+      "executor": { "actor": "agent://claude-code" },
+      "allowed_tools": ["Read", "Grep"]
+    },
+    {
+      "id": "change",
+      "executor": { "actor": "agent://claude-code" },
+      "allowed_tools": ["Edit", "Write"]
+    },
+    {
+      "id": "qa",
+      "executor": { "capability": "qa.browser" },
+      "allowed_tools": ["gstack.qa"]
+    },
+    {
+      "id": "finish",
+      "executor": { "actor": "agent://claude-code" },
+      "allowed_tools": []
+    }
+  ],
+  "edges": [
+    { "from": "inspect", "to": "change", "when": "always" },
+    { "from": "change", "to": "qa", "when": "always" },
+    { "from": "qa", "to": "finish", "when": "on_pass" },
+    { "from": "qa", "to": "change", "when": "on_fail" }
+  ],
+  "loops": [
+    {
+      "id": "repair",
+      "back_edge": { "from": "qa", "to": "change" },
+      "max_iterations": 2,
+      "budget": { "max_actions": 30 }
+    }
+  ]
+}

--- a/docs/specs/fixtures/workflow-conformance/deviation.json
+++ b/docs/specs/fixtures/workflow-conformance/deviation.json
@@ -1,0 +1,35 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_deviation",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_20"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "checked", "evidence": ["art_qa"] },
+      { "node_id": "finish", "iteration": 0, "actor": "agent://claude-code", "tools": [], "outcome": "completed", "grade": "checked", "evidence": ["art_finish"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_deviation",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": {
+      "grade": "checked",
+      "deviations": [
+        { "from": "inspect", "to": "qa", "reason": "undeclared_edge", "evidence": ["art_inspect", "art_qa"] }
+      ],
+      "gaps": []
+    },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/gap.json
+++ b/docs/specs/fixtures/workflow-conformance/gap.json
@@ -1,0 +1,35 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_gap",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_20"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_change"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "checked", "evidence": ["art_qa"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_gap",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": {
+      "grade": "checked",
+      "deviations": [],
+      "gaps": [
+        { "node_id": "finish", "reason": "completed_run_missing_required_terminal", "after": "qa", "evidence": ["art_qa"] }
+      ]
+    },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/loop-cap.json
+++ b/docs/specs/fixtures/workflow-conformance/loop-cap.json
@@ -1,0 +1,34 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_loop_cap",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_30"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_i0"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_c0"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "fail", "grade": "checked", "evidence": ["art_q0"] },
+      { "node_id": "change", "iteration": 1, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_c1"] },
+      { "node_id": "qa", "iteration": 1, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "fail", "grade": "checked", "evidence": ["art_q1"] },
+      { "node_id": "change", "iteration": 2, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_c2"] },
+      { "node_id": "qa", "iteration": 2, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "fail", "grade": "checked", "evidence": ["art_q2"] },
+      { "node_id": "change", "iteration": 3, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_c3"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_loop_cap",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": { "grade": "checked", "deviations": [], "gaps": [] },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 3, "max_iterations": 2, "limit_exceeded": true, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/not-preexisting.json
+++ b/docs/specs/fixtures/workflow-conformance/not-preexisting.json
@@ -1,0 +1,31 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_not_preexisting",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_signed_at": "2026-08-17T10:00:00Z",
+      "first_run_signed_at": "2026-08-17T10:01:00Z"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_change"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "checked", "evidence": ["art_qa"] },
+      { "node_id": "finish", "iteration": 0, "actor": "agent://claude-code", "tools": [], "outcome": "completed", "grade": "checked", "evidence": ["art_finish"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_not_preexisting",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "grade": "asserted",
+      "reason": "signed_timestamps_do_not_prove_log_order"
+    },
+    "path": { "grade": "checked", "deviations": [], "gaps": [] },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/fixtures/workflow-conformance/valid.json
+++ b/docs/specs/fixtures/workflow-conformance/valid.json
@@ -1,0 +1,30 @@
+{
+  "fixture_version": 1,
+  "run": {
+    "run_id": "run_valid",
+    "status": "completed",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": {
+      "declaration_checkpoint": "chk_10",
+      "declaration_tree_size": 10,
+      "first_run_leaf_index": 10,
+      "consistency_to": "chk_20"
+    },
+    "attempts": [
+      { "node_id": "inspect", "iteration": 0, "actor": "agent://claude-code", "tools": ["Read"], "outcome": "completed", "grade": "checked", "evidence": ["art_inspect"] },
+      { "node_id": "change", "iteration": 0, "actor": "agent://claude-code", "tools": ["Edit"], "outcome": "completed", "grade": "checked", "evidence": ["art_change"] },
+      { "node_id": "qa", "iteration": 0, "actor": "agent://gstack", "capabilities": ["qa.browser"], "tools": ["gstack.qa"], "outcome": "pass", "grade": "checked", "evidence": ["art_qa"] },
+      { "node_id": "finish", "iteration": 0, "actor": "agent://claude-code", "tools": [], "outcome": "completed", "grade": "checked", "evidence": ["art_finish"] }
+    ]
+  },
+  "expected_report": {
+    "run_id": "run_valid",
+    "workflow_ref": "art_workflow_fixture",
+    "pre_existence": { "grade": "checked" },
+    "path": { "grade": "checked", "deviations": [], "gaps": [] },
+    "authority": { "deviations": [] },
+    "loops": [
+      { "id": "repair", "iterations": 0, "max_iterations": 2, "limit_exceeded": false, "budget_exceeded": false }
+    ]
+  }
+}

--- a/docs/specs/workflow-declarations.md
+++ b/docs/specs/workflow-declarations.md
@@ -1,0 +1,244 @@
+# Workflow declarations: proving the allowed path
+
+**Status:** design, golden report fixtures written; no verifier or mint command yet
+**Pairs with:** [commitments](./commitments.md), [agent-invitations-rooms](./agent-invitations-rooms.md), `action/v2`, approval-use binding, Merkle consistency
+**Last updated:** 2026-08-17
+
+## The question
+
+Treeship proves what captured actions occurred and whether individual actions were authorized. It does not yet answer a workflow-level question:
+
+> Did the observed run follow the path that an authority declared before execution?
+
+A commitment names the promised outcome. A workflow declaration names the allowed path. They remain separate because an agent can follow an allowed path without fulfilling its promise, or fulfill a promise after deviating from the allowed path.
+
+## Load-bearing invariant
+
+> **A graph database may be a disposable query index, never the authority.**
+
+The authority is a signed `workflow.v1` declaration plus signed receipts, checkpoint inclusion, and consistency proofs. Any graph view is a deterministic projection over those portable objects. Treeship does not require or ship a graph database.
+
+Treeship is the proof layer for workflows, not an orchestrator. LangGraph, Temporal, Claude Code, gstack, MCP, A2A, and other runtimes continue to execute work. Treeship verifies the evidence they produce.
+
+## Three graphs, three jobs
+
+1. **Declared graph.** What an authority allowed before execution: nodes, edges, and bounded loops.
+2. **Observed graph.** What the available evidence says happened during one run. Reconstructed from attempts and receipts, not trusted from a runtime's narrative.
+3. **Evidence graph.** Why each observed node and transition is believed: signatures, parent links, approval uses, handoffs, artifact references, checkpoint inclusion, and trust roots.
+
+The declared graph is immutable once signed. A changed workflow is a new artifact. The observed graph uses repeated attempts with explicit iteration numbers. It never mutates the declared graph or turns a loop into a parent cycle.
+
+## Honest contract
+
+Workflow verification proves only what its evidence supports:
+
+- It can check that a signed declaration existed earlier in the same append-only log than the run evidence.
+- It can check that observed, signed actions fit declared nodes, tools, actors, capabilities, edges, and loop limits.
+- It can identify a declared step for which the run supplies no evidence.
+- It cannot prove an uncaptured action never happened.
+- It cannot infer semantic success from a tool's self-reported success.
+- It cannot upgrade an adapter's transition claim merely because the adapter signed it.
+- It does not enforce the workflow. Guard or the runtime may use this declaration for enforcement, but Treeship reports conformance after the fact.
+
+A clean report means: every action in the evidence set fit the declaration, no required evidence was missing, and declared limits held. It does not mean the evidence set is absolutely complete.
+
+## Report first
+
+The golden fixtures in [`fixtures/workflow-conformance/`](./fixtures/workflow-conformance/) define the first report contract before implementation:
+
+| Fixture | Required result |
+|---|---|
+| `valid.json` | a complete checked path has no deviation, gap, or exceeded limit |
+| `deviation.json` | `inspect -> qa` is an undeclared-edge **deviation** |
+| `gap.json` | a completed run with no required terminal has a **gap** |
+| `loop-cap.json` | three back-edge traversals exceed a limit of two |
+| `asserted-edge.json` | a path touching adapter-only evidence grades `asserted`, not `checked` |
+| `not-preexisting.json` | signed timestamps alone grade pre-existence `asserted` |
+| `authority-deviation.json` | a tool outside its node's allowed set is an authority deviation |
+
+These are design fixtures, not cryptographic vectors. Their `art_*` and `chk_*` values are readable placeholders. Implementation tests must construct and verify real envelopes and checkpoints rather than treating these placeholder IDs as proof.
+
+## Minimal `workflow.v1`
+
+`workflow.v1` is a registered predicate carried by the existing signed `receipt.v1` envelope. This reuses predicate validation, DSSE signing, artifact IDs, storage, and Merkle publication. It does not introduce another signature format.
+
+```json
+{
+  "kind": "workflow.v1",
+  "schema_version": "1",
+  "workflow_id": "claude-gstack-qa",
+  "authority": "human://operator",
+  "entry_node": "inspect",
+  "terminal_nodes": ["finish"],
+  "nodes": [
+    {
+      "id": "inspect",
+      "executor": { "actor": "agent://claude-code" },
+      "allowed_tools": ["Read", "Grep"]
+    },
+    {
+      "id": "qa",
+      "executor": { "capability": "qa.browser" },
+      "allowed_tools": ["gstack.qa"]
+    }
+  ],
+  "edges": [
+    { "from": "inspect", "to": "qa", "when": "always" },
+    { "from": "qa", "to": "finish", "when": "on_pass" },
+    { "from": "qa", "to": "inspect", "when": "on_fail" }
+  ],
+  "loops": [
+    {
+      "id": "repair",
+      "back_edge": { "from": "qa", "to": "inspect" },
+      "max_iterations": 2,
+      "budget": { "max_actions": 30 }
+    }
+  ]
+}
+```
+
+Only fields the first verifier checks belong in v1.
+
+### Nodes
+
+- `id` is unique and non-empty.
+- `executor` contains exactly one of `actor` or `capability`.
+- `allowed_tools` is the closed tool set for evidence attributed to that node. Existing Treeship wildcard matching may be reused; no second matching language is introduced.
+
+Input/output schemas, redaction rules, retry policy, idempotency, and generalized effect constraints are deferred. They enter a later version only with a verifier fixture that needs them.
+
+### Edges
+
+- `from` and `to` name declared nodes.
+- `when` is one of `always | on_pass | on_fail | on_refused`.
+- Arbitrary expressions are not accepted in v1. A condition the verifier cannot independently evaluate does not belong in a conformance declaration.
+
+### Entry and terminals
+
+`entry_node` and `terminal_nodes` are required. Without them, the verifier cannot distinguish an intentionally partial run from a completed run missing its beginning or end. A completed run that does not end at a permitted terminal reports a gap.
+
+### Loops
+
+A loop names one declared back edge. `max_iterations` counts verified traversals of that back edge, not an adapter's claimed iteration number. `budget.max_actions` counts captured signed actions attributed to attempts in that loop.
+
+V1 does not use cyclic parent relationships. Agent parentage remains a hierarchy. Repeated work creates a new attempt carrying `{ node_id, attempt, iteration }`.
+
+## Declaration pre-existence
+
+A workflow hash identifies content but proves no ordering. A signed timestamp is also only the signer's assertion.
+
+Pre-existence grades `checked` only when the verifier can establish all of the following:
+
+1. The signed workflow artifact is included in checkpoint of tree size `N`.
+2. The first run artifact is included at zero-based leaf index `>= N` in a later checkpoint.
+3. A valid consistency proof shows that the later checkpoint extends the declaration checkpoint.
+4. Both checkpoint signatures satisfy the verifier's own trust roots.
+
+This proves log order, not trusted wall-clock time. Without that chain, the declaration may still be signed and useful, but pre-existence grades `asserted`.
+
+## Deriving the observed path
+
+The verifier orders node attempts from cryptographically checked causal evidence where possible. It derives each transition between consecutive attempts. It does not need an `edge_taken.v1` statement in the first slice.
+
+Useful evidence includes:
+
+- signed parent artifact links,
+- approval grant and use binding,
+- signed handoffs,
+- artifact references,
+- key-bound action receipts,
+- evaluator receipts,
+- Merkle order under trusted checkpoints.
+
+A session event or adapter statement may help group evidence into an attempt, but it does not become stronger merely by naming a node or edge.
+
+## Edge and path provenance
+
+Each derived edge inherits the weakest grade of the evidence needed to establish it:
+
+| Grade | Meaning |
+|---|---|
+| `checked` | The verifier reconstructed the transition from signed, bound evidence and its trust policy accepted the relevant keys. |
+| `captured` | A configured runtime hook observed the transition, but no independent binding lets the verifier recompute it. |
+| `asserted` | The runtime or adapter reported the transition without supporting captured evidence. |
+
+The path grade is the weakest edge grade. A valid declared edge supported only by an adapter claim is therefore `asserted`, never bare "verified".
+
+"Signed" and "independent" are not synonyms. If the adapter that is under review minted the tool receipt, the receipt proves what that adapter asserted. The report names that provenance rather than laundering it into independence.
+
+## Report vocabulary
+
+Workflow conformance reuses the existing vocabulary:
+
+- **Deviation:** observed evidence outside the declared graph or node authority, such as an undeclared edge, wrong actor, or out-of-scope tool.
+- **Gap:** evidence required to complete the declared path is absent, such as a completed run with no permitted terminal.
+- **Commitment outcome:** `satisfied | violated | unfulfilled | refused`, reported by commitment verification rather than collapsed into path conformance.
+- **Provenance:** `checked | captured | asserted`.
+
+Path, authority, commitment, and provenance remain separate axes. One must not hide another.
+
+The initial machine report has this shape:
+
+```json
+{
+  "run_id": "run_...",
+  "workflow_ref": "art_...",
+  "pre_existence": { "grade": "checked" },
+  "path": {
+    "grade": "checked",
+    "deviations": [],
+    "gaps": []
+  },
+  "authority": { "deviations": [] },
+  "loops": [
+    {
+      "id": "repair",
+      "iterations": 1,
+      "max_iterations": 2,
+      "limit_exceeded": false,
+      "budget_exceeded": false
+    }
+  ]
+}
+```
+
+There is deliberately no single workflow score. Consumers may decide that any deviation, gap, or exceeded limit is fatal, but the substrate reports the file rather than assigning reputation.
+
+## Validation rules
+
+Minting refuses a declaration when:
+
+- node IDs are empty or duplicated,
+- entry or terminal IDs do not exist,
+- an edge references an unknown node,
+- `when` is outside the closed vocabulary,
+- an executor has neither or both of `actor` and `capability`,
+- a loop references an undeclared edge,
+- two loops claim the same back edge,
+- `max_iterations` is zero,
+- `max_actions` is zero when present.
+
+The verifier refuses vacuous input. A declaration needs at least one node, one terminal, and a non-empty evidence set before any path can grade `checked`.
+
+## First dogfood
+
+The first end-to-end workflow is a Claude Code and gstack QA loop in this repository:
+
+```text
+inspect -> change -> qa -> finish
+                    |
+                    +-- on_fail -> change, at most 2 times
+```
+
+Existing Claude Code hooks and Treeship receipts provide the evidence. No LangGraph or Temporal adapter is required for the first verdict. The deployment repair example waits until this smaller loop produces trustworthy reports.
+
+## Slices
+
+1. **Golden reports and minimal declaration spec.** The fixtures in this directory and this document. No runtime behavior yet.
+2. **Pure conformance reducer.** Parse a validated declaration plus already-verified observations and reproduce every golden report. No signing or CLI surface in this slice.
+3. **Signed, checkpoint-anchored declaration.** Register `workflow.v1`, mint it through `receipt.v1`, publish its checkpoint, and bind a run's first receipt to the declaration artifact.
+4. **Claude Code and gstack dogfood.** Group existing evidence into node attempts and verify the real QA loop.
+5. **External adapters.** Add adapters only after the report distinguishes checked, captured, and asserted paths end to end.
+
+`edge_taken.v1`, generalized workflow execution, optimization, graph databases, and automatic graph rewriting are explicitly deferred.

--- a/packages/cli/src/commands/grant.rs
+++ b/packages/cli/src/commands/grant.rs
@@ -426,6 +426,7 @@ pub fn list(config: Option<&str>, printer: &Printer) -> Result<(), Box<dyn std::
 /// signature re-checked rather than taken from the file.
 pub fn show(
     id: &str,
+    check_log: bool,
     config: Option<&str>,
     printer: &Printer,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -471,6 +472,39 @@ pub fn show(
         },
         None => String::new(),
     };
+    // --check-log: ask the hub for the dock's consistency chain and re-verify
+    // every link. Only meaningful when there is an anchored revocation to
+    // check; saying "log consistent" about a grant with no revocation would
+    // answer a question nobody asked.
+    let log_str = if check_log {
+        match (
+            revocations.anchor_for(&g.grant_id),
+            ctx.config
+                .resolve_hub(None)
+                .ok()
+                .map(|(_, e)| e.endpoint.clone())
+                .as_deref(),
+        ) {
+            (Some(a), Some(hub)) => Some(match crate::commands::revocation_source::check_dock_log(
+                hub, &a.dock_id,
+            ) {
+                crate::commands::revocation_source::LogCheck::Consistent { from, to } => {
+                    format!("consistent, {from} -> {to} (every link re-verified offline)")
+                }
+                crate::commands::revocation_source::LogCheck::Inconsistent(why) => {
+                    format!("INCONSISTENT -- {why}")
+                }
+                crate::commands::revocation_source::LogCheck::Unknown(why) => {
+                    format!("unknown -- {why}")
+                }
+            }),
+            (None, _) => Some("not checked -- no anchored revocation for this grant".to_string()),
+            (_, None) => Some("not checked -- no hub configured".to_string()),
+        }
+    } else {
+        None
+    };
+
     let revocation_str = match &revocation {
         RevocationStatus::NotRevoked => "not revoked".to_string(),
         RevocationStatus::RevokedAt(at) => format!("REVOKED at {at}{anchor_note}"),
@@ -520,6 +554,9 @@ pub fn show(
             ("revocation", &revocation_str),
         ],
     );
+    if let Some(l) = &log_str {
+        printer.info(&format!("  log:                 {l}"));
+    }
     Ok(())
 }
 

--- a/packages/cli/src/commands/revocation_source.rs
+++ b/packages/cli/src/commands/revocation_source.rs
@@ -96,6 +96,31 @@ pub struct RevocationEntry {
     anchor: Option<RevocationAnchor>,
 }
 
+/// Whether a dock's log is self-consistent, checked against the hub.
+///
+/// This is the step the anchor references exist for. #315 published
+/// `dock_id` so a client *could* ask; this is the asking.
+///
+/// What it establishes: the log has not been rewritten between the
+/// checkpoints the hub serves. A log that fails consistency has been forked,
+/// and a revocation served from it can be withdrawn without trace.
+///
+/// What it does NOT establish: that the revocation list is complete.
+/// Completeness is not provable from a list, and a consistent log can still
+/// be a log that never had the entry added.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogCheck {
+    /// Every consecutive proof from `from` to `to` verified.
+    Consistent { from: u64, to: u64 },
+    /// A proof in the chain did not verify. The log was rewritten.
+    Inconsistent(String),
+    /// Could not be established -- unreachable hub, no checkpoints, malformed
+    /// response. Deliberately distinct from `Inconsistent`: not knowing is not
+    /// the same as knowing something is wrong, and collapsing them would
+    /// either cry wolf or bury a real fork.
+    Unknown(String),
+}
+
 /// Log references a client can use to check a revocation for itself.
 #[derive(Debug, Clone)]
 pub struct RevocationAnchor {
@@ -334,6 +359,121 @@ fn signed_by(envelope: &Envelope, grantor: &str) -> bool {
 /// entries, and the caller's absence rule then reports `Unknown` rather than a
 /// false `NotRevoked`. Returning an error would make an offline `verify` fail
 /// outright when the honest answer is that it could not check.
+/// Walk a dock's consistency chain and verify every link offline.
+///
+/// The hub stores client-submitted proofs and says so outright: "the hub
+/// stores but never verifies them. re-verify each link offline against your
+/// trust roots." So this re-verifies, using core's RFC 6962
+/// `verify_consistency` -- the same primitive `audit` uses. Trusting the
+/// hub's chain because the hub served it would make the whole exercise
+/// circular.
+///
+/// A single failing link is `Inconsistent`: the log was rewritten between two
+/// checkpoints it published, and a revocation served from it can be withdrawn
+/// without trace.
+///
+/// An empty chain is `Unknown`, not `Consistent`. Nothing verified, so nothing
+/// was established -- reporting a clean result from zero proofs is the vacuous
+/// pass this codebase keeps finding.
+pub fn check_dock_log(endpoint: &str, dock_id: &str) -> LogCheck {
+    let base = endpoint.trim_end_matches('/');
+
+    // dock_id -> the checkpoint signer, which is what /consistency keys on.
+    let cp_url = format!("{base}/v1/merkle/checkpoint/latest?dock_id={dock_id}");
+    let Ok(cp_resp) = ureq::get(&cp_url)
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+    else {
+        return LogCheck::Unknown(format!("no checkpoint served for dock {dock_id}"));
+    };
+    let Ok(cp) = cp_resp.into_json::<serde_json::Value>() else {
+        return LogCheck::Unknown("checkpoint response was not JSON".into());
+    };
+    let Some(signer) = cp["signer_key_id"].as_str().filter(|s| !s.is_empty()) else {
+        return LogCheck::Unknown(format!("checkpoint for dock {dock_id} names no signer"));
+    };
+
+    let chain_url = format!("{base}/v1/merkle/consistency?signer={signer}&from=0");
+    let Ok(chain_resp) = ureq::get(&chain_url)
+        .timeout(std::time::Duration::from_secs(10))
+        .call()
+    else {
+        return LogCheck::Unknown(format!("consistency chain unreachable for signer {signer}"));
+    };
+    let Ok(body) = chain_resp.into_json::<serde_json::Value>() else {
+        return LogCheck::Unknown("consistency response was not JSON".into());
+    };
+
+    let empty = Vec::new();
+    let chain = body["chain"].as_array().unwrap_or(&empty);
+    if chain.is_empty() {
+        return LogCheck::Unknown(format!(
+            "no consistency proofs published for signer {signer}; nothing was verified"
+        ));
+    }
+
+    let mut lowest = u64::MAX;
+    let mut highest = 0u64;
+
+    for link in chain {
+        let (Some(from_size), Some(from_root), Some(to_size), Some(to_root)) = (
+            link["from_size"].as_u64(),
+            link["from_root"].as_str(),
+            link["to_size"].as_u64(),
+            link["to_root"].as_str(),
+        ) else {
+            return LogCheck::Unknown("a chain link was missing its sizes or roots".into());
+        };
+        // No default. Guessing the hash version and guessing wrong makes a
+        // genuine proof fail to verify, which this function would then report
+        // as `Inconsistent` -- accusing an honest log of having been
+        // rewritten. A false fork accusation is worse than admitting the
+        // version was not stated.
+        //
+        // (Trees default to V2, so v1 was the wrong guess to have made.)
+        let Some(version) = link["version"].as_u64() else {
+            return LogCheck::Unknown(format!(
+                "link {from_size}->{to_size} states no hash version; refusing to guess, \
+                 because guessing wrong reads as a rewritten log"
+            ));
+        };
+        let version = version as u8;
+
+        // `proof_json` is a JSON-encoded array carried as a string.
+        let proof: Vec<String> = link["proof_json"]
+            .as_str()
+            .and_then(|raw| serde_json::from_str(raw).ok())
+            .unwrap_or_default();
+        if proof.is_empty() && from_size != 0 {
+            return LogCheck::Unknown(format!(
+                "link {from_size}->{to_size} carried no proof; nothing to verify"
+            ));
+        }
+
+        if !treeship_core::merkle::verify_consistency(
+            version,
+            from_size as usize,
+            from_root,
+            to_size as usize,
+            to_root,
+            &proof,
+        ) {
+            return LogCheck::Inconsistent(format!(
+                "consistency proof {from_size}->{to_size} for signer {signer} does not verify -- \
+                 this log was rewritten, and a revocation served from it can be withdrawn"
+            ));
+        }
+
+        lowest = lowest.min(from_size);
+        highest = highest.max(to_size);
+    }
+
+    LogCheck::Consistent {
+        from: lowest,
+        to: highest,
+    }
+}
+
 pub fn fetch_hub_revocations(endpoint: &str) -> Vec<RevocationEntry> {
     let url = format!(
         "{}/.well-known/treeship/revoked.json",
@@ -706,5 +846,95 @@ mod tests {
             src.status("grn_c", ""),
             RevocationStatus::Unknown(_)
         ));
+    }
+
+    // ── check_dock_log: the shapes that must not be confused ──────────────
+    //
+    // These exercise the verification logic against real Merkle data rather
+    // than a live hub. Building the chain from `MerkleTree` means the proofs
+    // are genuine: a hand-written fixture would test that the parser accepts
+    // my own invention.
+
+    use treeship_core::merkle::{verify_consistency, MerkleTree};
+
+    fn tree_of(n: usize) -> (String, usize) {
+        let mut t = MerkleTree::new();
+        for i in 0..n {
+            t.append(&format!("art_{i:04x}"));
+        }
+        (hex::encode(t.root().expect("non-empty tree has a root")), n)
+    }
+
+    /// The load-bearing property: a genuine extension verifies.
+    #[test]
+    fn a_real_consistency_proof_verifies() {
+        let (old_root, old_size) = tree_of(4);
+        let (new_root, new_size) = tree_of(7);
+        let mut t = MerkleTree::new();
+        for i in 0..new_size {
+            t.append(&format!("art_{i:04x}"));
+        }
+        let proof = t
+            .consistency_proof(old_size)
+            .expect("4 -> 7 has a consistency proof");
+        assert!(
+            verify_consistency(2, old_size, &old_root, new_size, &new_root, &proof),
+            "a genuine extension must verify, or the check below proves nothing"
+        );
+    }
+
+    /// A rewritten log must fail. If this passed, `check_dock_log` reporting
+    /// `Consistent` would be worthless.
+    #[test]
+    fn a_rewritten_log_fails_consistency() {
+        let (_, old_size) = tree_of(4);
+        let (new_root, new_size) = tree_of(7);
+
+        // Same size, different history -- the shape of a log that dropped or
+        // swapped an entry rather than appending.
+        let mut forked = MerkleTree::new();
+        for i in 0..old_size {
+            forked.append(&format!("other_{i:04x}"));
+        }
+        let forged_old_root = hex::encode(forked.root().unwrap());
+
+        let mut t = MerkleTree::new();
+        for i in 0..new_size {
+            t.append(&format!("art_{i:04x}"));
+        }
+        let proof = t.consistency_proof(old_size).unwrap();
+
+        assert!(
+            !verify_consistency(2, old_size, &forged_old_root, new_size, &new_root, &proof),
+            "a proof must not verify against a root from a different history"
+        );
+    }
+
+    /// An unknown version is rejected rather than assumed compatible.
+    #[test]
+    fn an_unknown_merkle_version_is_rejected() {
+        let (old_root, old_size) = tree_of(4);
+        let (new_root, new_size) = tree_of(7);
+        let mut t = MerkleTree::new();
+        for i in 0..new_size {
+            t.append(&format!("art_{i:04x}"));
+        }
+        let proof = t.consistency_proof(old_size).unwrap();
+        assert!(
+            !verify_consistency(99, old_size, &old_root, new_size, &new_root, &proof),
+            "an unrecognised hashing version must not pass"
+        );
+    }
+
+    /// Unknown and Inconsistent are different answers and must stay different.
+    /// Collapsing them either cries wolf on an unreachable hub or buries a
+    /// real fork under a shrug.
+    #[test]
+    fn unknown_is_not_inconsistent() {
+        let unreachable = LogCheck::Unknown("hub unreachable".into());
+        let forked = LogCheck::Inconsistent("proof 4->7 does not verify".into());
+        assert_ne!(unreachable, forked);
+        assert!(matches!(unreachable, LogCheck::Unknown(_)));
+        assert!(matches!(forked, LogCheck::Inconsistent(_)));
     }
 }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1422,7 +1422,20 @@ enum GrantCommand {
     /// List every grant minted in this workspace.
     List,
     /// Show one grant, re-deriving its id and re-checking its signature.
-    Show { grant_id: String },
+    Show {
+        grant_id: String,
+        /// Verify the log holding this grant's revocation, against the hub.
+        ///
+        /// Walks the dock's consistency chain and re-verifies every link
+        /// offline (RFC 6962). Establishes that the log has not been
+        /// rewritten -- NOT that the revocation list is complete, which is not
+        /// provable from a list.
+        ///
+        /// Opt-in because it is two network round trips; `show` is otherwise
+        /// local.
+        #[arg(long)]
+        check_log: bool,
+    },
 
     /// Withdraw a grant. Mints a signed grant_revocation.v1 receipt.
     ///
@@ -3163,9 +3176,10 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
             GrantCommand::Revoke { grant_id, reason } => {
                 commands::grant::revoke(grant_id, reason.as_deref(), cli.config.as_deref(), printer)
             }
-            GrantCommand::Show { grant_id } => {
-                commands::grant::show(grant_id, cli.config.as_deref(), printer)
-            }
+            GrantCommand::Show {
+                grant_id,
+                check_log,
+            } => commands::grant::show(grant_id, *check_log, cli.config.as_deref(), printer),
         },
 
         Command::Approval(sub) => match sub {

--- a/packages/core/src/session/graph.rs
+++ b/packages/core/src/session/graph.rs
@@ -73,6 +73,11 @@ pub struct AgentEdge {
 pub struct AgentGraph {
     pub nodes: Vec<AgentNode>,
     pub edges: Vec<AgentEdge>,
+    /// Cycles found in the untrusted parent relationship. A cycle has no
+    /// meaningful root depth, so affected nodes retain depth 0 and the
+    /// malformed topology is reported rather than silently normalized.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub invalid_parent_cycles: Vec<Vec<String>>,
 }
 
 impl AgentGraph {
@@ -265,19 +270,36 @@ impl AgentGraph {
             }
         }
 
-        // Compute depths from parent map
+        // Compute depths from the untrusted parent map without recursion.
+        // A self-parent or A -> B -> A pair used to recurse until stack
+        // overflow here while composing a session receipt.
         let mut depth_cache: BTreeMap<String, u32> = BTreeMap::new();
+        let mut invalid_parent_cycles: BTreeSet<Vec<String>> = BTreeSet::new();
         let instances: Vec<String> = nodes_map.keys().cloned().collect();
         for inst in &instances {
-            let depth = compute_depth(inst, &parent_map, &mut depth_cache);
-            if let Some(node) = nodes_map.get_mut(inst) {
-                node.depth = depth;
+            match compute_depth(inst, &parent_map, &mut depth_cache) {
+                Ok(depth) => {
+                    if let Some(node) = nodes_map.get_mut(inst) {
+                        node.depth = depth;
+                    }
+                }
+                Err(mut cycle) => {
+                    // Canonicalize the cycle so starting the walk at a
+                    // different member cannot emit the same anomaly twice.
+                    cycle.sort();
+                    cycle.dedup();
+                    invalid_parent_cycles.insert(cycle);
+                }
             }
         }
 
         let nodes: Vec<AgentNode> = nodes_map.into_values().collect();
 
-        AgentGraph { nodes, edges }
+        AgentGraph {
+            nodes,
+            edges,
+            invalid_parent_cycles: invalid_parent_cycles.into_iter().collect(),
+        }
     }
 
     /// Return the maximum depth in the graph.
@@ -311,16 +333,46 @@ fn compute_depth(
     instance_id: &str,
     parent_map: &BTreeMap<String, String>,
     cache: &mut BTreeMap<String, u32>,
-) -> u32 {
-    if let Some(&d) = cache.get(instance_id) {
-        return d;
-    }
-    let depth = match parent_map.get(instance_id) {
-        Some(parent) => 1 + compute_depth(parent, parent_map, cache),
-        None => 0,
+) -> Result<u32, Vec<String>> {
+    let mut path = Vec::new();
+    let mut path_positions: BTreeMap<String, usize> = BTreeMap::new();
+    let mut current = instance_id.to_string();
+
+    let mut depth = loop {
+        if let Some(&cached) = cache.get(&current) {
+            break cached;
+        }
+        if let Some(&cycle_start) = path_positions.get(&current) {
+            return Err(path[cycle_start..].to_vec());
+        }
+
+        path_positions.insert(current.clone(), path.len());
+        path.push(current.clone());
+
+        match parent_map.get(&current) {
+            Some(parent) => current = parent.clone(),
+            None => {
+                // The final path member is the root. Preserve the existing
+                // convention that roots have depth 0.
+                let root = path
+                    .pop()
+                    .expect("depth path contains the current root; please report a bug");
+                cache.insert(root, 0);
+                break 0;
+            }
+        }
     };
-    cache.insert(instance_id.to_string(), depth);
-    depth
+
+    for child in path.into_iter().rev() {
+        depth = depth
+            .checked_add(1)
+            .expect("agent graph depth exceeds u32; please report a bug");
+        cache.insert(child, depth);
+    }
+
+    Ok(*cache
+        .get(instance_id)
+        .expect("depth walk caches the requested instance; please report a bug"))
 }
 
 #[cfg(test)]
@@ -399,6 +451,53 @@ mod tests {
         assert_eq!(graph.handoff_count(), 1);
         assert_eq!(graph.spawn_count(), 2);
         assert_eq!(graph.host_ids().len(), 2);
+    }
+
+    #[test]
+    fn parent_cycles_are_reported_without_recursing() {
+        let self_parent = AgentGraph::from_events(&[evt(
+            "a",
+            "h",
+            EventType::AgentStarted {
+                parent_agent_instance_id: Some("a".into()),
+            },
+        )]);
+        assert_eq!(self_parent.invalid_parent_cycles, vec![vec!["a"]]);
+        assert_eq!(self_parent.nodes[0].depth, 0);
+
+        let two_node_cycle = AgentGraph::from_events(&[
+            evt(
+                "a",
+                "h",
+                EventType::AgentStarted {
+                    parent_agent_instance_id: Some("b".into()),
+                },
+            ),
+            evt(
+                "b",
+                "h",
+                EventType::AgentStarted {
+                    parent_agent_instance_id: Some("a".into()),
+                },
+            ),
+        ]);
+        assert_eq!(
+            two_node_cycle.invalid_parent_cycles,
+            vec![vec!["a".to_string(), "b".to_string()]]
+        );
+        assert!(two_node_cycle.nodes.iter().all(|node| node.depth == 0));
+    }
+
+    #[test]
+    fn deep_parent_chains_do_not_use_the_call_stack() {
+        let mut parent_map = BTreeMap::new();
+        for i in 1..20_000 {
+            parent_map.insert(format!("n{i}"), format!("n{}", i - 1));
+        }
+
+        let depth = compute_depth("n19999", &parent_map, &mut BTreeMap::new())
+            .expect("an acyclic parent chain has a depth");
+        assert_eq!(depth, 19_999);
     }
 
     #[test]


### PR DESCRIPTION
#315 published `dock_id` so a client *could* ask whether a revocation's log has been rewritten. #316 read it. **Neither asked.** This asks.

```
treeship grant show <id> --check-log
```

Resolves `dock_id` → `/v1/merkle/checkpoint/latest` → `signer_key_id` → `/v1/merkle/consistency`, then **re-verifies every link** with core's RFC 6962 `verify_consistency`.

Re-verifies rather than trusts — the hub says outright that it *"stores but never verifies them; re-verify each link offline against your trust roots."* Believing the hub's chain because the hub served it would make the whole exercise circular.

## Three outcomes, kept distinct

| | |
|---|---|
| **Consistent {from, to}** | every link verified |
| **Inconsistent** | a link failed — the log was rewritten between two checkpoints it published, and a revocation served from it can be withdrawn without trace |
| **Unknown** | unreachable hub, no checkpoints, malformed link |

**Unknown is not folded into Inconsistent.** Not knowing isn't the same as knowing something is wrong; collapsing them either cries wolf on an honest hub or buries a real fork under a shrug.

An empty chain is Unknown, not Consistent — nothing verified, nothing established.

## A bug the test caught before it shipped

I defaulted a missing `version` field to **1**. Trees default to **V2**.

So a genuine V2 proof would have failed verification and been reported as `Inconsistent` — **falsely accusing an honest log of having been rewritten.** That's the worst direction for this check to be wrong in.

There's no default now: an unstated version is Unknown, because guessing wrong reads as a fork.

## On the tests

They build real trees and derive real proofs rather than using fixtures, and assert **both** directions — a genuine extension verifies, a same-size-different-history root does not. A hand-written fixture would only prove the parser accepts my own invention.

## Scope

Opt-in flag: two network round trips, and `show` is otherwise local. With no anchored revocation or no hub it says **"not checked"** and why, rather than reporting a clean log it never looked at.

Clippy caught the checker as dead code before this wiring — the same *built-it-never-called-it* shape as the hub backfill in #307.

558 core tests green, clippy clean, capability map current.