### PR TITLE
fix(sdk-python): attest_approval could not mint an approval at all

### DIFF
--- a/docs/content/docs/sdk/python.mdx
+++ b/docs/content/docs/sdk/python.mdx
@@ -65,9 +65,22 @@ result = ts.attest_action(
 
 Returns `ActionResult(artifact_id)`.
 
-### `attest_approval(approver, description, expires_in=None)`
+### `attest_approval(approver, description, allowed_actions=None, allowed_actors=None, allowed_subjects=None, max_uses=None, unscoped=False, expires_at=None)`
 
 Create a signed approval receipt with a binding nonce. (Replay posture is package-local in v0.9.6; cross-package enforcement lands in v0.10 via the local Approval Use Journal.)
+
+**A scope is required.** Pass at least one of `allowed_actions`, `allowed_actors`, `allowed_subjects` or `max_uses` — or `unscoped=True` to mint a bearer approval deliberately. An approval that constrains nothing *is* a bearer token, and the CLI refuses to create one by omission.
+
+`expires_at` is an RFC 3339 timestamp (`2030-12-31T23:59:59Z`), not a duration. It was named `expires_in` before, which invited `"1h"` — a value the CLI signed verbatim and then compared as text, producing an approval that was already expired.
+
+```python
+approval = ts.attest_approval(
+    approver="human://alice",
+    description="approve payment max $500",
+    allowed_actions=["payments.charge"],
+    max_uses=1,
+)
+```
 
 Returns `ApprovalResult(artifact_id, nonce)`.
 

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -40,6 +40,8 @@ ts.attest_decision(
 approval = ts.attest_approval(
     approver="human://alice",
     description="approve payment max $500",
+    allowed_actions=["payments.charge"],   # a scope is required
+    max_uses=1,
 )
 print(approval.nonce)  # binding token; replay enforcement is package-local in v0.9.6
 
@@ -68,7 +70,7 @@ print(result.artifact_id)
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `attest_action(actor, action, ...)` | `ActionResult` | Sign an action receipt |
-| `attest_approval(approver, description, ...)` | `ApprovalResult` | Sign an approval with nonce |
+| `attest_approval(approver, description, allowed_actions=..., ...)` | `ApprovalResult` | Sign a scoped approval with nonce |
 | `attest_handoff(from_actor, to_actor, artifacts)` | `ActionResult` | Sign a handoff receipt |
 | `attest_decision(actor, model, ...)` | `ActionResult` | Sign a decision receipt |
 | `verify(artifact_id)` | `VerifyResult` | Verify an artifact chain |

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -278,3 +278,93 @@ class CLIMissingErrorTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ApprovalScopeTests(unittest.TestCase):
+    """attest_approval sent no scope, so every call failed at the CLI.
+
+    The CLI refuses an approval that constrains nothing: an unscoped approval
+    is a bearer token, and minting one by omission rather than by choice is
+    how blanket authority gets created accidentally. The SDK exposed no way to
+    pass a scope, so there was no workaround from inside it.
+
+    These assert on the argv the SDK builds rather than on a live CLI, so they
+    fail on a wrong flag name rather than only on a wrong outcome.
+    """
+
+    def test_no_scope_is_refused_by_the_sdk_not_the_cli(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            with self.assertRaises(ValueError) as ctx:
+                ts.attest_approval(approver="me", description="d")
+            self.assertIn("scope", str(ctx.exception))
+            # Refused before spawning: a failing subprocess would be a worse
+            # error for the same mistake.
+            mock_run.assert_not_called()
+
+    def test_scope_flags_reach_the_cli(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1", "nonce": "n"}),
+            )
+            ts.attest_approval(
+                approver="me",
+                description="d",
+                allowed_actions=["deploy.*", "build.*"],
+                allowed_actors=["agent://ci"],
+                max_uses=3,
+            )
+            argv = mock_run.call_args.args[0]
+            self.assertEqual(argv.count("--allowed-action"), 2)
+            self.assertIn("deploy.*", argv)
+            self.assertIn("build.*", argv)
+            self.assertIn("--allowed-actor", argv)
+            self.assertIn("agent://ci", argv)
+            self.assertIn("--max-uses", argv)
+            self.assertIn("3", argv)
+            self.assertNotIn("--unscoped", argv)
+
+    def test_unscoped_is_explicit_and_reaches_the_cli(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1", "nonce": "n"}),
+            )
+            ts.attest_approval(approver="me", description="d", unscoped=True)
+            self.assertIn("--unscoped", mock_run.call_args.args[0])
+
+    def test_scope_and_unscoped_together_is_refused(self) -> None:
+        """Silently preferring one would make the caller's intent unknowable."""
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            with self.assertRaises(ValueError):
+                ts.attest_approval(
+                    approver="me",
+                    description="d",
+                    allowed_actions=["x"],
+                    unscoped=True,
+                )
+            mock_run.assert_not_called()
+
+    def test_expires_at_is_a_timestamp_not_a_duration(self) -> None:
+        """The parameter was `expires_in`, which invites `1h`.
+
+        The CLI used to accept that verbatim, sign it, then compare it as a
+        string -- producing an approval that was born expired. The CLI rejects
+        it now; the SDK stops inviting it.
+        """
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(
+                stdout=json.dumps({"id": "art_1", "nonce": "n"}),
+            )
+            ts.attest_approval(
+                approver="me",
+                description="d",
+                unscoped=True,
+                expires_at="2030-12-31T23:59:59Z",
+            )
+            argv = mock_run.call_args.args[0]
+            self.assertIn("--expires", argv)
+            self.assertIn("2030-12-31T23:59:59Z", argv)

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -370,14 +370,52 @@ class Treeship:
         self,
         approver: str,
         description: str,
-        expires_in: Optional[str] = None,
+        allowed_actions: Optional[List[str]] = None,
+        allowed_actors: Optional[List[str]] = None,
+        allowed_subjects: Optional[List[str]] = None,
+        max_uses: Optional[int] = None,
+        unscoped: bool = False,
+        expires_at: Optional[str] = None,
     ) -> ApprovalResult:
-        """Create a signed approval receipt with a binding nonce."""
+        """Create a signed approval receipt with a binding nonce.
+
+        A scope is required. The CLI refuses an approval that constrains
+        nothing -- an unscoped approval is a bearer token, and minting one by
+        omission rather than by choice is how blanket authority gets created
+        accidentally. Pass at least one of ``allowed_actions``,
+        ``allowed_actors``, ``allowed_subjects`` or ``max_uses``, or set
+        ``unscoped=True`` to say you meant it.
+
+        Before this existed the method sent no scope at all, so every call
+        failed with "approval has no scope" and there was no way to succeed
+        from inside the SDK.
+
+        ``expires_at`` is an RFC 3339 timestamp, not a duration. It was
+        previously named ``expires_in``, which reads as "expires in 1h" -- and
+        the CLI accepted such a value verbatim, signed it, and then compared
+        it as a string, producing an approval that was already expired. The
+        CLI rejects that now; the parameter is renamed so the SDK stops
+        inviting it.
+        """
         _reject_option_like("approver", approver)
         _check_length("approver", approver, _MAX_ACTOR_LEN)
         _check_length("description", description, _MAX_DESCRIPTION_LEN)
-        if expires_in is not None:
-            _reject_option_like("expires_in", expires_in)
+        if expires_at is not None:
+            _reject_option_like("expires_at", expires_at)
+
+        scopes = [allowed_actions, allowed_actors, allowed_subjects]
+        has_scope = any(v for v in scopes) or max_uses is not None
+        if not has_scope and not unscoped:
+            raise ValueError(
+                "attest_approval requires a scope: pass allowed_actions, "
+                "allowed_actors, allowed_subjects or max_uses, or "
+                "unscoped=True to mint a bearer approval deliberately"
+            )
+        if has_scope and unscoped:
+            raise ValueError(
+                "unscoped=True contradicts the scope arguments you passed; "
+                "an approval is either constrained or it is a bearer token"
+            )
 
         args: List[str] = [
             "attest", "approval",
@@ -385,8 +423,20 @@ class Treeship:
             "--description", description,
             "--format", "json",
         ]
-        if expires_in is not None:
-            args += ["--expires", expires_in]
+        for flag, values in (
+            ("--allowed-action", allowed_actions),
+            ("--allowed-actor", allowed_actors),
+            ("--allowed-subject", allowed_subjects),
+        ):
+            for value in values or []:
+                _reject_option_like(flag.lstrip("-"), value)
+                args += [flag, value]
+        if max_uses is not None:
+            args += ["--max-uses", str(max_uses)]
+        if unscoped:
+            args.append("--unscoped")
+        if expires_at is not None:
+            args += ["--expires", expires_at]
         result = self._run_cli_json(args)
         return ApprovalResult(
             artifact_id=self._artifact_id(result, args),


### PR DESCRIPTION
`attest_approval` sent **no scope flag**, so the CLI refused every call:

```
approval has no scope (no --allowed-actor / --allowed-action /
--allowed-subject / --max-uses). Pass --unscoped to mint a bearer
approval explicitly, or add a scope constraint.
```

And the method exposed **no scope parameter**, so there was no way to succeed from inside the SDK. Not a misconfiguration — the code path could not work.

## The CLI is right to refuse

An approval that constrains nothing **is** a bearer token, and minting one by omission rather than by choice is how blanket authority gets created by accident.

So the SDK now takes `allowed_actions`, `allowed_actors`, `allowed_subjects`, `max_uses`, and an explicit `unscoped=True` for the bearer case.

It **refuses in Python before spawning anything** — a failing subprocess is a worse error for the same mistake, since the caller gets a CLI message about flags they never wrote. Passing both a scope *and* `unscoped=True` is refused rather than silently preferring one: either choice makes the caller's intent unknowable afterwards.

## `expires_in` → `expires_at`

The old name reads as *"expires in 1h"* — and the CLI used to accept exactly that: signed verbatim, then compared as a string, producing an approval that was **born expired**. #328 makes the CLI reject it; this stops the SDK inviting it.

## Docs

The README's example was **itself a call that could not succeed**, and `sdk/python.mdx` documented the old signature. Anyone following either got the same failure. Both fixed.

## Tests

Assert on the **argv the SDK builds**, not on a live CLI — so a wrong flag name fails rather than only a wrong outcome. 51 tests pass; all four paths (no-scope, scoped, unscoped, contradiction) verified against a real binary.

Found by the docs QA in #321.