### PR TITLE
fix(core-wasm): the published package could not be loaded by Node at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,15 @@ jobs:
       # nothing looked.
       - name: No committed conflict markers
         run: python3 scripts/check-conflict-markers.py
+      # v0.24.0 published a bundler-only wasm build that would not load in
+      # Node at all. Nobody caught it because the only consumer exercised was
+      # the website, which vendors and bundles the wasm. This installs the
+      # tarball and imports it the way a user does.
+      - name: core-wasm installs and verifies under Node
+        run: |
+          cargo install wasm-pack --version 0.14.0 --locked || true
+          bash packages/core-wasm/build-npm.sh "$(node -p "require('./packages/core-wasm/pkg/package.json').version" 2>/dev/null || echo 0.0.0-ci)"
+          bash scripts/check-wasm-loads.sh packages/core-wasm/pkg
       - name: Every protocol spec is indexed
         run: python3 scripts/check-specs-index.py
       # `schemas/` is the publishable copy; the predicate registry has its own.

--- a/packages/core-wasm/build-npm.sh
+++ b/packages/core-wasm/build-npm.sh
@@ -27,8 +27,36 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
   exit 3
 fi
 
-echo "Building @treeship/core-wasm v${VERSION} with wasm-pack..."
+# Two targets, not one.
+#
+# The bundler build emits `import * as wasm from "./..._bg.wasm"`, which needs
+# a bundler to resolve. Published alone, it made `@treeship/core-wasm` fail to
+# load in Node with
+#
+#     WebAssembly.Table.grow(): failed to grow table by 4
+#
+# at `__wbindgen_start()` -- reproduced on Node 22.20.0 and 22.23.1 from a
+# clean install. That took down `@treeship/verify`, the "no CLI required"
+# verifier, and every SDK method that calls it. The site was unaffected
+# because it vendors the wasm and bundles it, which is exactly why this went
+# unnoticed.
+#
+# The `exports` map below routes Node to the nodejs build and everything else
+# to the bundler build, so both consumers get a package that works.
+echo "Building @treeship/core-wasm v${VERSION} with wasm-pack (bundler + nodejs)..."
 wasm-pack build --target bundler --out-dir pkg --release
+wasm-pack build --target nodejs --out-dir pkg/node --release
+# wasm-pack writes a full package.json into each out-dir; the nested one would
+# shadow the real manifest. Replace it with a type marker rather than deleting
+# it outright.
+#
+# The marker is load-bearing. The nodejs target emits CommonJS, the root
+# manifest says "type": "module", and without this Node reads node/*.js as ESM
+# and dies with `exports is not defined in ES module scope`. Deleting the
+# nested manifest fixed the shadowing and introduced that, which the tarball
+# test caught -- the exports map alone was not enough.
+rm -f pkg/node/README.md pkg/node/.gitignore
+printf '{\n  "type": "commonjs"\n}\n' > pkg/node/package.json
 
 # Optional: shrink with wasm-opt if it's on PATH (not required; wasm-pack
 # already produces a minimal binary under our workspace release profile).
@@ -73,11 +101,39 @@ Object.assign(pkg, {
   sideEffects: false,
 });
 
-// Make sure the files array covers everything wasm-pack emits.
+// Route Node to the nodejs build and everything else to the bundler build.
+//
+// `main` stays the bundler entry so older resolvers keep the behaviour they
+// had; `exports.node` is what stops Node from loading a build that needs a
+// bundler and failing at `WebAssembly.Table.grow()`.
+//
+// `import` and `require` are both mapped under node because the nodejs target
+// emits CommonJS, and a bare `import` of this package in Node must not fall
+// through to the bundler build.
+pkg.exports = {
+  '.': {
+    node: {
+      require: './node/treeship_core_wasm.js',
+      import: './node/treeship_core_wasm.js',
+      types: './node/treeship_core_wasm.d.ts',
+    },
+    default: {
+      import: './treeship_core_wasm.js',
+      types: './treeship_core_wasm.d.ts',
+    },
+  },
+  './package.json': './package.json',
+};
+
+// Make sure the files array covers everything wasm-pack emits, including the
+// nodejs build -- omitting `node/` would publish an exports map pointing at
+// files that are not in the tarball, which fails at install rather than at
+// import and is harder to diagnose.
 pkg.files = [
   '*.wasm',
   '*.js',
   '*.d.ts',
+  'node/',
   'README.md',
   'LICENSE',
 ];

--- a/scripts/check-wasm-loads.sh
+++ b/scripts/check-wasm-loads.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fail when the published @treeship/core-wasm layout cannot be loaded by Node.
+#
+# v0.24.0 shipped only the wasm-pack `--target bundler` build. It emits
+#   import * as wasm from "./treeship_core_wasm_bg.wasm";
+# which needs a bundler to resolve, so importing the package in Node died with
+#
+#   WebAssembly.Table.grow(): failed to grow table by 4
+#
+# at __wbindgen_start(). That took down @treeship/verify -- the "no CLI
+# required" verifier -- and every SDK method calling it.
+#
+# It went unnoticed because the only consumer anyone exercised was the website,
+# which vendors the wasm and bundles it. Nothing ever installed the tarball and
+# imported it the way a user does. This does exactly that.
+set -euo pipefail
+
+PKG_DIR="${1:-packages/core-wasm/pkg}"
+[ -d "$PKG_DIR" ] || { echo "  err   $PKG_DIR not built; run build-npm.sh <version> first"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TARBALL="$(cd "$PKG_DIR" && npm pack --silent | tail -1)"
+cp "$PKG_DIR/$TARBALL" "$TMP/"
+cd "$TMP"
+npm init -y >/dev/null 2>&1
+npm i "./$TARBALL" --silent >/dev/null 2>&1
+
+cat > esm.mjs <<'EOF'
+const m = await import('@treeship/core-wasm');
+if (typeof m.verify_envelope !== 'function') { console.error('verify_envelope missing'); process.exit(1); }
+// Loading is not enough: exercise it, or a stub would pass.
+const bad = JSON.stringify({payload:"e30",payloadType:"application/vnd.treeship.action+json;v=2",signatures:[{sig:"AAAA",keyid:"k"}]});
+const r = JSON.parse(m.verify_envelope(bad, "{}"));
+if (r.valid !== false) { console.error('a tampered envelope verified; the module is not doing the work'); process.exit(1); }
+console.log('    esm  ok — ' + m.version());
+EOF
+
+cat > cjs.cjs <<'EOF'
+const m = require('@treeship/core-wasm');
+if (typeof m.verify_envelope !== 'function') { console.error('verify_envelope missing'); process.exit(1); }
+console.log('    cjs  ok — ' + m.version());
+EOF
+
+node esm.mjs
+node cjs.cjs
+echo "  ✓ @treeship/core-wasm installs and verifies under $(node --version)"


### PR DESCRIPTION
`@treeship/core-wasm@0.24.0` throws on import under Node 22:

```
WebAssembly.Table.grow(): failed to grow table by 4
```

Reproduced from a clean install on **22.20.0 and 22.23.1**. Not a runtime edge case — **the module never finishes loading**, so every export is unreachable. That takes down `@treeship/verify` (the "zero-dependency, no CLI required" verifier the docs lead with) and every SDK method calling into it.

## Cause

`build-npm.sh` ran only `wasm-pack --target bundler`, which emits:

```js
import * as wasm from "./treeship_core_wasm_bg.wasm";
```

That import is a **bundler contract**. Node's ESM wasm loader resolves it differently and fails inside `__wbindgen_start()`.

## Why it survived a release

The only consumer anyone exercised was **the website**, which vendors the wasm and lets Next bundle it — the one environment where the bundler build is correct.

**Nothing ever installed the published tarball and imported it the way a user does.**

## Fix

Build both targets and route them: `exports.node` → nodejs build, `default` → bundler build, `main` unchanged so older resolvers behave as before.

**A second failure only the tarball test could find:** the nodejs target emits CommonJS while the root manifest says `"type": "module"`, so Node read `node/*.js` as ESM and died with `exports is not defined in ES module scope`. The exports map alone wasn't enough. `pkg/node/package.json` is now a `{"type":"commonjs"}` marker rather than deleted — deleting it fixed the shadowing and caused this.

## The gate

`check-wasm-loads.sh` packs the built package, installs the tarball into a scratch project, and imports it as **both ESM and CommonJS**.

It doesn't stop at "it loaded": it runs `verify_envelope` over a tampered envelope and fails unless the result is invalid — **a module that loads and does nothing would otherwise pass**.

```
esm  ok — treeship-core-wasm 0.24.0
cjs  ok — treeship-core-wasm 0.24.0
tampered -> valid: false | "no valid signature from any trusted key"
```

## Note

Found by a docs QA pass — the second time this week an audit of the *documentation* turned up a *product* bug.