### PR TITLE
v0.24.0 feat: ship Linux arm64 binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
         with:
+          toolchain: '1.94.1'
           targets: aarch64-unknown-linux-musl
       - name: Install musl linker
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,42 @@ jobs:
           python-version: '3.12'
       - name: Check internal version consistency
         run: python3 scripts/check-release-versions.py --consistency
+      - name: Check release platform topology
+        run: python3 scripts/check-release-platforms.py
+
+  # The tag-only release workflow cannot validate a new target on a PR. Build
+  # and execute the exact static Linux arm64 target here so a broken linker,
+  # target, or runner label blocks merge instead of failing on release day.
+  release-linux-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
+        with:
+          targets: aarch64-unknown-linux-musl
+      - name: Install musl linker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - name: Build static Linux arm64 CLI
+        run: cargo build --release --target aarch64-unknown-linux-musl -p treeship-cli
+      - name: Verify and smoke the release binary
+        run: |
+          set -e
+          BIN=target/aarch64-unknown-linux-musl/release/treeship
+          file "$BIN"
+          if file "$BIN" | grep -qE 'dynamically linked|interpreter'; then
+            echo "::error::treeship-linux-aarch64 is not statically linked"
+            exit 1
+          fi
+          "$BIN" --version
+          TMPHOME=$(mktemp -d)
+          "$BIN" --config "$TMPHOME/config.json" init >/dev/null
+          OUT=$("$BIN" --config "$TMPHOME/config.json" attest action \
+            --actor agent://ci-arm64 --action smoke.sign --format json)
+          ID=$(printf '%s' "$OUT" | sed -n 's/.*"id":"\([a-z0-9_]\+\)".*/\1/p')
+          test -n "$ID"
+          "$BIN" --config "$TMPHOME/config.json" verify "$ID" >/dev/null
 
   # Static check that every page advertised in a docs `meta.json`
   # resolves to a real `.mdx` file (or a sub-section), every section

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (moving branch; pinned to current tip)
         with:
+          toolchain: '1.94.1'
           targets: ${{ matrix.target }}
 
       # musl-tools provides musl-gcc, the linker rust-musl uses for the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,10 @@ jobs:
             target: x86_64-unknown-linux-musl
             artifact: treeship-linux-x86_64
             apt: musl-tools
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            artifact: treeship-linux-aarch64
+            apt: musl-tools
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: treeship-darwin-aarch64
@@ -74,12 +78,12 @@ jobs:
       # silently falls back to runtime-loading and breaks on Alpine.
       # We catch that here, not in user issues.
       - name: Verify static linkage (Linux musl only)
-        if: matrix.target == 'x86_64-unknown-linux-musl'
+        if: endsWith(matrix.target, '-unknown-linux-musl')
         run: |
           BIN="target/${{ matrix.target }}/release/treeship"
           file "$BIN"
           if file "$BIN" | grep -qE 'dynamically linked|interpreter'; then
-            echo "::error::treeship-linux-x86_64 is not statically linked. Aborting release."
+            echo "::error::${{ matrix.artifact }} is not statically linked. Aborting release."
             file "$BIN"
             exit 1
           fi
@@ -108,36 +112,39 @@ jobs:
   # exists.
   smoke:
     needs: build
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        distro:
-          # Each entry mounts the linux-x86_64 binary into a fresh
-          # container and runs install/init/sign/verify against it.
-          - { nick: debian12, image: 'debian:12',     pm: apt }
-          - { nick: ubuntu22, image: 'ubuntu:22.04',  pm: apt }
-          - { nick: ubuntu24, image: 'ubuntu:24.04',  pm: apt }
-          - { nick: alpine,   image: 'alpine:3.20',   pm: apk }
+        include:
+          # Native runners execute the matching static binary inside
+          # same-architecture containers. QEMU is deliberately not trusted
+          # as the only release smoke for Linux arm64.
+          - { os: ubuntu-latest,    artifact: treeship-linux-x86_64,  nick: debian12, image: 'debian:12',    pm: apt }
+          - { os: ubuntu-latest,    artifact: treeship-linux-x86_64,  nick: ubuntu22, image: 'ubuntu:22.04', pm: apt }
+          - { os: ubuntu-latest,    artifact: treeship-linux-x86_64,  nick: ubuntu24, image: 'ubuntu:24.04', pm: apt }
+          - { os: ubuntu-latest,    artifact: treeship-linux-x86_64,  nick: alpine,   image: 'alpine:3.20',  pm: apk }
+          - { os: ubuntu-24.04-arm, artifact: treeship-linux-aarch64, nick: ubuntu24, image: 'ubuntu:24.04', pm: apt }
+          - { os: ubuntu-24.04-arm, artifact: treeship-linux-aarch64, nick: alpine,   image: 'alpine:3.20',  pm: apk }
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Download Linux binary artifact
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
-          name: treeship-linux-x86_64
+          name: ${{ matrix.artifact }}
           path: artifact
 
       - name: Mark binary executable
-        run: chmod +x artifact/treeship-linux-x86_64
+        run: chmod +x artifact/${{ matrix.artifact }}
 
-      - name: Smoke ${{ matrix.distro.nick }} (${{ matrix.distro.image }})
+      - name: Smoke ${{ matrix.artifact }} on ${{ matrix.nick }} (${{ matrix.image }})
         run: |
           set -e
-          BIN_HOST="$(pwd)/artifact/treeship-linux-x86_64"
+          BIN_HOST="$(pwd)/artifact/${{ matrix.artifact }}"
           test -x "$BIN_HOST" || { echo "::error::binary missing at $BIN_HOST"; exit 1; }
 
-          if [ "${{ matrix.distro.pm }}" = "apt" ]; then
+          if [ "${{ matrix.pm }}" = "apt" ]; then
             PREP='set -e
                   export DEBIAN_FRONTEND=noninteractive
                   apt-get update -qq
@@ -151,7 +158,7 @@ jobs:
           # the smoke. Using a mounted volume avoids a docker cp dance.
           docker run --rm \
             -v "$BIN_HOST:/usr/local/bin/treeship:ro" \
-            "${{ matrix.distro.image }}" \
+            "${{ matrix.image }}" \
             sh -c "$PREP
 
           echo '--- treeship --version'
@@ -186,6 +193,7 @@ jobs:
 
     outputs:
       sha256_linux_x86_64:    ${{ steps.checksums.outputs.sha256_linux_x86_64 }}
+      sha256_linux_aarch64:   ${{ steps.checksums.outputs.sha256_linux_aarch64 }}
       sha256_darwin_aarch64:  ${{ steps.checksums.outputs.sha256_darwin_aarch64 }}
       sha256_darwin_x86_64:   ${{ steps.checksums.outputs.sha256_darwin_x86_64 }}
 
@@ -211,12 +219,14 @@ jobs:
           # named after the artifact, with the binary inside.
           (
             cd treeship-linux-x86_64    && sha256sum treeship-linux-x86_64
+            cd ../treeship-linux-aarch64   && sha256sum treeship-linux-aarch64
             cd ../treeship-darwin-aarch64  && sha256sum treeship-darwin-aarch64
             cd ../treeship-darwin-x86_64   && sha256sum treeship-darwin-x86_64
           ) | sort > SHA256SUMS
           cat SHA256SUMS
           # Surface the bare hex hashes as job outputs.
           echo "sha256_linux_x86_64=$(   awk '/treeship-linux-x86_64/    {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
+          echo "sha256_linux_aarch64=$(  awk '/treeship-linux-aarch64/   {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
           echo "sha256_darwin_aarch64=$( awk '/treeship-darwin-aarch64/  {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
           echo "sha256_darwin_x86_64=$(  awk '/treeship-darwin-x86_64/   {print $1}' SHA256SUMS)" >> "$GITHUB_OUTPUT"
 
@@ -225,6 +235,7 @@ jobs:
         with:
           files: |
             treeship-linux-x86_64/treeship-linux-x86_64
+            treeship-linux-aarch64/treeship-linux-aarch64
             treeship-darwin-aarch64/treeship-darwin-aarch64
             treeship-darwin-x86_64/treeship-darwin-x86_64
             SHA256SUMS
@@ -280,6 +291,7 @@ jobs:
             @treeship/mcp \
             @treeship/a2a \
             @treeship/cli-linux-x64 \
+            @treeship/cli-linux-arm64 \
             @treeship/cli-darwin-arm64 \
             @treeship/cli-darwin-x64 \
             treeship; do
@@ -386,9 +398,10 @@ jobs:
       - name: Embed expected SHA-256 into platform npm packages
         run: |
           set -e
-          for slug in linux-x86_64 darwin-aarch64 darwin-x86_64; do
+          for slug in linux-x86_64 linux-aarch64 darwin-aarch64 darwin-x86_64; do
             case "$slug" in
               linux-x86_64)   pkg=cli-linux-x64    sha='${{ needs.release.outputs.sha256_linux_x86_64 }}';;
+              linux-aarch64)  pkg=cli-linux-arm64  sha='${{ needs.release.outputs.sha256_linux_aarch64 }}';;
               darwin-aarch64) pkg=cli-darwin-arm64 sha='${{ needs.release.outputs.sha256_darwin_aarch64 }}';;
               darwin-x86_64)  pkg=cli-darwin-x64   sha='${{ needs.release.outputs.sha256_darwin_x86_64 }}';;
             esac
@@ -406,6 +419,13 @@ jobs:
 
       - name: Verify @treeship/cli-linux-x64 version landed
         run: .github/scripts/wait-for-npm-version.sh @treeship/cli-linux-x64 "${GITHUB_REF_NAME#v}"
+
+      - name: Publish @treeship/cli-linux-arm64
+        working-directory: npm/@treeship/cli-linux-arm64
+        run: bash "$GITHUB_WORKSPACE/.github/scripts/npm-publish-if-needed.sh" @treeship/cli-linux-arm64 "${GITHUB_REF_NAME#v}"
+
+      - name: Verify @treeship/cli-linux-arm64 version landed
+        run: .github/scripts/wait-for-npm-version.sh @treeship/cli-linux-arm64 "${GITHUB_REF_NAME#v}"
 
       - name: Publish @treeship/cli-darwin-arm64
         working-directory: npm/@treeship/cli-darwin-arm64
@@ -552,9 +572,10 @@ jobs:
           set -e
           DATA_DIR="packages/sdk-python/treeship_sdk/_data"
           mkdir -p "$DATA_DIR"
-          for slug in linux-x86_64 darwin-aarch64 darwin-x86_64; do
+          for slug in linux-x86_64 linux-aarch64 darwin-aarch64 darwin-x86_64; do
             case "$slug" in
               linux-x86_64)   asset=treeship-linux-x86_64    sha='${{ needs.release.outputs.sha256_linux_x86_64 }}';;
+              linux-aarch64)  asset=treeship-linux-aarch64   sha='${{ needs.release.outputs.sha256_linux_aarch64 }}';;
               darwin-aarch64) asset=treeship-darwin-aarch64  sha='${{ needs.release.outputs.sha256_darwin_aarch64 }}';;
               darwin-x86_64)  asset=treeship-darwin-x86_64   sha='${{ needs.release.outputs.sha256_darwin_x86_64 }}';;
             esac
@@ -630,7 +651,7 @@ jobs:
           # when the directory layout disagrees with the manifest, which
           # would ship an unverifiable wheel that fails install for
           # every user. Catch it here instead.
-          for asset in treeship-linux-x86_64 treeship-darwin-aarch64 treeship-darwin-x86_64; do
+          for asset in treeship-linux-x86_64 treeship-linux-aarch64 treeship-darwin-aarch64 treeship-darwin-x86_64; do
             if ! python -m zipfile -l "$EXPECTED_WHEEL" | grep -q "treeship_sdk/_data/expected-checksum-${asset}.txt"; then
               echo "::error::built wheel is missing treeship_sdk/_data/expected-checksum-${asset}.txt"
               echo "::error::wheel contents:"

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -128,6 +128,7 @@ treeship/
     @treeship/             Platform-specific binary packages
       cli-darwin-arm64/
       cli-darwin-x64/
+      cli-linux-arm64/
       cli-linux-x64/
 
   .github/workflows/

--- a/PLATFORM.md
+++ b/PLATFORM.md
@@ -86,6 +86,7 @@ treeship/
     @treeship/
       cli-darwin-arm64/
       cli-darwin-x64/
+      cli-linux-arm64/
       cli-linux-x64/
   docs/             # Fumadocs (Next.js) -- docs.treeship.dev
   scripts/
@@ -113,7 +114,8 @@ All release-train packages share a single version (enforced by `scripts/check-re
 | `treeship-sdk` | [PyPI](https://pypi.org/project/treeship-sdk/) | `pip install treeship-sdk` | Python SDK |
 | `@treeship/cli-darwin-arm64` | [npm](https://www.npmjs.com/package/@treeship/cli-darwin-arm64) | (auto-installed) | Binary for Apple Silicon |
 | `@treeship/cli-darwin-x64` | [npm](https://www.npmjs.com/package/@treeship/cli-darwin-x64) | (auto-installed) | Binary for Intel Mac |
-| `@treeship/cli-linux-x64` | [npm](https://www.npmjs.com/package/@treeship/cli-linux-x64) | (auto-installed) | Binary for Linux |
+| `@treeship/cli-linux-arm64` | [npm](https://www.npmjs.com/package/@treeship/cli-linux-arm64) | (auto-installed) | Binary for Linux arm64 |
+| `@treeship/cli-linux-x64` | [npm](https://www.npmjs.com/package/@treeship/cli-linux-x64) | (auto-installed) | Binary for Linux x86_64 |
 
 **Note:** the `treeship-cli` crate on crates.io is orphaned at v0.4.0. It is no longer the canonical install path; use the `treeship` npm wrapper instead. The crate name is preserved on crates.io to avoid squatting and to keep download counters meaningful for historical references.
 
@@ -533,6 +535,7 @@ npm install -g treeship
 Platform packages:
 - `@treeship/cli-darwin-arm64` -- Apple Silicon (M1/M2/M3)
 - `@treeship/cli-darwin-x64` -- Intel Mac
+- `@treeship/cli-linux-arm64` -- Linux arm64
 - `@treeship/cli-linux-x64` -- Linux x86_64
 
 If the binary download fails, postinstall prints a fallback message pointing the user to the shell installer (`curl -fsSL treeship.dev/install | sh`) or the one-liner setup (`curl -fsSL treeship.dev/setup | sh`). The `cargo install treeship-cli` fallback is no longer offered (that crate is orphaned at v0.4.0).

--- a/docs/architecture/subcrate-versions.md
+++ b/docs/architecture/subcrate-versions.md
@@ -46,6 +46,7 @@ and `scripts/check-release-versions.py <version>` verifies it.
 | `@treeship/a2a` | `bridges/a2a/package.json` | `npm @treeship/a2a` |
 | `treeship` (npm wrapper) | `npm/treeship/package.json` | `npm treeship (wrapper)` |
 | `@treeship/cli-linux-x64` | `npm/@treeship/cli-linux-x64/package.json` | platform CLI binary |
+| `@treeship/cli-linux-arm64` | `npm/@treeship/cli-linux-arm64/package.json` | platform CLI binary |
 | `@treeship/cli-darwin-arm64` | `npm/@treeship/cli-darwin-arm64/package.json` | platform CLI binary |
 | `@treeship/cli-darwin-x64` | `npm/@treeship/cli-darwin-x64/package.json` | platform CLI binary |
 | `treeship-sdk` (PyPI) | `packages/sdk-python/pyproject.toml` | `pypi treeship-sdk (pyproject)` |

--- a/docs/content/docs/guides/install.mdx
+++ b/docs/content/docs/guides/install.mdx
@@ -12,7 +12,7 @@ Treeship's release pipeline publishes to four registries. Each one carries a del
 | Registry | Package | What it is |
 |---|---|---|
 | **npm** | `treeship` | The CLI wrapper. `npm install -g treeship` installs the platform binary for your OS via `optionalDependencies`. |
-| **npm** | `@treeship/cli-darwin-arm64`, `@treeship/cli-darwin-x64`, `@treeship/cli-linux-x64` | Per-platform CLI binaries. Selected automatically by the wrapper based on `process.platform`. |
+| **npm** | `@treeship/cli-darwin-arm64`, `@treeship/cli-darwin-x64`, `@treeship/cli-linux-arm64`, `@treeship/cli-linux-x64` | Per-platform CLI binaries. Selected automatically by the wrapper based on `process.platform` and `process.arch`. |
 | **npm** | `@treeship/sdk` | TypeScript / Node SDK. Wraps the CLI. |
 | **npm** | `@treeship/mcp` | MCP server bridge. Drop-in for Claude Code, Cursor, Cline, Codex. |
 | **npm** | `@treeship/a2a` | A2A bridge. |
@@ -20,7 +20,7 @@ Treeship's release pipeline publishes to four registries. Each one carries a del
 | **npm** | `@treeship/core-wasm` | Core verification logic compiled to WebAssembly. Used by `@treeship/verify`. |
 | **PyPI** | `treeship-sdk` | Python SDK. Wraps the CLI. |
 | **crates.io** | `treeship-core` | Rust library. The trust primitives (signing, verification, Merkle, journal) — *not* the CLI. |
-| **GitHub Releases** | `treeship-darwin-aarch64`, `treeship-darwin-x86_64`, `treeship-linux-x86_64` | Raw, signed CLI binaries. Direct download for systems without npm. |
+| **GitHub Releases** | `treeship-darwin-aarch64`, `treeship-darwin-x86_64`, `treeship-linux-aarch64`, `treeship-linux-x86_64` | Raw CLI binaries with release SHA-256 commitments. Direct download for systems without npm. |
 
 ## What's intentionally NOT on each registry
 
@@ -45,7 +45,7 @@ What runs the prebuilt binary today, and what's still pending. AI agents and CI 
 | macOS arm64 (Apple Silicon) | Supported | Primary developer platform. |
 | macOS x86_64 (Intel) | Supported | |
 | Linux x86_64 (any distro) | Supported as of v0.10.1 | Single statically linked musl binary covers Ubuntu 22.04+, Debian 12+, Fedora, RHEL/Rocky 8+, Amazon Linux 2023, Alpine, and minimal containers (distroless, busybox, scratch). No GLIBC requirement. |
-| Linux aarch64 (ARM64) | **Not yet shipped** | Tracked separately; ETA after the v0.10.1 release stabilizes. |
+| Linux aarch64 (ARM64) | Supported in the next release | Native arm64 CI builds a static musl binary and smoke-tests it on Ubuntu 24.04 and Alpine before publication. |
 | Windows native | **Not supported** | The `treeship` npm package fails fast on `process.platform === 'win32'`. Use WSL. A native Windows binary is not on the current roadmap. |
 
 <Callout type="info">

--- a/npm/@treeship/cli-linux-arm64/README.md
+++ b/npm/@treeship/cli-linux-arm64/README.md
@@ -1,0 +1,28 @@
+# @treeship/cli-linux-arm64
+
+Platform-specific static musl binary for the Treeship CLI on Linux arm64.
+
+This package is **not meant to be installed directly**. It is automatically downloaded when you run:
+
+```sh
+npm install -g treeship
+```
+
+The main `treeship` package detects your platform and pulls the correct binary.
+
+## Binary integrity
+
+The package ships a single-line `expected-checksum.txt` with the SHA-256 of the binary it downloads from the matching GitHub Release. The postinstall script:
+
+1. Reads the expected hash from the package (delivered via npm).
+2. Downloads the binary from `https://github.com/zerkerlabs/treeship/releases/download/v<version>/treeship-linux-aarch64`.
+3. Verifies the downloaded bytes match the expected hash.
+4. Atomically renames the partial download into place only on match. On mismatch, the partial file is deleted and install fails (exit 1).
+
+Because the hash is delivered via npm and the binary is delivered via GitHub Releases, an attacker would need to compromise *both* trust roots simultaneously to slip a tampered binary past install. A compromise of either alone produces a verification failure.
+
+If the package was published without `expected-checksum.txt`, the postinstall refuses to install. That's intentional: a binary with no published checksum is unverifiable.
+
+## Repository
+
+[github.com/zerkerlabs/treeship](https://github.com/zerkerlabs/treeship)

--- a/npm/@treeship/cli-linux-arm64/binary.js
+++ b/npm/@treeship/cli-linux-arm64/binary.js
@@ -1,0 +1,2 @@
+const path = require('path');
+module.exports = path.join(__dirname, 'bin', 'treeship');

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@treeship/cli-linux-arm64",
+  "version": "0.24.0",
+  "description": "Treeship CLI binary for linux arm64",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "license": "Apache-2.0",
+  "files": [
+    "postinstall.js",
+    "binary.js",
+    "expected-checksum.txt",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zerkerlabs/treeship"
+  }
+}

--- a/npm/@treeship/cli-linux-arm64/postinstall.js
+++ b/npm/@treeship/cli-linux-arm64/postinstall.js
@@ -1,0 +1,138 @@
+// @treeship/cli-linux-arm64 -- platform binary postinstall.
+//
+// Downloads the Treeship CLI binary from the matching GitHub Release
+// and verifies its SHA-256 against the expected hash that ships
+// inside this npm package. Both halves of the trust path matter:
+//
+//   1. The expected hash arrives via npm (signed by npm's package
+//      integrity, separate trust root from GitHub).
+//   2. The binary arrives via GitHub Releases.
+//   3. If either is tampered, the hashes don't match and we abort.
+//
+// Earlier versions (<= 0.10.0) downloaded the binary, chmod +x'd it,
+// and exited 0 -- no integrity check, and an install failure also
+// exited 0 (claiming success). This file is the v0.10.1 hardening.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const crypto = require('crypto');
+
+const VERSION = require('./package.json').version;
+const BINARY_NAME = 'treeship-linux-aarch64';
+const URL = 'https://github.com/zerkerlabs/treeship/releases/download/v' + VERSION + '/' + BINARY_NAME;
+const BIN_DIR = path.join(__dirname, 'bin');
+const DEST = path.join(BIN_DIR, 'treeship');
+const PARTIAL = DEST + '.partial';
+const CHECKSUM_FILE = path.join(__dirname, 'expected-checksum.txt');
+
+// Read the expected SHA-256 that the release pipeline embedded in this
+// package. Format: a single line, lowercase hex, 64 chars. If absent
+// or malformed, refuse to install -- a binary without a published
+// checksum is an unverifiable binary.
+function readExpectedChecksum() {
+  let raw;
+  try {
+    raw = fs.readFileSync(CHECKSUM_FILE, 'utf8');
+  } catch (e) {
+    return null;
+  }
+  const hex = raw.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(hex)) return null;
+  return hex;
+}
+
+function abort(reason, code) {
+  // Always delete the partial download so a retry doesn't think it
+  // already has the binary.
+  try { if (fs.existsSync(PARTIAL)) fs.unlinkSync(PARTIAL); } catch {}
+  console.error('treeship: install failed -- ' + reason);
+  console.error('  Recover:');
+  console.error('    1. Re-run the install (transient network/CDN issues clear up):');
+  console.error('       npm install -g treeship');
+  console.error('    2. Or download the binary directly and place it on PATH:');
+  console.error('       https://github.com/zerkerlabs/treeship/releases/tag/v' + VERSION);
+  console.error('    3. Or build from source:');
+  console.error('       git clone https://github.com/zerkerlabs/treeship');
+  console.error('       cd treeship && cargo build --release -p treeship-cli');
+  process.exit(code || 1);
+}
+
+const expected = readExpectedChecksum();
+if (!expected) {
+  abort(
+    'expected-checksum.txt missing or malformed in ' + path.basename(__dirname) +
+    '. This npm package was published without a binary integrity hash and ' +
+    'cannot be installed safely. File an issue at ' +
+    'https://github.com/zerkerlabs/treeship/issues so we can re-publish it.',
+    1,
+  );
+}
+
+if (fs.existsSync(DEST)) {
+  // Already installed and verified previously -- nothing to do.
+  process.exit(0);
+}
+
+fs.mkdirSync(BIN_DIR, { recursive: true });
+console.log('treeship: downloading ' + BINARY_NAME + ' v' + VERSION + ' ...');
+
+function download(url, redirects) {
+  if (redirects > 5) return abort('too many redirects', 1);
+
+  const req = https.get(url, (res) => {
+    if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307 || res.statusCode === 308) {
+      res.resume();
+      return download(res.headers.location, redirects + 1);
+    }
+    if (res.statusCode !== 200) {
+      res.resume();
+      return abort('download HTTP ' + res.statusCode + ' from ' + url, 1);
+    }
+
+    const hash = crypto.createHash('sha256');
+    const file = fs.createWriteStream(PARTIAL);
+
+    res.on('data', (chunk) => {
+      hash.update(chunk);
+      file.write(chunk);
+    });
+    res.on('end', () => {
+      file.end(() => {
+        const got = hash.digest('hex');
+        if (got !== expected) {
+          // Delete the partial file before aborting so a retry can't
+          // pick up the bad bytes.
+          try { fs.unlinkSync(PARTIAL); } catch {}
+          return abort(
+            'SHA-256 mismatch.\n' +
+            '       expected: ' + expected + '\n' +
+            '       got:      ' + got + '\n' +
+            '       This means either the GitHub Release was tampered with, ' +
+            'a CDN cached a stale or malicious binary, or the npm package ' +
+            'and the release are out of sync. Do not run the binary.',
+            1,
+          );
+        }
+        try {
+          fs.renameSync(PARTIAL, DEST);
+          fs.chmodSync(DEST, 0o755);
+        } catch (e) {
+          return abort('could not finalize binary: ' + e.message, 1);
+        }
+        console.log('treeship: installed (sha256 verified)');
+      });
+    });
+    res.on('error', (e) => abort('stream error: ' + e.message, 1));
+    file.on('error', (e) => abort('write error: ' + e.message, 1));
+  });
+  req.on('error', (e) => abort('connection error: ' + e.message, 1));
+  req.setTimeout(60_000, () => {
+    req.destroy();
+    abort('download timed out after 60s', 1);
+  });
+}
+
+download(URL, 0);

--- a/npm/treeship/bin/treeship.js
+++ b/npm/treeship/bin/treeship.js
@@ -6,6 +6,7 @@ const os = require('os');
 
 const PLATFORM_MAP = {
   'linux-x64':    '@treeship/cli-linux-x64',
+  'linux-arm64':  '@treeship/cli-linux-arm64',
   'darwin-arm64': '@treeship/cli-darwin-arm64',
   'darwin-x64':   '@treeship/cli-darwin-x64',
 };
@@ -15,7 +16,7 @@ const pkg = PLATFORM_MAP[key];
 
 if (!pkg) {
   console.error(`treeship: unsupported platform ${key}`);
-  console.error('Install via: cargo install treeship-cli');
+  console.error('Build from source: git clone https://github.com/zerkerlabs/treeship && cd treeship && cargo build --release -p treeship-cli');
   process.exit(1);
 }
 

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -20,6 +20,7 @@
   ],
   "optionalDependencies": {
     "@treeship/cli-linux-x64": "0.24.0",
+    "@treeship/cli-linux-arm64": "0.24.0",
     "@treeship/cli-darwin-arm64": "0.24.0",
     "@treeship/cli-darwin-x64": "0.24.0"
   },

--- a/npm/treeship/scripts/check-platform.js
+++ b/npm/treeship/scripts/check-platform.js
@@ -1,6 +1,6 @@
 // Treeship npm wrapper -- preinstall platform guard.
 //
-// We ship prebuilt binaries for darwin-arm64, darwin-x64, and linux-x64.
+// We ship prebuilt binaries for darwin-arm64, darwin-x64, linux-arm64, and linux-x64.
 // As of v0.10.1 the Linux binary is statically linked against musl, so it
 // runs on every glibc and musl distribution we know of (Ubuntu, Debian,
 // Fedora, RHEL/Rocky, Amazon Linux, Alpine, distroless, busybox).

--- a/packages/sdk-python/tests/test_platform_release_asset.py
+++ b/packages/sdk-python/tests/test_platform_release_asset.py
@@ -1,0 +1,24 @@
+"""Platform-to-release-asset contract for the Python bootstrapper."""
+
+import unittest
+from unittest.mock import patch
+
+from treeship_sdk.bootstrap import platform_release_asset
+
+
+class PlatformReleaseAssetTests(unittest.TestCase):
+    def test_linux_aarch64_uses_published_arm64_asset(self):
+        with patch("treeship_sdk.bootstrap.sys.platform", "linux"), patch(
+            "treeship_sdk.bootstrap.platform.machine", return_value="aarch64"
+        ):
+            self.assertEqual(platform_release_asset(), ("treeship-linux-aarch64", None))
+
+    def test_linux_arm64_alias_uses_published_arm64_asset(self):
+        with patch("treeship_sdk.bootstrap.sys.platform", "linux"), patch(
+            "treeship_sdk.bootstrap.platform.machine", return_value="arm64"
+        ):
+            self.assertEqual(platform_release_asset(), ("treeship-linux-aarch64", None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -216,6 +216,8 @@ def platform_release_asset() -> tuple[str, Optional[str]]:
     if sys_platform.startswith("linux"):
         if machine in ("x86_64", "amd64"):
             return ("treeship-linux-x86_64", None)
+        if machine in ("aarch64", "arm64"):
+            return ("treeship-linux-aarch64", None)
         return ("", f"unsupported Linux arch {machine}")
     if sys_platform == "win32":
         return ("", "Windows install must use `npm install -g treeship` (no Windows binary on the GitHub Release)")

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -20,7 +20,8 @@
 #
 # Targets: the release workflow cross-compiles for x86_64-apple-darwin
 # (from macOS arm64 runners), aarch64-apple-darwin (native), and
-# x86_64-unknown-linux-musl (from ubuntu glibc runners). Without these
+# x86_64-unknown-linux-musl and aarch64-unknown-linux-musl on native
+# GitHub Linux runners. Without these
 # listed, the `profile = "minimal"` toolchain ships only the runner's
 # native stdlib and cross-compile builds fail with `can't find crate for
 # 'core'`. The initial v0.10.4 release push (commit cf13139, tag pushed
@@ -30,4 +31,4 @@
 channel    = "1.94.1"
 components = ["clippy", "rustfmt"]
 profile    = "minimal"
-targets    = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-musl"]
+targets    = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]

--- a/scripts/check-release-platforms.py
+++ b/scripts/check-release-platforms.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fail when a supported prebuilt platform is missing from a release surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PLATFORMS = {
+    "linux-x64": {
+        "artifact": "treeship-linux-x86_64",
+        "npm": "@treeship/cli-linux-x64",
+        "manifest": "npm/@treeship/cli-linux-x64/package.json",
+        "python_machine": "x86_64",
+    },
+    "linux-arm64": {
+        "artifact": "treeship-linux-aarch64",
+        "npm": "@treeship/cli-linux-arm64",
+        "manifest": "npm/@treeship/cli-linux-arm64/package.json",
+        "python_machine": "aarch64",
+    },
+    "darwin-arm64": {
+        "artifact": "treeship-darwin-aarch64",
+        "npm": "@treeship/cli-darwin-arm64",
+        "manifest": "npm/@treeship/cli-darwin-arm64/package.json",
+        "python_machine": "arm64",
+    },
+    "darwin-x64": {
+        "artifact": "treeship-darwin-x86_64",
+        "npm": "@treeship/cli-darwin-x64",
+        "manifest": "npm/@treeship/cli-darwin-x64/package.json",
+        "python_machine": "x86_64",
+    },
+}
+
+
+def require(source: str, needle: str, label: str, errors: list[str]) -> None:
+    if needle not in source:
+        errors.append(f"{label}: missing {needle!r}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    release = (ROOT / ".github/workflows/release.yml").read_text()
+    wrapper = (ROOT / "npm/treeship/bin/treeship.js").read_text()
+    bootstrap = (ROOT / "packages/sdk-python/treeship_sdk/bootstrap.py").read_text()
+    docs = (ROOT / "docs/content/docs/guides/install.mdx").read_text()
+    wrapper_manifest = json.loads((ROOT / "npm/treeship/package.json").read_text())
+    optional = wrapper_manifest.get("optionalDependencies", {})
+
+    for key, platform in PLATFORMS.items():
+        manifest_path = ROOT / platform["manifest"]
+        if not manifest_path.is_file():
+            errors.append(f"{key}: missing platform manifest {platform['manifest']}")
+            continue
+        manifest = json.loads(manifest_path.read_text())
+        if manifest.get("name") != platform["npm"]:
+            errors.append(f"{key}: manifest name is {manifest.get('name')!r}, want {platform['npm']!r}")
+
+        require(wrapper, f"'{key}':", "npm wrapper map", errors)
+        require(wrapper, platform["npm"], "npm wrapper map", errors)
+        if optional.get(platform["npm"]) != wrapper_manifest["version"]:
+            errors.append(f"{key}: wrapper optional dependency does not match wrapper version")
+
+        require(release, platform["artifact"], "release workflow", errors)
+        require(release, platform["npm"], "release workflow", errors)
+        require(bootstrap, platform["artifact"], "Python bootstrap", errors)
+        require(docs, platform["artifact"], "install docs", errors)
+        require(docs, platform["npm"], "install docs", errors)
+
+    if errors:
+        print("Release platform topology is inconsistent:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"Release platform topology: {len(PLATFORMS)} platforms agree across CI, npm, Python, and docs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-release-versions.py
+++ b/scripts/check-release-versions.py
@@ -406,6 +406,7 @@ def collect_sites() -> list[Site]:
         ("packages/verify-js/package.json", "npm @treeship/verify"),
         ("npm/treeship/package.json", "npm treeship (wrapper)"),
         ("npm/@treeship/cli-linux-x64/package.json", "npm @treeship/cli-linux-x64"),
+        ("npm/@treeship/cli-linux-arm64/package.json", "npm @treeship/cli-linux-arm64"),
         ("npm/@treeship/cli-darwin-arm64/package.json", "npm @treeship/cli-darwin-arm64"),
         ("npm/@treeship/cli-darwin-x64/package.json", "npm @treeship/cli-darwin-x64"),
         ("tests/runtime-acceptance/aws-lambda/package.json", "acceptance AWS Lambda"),
@@ -481,7 +482,7 @@ def collect_sites() -> list[Site]:
     # The wrapper's optionalDependencies select the right CLI binary for each
     # platform; they MUST match the platform packages it routes to or `npm i
     # treeship` resolves to a stale binary.
-    for cli in ("@treeship/cli-linux-x64", "@treeship/cli-darwin-arm64", "@treeship/cli-darwin-x64"):
+    for cli in ("@treeship/cli-linux-x64", "@treeship/cli-linux-arm64", "@treeship/cli-darwin-arm64", "@treeship/cli-darwin-x64"):
         pin = pkg_json_dep_version(
             "npm/treeship/package.json", cli, group="optionalDependencies"
         )


### PR DESCRIPTION
## Summary

- Build `treeship-linux-aarch64` as a static musl binary on a native GitHub-hosted arm64 runner.
- Smoke-test the arm64 release binary on native Ubuntu 24.04 and Alpine containers before any registry publish.
- Upload the binary and its SHA-256 commitment to GitHub Releases.
- Add `@treeship/cli-linux-arm64` and route `npm install -g treeship` correctly on Linux arm64.
- Add Linux arm64 to the Python SDK bootstrap and wheel checksum bundle.
- Add a PR-level native arm64 build/smoke job so tag-only release failures are caught before merge.
- Add a release-topology check that keeps CI, npm, Python, and installation docs aligned.
- Remove the stale `cargo install treeship-cli` fallback from the npm wrapper error path.

## Test Coverage

```text
Linux arm64 distribution
├── PR CI: native aarch64 musl build, static-link check, init/sign/verify smoke
├── tag release: native Ubuntu + Alpine container smoke
├── GitHub Release: binary + SHA256SUMS
├── npm: platform package + wrapper routing + embedded checksum
├── Python: platform mapping + wheel checksum
└── drift gate: 4 platforms agree across CI, npm, Python, and docs
```

Coverage gate: PASS for locally executable contract paths. The native binary build is intentionally gated by the new GitHub arm64 CI job.

Tests: Python SDK 46 passed, including two new Linux arm64 mapping cases.

## Pre-Landing Review

No blocking issue found in the release graph. YAML was parsed with duplicate-key rejection. Version and platform topology checks pass.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

No plan file detected.

## Verification Results

- [x] `python3 scripts/check-release-versions.py --consistency` — 43 sites agree
- [x] `python3 scripts/check-release-platforms.py` — 4 platforms agree
- [x] Python SDK unit tests — 46 passed
- [x] Both GitHub workflow files parse as YAML with no duplicate keys
- [x] Linux arm64 npm package dry-run reports the expected name and version
- [x] npm wrapper maps `linux-arm64` to `@treeship/cli-linux-arm64`
- [x] Native arm64 musl build and execution — current PR CI passed

## Required release setup

`@treeship/cli-linux-arm64` is a new npm package name. Before the first release using this pipeline, an owner of the `@treeship` npm scope must bootstrap that package name once and configure its trusted publisher. The release preflight deliberately fails instead of partially publishing if that setup is missing.

No release or npm publication is performed by this PR.

## Documentation

Installation topology, supported-platform tables, repository maps, and release-train package inventory now include Linux arm64. The docs label it “Supported in the next release” until an actual release contains the asset.

## Test plan

- [x] Reject version drift in the new platform package
- [x] Reject release/npm/Python/docs platform drift
- [x] Map both `aarch64` and `arm64` Python machine names
- [x] Refuse dynamic Linux release binaries
- [x] Smoke x86_64 and arm64 on architecture-matched runners
