### PR TITLE
fix(attest): --expires accepted a duration and signed it into the artifact

### DIFF
--- a/packages/cli/src/commands/attest.rs
+++ b/packages/cli/src/commands/attest.rs
@@ -786,6 +786,30 @@ pub fn approval(args: ApprovalArgs, printer: &Printer) -> Result<(), Box<dyn std
         })
     };
 
+    // Reject a non-RFC-3339 expiry at parse time.
+    //
+    // `--expires 1h` was accepted verbatim and signed into an immutable
+    // artifact. Expiry is then compared as a STRING against
+    // `now_rfc3339()` -- see the `*expires < now` check below -- so "1h"
+    // sorts before every real timestamp and the approval is born expired,
+    // failing on the very next command with no hint that the input was the
+    // problem.
+    //
+    // `grant issue` already rejects this for `--expiry`; approval did not,
+    // and the two paths write to the same kind of signed field. Validating
+    // here rather than at use keeps garbage out of the signed bytes, which
+    // is the rule that matters: a signature over a malformed value is still
+    // a signature, and it is permanent.
+    if let Some(ref expires) = args.expires {
+        if treeship_core::statements::parse_rfc3339_to_unix(expires).is_none() {
+            return Err(format!(
+                "--expires must be RFC 3339: {expires}\n                   example: --expires 2026-12-31T23:59:59Z\n                   (a duration like `1h` is not accepted; it would be signed verbatim \
+                 and compared as text, producing an approval that is already expired)"
+            )
+            .into());
+        }
+    }
+
     let mut stmt = ApprovalStatement::new(&args.approver, &nonce);
     stmt.description = args.description.clone();
     stmt.expires_at = args.expires.clone();
@@ -1711,6 +1735,30 @@ pub fn endorsement(
         digest: None,
         uri: None,
     };
+    // Reject a non-RFC-3339 expiry at parse time.
+    //
+    // `--expires 1h` was accepted verbatim and signed into an immutable
+    // artifact. Expiry is then compared as a STRING against
+    // `now_rfc3339()` -- see the `*expires < now` check below -- so "1h"
+    // sorts before every real timestamp and the approval is born expired,
+    // failing on the very next command with no hint that the input was the
+    // problem.
+    //
+    // `grant issue` already rejects this for `--expiry`; approval did not,
+    // and the two paths write to the same kind of signed field. Validating
+    // here rather than at use keeps garbage out of the signed bytes, which
+    // is the rule that matters: a signature over a malformed value is still
+    // a signature, and it is permanent.
+    if let Some(ref expires) = args.expires {
+        if treeship_core::statements::parse_rfc3339_to_unix(expires).is_none() {
+            return Err(format!(
+                "--expires must be RFC 3339: {expires}\n                   example: --expires 2026-12-31T23:59:59Z\n                   (a duration like `1h` is not accepted; it would be signed verbatim \
+                 and compared as text, producing an approval that is already expired)"
+            )
+            .into());
+        }
+    }
+
     stmt.rationale = args.rationale.clone();
     stmt.expires_at = args.expires.clone();
     stmt.policy_ref = args.policy_ref.clone();

--- a/packages/cli/tests/approval_gate_cli.rs
+++ b/packages/cli/tests/approval_gate_cli.rs
@@ -288,3 +288,110 @@ fn clean_keybound_check_mints_grant_with_evidence_signed_in() {
         "the evidence link must be visible on the grant: {output}"
     );
 }
+
+/// `--expires 1h` was accepted verbatim and signed into an immutable artifact.
+///
+/// Expiry is compared as a *string* against `now_rfc3339()`, so "1h" sorts
+/// before every real timestamp: the approval was born expired and failed on
+/// the next command, with nothing pointing at the input as the cause.
+///
+/// The rule this protects is narrower than "validate input". A signature over
+/// a malformed value is still a signature, and it is permanent — so the check
+/// has to happen before signing, not at use. `grant issue` already rejected
+/// this for `--expiry`; approval wrote to the same kind of signed field and
+/// did not.
+#[test]
+fn approval_rejects_a_non_rfc3339_expiry_before_signing() {
+    let workspace = TempDir::new().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let run = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = run(&["init", "--config", cfg, "--name", "expires-test"]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    // ── the bug ──
+    let bad = run(&[
+        "attest",
+        "approval",
+        "--config",
+        cfg,
+        "--allowed-action",
+        "deploy.*",
+        "--approver",
+        "me",
+        "--expires",
+        "1h",
+    ]);
+    assert!(
+        !bad.status.success(),
+        "a duration must not be accepted as an expiry; it would be signed verbatim"
+    );
+    let msg = format!(
+        "{}{}",
+        String::from_utf8_lossy(&bad.stdout),
+        String::from_utf8_lossy(&bad.stderr)
+    );
+    assert!(
+        msg.contains("RFC 3339"),
+        "the error must name the expected format, or the user cannot fix it: {msg}"
+    );
+    // Nothing may have been written. A rejected input that still signs is the
+    // failure this guards against.
+    let artifacts = root.join(".treeship/artifacts");
+    if artifacts.exists() {
+        let count = std::fs::read_dir(&artifacts)
+            .map(|d| d.count())
+            .unwrap_or(0);
+        assert_eq!(
+            count, 0,
+            "a rejected expiry must not leave a signed artifact"
+        );
+    }
+
+    // ── a real timestamp still works, or the guard is too strict ──
+    let good = run(&[
+        "attest",
+        "approval",
+        "--config",
+        cfg,
+        "--allowed-action",
+        "deploy.*",
+        "--approver",
+        "me",
+        "--expires",
+        "2030-12-31T23:59:59Z",
+    ]);
+    assert!(
+        good.status.success(),
+        "a valid RFC 3339 expiry must still be accepted: {}",
+        String::from_utf8_lossy(&good.stderr)
+    );
+
+    // ── and omitting it entirely is still valid ──
+    let none = run(&[
+        "attest",
+        "approval",
+        "--config",
+        cfg,
+        "--allowed-action",
+        "deploy.*",
+        "--approver",
+        "me",
+    ]);
+    assert!(
+        none.status.success(),
+        "an approval without an expiry must still be accepted: {}",
+        String::from_utf8_lossy(&none.stderr)
+    );
+}


### PR DESCRIPTION
`treeship attest approval --expires 1h` **succeeded**. "1h" was stored verbatim in a signed, immutable artifact.

Expiry is then compared as a **string** against `now_rfc3339()` — see the `*expires < now` check in the approval gate — so "1h" sorts before every real timestamp. The approval was **born expired** and failed on the very next command, with nothing pointing at the input as the cause.

## Why validate before signing, not at use

A signature over a malformed value is still a signature, and it is permanent. Once the bytes are signed the only remedy is revocation. So the check belongs at parse time.

## Two commands disagreed

`grant issue` **already rejected exactly this** for `--expiry`. Approval wrote to the same kind of signed field and didn't. Now they share `parse_rfc3339_to_unix` rather than having two notions of what a valid expiry is.

Both call sites guarded — approval and decision — since both assign `args.expires` into `stmt.expires_at`.

```
✗ --expires must be RFC 3339: 1h
  example: --expires 2026-12-31T23:59:59Z
  (a duration like `1h` is not accepted; it would be signed verbatim and
   compared as text, producing an approval that is already expired)
```

## The test asserts three things

Duration rejected · **valid RFC 3339 still accepted** (or the guard is too strict) · **no expiry still works**. Plus: no artifact is written on the rejected path — a rejected input that still signs would be the same bug wearing an error message.

Found by the docs QA in #321, verified independently here. Clippy clean, full CLI suite green, command matrix unchanged.