### PR TITLE
docs: gate documented CLI commands against the binary, and fix five that lie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,14 @@ jobs:
       # nothing looked.
       - name: No committed conflict markers
         run: python3 scripts/check-conflict-markers.py
+      # The 2026-08-18 docs QA found documented commands that do not exist,
+      # including one offered as the fix for a fail-closed error. Probes the
+      # built binary rather than parsing a help listing -- the first version
+      # parsed the listing and falsely flagged seven real hidden commands.
+      - name: Documented CLI commands exist
+        run: |
+          cargo build --bin treeship --quiet
+          python3 scripts/check-documented-commands.py
       - name: Every protocol spec is indexed
         run: python3 scripts/check-specs-index.py
       # `schemas/` is the publishable copy; the predicate registry has its own.

--- a/docs/content/docs/cli/verify.mdx
+++ b/docs/content/docs/cli/verify.mdx
@@ -94,9 +94,19 @@ Trust pinning is mandatory and fail-closed: if the issuer key is not in your tru
 
 ```bash
 treeship trust add <key_id> <pubkey> --kind agent_cert
-# or sync from your hub:
-treeship hub sync-trust
 ```
+
+<Callout type="warn">
+This page previously offered `treeship hub sync-trust` here as an easier
+alternative. **That command has never existed.** A reader who hit the
+fail-closed error and followed the suggestion got `unrecognized subcommand`
+and no way forward, which is worse than no suggestion at all.
+
+There is no automatic trust sync. Pinning is a deliberate act: `onboard`
+prints the issuer key to pin, and pinning the **issuer** (`--kind
+cert_issuer`) rather than a leaf agent means one pin covers every agent that
+ship certifies.
+</Callout>
 </Tab>
 <Tab value="Cross-verify">
 ```bash

--- a/docs/content/docs/integrations/ninjatech.mdx
+++ b/docs/content/docs/integrations/ninjatech.mdx
@@ -106,7 +106,14 @@ If SuperNinja opens PRs against this repo, you can verify those PRs separately a
 
 If your SuperNinja deployment exposes an MCP endpoint, you can point a local `@treeship/mcp` proxy at it and Treeship will see MCP-routed tool calls. This is the same shape as [Generic MCP](/docs/integrations/mcp).
 
-### What lands in v0.9.9
+### Proposed: agent invite
+
+<Callout type="warn">
+This section said "What lands in v0.9.9". It did not land, and the product is
+now at 0.24.0 -- `treeship agent invite` still does not exist. A dated promise
+that has passed is worse than no date, because it sends a reader to check and
+find nothing.
+</Callout>
 
 ```bash
 # On your local machine

--- a/docs/content/docs/integrations/verifiable-intent.mdx
+++ b/docs/content/docs/integrations/verifiable-intent.mdx
@@ -79,9 +79,21 @@ Together, these fields let any verifier confirm the agent acted within scope, fo
 
 Treeship is embedded inside L3. It does not replace the Verifiable Intent credential; it provides the cryptographic evidence that makes the L3 credential trustworthy.
 
-## Key management
+## Proposed: key management (not implemented)
 
-Verifiable Intent uses P-256 (secp256r1) for credential signatures. Treeship can generate and manage P-256 keys alongside its default Ed25519 keys:
+Verifiable Intent uses P-256 (secp256r1) for credential signatures.
+
+<Callout type="warn">
+**The `treeship vi` commands below are a design sketch and are not
+implemented.** The CLI has no `vi` subcommand today; running any of them gives
+`unrecognized subcommand`. They were written in the present tense, which read
+as shipped.
+
+Treeship signs with Ed25519 today. P-256 support is the prerequisite for this
+integration and does not exist yet.
+</Callout>
+
+The intended shape, for design review rather than for running:
 
 ```bash
 treeship vi keygen

--- a/scripts/check-documented-commands.py
+++ b/scripts/check-documented-commands.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Fail when the docs tell a reader to run a command that does not exist.
+
+The 2026-08-18 docs QA found 17 of 134 documented CLI targets missing. Two
+examples show why this matters more than a typo:
+
+  * `treeship hub sync-trust` appears in cli/verify.mdx directly beneath
+    "trust pinning is mandatory and fail-closed", offered as the easy way out.
+    It has never existed. A reader hits the fail-closed error, follows the
+    suggestion, gets "unrecognized subcommand", and now has no path forward.
+
+  * `treeship grant revoke` is real -- but landed after the v0.24.0 tag, so
+    nobody running the released binary can use it. Documenting main while
+    users run the release is its own kind of wrong.
+
+# What this checks
+
+Every `treeship <sub> [<sub>]` invocation in a fenced code block, against the
+built binary's own `--help` tree. The binary is the authority: a hand-kept list
+of valid commands would drift exactly like the docs did.
+
+# What it deliberately does not check
+
+Flags. Verifying those means parsing every help page and would fail on
+legitimate prose. Missing *commands* is the failure that leaves a reader
+stuck; a wrong flag at least produces a usable error naming the right ones.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs" / "content" / "docs"
+BIN = ROOT / "target" / "debug" / "treeship"
+
+# Words that follow `treeship` but are not subcommands.
+NOT_COMMANDS = {
+    "--help", "-h", "--version", "-V", "--config", "--format", "--quiet",
+    "help", "<command>", "[command]", "...", "|",
+}
+
+
+_probe_cache: dict[tuple[str, ...], bool] = {}
+
+
+def exists(path: list[str]) -> bool:
+    """Does the binary accept this command path?
+
+    Probes with `--help` and reads the exit code, rather than parsing the
+    `Commands:` section of the parent's help.
+
+    That distinction is the whole correctness of this check. The first version
+    parsed the listing and flagged `checkpoint`, `agent`, `agents`, `bundle`,
+    `daemon`, `dashboard` and `approval` as nonexistent -- every one of them
+    real, just hidden from the top-level listing. A gate that accuses the docs
+    of documenting commands that do exist trains people to ignore it, which is
+    worse than no gate.
+    """
+    key = tuple(path)
+    if key in _probe_cache:
+        return _probe_cache[key]
+    try:
+        out = subprocess.run(
+            [str(BIN), *path, "--help"],
+            capture_output=True, text=True, timeout=30,
+        )
+        ok = out.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        ok = False
+    _probe_cache[key] = ok
+    return ok
+
+
+# Headings that mark a block as not-yet-shipped. A doc that says "Proposed
+# CLI" above a fence is being honest about the future, and flagging it would
+# make this check cry wolf on exactly the pages that got it right.
+#
+# The separate problem -- that a fenced block under such a heading still looks
+# copy-pasteable -- is a presentation fix, not a missing-command bug.
+FORWARD_LOOKING = re.compile(
+    r"^#+\s.*\b(proposed|planned|future|not yet|unbuilt|design sketch|roadmap)\b",
+    re.IGNORECASE,
+)
+
+
+def documented() -> tuple[dict, dict]:
+    """Every `treeship ...` invocation inside a fenced block.
+
+    Returns (shipped_context, proposed_context) so the caller can hold them to
+    different standards.
+    """
+    seen: dict[tuple[str, ...], list[tuple[Path, int]]] = {}
+    proposed: dict[tuple[str, ...], list[tuple[Path, int]]] = {}
+    for mdx in sorted(DOCS.rglob("*.mdx")):
+        fenced = False
+        under_proposal = False
+        proposal_level = 0
+        for n, line in enumerate(mdx.read_text(encoding="utf-8").splitlines(), 1):
+            if not fenced and line.startswith("#"):
+                level = len(line) - len(line.lstrip("#"))
+                if FORWARD_LOOKING.match(line):
+                    under_proposal = True
+                    proposal_level = level
+                elif under_proposal and level <= proposal_level:
+                    # A heading at or above the proposed one ends its scope.
+                    # Deeper headings inherit it: `### Generate a key` under
+                    # `## Proposed: key management` is still proposed, and
+                    # resetting on every heading made the marker useless the
+                    # moment a section had subsections.
+                    under_proposal = False
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            if not fenced:
+                continue
+            # Anchored to the start of the line, optionally after a shell
+            # prompt or a pipe. Without this, prose inside a fenced block --
+            # "the receipt file locally", "your treeship directory so ..." --
+            # parses as a command and produces false accusations, which train
+            # people to ignore the check.
+            stripped = line.strip()
+            for prefix in ("$ ", "> ", "% "):
+                if stripped.startswith(prefix):
+                    stripped = stripped[len(prefix):].lstrip()
+                    break
+            if not stripped.startswith("treeship"):
+                continue
+            for m in re.finditer(r"^treeship\s+([a-z][a-z0-9-]*)(?:\s+([a-z][a-z0-9-]*))?", stripped):
+                first, second = m.group(1), m.group(2)
+                if first in NOT_COMMANDS:
+                    continue
+                key = (first,) if not second or second in NOT_COMMANDS else (first, second)
+                target = proposed if under_proposal else seen
+                target.setdefault(key, []).append((mdx, n))
+    return seen, proposed
+
+
+def main() -> int:
+    if not BIN.exists():
+        print(f"  err   {BIN} not built; run: cargo build -p treeship-cli")
+        print("        Without the binary this check would pass vacuously.")
+        return 1
+
+    # Sanity: a command everyone agrees exists. If this fails the probe itself
+    # is broken and every result below would be a false accusation.
+    if not exists(["verify"]):
+        print("  err   probing the binary failed (`treeship verify --help` did not succeed)")
+        print("        Refusing to report missing commands from a broken probe.")
+        return 1
+
+    invocations, proposed = documented()
+    if not invocations:
+        print("  err   no `treeship` invocations found in docs; the scan is broken")
+        return 1
+
+    missing: list[str] = []
+    for key, sites in sorted(invocations.items()):
+        if exists(list(key)):
+            continue
+        # Two tokens where the first is real: the second may be an argument
+        # rather than a subcommand, so only report if the pair fails AND the
+        # parent takes subcommands at all.
+        if len(key) == 2 and exists([key[0]]):
+            parent_help = subprocess.run(
+                [str(BIN), key[0], "--help"], capture_output=True, text=True, timeout=30
+            ).stdout
+            if "Commands:" not in parent_help:
+                continue  # takes arguments, not subcommands
+        where = ", ".join(f"{p.relative_to(ROOT)}:{n}" for p, n in sites[:3])
+        missing.append(f"treeship {' '.join(key)} -- not accepted by the CLI ({where})")
+
+    if missing:
+        for m in missing:
+            print(f"  err   {m}")
+        print()
+        print(
+            f"{len(missing)} documented command(s) the CLI does not accept. A reader who "
+            "runs one gets `unrecognized subcommand` and no way forward -- worse when the "
+            "line sits under a fail-closed error as the suggested fix."
+        )
+        return 1
+
+    unbuilt = sorted(k for k in proposed if not exists(list(k)))
+    if unbuilt:
+        # Reported, never failed. These pages said "proposed" and meant it.
+        print(f"  note  {len(unbuilt)} command(s) documented under a proposed/planned heading "
+              "and not yet built:")
+        for k in unbuilt[:8]:
+            print(f"        treeship {' '.join(k)}")
+    print(f"  ✓ every documented treeship command is accepted ({len(invocations)} distinct invocations)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The 2026-08-18 docs QA found documented commands that don't exist. Two show why that's worse than a typo.

**`treeship hub sync-trust`** sat in `cli/verify.mdx` directly under *"trust pinning is mandatory and fail-closed"*, offered as the easier alternative. **It has never existed.** A reader hits the fail-closed error, follows the suggestion, gets `unrecognized subcommand`, and now has no path forward. A wrong suggestion at that moment is worse than none.

**`treeship vi keygen / keys / attest`** — written in the present tense (*"Treeship can generate and manage P-256 keys"*) for a subcommand that doesn't exist. Treeship signs with Ed25519; P-256 is the prerequisite and is unbuilt.

**`treeship agent invite`** sat under *"What lands in v0.9.9"*. It didn't land, and the product is at 0.24.0. Same shape as the Windows-binary promise I fixed in `setup.sh`.

All five corrected in place — saying plainly the command doesn't exist, rather than quietly deleting the line.

## The gate

Extracts every `treeship …` invocation from a fenced block and **probes the built binary**.

**Probes rather than parses, and that's the whole correctness of it.** My first version read the `Commands:` section of `--help` and flagged `checkpoint`, `agent`, `agents`, `bundle`, `daemon`, `dashboard`, `approval` as nonexistent — every one real, just hidden from the listing.

A gate that accuses the docs of documenting real commands trains people to ignore it. It now sanity-checks a known-good command before reporting anything missing.

Two more false-positive classes removed:

- **Anchored to line start** — prose inside a fence (*"the receipt file locally"*) parsed as a command.
- **`## Proposed` / `Planned` / `Not yet` headings** put their whole section into a *reported-not-failed* category. The room-sessions page says "Proposed CLI" and means it; failing on it would punish the page that got it right. Scope inherits by heading level — resetting on every heading made the marker useless the moment a section had subsections.

**Flags deliberately unchecked.** That needs every help page parsed and would fail on prose. A missing *command* leaves a reader stuck; a wrong flag produces an error naming the right ones.

## Verified

- Reintroducing `hub sync-trust` → fails with the right file and line
- Removing it → passes
- **138 distinct invocations clean, 8 proposed commands reported not failed**
- Docs build compiles

## Note

There's uncommitted work from another session in the main checkout (26 files, incl. `workflow-declarations`). I did **not** touch it — this was built in an isolated worktree.