### PR TITLE
v0.24.0 feat: verify Reason authorization before signing

### DIFF
--- a/docs/content/docs/cli/command-matrix.mdx
+++ b/docs/content/docs/cli/command-matrix.mdx
@@ -174,6 +174,20 @@ treeship attest receipt [OPTIONS] --system <URI> --kind <KIND>
 | `--payload-file <PATH>` | Read receipt payload JSON from a file |
 | `--payload-digest <DIGEST>` | Digest of the external payload, for example sha256:&lt;hex&gt; |
 
+### `treeship attest reason-authorization`
+
+Atomically verify and attest an authorized Zerker Reason bundle
+
+```
+treeship attest reason-authorization [OPTIONS] --bundle-file <PATH>
+```
+
+| Option | Description |
+|---|---|
+| `--bundle-file <PATH>` | Atomic zerker.reason.authorization-bundle.v1 JSON file (`-` for stdin) |
+| `--reason-bin <PATH>` | Zerker Reason verifier executable [default: reason] |
+| `--timeout-ms <MS>` | Maximum verifier runtime in milliseconds [default: 2000] |
+
 ### `treeship attest card`
 
 Mint a signed agent capability card (agent_card.v1)

--- a/docs/content/docs/integrations/zerker-reason.mdx
+++ b/docs/content/docs/integrations/zerker-reason.mdx
@@ -1,29 +1,35 @@
 ---
 title: Zerker Reason authorization certificates
-description: Sign and chain an independently verifiable Zerker Reason action-authorization certificate as a Treeship receipt.
+description: Atomically verify an exact Zerker Reason authorization bundle before signing its byte commitment as a Treeship receipt.
 ---
 
-Zerker Reason decides whether an exact proposed action follows from a governed mission, policy, and evidence. Treeship can preserve that authorization certificate as a signed, chained artifact.
+Zerker Reason decides whether an exact proposed action follows from a governed mission, policy, and evidence. Treeship can preserve a verified authorization certificate as a signed, chained artifact.
 
 The two verifiers answer different questions:
 
 | Verifier | Question |
 |---|---|
-| `reason verify-authorization` | Does this authorization result recompute from this exact mission, action, policy, and evidence? |
-| `treeship verify` | Which key signed these exact certificate bytes, and where do they sit in the artifact chain? |
+| `reason verify-authorization-bundle` | Does this authorization result recompute from this exact mission, action, policy, and evidence, and is it authorized? |
+| `treeship verify` | Which key signed the certificate and exact bundle-byte commitment, and where does the receipt sit in the artifact chain? |
 
-Run both. A Treeship signature does not replace semantic proof verification, and a valid Reason certificate does not identify who preserved or relied on it.
+Both must run. A Treeship signature does not replace Reason semantic verification, and a valid Reason certificate does not identify the Treeship signer.
 
-## Create the authorization certificate
+## Build one atomic bundle
+
+Create the certificate, then place the original request and certificate in the v1 bundle:
 
 ```bash
 reason authorize action-request.json \
   --certificate-out authorization.json
 
-reason verify-authorization action-request.json authorization.json
+jq -n \
+  --slurpfile request action-request.json \
+  --slurpfile certificate authorization.json \
+  '{schema:"zerker.reason.authorization-bundle.v1",request:$request[0],certificate:$certificate[0]}' \
+  > authorization-bundle.json
 ```
 
-Only continue when verification succeeds. Reason uses four fail-closed authorization outcomes:
+Reason has four fail-closed authorization outcomes:
 
 | Certificate status | Meaning |
 |---|---|
@@ -32,59 +38,54 @@ Only continue when verification succeeds. Reason uses four fail-closed authoriza
 | `denied` | Explicit denial was proved |
 | `conflicted` | Authorization and denial were both proved |
 
-Treeship records every outcome. Denials and conflicts are evidence too.
+Only `authorized` can produce a `reason.authorization.v1` Treeship receipt through the dedicated adapter.
 
-## Sign and chain the certificate
+## Verify, then sign atomically
 
 ```bash
-treeship attest receipt \
-  --system system://zerker-reason \
-  --kind reason.authorization.v1 \
-  --payload-file authorization.json
+treeship attest reason-authorization \
+  --bundle-file authorization-bundle.json
 ```
 
-`reason.authorization.v1` is a registered Treeship predicate. Before signing, Treeship requires the top-level `zerker.reason.authorization.v1` fields, validates their JSON types, and enforces the closed four-state status vocabulary. The complete published JSON Schema also specifies the nested mission, action, and reasoning objects.
+The adapter:
 
-The receipt payload contains the certificate itself, including:
+1. reads one bounded bundle source exactly once;
+2. sends those exact bytes over stdin to `reason verify-authorization-bundle - --require-authorized`;
+3. requires exit zero and the exact `verified` plus `authorized` v1 output contract;
+4. validates the authorized certificate as a registered Treeship predicate;
+5. only then opens the Treeship key and artifact stores and signs the receipt.
 
-- request, mission, and action digests;
-- exact tool name, arguments, and declared effects;
-- complete Reason result;
-- proof and disproof DAGs when present;
-- temporal and authority reports;
-- deterministic authorization issues.
+The receipt embeds the complete authorization certificate. Its `payloadDigest` and `meta.authorization_bundle.digest` are SHA-256 commitments to the exact bundle bytes supplied to Reason. `meta.reason_verification` preserves Reason's request and reasoning-result digests.
 
-Treat this payload as potentially sensitive. If tool arguments or policy evidence cannot be disclosed, do not use `--payload-file`. Store the certificate privately and attest only a `--payload-digest` under an unregistered private kind until a selective-disclosure profile is defined.
+Malformed input, tampering, mismatches, stale or insufficient evidence, denial, conflict, timeout, oversized input or output, missing verifier, and malformed verifier output all fail before signing or storage. The verifier defaults to `reason` on `PATH`, a two-second timeout, a 1 MiB input limit, and a 64 KiB output limit. Operators can select a pinned executable and a narrower operational timeout:
 
-## Verify the composition
+```bash
+treeship attest reason-authorization \
+  --bundle-file authorization-bundle.json \
+  --reason-bin /opt/zerker/bin/reason \
+  --timeout-ms 1000
+```
+
+Use `--bundle-file -` to supply the same atomic bundle on stdin.
+
+The generic `treeship attest receipt` path refuses `reason.authorization.v1`. This prevents an unverified certificate from being hand-signed under the dedicated adapter's receipt kind.
+
+## Verify the resulting evidence
 
 ```bash
 # Verifies the Treeship signature and chain.
 treeship verify last --full
 
-# Verifies the authorization semantics against the original request.
-reason verify-authorization action-request.json authorization.json
+# Independently replays Reason semantics over the preserved private bundle.
+reason verify-authorization-bundle authorization-bundle.json --require-authorized
 ```
 
-For offline handoff, export the Treeship receipt or include it in a bundle alongside the private authorization files according to your disclosure policy.
+For offline handoff, export the Treeship receipt and retain the original bundle bytes according to your disclosure policy. The receipt's bundle digest lets a counterparty detect substitution before Reason replay.
+
+The certificate can include tool arguments, governed policy evidence, proof DAGs, and other sensitive material. If those fields cannot be disclosed, do not use this adapter until a selective-disclosure profile is defined. A digest-only generic receipt must not claim `reason.authorization.v1`.
 
 ## Trust boundary
 
-The `system` URI is a label in the signed receipt. It becomes a proven system identity only when the signing key is bound to that identity under the verifier's trust roots. Anyone controlling a Treeship signing key can otherwise claim `system://zerker-reason`.
+`system://zerker-reason` is a signed label. It becomes a proven system identity only when the Treeship signing key is bound to that identity under the verifier's trust roots. This command enforces local Reason verification before it asks Treeship to sign. The resulting receipt proves signer identity and byte commitments, not that a particular executable ran: anyone controlling the signing key could construct a different receipt outside this CLI. Counterparties must still replay Reason over the committed bundle. Treeship does not implement or independently duplicate Reason semantics.
 
-The generic `attest receipt` command validates the certificate schema but does not execute the Reason verifier. The safe producer sequence is therefore:
-
-1. run `reason verify-authorization`;
-2. sign the exact verified certificate bytes with Treeship;
-3. preserve the original request for independent semantic replay;
-4. let each counterparty apply its own Treeship trust roots.
-
-A future dedicated adapter can make steps 1 and 2 atomic. Until then, verification is intentionally two-stage and neither stage claims the other passed.
-
-## Component roles
-
-- Zerker Reason produces and independently verifies the authorization certificate.
-- Treeship signs, chains, checkpoints, and transports the certificate.
-- Guard consumes a verified authorization result and enforces the action boundary.
-- Gateway authenticates and routes the request.
-- ZMem supplies governed premises.
+This command creates evidence; it does not execute the authorized action or consume a replay token. Re-attesting the same bundle is allowed and does not renew stale evidence. Gateway or another enforcement point must separately compare the actual action, run Reason, and block before payment or forwarding.

--- a/docs/content/docs/reference/feature-matrix.mdx
+++ b/docs/content/docs/reference/feature-matrix.mdx
@@ -31,7 +31,7 @@ Pick `stable` only when the code, docs, and tests all line up. If the docs page 
 | Feature | Status | CLI | Docs |
 |---|---|---|---|
 | Receipts (signed artifacts) | `stable` | `treeship attest action`, `treeship wrap`, `treeship log` | [Artifacts](/docs/concepts/artifacts) |
-| Zerker Reason authorization receipts | `beta` | `treeship attest receipt` | [Zerker Reason authorization certificates](/docs/integrations/zerker-reason) |
+| Zerker Reason authorization receipts | `beta` | `treeship attest reason-authorization` | [Zerker Reason authorization certificates](/docs/integrations/zerker-reason) |
 | action/v2 receipt emission (CLI) | `beta` | `treeship attest action --v2` | -- |
 | Session reports | `stable` | `treeship session start`, `treeship session close`, `treeship session report` | [Session Receipts](/docs/concepts/session-receipts), [session](/docs/cli/session) |
 | Session packages (.treeship bundles) | `stable` | `treeship package inspect`, `treeship package verify`, `treeship bundle export`, `treeship bundle import` | [package](/docs/cli/package), [bundle](/docs/cli/bundle) |

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -47,7 +47,7 @@
   section: core
   status: beta
   cli:
-    - treeship attest receipt
+    - treeship attest reason-authorization
   packages:
     - treeship-core
     - treeship-cli
@@ -55,7 +55,8 @@
     - docs/content/docs/integrations/zerker-reason.mdx
   tests:
     - packages/core/src/predicates/mod.rs
-  notes: "Registers reason.authorization.v1 as a typed receipt payload for complete Zerker Reason action-authorization certificates. Treeship verifies schema, signature, and chain; semantic replay remains a separate reason verify-authorization step. The generic receipt command does not invoke Reason automatically."
+    - packages/cli/tests/reason_authorization_cli.rs
+  notes: "Reads one bounded authorization bundle, passes those exact bytes to the independent Reason CLI, requires the exact verified+authorized v1 result, then signs a receipt containing the certificate and SHA-256 commitment to the verified bundle bytes. The generic receipt path refuses this dedicated kind."
 
 - id: action-v2-emission
   name: action/v2 receipt emission (CLI)

--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -34,6 +34,10 @@ pub(crate) fn close_only_kind_owner(kind: &str) -> Option<&'static str> {
         // session.v1 records carry a self-declared `attestation_class` that
         // `session close` derives from consumed approvals / tool runtimes.
         "session.v1" => Some("treeship session close"),
+        // A reason.authorization.v1 receipt is evidence that the dedicated
+        // adapter ran Reason over the exact committed bundle bytes. Allowing
+        // generic hand-signing under the same kind would create a bypass.
+        "reason.authorization.v1" => Some("treeship attest reason-authorization"),
         _ => None,
     }
 }
@@ -1046,6 +1050,18 @@ pub struct ReceiptArgs {
 }
 
 pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    // Dedicated kinds must fail before opening keys or reading caller-selected
+    // payload files. This closes the generic hand-signing bypass without any
+    // signing or storage side effect.
+    if let Some(owner) = close_only_kind_owner(&args.kind) {
+        return Err(format!(
+            "kind '{}' is minted only by `{owner}` from verified sealed evidence; \
+             it cannot be hand-signed via `attest receipt`.",
+            args.kind
+        )
+        .into());
+    }
+
     let ctx = ctx::open(args.config.as_deref())?;
 
     let payload_text = match (&args.payload, &args.payload_file) {
@@ -1064,25 +1080,6 @@ pub fn receipt(args: ReceiptArgs, printer: &Printer) -> Result<(), Box<dyn std::
         .map(serde_json::from_str)
         .transpose()
         .map_err(|e| format!("receipt payload is not valid JSON: {e}"))?;
-
-    // AUD-06: some receipt kinds are minted ONLY by a command that derives
-    // every field from sealed session evidence (e.g. `session close` computes
-    // `attestation_class` from consumed approvals / tool runtimes). Letting a
-    // caller hand-sign them through the generic attest path is a trust-ladder
-    // laundering vector: an attacker mints `session.v1` with
-    // `attestation_class:"countersigned"` and an inflated `action_count`, no
-    // countersignature or runtime evidence, and it aggregates into the highest
-    // trust classes. Refuse those kinds here.
-    if let Some(owner) = close_only_kind_owner(&args.kind) {
-        return Err(format!(
-            "kind '{}' is minted only by `{owner}` from sealed session evidence; \
-             it cannot be hand-signed via `attest receipt`. This prevents forging a \
-             work-history record with a self-declared attestation_class. \
-             See docs/specs/work-history.md.",
-            args.kind
-        )
-        .into());
-    }
 
     // Typed-predicate validation: if `kind` is a registered predicate, the
     // payload must conform to its schema before we sign. Unregistered kinds
@@ -2029,7 +2026,7 @@ fn backfill_action_artifact_id(
 }
 
 /// Write the artifact_id to {storage_dir}/.last for auto-chaining.
-fn write_last(storage_dir: &str, artifact_id: &str) {
+pub(crate) fn write_last(storage_dir: &str, artifact_id: &str) {
     let last_path = std::path::Path::new(storage_dir).join(".last");
     let _ = std::fs::write(&last_path, artifact_id);
     #[cfg(unix)]
@@ -2051,6 +2048,14 @@ mod aud06_tests {
         assert_eq!(
             close_only_kind_owner("session.v1"),
             Some("treeship session close")
+        );
+    }
+
+    #[test]
+    fn reason_authorization_is_owned_by_the_verified_adapter() {
+        assert_eq!(
+            close_only_kind_owner("reason.authorization.v1"),
+            Some("treeship attest reason-authorization")
         );
     }
 

--- a/packages/cli/src/commands/mod.rs
+++ b/packages/cli/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod profile;
 pub mod prove;
 pub mod publish;
 pub mod quickstart;
+pub mod reason_authorization;
 pub mod receipt;
 pub mod resolve;
 pub mod revocation_source;

--- a/packages/cli/src/commands/reason_authorization.rs
+++ b/packages/cli/src/commands/reason_authorization.rs
@@ -1,0 +1,412 @@
+//! Atomic Zerker Reason verification and Treeship receipt signing.
+//!
+//! The command reads one bounded authorization bundle into memory, sends those
+//! exact bytes to `reason verify-authorization-bundle`, and only after a strict
+//! verified+authorized result commits their SHA-256 digest into a signed
+//! Treeship receipt. No key or artifact store is opened before Reason succeeds.
+
+use std::{
+    env,
+    fs::File,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use treeship_core::{
+    attestation::sign,
+    statements::{payload_type, ReceiptStatement},
+    storage::Record,
+};
+
+use crate::{ctx, printer::Printer};
+
+const BUNDLE_SCHEMA: &str = "zerker.reason.authorization-bundle.v1";
+const CERTIFICATE_SCHEMA: &str = "zerker.reason.authorization.v1";
+const VERIFICATION_SCHEMA: &str = "zerker.reason.authorization-verification.v1";
+const RECEIPT_KIND: &str = "reason.authorization.v1";
+const REASON_SYSTEM: &str = "system://zerker-reason";
+const MAX_INPUT_BYTES: usize = 1 << 20;
+const MAX_OUTPUT_BYTES: usize = 64 << 10;
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub struct Args {
+    pub bundle_file: String,
+    pub reason_bin: String,
+    pub timeout_ms: u64,
+    pub config: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BundleForReceipt {
+    schema: String,
+    #[serde(rename = "request")]
+    _request: Value,
+    certificate: Value,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct VerificationOutput {
+    schema: String,
+    status: String,
+    authorization_status: String,
+    request_digest: String,
+    reasoning_result_digest: String,
+}
+
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    overflow: bool,
+}
+
+/// Verify one Reason bundle and sign a receipt that commits to its exact bytes.
+pub fn run(args: Args, printer: &Printer) -> Result<(), Box<dyn std::error::Error>> {
+    if args.timeout_ms == 0 {
+        return Err("--timeout-ms must be greater than zero; no receipt was signed".into());
+    }
+
+    // One read, before either verifier or signer use. A path cannot be swapped
+    // between verification and commitment because neither stage reopens it.
+    let bundle_bytes = read_bundle(&args.bundle_file)?;
+    let bundle_digest = sha256_digest(&bundle_bytes);
+    let verification = verify_with_reason(
+        &args.reason_bin,
+        &bundle_bytes,
+        Duration::from_millis(args.timeout_ms),
+    )?;
+    let bundle: BundleForReceipt = serde_json::from_slice(&bundle_bytes).map_err(|e| {
+        format!(
+            "verified Reason bundle could not be decoded for signing: {e}; no receipt was signed"
+        )
+    })?;
+
+    if bundle.schema != BUNDLE_SCHEMA {
+        return Err(format!(
+            "verified Reason bundle has schema {:?}, expected {BUNDLE_SCHEMA:?}; no receipt was signed",
+            bundle.schema
+        )
+        .into());
+    }
+    let certificate = bundle.certificate.as_object().ok_or_else(|| {
+        "verified Reason bundle certificate is not an object; no receipt was signed".to_string()
+    })?;
+    if certificate.get("schema").and_then(Value::as_str) != Some(CERTIFICATE_SCHEMA)
+        || certificate.get("status").and_then(Value::as_str) != Some("authorized")
+        || certificate.get("request_digest").and_then(Value::as_str)
+            != Some(verification.request_digest.as_str())
+    {
+        return Err(
+            "Reason output does not match an authorized v1 certificate in the verified bundle; no receipt was signed"
+                .into(),
+        );
+    }
+
+    // Reason owns semantic validation. Treeship also applies the registered
+    // structural predicate before signing so the dedicated and generic schema
+    // surfaces cannot disagree about the receipt payload shape.
+    treeship_core::predicates::validate(RECEIPT_KIND, Some(&bundle.certificate))
+        .map_err(|e| format!("verified Reason certificate failed Treeship predicate validation: {e}; no receipt was signed"))?;
+
+    // Opening the key and artifact stores happens only after every verifier
+    // gate above has passed. Failures cannot create a signed side effect.
+    let ctx = ctx::open(args.config.as_deref())?;
+    let mut statement = ReceiptStatement::new(REASON_SYSTEM, RECEIPT_KIND);
+    statement.payload = Some(bundle.certificate);
+    statement.payload_digest = Some(bundle_digest.clone());
+    statement.meta = Some(serde_json::json!({
+        "authorization_bundle": {
+            "schema": BUNDLE_SCHEMA,
+            "digest": bundle_digest,
+        },
+        "reason_verification": verification,
+    }));
+
+    let signer = ctx.keys.default_signer()?;
+    let receipt_payload_type = payload_type("receipt");
+    let signed = sign(&receipt_payload_type, &statement, signer.as_ref())?;
+    ctx.storage.write(&Record {
+        artifact_id: signed.artifact_id.clone(),
+        digest: signed.digest.clone(),
+        payload_type: receipt_payload_type,
+        key_id: signer.key_id().to_string(),
+        signed_at: statement.timestamp.clone(),
+        parent_id: None,
+        envelope: signed.envelope,
+        hub_url: None,
+        anchors: Vec::new(),
+    })?;
+    super::attest::write_last(&ctx.config.storage_dir, &signed.artifact_id);
+
+    printer.success(
+        "Reason authorization verified and attested",
+        &[
+            ("id", &signed.artifact_id),
+            ("request", &verification.request_digest),
+            ("bundle", &bundle_digest),
+            ("signed", &statement.timestamp),
+        ],
+    );
+    printer.hint(&format!("treeship verify {}", signed.artifact_id));
+    printer.blank();
+    Ok(())
+}
+
+fn read_bundle(path: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let bytes = if path == "-" {
+        read_bounded(io::stdin().lock(), MAX_INPUT_BYTES)?
+    } else {
+        // Security-sensitive single-open read: the same descriptor is bounded
+        // and consumed, and the path is never resolved again.
+        read_bounded(File::open(path)?, MAX_INPUT_BYTES)?
+    };
+    Ok(bytes)
+}
+
+fn read_bounded(reader: impl Read, limit: usize) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    reader.take(limit as u64 + 1).read_to_end(&mut bytes)?;
+    if bytes.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Reason authorization bundle exceeds the {limit}-byte limit"),
+        ));
+    }
+    Ok(bytes)
+}
+
+fn verify_with_reason(
+    binary: &str,
+    bundle: &[u8],
+    timeout: Duration,
+) -> Result<VerificationOutput, Box<dyn std::error::Error>> {
+    let resolved = resolve_binary(binary)?;
+    let mut command = Command::new(&resolved);
+    command
+        .args([
+            "--format",
+            "json",
+            "verify-authorization-bundle",
+            "-",
+            "--require-authorized",
+        ])
+        .env_clear()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_process_group(&mut command);
+
+    let mut child = command.spawn().map_err(|e| {
+        format!(
+            "could not start Reason verifier {}: {e}; no receipt was signed",
+            resolved.display()
+        )
+    })?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or("Reason verifier stdin was unavailable; no receipt was signed")?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("Reason verifier stdout was unavailable; no receipt was signed")?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("Reason verifier stderr was unavailable; no receipt was signed")?;
+
+    let input = bundle.to_vec();
+    let writer = thread::spawn(move || -> io::Result<()> {
+        stdin.write_all(&input)?;
+        stdin.flush()
+    });
+    let stdout_reader = thread::spawn(move || capture_output(stdout, MAX_OUTPUT_BYTES));
+    let stderr_reader = thread::spawn(move || capture_output(stderr, MAX_OUTPUT_BYTES));
+
+    let status = wait_bounded(&mut child, timeout)?;
+    // The verifier contract is one bounded process. Kill any descendants that
+    // outlived their parent before joining pipe readers; otherwise an inherited
+    // descriptor could keep this command blocked after a forged success exit.
+    kill_process_group(&mut child);
+    let write_result = writer
+        .join()
+        .map_err(|_| "Reason verifier stdin writer panicked; no receipt was signed")?;
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| "Reason verifier stdout reader panicked; no receipt was signed")??;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| "Reason verifier stderr reader panicked; no receipt was signed")??;
+
+    if let Err(error) = write_result {
+        return Err(format!(
+            "Reason verifier did not consume the complete authorization bundle: {error}; no receipt was signed"
+        )
+        .into());
+    }
+    if stdout.overflow || stderr.overflow {
+        return Err(
+            "Reason verifier output exceeded the 65536-byte limit; no receipt was signed".into(),
+        );
+    }
+    if !status.success() {
+        return Err(format!(
+            "Reason verifier rejected or did not authorize the bundle (exit {}); no receipt was signed",
+            exit_label(status)
+        )
+        .into());
+    }
+
+    let verification: VerificationOutput = serde_json::from_slice(&stdout.bytes).map_err(|e| {
+        format!("Reason verifier returned malformed JSON: {e}; no receipt was signed")
+    })?;
+    if verification.schema != VERIFICATION_SCHEMA
+        || verification.status != "verified"
+        || verification.authorization_status != "authorized"
+        || !valid_digest(&verification.request_digest)
+        || !valid_digest(&verification.reasoning_result_digest)
+    {
+        return Err("Reason verifier did not return the exact v1 verified+authorized contract; no receipt was signed".into());
+    }
+    Ok(verification)
+}
+
+fn wait_bounded(
+    child: &mut Child,
+    timeout: Duration,
+) -> Result<ExitStatus, Box<dyn std::error::Error>> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or("Reason verifier timeout is too large; no receipt was signed")?;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return Ok(status),
+            Ok(None) => {}
+            Err(error) => {
+                kill_process_group(child);
+                let _ = child.wait();
+                return Err(format!(
+                    "could not wait for Reason verifier: {error}; no receipt was signed"
+                )
+                .into());
+            }
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            kill_process_group(child);
+            let _ = child.wait();
+            return Err(format!(
+                "Reason verifier timed out after {} ms; no receipt was signed",
+                timeout.as_millis()
+            )
+            .into());
+        }
+        thread::sleep(POLL_INTERVAL.min(deadline.saturating_duration_since(now)));
+    }
+}
+
+fn capture_output(mut reader: impl Read, limit: usize) -> io::Result<CapturedOutput> {
+    let mut bytes = Vec::with_capacity(limit);
+    let mut overflow = false;
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let count = reader.read(&mut chunk)?;
+        if count == 0 {
+            break;
+        }
+        let remaining = limit.saturating_sub(bytes.len());
+        let retained = remaining.min(count);
+        bytes.extend_from_slice(&chunk[..retained]);
+        overflow |= retained != count;
+        // Continue draining after overflow so a malicious verifier cannot fill
+        // its pipe and prevent the timeout/exit path from making progress.
+    }
+    Ok(CapturedOutput { bytes, overflow })
+}
+
+fn resolve_binary(binary: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    if binary.trim().is_empty() {
+        return Err("--reason-bin must not be empty; no receipt was signed".into());
+    }
+    let candidate = Path::new(binary);
+    if candidate.components().count() > 1 {
+        return Ok(candidate.to_path_buf());
+    }
+    let path = env::var_os("PATH")
+        .ok_or("PATH is not set and --reason-bin is not a path; no receipt was signed")?;
+    for directory in env::split_paths(&path) {
+        let candidate = directory.join(binary);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+    Err(format!("could not find Reason verifier {binary:?} on PATH; no receipt was signed").into())
+}
+
+fn sha256_digest(bytes: &[u8]) -> String {
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+fn valid_digest(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|hex| {
+        hex.len() == 64
+            && hex
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    })
+}
+
+fn exit_label(status: ExitStatus) -> String {
+    status
+        .code()
+        .map_or_else(|| "by signal".to_string(), |code| code.to_string())
+}
+
+#[cfg(unix)]
+fn configure_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn configure_process_group(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn kill_process_group(child: &mut Child) {
+    // SAFETY: `child.id()` is the process-group id established immediately
+    // before spawn. killpg receives no pointers and SIGKILL cannot invoke code
+    // in this process. Falling back to Child::kill handles a setup race.
+    let killed = unsafe { libc::killpg(child.id() as libc::pid_t, libc::SIGKILL) } == 0;
+    if !killed {
+        let _ = child.kill();
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(child: &mut Child) {
+    let _ = child.kill();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_reader_rejects_the_sentinel_byte() {
+        let error = read_bounded("12345".as_bytes(), 4).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn digest_validation_rejects_uppercase_and_wrong_length() {
+        assert!(valid_digest(&format!("sha256:{}", "a".repeat(64))));
+        assert!(!valid_digest(&format!("sha256:{}", "A".repeat(64))));
+        assert!(!valid_digest(&format!("sha256:{}", "a".repeat(63))));
+    }
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1642,6 +1642,15 @@ enum AttestCommand {
     ///     --payload '{"eventId":"evt_abc","status":"succeeded"}'
     Receipt(AttestReceiptArgs),
 
+    /// Atomically verify and attest an authorized Zerker Reason bundle
+    ///
+    /// Reads the bundle once, passes those exact bytes to Reason over stdin,
+    /// and signs their digest only after Reason returns verified+authorized.
+    ///
+    /// Example:
+    ///   treeship attest reason-authorization --bundle-file authorization-bundle.json
+    ReasonAuthorization(AttestReasonAuthorizationArgs),
+
     /// Mint a signed agent capability card (agent_card.v1)
     ///
     /// Declares an agent's identity and capability set as a typed, signed
@@ -1925,6 +1934,21 @@ struct AttestReceiptArgs {
     /// Digest of the external payload, for example sha256:<hex>
     #[arg(long, value_name = "DIGEST")]
     payload_digest: Option<String>,
+}
+
+#[derive(Args)]
+struct AttestReasonAuthorizationArgs {
+    /// Atomic zerker.reason.authorization-bundle.v1 JSON file (`-` for stdin)
+    #[arg(long, required = true, value_name = "PATH")]
+    bundle_file: String,
+
+    /// Zerker Reason verifier executable
+    #[arg(long, default_value = "reason", value_name = "PATH")]
+    reason_bin: String,
+
+    /// Maximum verifier runtime in milliseconds
+    #[arg(long, default_value_t = 2_000, value_name = "MS")]
+    timeout_ms: u64,
 }
 
 #[derive(Args)]
@@ -3292,6 +3316,15 @@ fn dispatch(cli: &Cli, printer: &Printer) -> Result<(), Box<dyn std::error::Erro
                     payload: a.payload.clone(),
                     payload_file: a.payload_file.clone(),
                     payload_digest: a.payload_digest.clone(),
+                    config: cli.config.clone(),
+                },
+                printer,
+            ),
+            AttestCommand::ReasonAuthorization(a) => commands::reason_authorization::run(
+                commands::reason_authorization::Args {
+                    bundle_file: a.bundle_file.clone(),
+                    reason_bin: a.reason_bin.clone(),
+                    timeout_ms: a.timeout_ms,
                     config: cli.config.clone(),
                 },
                 printer,

--- a/packages/cli/tests/reason_authorization_cli.rs
+++ b/packages/cli/tests/reason_authorization_cli.rs
@@ -1,0 +1,369 @@
+//! Failure-first end-to-end tests for the atomic Reason verify-then-sign adapter.
+//!
+//! The load-bearing ordering invariant is observable on disk: every malformed,
+//! denied, verifier-rejected, timed-out, or forged verifier result leaves the artifact
+//! store empty. The success case also proves that the verifier received the
+//! exact bytes whose SHA-256 digest is committed into the signed receipt.
+
+#![cfg(unix)]
+
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+const DIGEST_A: &str = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DIGEST_B: &str = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Workspace {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let workspace = Self { _tmp: tmp, root };
+        let output = workspace
+            .cmd()
+            .args(["init", "--config"])
+            .arg(workspace.config())
+            .args(["--name", "reason-adapter-test"])
+            .output()
+            .expect("treeship init");
+        assert_success(&output, "init");
+        workspace
+    }
+
+    fn config(&self) -> String {
+        self.root
+            .join(".treeship/config.json")
+            .display()
+            .to_string()
+    }
+
+    fn cmd(&self) -> Command {
+        let mut command = Command::new(cli_path());
+        command
+            .env("HOME", &self.root)
+            .env("TREESHIP_ALLOW_INSECURE_KEY_PERMS", "1")
+            .current_dir(&self.root);
+        command
+    }
+
+    fn bundle_path(&self, bytes: &[u8]) -> PathBuf {
+        let path = self.root.join("authorization-bundle.json");
+        fs::write(&path, bytes).unwrap();
+        path
+    }
+
+    fn verifier(&self, name: &str, body: &str) -> PathBuf {
+        let path = self.root.join(name);
+        fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    fn attest(&self, bundle: &Path, verifier: &Path, timeout_ms: u64) -> std::process::Output {
+        self.cmd()
+            .args(["attest", "reason-authorization", "--bundle-file"])
+            .arg(bundle)
+            .args(["--reason-bin"])
+            .arg(verifier)
+            .args([
+                "--timeout-ms",
+                &timeout_ms.to_string(),
+                "--format",
+                "json",
+                "--config",
+            ])
+            .arg(self.config())
+            .output()
+            .expect("attest reason-authorization")
+    }
+
+    fn artifact_count(&self) -> usize {
+        let index = self.root.join(".treeship/artifacts/index.json");
+        if !index.exists() {
+            return 0;
+        }
+        let value: Value = serde_json::from_slice(&fs::read(index).unwrap()).unwrap();
+        value["entries"].as_array().unwrap().len()
+    }
+
+    fn record(&self, artifact_id: &str) -> Value {
+        serde_json::from_slice(
+            &fs::read(
+                self.root
+                    .join(".treeship/artifacts")
+                    .join(format!("{artifact_id}.json")),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+}
+
+fn authorized_bundle() -> Vec<u8> {
+    // This is an adapter transport fixture, not a Reason proof vector. The
+    // verifier subprocess is the test double under explicit control below.
+    // Fields are hand-authored from the public v1 transport schemas.
+    serde_json::to_vec(&json!({
+        "schema": "zerker.reason.authorization-bundle.v1",
+        "request": {
+            "schema": "zerker.reason.action.v1",
+            "mission": {},
+            "action": {},
+            "policy": {}
+        },
+        "certificate": {
+            "schema": "zerker.reason.authorization.v1",
+            "status": "authorized",
+            "request_digest": DIGEST_A,
+            "mission": {},
+            "action": {},
+            "reasoning": {},
+            "issues": []
+        }
+    }))
+    .unwrap()
+}
+
+fn verification_json(status: &str) -> String {
+    json!({
+        "schema": "zerker.reason.authorization-verification.v1",
+        "status": "verified",
+        "authorization_status": status,
+        "request_digest": DIGEST_A,
+        "reasoning_result_digest": DIGEST_B
+    })
+    .to_string()
+}
+
+fn assert_success(output: &std::process::Output, operation: &str) {
+    assert!(
+        output.status.success(),
+        "{operation} failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failed_without_artifact(
+    workspace: &Workspace,
+    output: &std::process::Output,
+    case: &str,
+) {
+    assert!(
+        !output.status.success(),
+        "{case} unexpectedly succeeded: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        workspace.artifact_count(),
+        0,
+        "{case} signed or stored an artifact before all gates passed"
+    );
+}
+
+#[test]
+fn exact_verified_bundle_bytes_are_committed_before_receipt_signing() {
+    let workspace = Workspace::new();
+    let bytes = authorized_bundle();
+    let bundle = workspace.bundle_path(&bytes);
+    let captured = workspace.root.join("captured-bundle");
+    let verifier = workspace.verifier(
+        "reason-ok",
+        &format!(
+            "/bin/cat > '{}'\nprintf '%s\\n' '{}'",
+            captured.display(),
+            verification_json("authorized")
+        ),
+    );
+
+    let output = workspace.attest(&bundle, &verifier, 2_000);
+    assert_success(&output, "atomic attestation");
+    assert_eq!(
+        fs::read(captured).unwrap(),
+        bytes,
+        "Reason saw different bytes"
+    );
+    assert_eq!(workspace.artifact_count(), 1);
+
+    let response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let artifact_id = response["id"].as_str().expect("success id");
+    let record = workspace.record(artifact_id);
+    let payload = URL_SAFE_NO_PAD
+        .decode(record["envelope"]["payload"].as_str().unwrap())
+        .unwrap();
+    let statement: Value = serde_json::from_slice(&payload).unwrap();
+    let expected_digest = format!("sha256:{:x}", Sha256::digest(&bytes));
+    assert_eq!(statement["kind"], "reason.authorization.v1");
+    assert_eq!(statement["payload"]["status"], "authorized");
+    assert_eq!(statement["payloadDigest"], expected_digest);
+    assert_eq!(
+        statement["meta"]["authorization_bundle"]["digest"],
+        expected_digest
+    );
+    assert_eq!(
+        statement["meta"]["reason_verification"]["status"],
+        "verified"
+    );
+
+    let verify = workspace
+        .cmd()
+        .args(["verify", artifact_id, "--no-chain", "--config"])
+        .arg(workspace.config())
+        .output()
+        .expect("treeship verify");
+    assert_success(&verify, "verify signed receipt");
+}
+
+#[test]
+fn verifier_descendant_cannot_hold_success_pipes_open() {
+    let workspace = Workspace::new();
+    let bundle = workspace.bundle_path(&authorized_bundle());
+    let verifier = workspace.verifier(
+        "reason-orphan",
+        &format!(
+            "/bin/cat >/dev/null\n/bin/sleep 5 &\nprintf '%s\\n' '{}'",
+            verification_json("authorized")
+        ),
+    );
+
+    let started = Instant::now();
+    let output = workspace.attest(&bundle, &verifier, 2_000);
+    assert_success(&output, "verifier with inherited descendant pipes");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "adapter waited for an outliving verifier descendant: {:?}",
+        started.elapsed()
+    );
+}
+
+#[test]
+fn verifier_and_bundle_failures_leave_no_signed_side_effect() {
+    let mut extra: Value = serde_json::from_str(&verification_json("authorized")).unwrap();
+    extra["extra"] = json!(true);
+    let cases = [
+        (
+            "verifier-rejection",
+            "/bin/cat >/dev/null\nexit 1".to_string(),
+            2_000,
+        ),
+        (
+            "verified-denial",
+            format!(
+                "/bin/cat >/dev/null\nprintf '%s\\n' '{}'",
+                verification_json("denied")
+            ),
+            2_000,
+        ),
+        (
+            "malformed-output",
+            "/bin/cat >/dev/null\nprintf 'not-json'".to_string(),
+            2_000,
+        ),
+        (
+            "unknown-output-field",
+            format!("/bin/cat >/dev/null\nprintf '%s\\n' '{}'", extra),
+            2_000,
+        ),
+        (
+            "timeout",
+            "/bin/cat >/dev/null\n/bin/sleep 5".to_string(),
+            30,
+        ),
+    ];
+
+    for (name, body, timeout) in cases {
+        let workspace = Workspace::new();
+        let bundle = workspace.bundle_path(&authorized_bundle());
+        let verifier = workspace.verifier(&format!("reason-{name}"), &body);
+        let output = workspace.attest(&bundle, &verifier, timeout);
+        assert_failed_without_artifact(&workspace, &output, name);
+    }
+}
+
+#[test]
+fn oversized_input_is_rejected_before_the_verifier_starts() {
+    let workspace = Workspace::new();
+    let bundle = workspace.bundle_path(&vec![b'x'; (1 << 20) + 1]);
+    let marker = workspace.root.join("verifier-started");
+    let verifier = workspace.verifier(
+        "reason-marker",
+        &format!("/usr/bin/touch '{}'", marker.display()),
+    );
+
+    let output = workspace.attest(&bundle, &verifier, 2_000);
+    assert_failed_without_artifact(&workspace, &output, "oversized input");
+    assert!(!marker.exists(), "verifier started for oversized input");
+}
+
+#[test]
+fn oversized_verifier_output_fails_closed_before_signing() {
+    let workspace = Workspace::new();
+    let bundle = workspace.bundle_path(&authorized_bundle());
+    let output = "x".repeat((64 << 10) + 1);
+    let verifier = workspace.verifier(
+        "reason-loud",
+        &format!("/bin/cat >/dev/null\nprintf '%s' '{}'", output),
+    );
+
+    let result = workspace.attest(&bundle, &verifier, 2_000);
+    assert_failed_without_artifact(&workspace, &result, "oversized output");
+}
+
+#[test]
+fn generic_receipt_cannot_bypass_reason_verification() {
+    let workspace = Workspace::new();
+    let certificate = json!({
+        "schema": "zerker.reason.authorization.v1",
+        "status": "authorized",
+        "request_digest": DIGEST_A,
+        "mission": {},
+        "action": {},
+        "reasoning": {},
+        "issues": []
+    })
+    .to_string();
+    let output = workspace
+        .cmd()
+        .args([
+            "attest",
+            "receipt",
+            "--system",
+            "system://zerker-reason",
+            "--kind",
+            "reason.authorization.v1",
+            "--payload",
+            &certificate,
+            "--config",
+        ])
+        .arg(workspace.config())
+        .output()
+        .expect("generic receipt bypass attempt");
+
+    assert_failed_without_artifact(&workspace, &output, "generic receipt bypass");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("reason-authorization"),
+        "error must direct the caller to the verified adapter: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- add `treeship attest reason-authorization` as the only supported signing path for `reason.authorization.v1`
- read one bounded authorization bundle once, pass those exact bytes to Reason over stdin, and sign only after strict `verified` + `authorized` output
- commit the exact bundle-byte digest plus Reason request and reasoning-result digests in the Treeship receipt
- block generic `treeship attest receipt` from hand-signing the Reason authorization kind
- document the separate Reason semantic-verification and Treeship signature-verification boundaries

## Why

A valid Treeship signature does not make an invalid Reason certificate valid. The previous generic receipt path could validate the predicate shape and sign it without invoking `reason verify-authorization`.

This adapter closes that boundary without reimplementing Reason semantics in Rust or reopening request/certificate paths between verification and signing.

## Contract

```bash
treeship attest reason-authorization \
  --bundle-file authorization-bundle.json \
  --reason-bin /opt/zerker/bin/reason \
  --timeout-ms 1000
```

The command invokes:

```bash
reason --format json verify-authorization-bundle - --require-authorized
```

Only exact v1 `verified` and `authorized` output may reach Treeship key or artifact storage. Denial, conflict, insufficient evidence, malformed input/output, timeout, oversized I/O, missing verifier, and certificate mismatch fail before a signed artifact is created.

## Security properties

- one bounded, single-read bundle source
- exact bytes sent to Reason stdin and SHA-256 committed in the receipt
- no shell invocation
- bounded verifier runtime and output
- inherited descendant pipes cannot hold success open
- strict versioned verifier output
- generic Reason-receipt signing bypass rejected
- Reason and Treeship verifier responsibilities remain separate

## Validation

Revalidated after rebasing onto current `main`:

- dedicated Reason adapter suite: 6/6 passed
- `cargo fmt --all --check`
- `cargo clippy --locked -p treeship-cli --all-targets -- -D warnings`
- strict feature inventory: 48 entries
- generated CLI command matrix check
- generated feature matrix check
- `git diff --check`

The unattended campaign also ran the complete shipped Rust suites, packaging and documentation gates, cross-SDK parity tests, and real Reason authorized and tampered/no-artifact paths before this branch was delivered.

## Dependencies

Requires the atomic bundle command merged in zerkerlabs/reason#4 (`d796c6f0`). Reason remains a separately installed and independently versioned executable.

## Limitations

The receipt embeds the complete authorization certificate. Do not use this adapter for sensitive certificates until the disclosure policy permits that payload or a selective-disclosure profile ships.

This PR creates signed evidence. It does not execute or consume an authorized action; Gateway or another enforcement point must still compare and enforce the concrete call.
