### PR TITLE
fix(setup): --help promised Verified where the code deliberately sets Active

### DIFF
--- a/packages/cli/src/commands/setup.rs
+++ b/packages/cli/src/commands/setup.rs
@@ -8,17 +8,28 @@
 //!   4. confirm with the user before instrumenting (or `--yes`)
 //!   5. delegate to existing `add::run` for actual config writes
 //!   6. optional smoke session that proves Treeship can capture; on success,
-//!      promote the matching card's status to `Verified`
+//!      promote the matching card's status to `Active`
 //!
 //! `setup` deliberately doesn't have its own detector or its own
 //! instrumenter. Adding either would re-introduce the "two of these
 //! exist now" problem that PRs 1 and 2 closed.
 //!
-//! Verification semantics: `Verified` means a smoke session proved
-//! Treeship can capture session events end-to-end on this machine, against
-//! a real isolated keystore. It is *not* a claim about the live agent
-//! itself doing the right thing -- v0.9.8 has no global identity check.
-//! The verify pass output preserves this honesty.
+//! Verification semantics. The smoke session proves Treeship can capture
+//! session events end-to-end on this machine against a real isolated
+//! keystore. It does NOT exercise any specific harness's capture path: no
+//! Claude native hook fires, no Cursor MCP tool is routed, no Codex
+//! shell-wrap is tested. So confirmed cards move Draft -> **Active**, and
+//! `CardStatus::Verified` is deliberately not used here.
+//!
+//! This header used to say the smoke promotes cards to `Verified`. The code
+//! has always set `Active`, with a comment explaining that marking harnesses
+//! Verified "would over-claim". The help text over-claimed in precisely the
+//! place the implementation refused to -- which is worse than a normal doc
+//! drift, because the two were written against different intentions and
+//! nothing compared them.
+//!
+//! `HarnessStatus::Verified` remains reserved for per-harness smokes that
+//! assert on specific signals (files.read, mcp.call, and so on).
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -420,7 +420,12 @@ enum Command {
     ///   3. confirm before modifying any agent's config
     ///   4. instrument those agents (Treeship MCP, hooks, skill files)
     ///   5. run a smoke session to prove Treeship can capture
-    ///   6. promote cards to Verified on smoke success
+    ///   6. promote confirmed cards to Active on smoke success
+    ///
+    /// The smoke proves Treeship can capture on this machine; it does not
+    /// exercise any specific harness's path, so cards move to Active rather
+    /// than Verified. `Verified` is reserved for per-harness smokes that
+    /// assert on specific signals.
     ///
     /// Examples:
     ///   treeship setup


### PR DESCRIPTION
`treeship setup --help` said:

```
6. promote cards to Verified on smoke success
```

The code has **always** set `CardStatus::Active`, and the comment above it explains why in detail:

> the smoke session proves Treeship can capture on this machine, but exercises no specific harness path — *"no Claude native hook fired, no Cursor MCP tool was routed, no Codex shell-wrap was tested. Marking harnesses Verified here would over-claim."*

**So the help text over-claimed in exactly the place the implementation refused to.**

That's worse than ordinary doc drift: the two were written against different intentions and nothing compared them. A user reading `--help` was told the tool asserts something the tool had specifically declined to assert.

## Both surfaces

The clap doc comment in `main.rs` is the one users see. The module header in `setup.rs` **does not render in `--help`** — which is why fixing only the header left the false claim live, and I had to check the rendered output to catch that. Header corrected too, since it was equally wrong and is what the next reader of the file sees.

## Also says what it doesn't establish

The help now states what the smoke does and doesn't prove, and that `Verified` is reserved for per-harness smokes asserting on specific signals. **Naming the reservation matters** — without it, "Active" reads as a weaker version of the same claim rather than a different one.

```
promote confirmed cards to Active
```

Clippy clean, command matrix unchanged, lockfiles in sync.

Found by the docs QA in #321 — the sharpest finding in that report.