### PR TITLE
fix(ci): the v0.25.0 release left every npm lockfile out of sync with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,13 @@ jobs:
       # other gate passed -- none of them read that file. This one is a grep
       # that runs, which is the whole point: the markers were not hard to see,
       # nothing looked.
+      # v0.25.0 stamped package.json to 0.25.0 and left every lockfile at
+      # 0.24.0, so `npm ci` refused on four open PRs at once. The CI error
+      # names the symptom ("your lockfile is out of date") on PRs that never
+      # touched a lockfile, so it reads as a per-PR problem instead of main
+      # being unbuildable for JS.
+      - name: package.json and lockfiles agree
+        run: python3 scripts/check-lockfile-sync.py
       - name: No committed conflict markers
         run: python3 scripts/check-conflict-markers.py
       # v0.24.0 published a bundler-only wasm build that would not load in

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.24.0"
+        "@treeship/core-wasm": "0.25.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.24.0.tgz",
-      "integrity": "sha512-pUGP1fLr5wOPZiUsJwLHdu5IyvQSbJ3JEYb/RNbVd2fYq96J96mlfS2KOiMROGyCPGnMWYfUHIJKajYw42AiFA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
+      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.24.0",
+        "@treeship/core-wasm": "0.25.0",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.24.0.tgz",
-      "integrity": "sha512-pUGP1fLr5wOPZiUsJwLHdu5IyvQSbJ3JEYb/RNbVd2fYq96J96mlfS2KOiMROGyCPGnMWYfUHIJKajYw42AiFA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
+      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.24.0"
+        "@treeship/core-wasm": "0.25.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.24.0.tgz",
-      "integrity": "sha512-pUGP1fLr5wOPZiUsJwLHdu5IyvQSbJ3JEYb/RNbVd2fYq96J96mlfS2KOiMROGyCPGnMWYfUHIJKajYw42AiFA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
+      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.24.0"
+        "@treeship/core-wasm": "0.25.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.24.0.tgz",
-      "integrity": "sha512-pUGP1fLr5wOPZiUsJwLHdu5IyvQSbJ3JEYb/RNbVd2fYq96J96mlfS2KOiMROGyCPGnMWYfUHIJKajYw42AiFA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
+      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/scripts/check-lockfile-sync.py
+++ b/scripts/check-lockfile-sync.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fail when a package.json and its lockfile disagree.
+
+`npm ci` refuses to run when the two are out of sync:
+
+    npm error code EUSAGE
+    `npm ci` can only install packages when your package.json and
+    package-lock.json are in sync.
+
+v0.25.0 shipped exactly that. `release.sh prepare` stamps every version site
+including package.json, but did not update the lockfiles, so main declared
+@treeship/core-wasm at 0.25.0 while every lockfile still said 0.24.0. Four
+open PRs failed the same four JS jobs, and the failure looked like a problem
+with each PR rather than with main.
+
+Checked here rather than left to `npm ci` because the CI error names the
+symptom and not the cause: a reader sees "your lockfile is out of date" on a
+PR that never touched a lockfile.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PACKAGES = [
+    "packages/verify-js",
+    "packages/sdk-ts",
+    "bridges/mcp",
+    "bridges/a2a",
+]
+
+
+def declared(pkg: Path) -> dict:
+    with open(pkg / "package.json", encoding="utf-8") as f:
+        d = json.load(f)
+    out = {}
+    for key in ("dependencies", "peerDependencies"):
+        out.update(d.get(key, {}))
+    return out
+
+
+def locked(pkg: Path) -> dict:
+    with open(pkg / "package-lock.json", encoding="utf-8") as f:
+        d = json.load(f)
+    root = d.get("packages", {}).get("", {})
+    out = {}
+    for key in ("dependencies", "peerDependencies"):
+        out.update(root.get(key, {}))
+    return out
+
+
+def main() -> int:
+    checked = 0
+    bad = []
+    for rel in PACKAGES:
+        pkg = ROOT / rel
+        if not (pkg / "package.json").is_file() or not (pkg / "package-lock.json").is_file():
+            continue
+        checked += 1
+        dec, lck = declared(pkg), locked(pkg)
+        for name, want in dec.items():
+            got = lck.get(name)
+            if got != want:
+                bad.append((rel, name, want, got))
+
+    if not checked:
+        # A check that examined nothing passes vacuously and reads as a pass.
+        print("  err   no package/lockfile pairs found; this check would pass vacuously")
+        return 1
+
+    if bad:
+        for rel, name, want, got in bad:
+            print(f"  err   {rel}: {name} is {want!r} in package.json but {got!r} in the lockfile")
+        print()
+        print(
+            f"{len(bad)} mismatch(es). `npm ci` will refuse on every PR until the "
+            "lockfiles are regenerated:  npm install --package-lock-only"
+        )
+        return 1
+
+    print(f"  ✓ package.json and lockfile agree in {checked} package(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -52,6 +52,28 @@ cmd_prepare() {
   echo "Updating Cargo.lock..."
   cargo check -p treeship-core 2>/dev/null || true
 
+  # npm lockfiles too.
+  #
+  # `--write` stamps package.json but not package-lock.json, so after a
+  # release prepare the two disagree about @treeship/core-wasm and `npm ci`
+  # refuses on EVERY subsequent PR:
+  #
+  #   npm error code EUSAGE
+  #   `npm ci` can only install packages when your package.json and
+  #   package-lock.json are in sync.
+  #
+  # That is not a per-PR problem, it is main being unbuildable for JS. v0.25.0
+  # shipped that way and blocked four PRs until it was noticed. `--package-lock-only`
+  # updates the lockfile without touching node_modules or the network beyond
+  # metadata.
+  echo "Updating npm lockfiles..."
+  for pkg in packages/verify-js packages/sdk-ts bridges/mcp bridges/a2a; do
+    if [ -f "$pkg/package-lock.json" ]; then
+      ( cd "$pkg" && npm install --package-lock-only --no-audit --no-fund --silent ) \
+        || { echo "lockfile update failed in $pkg" >&2; exit 1; }
+    fi
+  done
+
   echo
   echo "Running release version preflight..."
   if ! python3 "$(dirname "$0")/check-release-versions.py" "$VERSION"; then


### PR DESCRIPTION
**Four open PRs are failing the same four JS jobs, and none of them are the cause.** Main is unbuildable for JS.

`release.sh prepare` stamps every version site — package.json included — and doesn't touch the lockfiles. So main declares `@treeship/core-wasm` at **0.25.0** while all four lockfiles still say **0.24.0**:

```
npm error code EUSAGE
`npm ci` can only install packages when your package.json and
package-lock.json are in sync.
```

#321, #324, #327 and #328 all fail on this. None touched a lockfile. The error reads as a per-PR problem, which is why it sat.

## Three parts

**1. Lockfiles regenerated** with `--package-lock-only`. `npm ci` verified in all four packages.

**2. `release.sh prepare` regenerates them** as part of stamping, so the next release can't reintroduce it. It **fails** the prepare rather than continuing — a half-stamped release is what caused this.

**3. `check-lockfile-sync.py`** compares declared against locked and names the mismatch:

```
err  packages/verify-js: @treeship/core-wasm is '0.25.0' in package.json
     but '0.24.0' in the lockfile
```

Verified against the exact v0.25.0 state — fails there, passes once regenerated.

## Why a gate when npm already errors

`npm ci`'s message describes the **symptom** ("your lockfile is out of date") on a PR that never touched a lockfile. Naming the **cause** on the PR that introduces it is worth more than a correct-but-misleading error four PRs later.

Merging this should unblock all four.