### PR TITLE
docs: two install routes that do not exist, and a warning with the wrong fact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,12 @@ jobs:
           cargo install wasm-pack --version 0.14.0 --locked || true
           bash packages/core-wasm/build-npm.sh "$(node -p "require('./packages/core-wasm/pkg/package.json').version" 2>/dev/null || echo 0.0.0-ci)"
           bash scripts/check-wasm-loads.sh packages/core-wasm/pkg
+      # Three separate cases: a Homebrew formula that does not exist, a Kimi
+      # skill shipping `cargo install treeship-cli`, and that command being
+      # described as "orphaned at v0.4.0" when it actually fails outright.
+      # Offline by default -- a registry outage must not fail CI.
+      - name: Documented install routes exist
+        run: python3 scripts/check-install-routes.py
       - name: Every protocol spec is indexed
         run: python3 scripts/check-specs-index.py
       # `schemas/` is the publishable copy; the predicate registry has its own.

--- a/docs/content/docs/cli/otel.mdx
+++ b/docs/content/docs/cli/otel.mdx
@@ -25,7 +25,11 @@ Rebuild from source with: cargo build --release --bin treeship --features otel
 ```
 
 <Callout type="warn">
-Do NOT use `cargo install treeship-cli` from crates.io -- that crate is orphaned at v0.4.0. The CLI ships exclusively via the npm wrapper (`npm install -g treeship`) and the `treeship.dev/install` script, which fetch a prebuilt platform binary. To get a Rust toolchain build, clone the repo and `cargo build` as above.
+Do NOT use `cargo install treeship-cli` from crates.io. It does not install an old
+version -- it fails: all seven published versions are yanked, so crates.io reports
+`max_version: 0.0.0` and cargo answers *could not find `treeship-cli` in registry*.
+(This previously said "orphaned at v0.4.0", which implied you would get 0.4.0. The
+newest yanked version is 0.5.0, and none of them are installable.) The CLI ships exclusively via the npm wrapper (`npm install -g treeship`) and the `treeship.dev/install` script, which fetch a prebuilt platform binary. To get a Rust toolchain build, clone the repo and `cargo build` as above.
 </Callout>
 
 ## Commands

--- a/docs/content/docs/guides/first-run.mdx
+++ b/docs/content/docs/guides/first-run.mdx
@@ -22,7 +22,22 @@ The fastest path to a signed receipt is a single `treeship setup`. It detects th
 npm install -g treeship
 ```
 
-Or via Homebrew, Cargo, or the binary download — see [installation](/docs/guides/quickstart#install).
+Or via the binary download — see [installation](/docs/guides/quickstart#install).
+
+<Callout type="warn">
+This line used to offer **Homebrew** and **Cargo**. Neither works:
+
+- There is no Homebrew formula. `brew info treeship` returns *No available
+  formula with the name "treeship"*, and the quickstart it links to never
+  mentioned Homebrew either.
+- `cargo install treeship-cli` fails outright. All seven published versions
+  are yanked, so crates.io reports `max_version: 0.0.0` and cargo answers
+  *could not find `treeship-cli` in registry `crates-io`*.
+
+Naming an install route that does not exist costs more than listing one
+fewer option: the reader tries it, it fails, and they have no way to tell
+whether they mistyped it or it was never real.
+</Callout>
 
 </Step>
 

--- a/scripts/check-install-routes.py
+++ b/scripts/check-install-routes.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Fail when the docs name an install route that does not exist.
+
+Three separate cases produced this file:
+
+  * `first-run.mdx` offered "Homebrew, Cargo, or the binary download". There is
+    no Homebrew formula -- `brew info treeship` returns "No available formula"
+    -- and the quickstart it linked to never mentioned Homebrew either.
+  * `cargo install treeship-cli` was described as "orphaned at v0.4.0", which
+    implies you would get 0.4.0. All seven published versions are yanked, so
+    crates.io reports `max_version: 0.0.0` and cargo fails outright.
+  * A Kimi skill shipped `cargo install treeship-cli` as its install line and
+    had to be corrected in a previous release.
+
+Naming a route that does not exist costs more than listing one fewer option:
+the reader tries it, it fails, and they cannot tell whether they mistyped it or
+it was never real.
+
+Network checks are opt-in via --online, because CI should not fail on a
+registry outage. Offline it enforces the prose rules, which is where every one
+of the three cases actually lived.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs" / "content" / "docs"
+
+# Routes that do not exist. Each entry is a pattern plus why it is banned, so a
+# failure explains itself rather than pointing at a list.
+BANNED = [
+    (
+        re.compile(r"\bbrew install treeship\b|\bvia Homebrew\b|\bHomebrew,", re.I),
+        "there is no Homebrew formula; `brew info treeship` returns 'No available formula'",
+    ),
+    (
+        re.compile(r"cargo install\s+treeship-cli(?!\s*(--git|\s*`?\s*from\s+crates))", re.I),
+        "every published treeship-cli version is yanked; cargo fails with "
+        "'could not find treeship-cli in registry'",
+    ),
+]
+
+# Lines that discuss the banned route rather than recommending it. Kept
+# explicit: a heuristic would eventually hide a real recommendation.
+DISCUSSION = re.compile(
+    r"do not use|don't use|does not install|fails outright|used to offer|previously said|"
+    r"no Homebrew formula|not on crates\.io|orphaned|yanked|would take several minutes",
+    re.I,
+)
+
+
+def offenders():
+    found = []
+    for mdx in sorted(DOCS.rglob("*.mdx")):
+        # The changelog records past mistakes verbatim; rewriting history to
+        # satisfy a lint would defeat the point of having one.
+        if mdx.name == "changelog.mdx":
+            continue
+        for n, line in enumerate(mdx.read_text(encoding="utf-8").splitlines(), 1):
+            if DISCUSSION.search(line):
+                continue
+            for pat, why in BANNED:
+                if pat.search(line):
+                    found.append((mdx.relative_to(ROOT), n, why, line.strip()[:88]))
+    return found
+
+
+def crates_io_still_yanked():
+    """Confirm the premise. If the crate is ever un-yanked, this check is wrong."""
+    url = "https://crates.io/api/v1/crates/treeship-cli"
+    req = urllib.request.Request(url, headers={"User-Agent": "treeship-docs-check"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        data = json.load(r)
+    versions = data.get("versions", [])
+    if not versions:
+        return None, "no versions returned; cannot confirm"
+    all_yanked = all(v.get("yanked") for v in versions)
+    return all_yanked, f"{len(versions)} version(s), all yanked={all_yanked}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--online", action="store_true", help="also verify the premise against crates.io")
+    args = ap.parse_args()
+
+    docs = list(DOCS.rglob("*.mdx"))
+    if not docs:
+        print("  err   no docs found; this check would pass vacuously")
+        return 1
+
+    if args.online:
+        try:
+            yanked, detail = crates_io_still_yanked()
+        except Exception as e:  # noqa: BLE001 - a registry outage must not fail CI
+            print(f"  note  could not reach crates.io ({e}); skipping premise check")
+        else:
+            if yanked is False:
+                print("  err   treeship-cli is no longer fully yanked on crates.io "
+                      f"({detail}). This check's premise changed -- revisit the docs "
+                      "and this file together.")
+                return 1
+            print(f"  note  crates.io premise holds: {detail}")
+
+    found = offenders()
+    if found:
+        for path, line, why, text in found:
+            print(f"  err   {path}:{line}: names an install route that does not exist")
+            print(f"        {text}")
+            print(f"        why: {why}")
+        print()
+        print(f"{len(found)} nonexistent install route(s). A reader who tries one cannot "
+              "tell whether they mistyped it or it was never real.")
+        return 1
+
+    print(f"  ✓ no nonexistent install routes in {len(docs)} docs pages")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Homebrew.** `first-run.mdx` offered *"Homebrew, Cargo, or the binary download"*. There is no formula:

```
$ brew info treeship
Error: No available formula with the name "treeship". Did you mean tree-sitter?
```

formulae.brew.sh 404s, and the quickstart it linked to never mentioned Homebrew either — so a reader following the link found nothing and couldn't tell whether they'd misread it.

**Cargo.** Same line. `cargo install treeship-cli` doesn't install an old version — **it fails**. All seven published versions are yanked, so crates.io reports `max_version: 0.0.0` and cargo answers *could not find `treeship-cli` in registry `crates-io`*.

**And the existing warning had the wrong fact.** `otel.mdx` said the crate is *"orphaned at v0.4.0"*, implying you'd get 0.4.0. The newest yanked version is **0.5.0** and none are installable.

The instinct was right and the detail was wrong — the harder kind of error to catch, because it reads as authoritative.

## What I deliberately left alone

The installer's own fallback at `treeship.dev/install` runs `cargo install --git`, not crates.io. **That path works** — it builds from source in a couple of minutes. The QA report flagged it as contradicting the docs; it contradicts the *crates.io* prohibition, not the git build, and those are different things.

## The gate

`check-install-routes.py` fails on either route appearing as a recommendation and prints **why**, rather than pointing at a list.

Prose that *discusses* the banned route — "do not use", "fails outright", "used to offer" — is allowed **explicitly**, not by heuristic. A heuristic would eventually hide a real recommendation. `changelog.mdx` is skipped: it records past mistakes verbatim, and rewriting history to satisfy a lint defeats the point of keeping one.

With `--online` it **verifies its own premise** against crates.io and fails if the crate is ever un-yanked, since the check would then be wrong:

```
note  crates.io premise holds: 7 version(s), all yanked=True
✓ no nonexistent install routes in 126 docs pages
```

A registry outage prints a note and passes — CI shouldn't fail on someone else's downtime.

Verified both directions: reintroducing either route fails with the right file, line and reason; removing them passes.

Docs build compiles.