### PR TITLE
fix(wrap): --format json printed nothing, then printed unparseable output

### DIFF
--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -87,6 +87,22 @@ pub fn run(
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
 
+    // In JSON mode the child's stdout must not share our stdout.
+    //
+    // `--format json` promises one machine-readable document on stdout. The
+    // child's own output was written there with `println!`, so a caller got
+    //
+    //     hi
+    //     {"artifact_id": "art_...", ...}
+    //
+    // and `json.loads` failed on the first line. Emitting the receipt was
+    // necessary but not sufficient: the stream also has to be clean.
+    //
+    // The child's output is not discarded -- it moves to stderr, so a human
+    // running `--format json` still sees it and a pipeline still gets exactly
+    // one JSON document. It is captured into `stdout_buf` either way, so the
+    // output digest in the receipt is unchanged.
+    let child_stdout_to_stderr = printer.format == crate::printer::Format::Json;
     let sb = Arc::clone(&stdout_buf);
     let stdout_thread = std::thread::spawn(move || {
         if let Some(pipe) = stdout_pipe {
@@ -98,7 +114,11 @@ pub fn run(
             // truncates the captured output, which is the honest outcome:
             // the bytes really did stop being readable.
             for l in reader.lines().map_while(Result::ok) {
-                println!("{}", l);
+                if child_stdout_to_stderr {
+                    eprintln!("{}", l);
+                } else {
+                    println!("{}", l);
+                }
                 let mut buf = sb.lock().unwrap();
                 buf.extend_from_slice(l.as_bytes());
                 buf.push(b'\n');
@@ -416,6 +436,35 @@ pub fn run(
     } else {
         "none detected".to_string()
     };
+
+    // JSON mode emits one document and returns.
+    //
+    // Every line below goes through `printer.info`, which returns early when
+    // the format is JSON. So `wrap --format json` printed NOTHING -- not the
+    // artifact id, not an error -- and still exited 0. The only thing on the
+    // pipe was the wrapped command's own stdout, so a caller parsing the
+    // output got the program's output where a receipt should be.
+    //
+    // That is why the Python SDK's `wrap()` could not work: it asks for
+    // `--format json` and parses the result, and there was never a result.
+    //
+    // Same shape as `session event --format json` (#311): a document built
+    // and then handed to a printer that discards it in the very mode that
+    // asked for it. A sweep of every command that accepts `--format json`
+    // found exactly two left -- this and `profile`.
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "artifact_id": result.artifact_id,
+            "digest": result.digest,
+            "command": args,
+            "exit_code": exit_code,
+            "succeeded": succeeded,
+            "elapsed_ms": elapsed_ms,
+            "files_changed": files_changed_count,
+            "hub_url": hub_url,
+        }));
+        return Ok(());
+    }
 
     let separator = "  ----------------------------------------";
 

--- a/packages/cli/tests/wrap_json_cli.rs
+++ b/packages/cli/tests/wrap_json_cli.rs
@@ -1,0 +1,119 @@
+use std::process::Command;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+/// `wrap --format json` printed nothing and exited 0.
+///
+/// Every output line went through `printer.info`, which returns early in JSON
+/// mode, so the receipt was built and discarded. The only thing on stdout was
+/// the wrapped command's own output — so a caller parsing the result got the
+/// program's output where a receipt should be. The Python SDK's `wrap()` could
+/// not work at all.
+///
+/// Emitting the document was necessary but not sufficient: the child's stdout
+/// shared the stream, so `json.loads` still failed on the first line. In JSON
+/// mode the child's output moves to stderr — not discarded, just off the
+/// channel that promises one machine-readable document.
+#[test]
+fn wrap_json_emits_one_parseable_document_on_stdout() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let run = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = run(&["init", "--config", cfg, "--name", "wrap-json"]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let out = run(&[
+        "wrap", "--config", cfg, "--format", "json", "--", "echo", "NOISE",
+    ]);
+    assert!(
+        out.status.success(),
+        "wrap: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "`--format json` produced no output; exit 0 with an empty document is \
+         the shape that made this bug invisible"
+    );
+
+    // The load-bearing assertion: stdout parses whole. Before the fix it began
+    // with the wrapped program's output and failed here.
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must be exactly one JSON document, got {e}:\n{stdout}"));
+
+    assert!(
+        json["artifact_id"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("art_")),
+        "artifact_id is what an SDK reads off this call: {json}"
+    );
+    assert!(json["digest"].as_str().is_some(), "{json}");
+    assert_eq!(json["exit_code"], 0, "{json}");
+    assert_eq!(json["succeeded"], true, "{json}");
+
+    // The child's output is moved, not dropped. A caller running --format json
+    // interactively must still see what their command printed.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NOISE"),
+        "the wrapped command's output must still reach the user on stderr: {stderr}"
+    );
+    // Not `!stdout.contains("NOISE")` -- that fails on the correct output,
+    // because the argv is legitimately in the document as `command`. The real
+    // property is that stdout holds NOTHING but the document: no bare line
+    // before it. Parsing whole (above) proves that; this pins the reason.
+    assert_eq!(
+        json["command"],
+        serde_json::json!(["echo", "NOISE"]),
+        "the argv belongs in the document; the child's stdout does not: {json}"
+    );
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "stdout must begin with the document, not the wrapped program's output: {stdout}"
+    );
+}
+
+/// Human mode is unchanged: the child's output belongs on stdout there.
+#[test]
+fn wrap_human_mode_still_passes_child_stdout_through() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let run = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = run(&["init", "--config", cfg, "--name", "wrap-human"]);
+    assert!(init.status.success());
+
+    let out = run(&["wrap", "--config", cfg, "--", "echo", "VISIBLE"]);
+    assert!(
+        out.status.success(),
+        "wrap: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("VISIBLE"),
+        "human mode must keep the child's output on stdout"
+    );
+}


### PR DESCRIPTION
`treeship wrap --format json` exited 0 and emitted **no receipt**. Every line went through `printer.info`, which returns early in JSON mode — so the document was built and discarded. The only thing on stdout was the wrapped command's own output.

The Python SDK's `wrap()` therefore **could not work at all**: it asks for `--format json` and parses the result, and there was never a result.

## The sweep

Same shape as `session event --format json` (#311), so I checked every command that accepts `--format json` before fixing one. `wrap` was the **only** remaining case — `attest action`, `attest approval`, `session event`, `session status`, `status`, `history`, `profile`, `log`, `keys list`, `trust list`, `grant list`, `agents list` and `verify` all emit correctly.

## Emitting the document wasn't enough

This only surfaced by driving the **real SDK** rather than reading CLI output. The child's stdout shared the stream:

```
hi
{"artifact_id": "art_...", ...}
```

and `json.loads` failed on line 1.

In JSON mode the child's output now goes to **stderr** — not discarded. A human running `--format json` still sees what their command printed, and it's still captured into the output buffer, so the receipt's digest is unchanged. Human mode is untouched.

## Two corrections to my own work

**My sweep first reported `profile` as broken.** False positive — I discarded stderr, where `profile` correctly reports an error *as JSON*. Re-run capturing both streams, it passes. Worth recording: the flawed method would have produced a fix for a non-bug.

**My first test asserted `!stdout.contains("NOISE")`** — which fails on *correct* output, because the argv is legitimately in the document as `command`. The test caught it. It now asserts stdout parses whole and begins with `{`.

Clippy clean, full CLI suite green, command matrix unchanged. Found by the docs QA in #321.