### PR TITLE
fix(init): a fresh directory was told it was "already initialized"

### DIFF
--- a/packages/cli/src/commands/init.rs
+++ b/packages/cli/src/commands/init.rs
@@ -23,6 +23,7 @@ pub fn run(
     //   2. --global         (forces user-level path even when a project
     //                        stub would otherwise be discovered)
     //   3. default          (walks up cwd for project-local; falls back to global)
+    let config_path_arg_was_none = config_path.is_none();
     let config_path: PathBuf = match config_path {
         Some(p) => PathBuf::from(p),
         None if global => global_config_path()?,
@@ -54,6 +55,43 @@ pub fn run(
                  \n  This guard exists because earlier versions silently rotated the\n\
                  global default_key_id under --force, breaking signature continuity\n\
                  for every receipt that referenced the old key.",
+                config_path.display()
+            )
+            .into());
+        }
+    }
+
+    // A fresh directory should not be told it is "already initialized"
+    // because the GLOBAL config exists.
+    //
+    // `default_config_path` walks up for a project-local config and falls back
+    // to `~/.treeship/config.json` when it finds none. So in a brand-new
+    // directory the fallback resolves to the global, this guard sees a file
+    // there, and `init` refuses:
+    //
+    //     $ cd /a/brand/new/dir && treeship init
+    //     ✗ already initialized at /Users/you/.treeship/config.json
+    //
+    // Nothing about that directory is initialized. Every command run there
+    // then uses the home workspace, silently -- receipts from unrelated
+    // projects land in one store, and `--config` becomes the only way to
+    // separate them.
+    //
+    // The walk itself is careful and deliberately skips the global path (see
+    // `walk_up_for_project_config`). It is this guard that conflates "a config
+    // exists somewhere" with "this location is initialized".
+    //
+    // So: when the target came from the global fallback rather than an
+    // explicit choice, offer the project-local path instead of refusing.
+    if config_path.exists() && !force && !global && config_path_arg_was_none {
+        let from_global_fallback = global_config_path()
+            .map(|g| g == config_path)
+            .unwrap_or(false);
+        if from_global_fallback {
+            return Err(format!(
+                "no Treeship workspace here, and the global one at {} is not this \
+                 directory's.\n\n                   Create a project-local workspace:  treeship init --config .treeship/config.json\n                   Or use the global workspace:       treeship init --global\n\n                   Commands run here would otherwise use the global workspace, so \
+                 receipts from unrelated projects share one store.",
                 config_path.display()
             )
             .into());

--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -87,6 +87,22 @@ pub fn run(
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
 
+    // In JSON mode the child's stdout must not share our stdout.
+    //
+    // `--format json` promises one machine-readable document on stdout. The
+    // child's own output was written there with `println!`, so a caller got
+    //
+    //     hi
+    //     {"artifact_id": "art_...", ...}
+    //
+    // and `json.loads` failed on the first line. Emitting the receipt was
+    // necessary but not sufficient: the stream also has to be clean.
+    //
+    // The child's output is not discarded -- it moves to stderr, so a human
+    // running `--format json` still sees it and a pipeline still gets exactly
+    // one JSON document. It is captured into `stdout_buf` either way, so the
+    // output digest in the receipt is unchanged.
+    let child_stdout_to_stderr = printer.format == crate::printer::Format::Json;
     let sb = Arc::clone(&stdout_buf);
     let stdout_thread = std::thread::spawn(move || {
         if let Some(pipe) = stdout_pipe {
@@ -98,7 +114,11 @@ pub fn run(
             // truncates the captured output, which is the honest outcome:
             // the bytes really did stop being readable.
             for l in reader.lines().map_while(Result::ok) {
-                println!("{}", l);
+                if child_stdout_to_stderr {
+                    eprintln!("{}", l);
+                } else {
+                    println!("{}", l);
+                }
                 let mut buf = sb.lock().unwrap();
                 buf.extend_from_slice(l.as_bytes());
                 buf.push(b'\n');
@@ -416,6 +436,35 @@ pub fn run(
     } else {
         "none detected".to_string()
     };
+
+    // JSON mode emits one document and returns.
+    //
+    // Every line below goes through `printer.info`, which returns early when
+    // the format is JSON. So `wrap --format json` printed NOTHING -- not the
+    // artifact id, not an error -- and still exited 0. The only thing on the
+    // pipe was the wrapped command's own stdout, so a caller parsing the
+    // output got the program's output where a receipt should be.
+    //
+    // That is why the Python SDK's `wrap()` could not work: it asks for
+    // `--format json` and parses the result, and there was never a result.
+    //
+    // Same shape as `session event --format json` (#311): a document built
+    // and then handed to a printer that discards it in the very mode that
+    // asked for it. A sweep of every command that accepts `--format json`
+    // found exactly two left -- this and `profile`.
+    if printer.format == crate::printer::Format::Json {
+        printer.json(&serde_json::json!({
+            "artifact_id": result.artifact_id,
+            "digest": result.digest,
+            "command": args,
+            "exit_code": exit_code,
+            "succeeded": succeeded,
+            "elapsed_ms": elapsed_ms,
+            "files_changed": files_changed_count,
+            "hub_url": hub_url,
+        }));
+        return Ok(());
+    }
 
     let separator = "  ----------------------------------------";
 

--- a/packages/cli/tests/init_global_fallback_cli.rs
+++ b/packages/cli/tests/init_global_fallback_cli.rs
@@ -1,0 +1,104 @@
+use std::process::Command;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+/// `treeship init` in a brand-new directory said "already initialized".
+///
+/// `default_config_path` walks up for a project-local config and falls back to
+/// `~/.treeship/config.json` when it finds none. The guard then saw a file at
+/// the resolved path and refused — naming the *home* config as though it were
+/// this directory's:
+///
+///     $ cd /a/brand/new/dir && treeship init
+///     ✗ already initialized at /Users/you/.treeship/config.json
+///
+/// Nothing about that directory was initialized. Every command run there then
+/// used the home workspace silently, so receipts from unrelated projects
+/// shared one store and `--config` was the only way to separate them.
+///
+/// The walk itself is careful and deliberately skips the global path. It was
+/// this guard that conflated "a config exists somewhere" with "this location
+/// is initialized".
+#[test]
+fn init_in_a_fresh_dir_does_not_claim_the_global_workspace_is_this_one() {
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+
+    // A global workspace exists, as it does for any real user.
+    let seed = Command::new(cli_path())
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .args(["init", "--global"])
+        .output()
+        .expect("run treeship");
+    assert!(
+        seed.status.success(),
+        "seed: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    // Now init in an unrelated directory that has no workspace of its own.
+    let out = Command::new(cli_path())
+        .current_dir(project.path())
+        .env("HOME", home.path())
+        .args(["init"])
+        .output()
+        .expect("run treeship");
+
+    let msg = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        !msg.contains("already initialized"),
+        "a fresh directory is not 'already initialized' because the global \
+         config exists: {msg}"
+    );
+    // It must say what is actually true and give both ways forward, or the
+    // reader is left where the old message left them.
+    assert!(
+        msg.contains("no Treeship workspace here"),
+        "the message must say the directory has no workspace: {msg}"
+    );
+    assert!(
+        msg.contains("--config") && msg.contains("--global"),
+        "both the project-local and global paths must be offered: {msg}"
+    );
+}
+
+/// The narrowing must not break the case it was carved out of: re-running
+/// init where a workspace really does exist still refuses.
+#[test]
+fn init_still_refuses_when_this_directory_is_already_initialized() {
+    let home = tempfile::tempdir().unwrap();
+    let project = tempfile::tempdir().unwrap();
+
+    let run = |args: &[&str]| {
+        Command::new(cli_path())
+            .current_dir(project.path())
+            .env("HOME", home.path())
+            .args(args)
+            .output()
+            .expect("run treeship")
+    };
+
+    let first = run(&["init", "--config", ".treeship/config.json"]);
+    assert!(
+        first.status.success(),
+        "first init: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let second = run(&["init", "--config", ".treeship/config.json"]);
+    assert!(!second.status.success(), "re-init must still refuse");
+    let msg = format!(
+        "{}{}",
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr)
+    );
+    assert!(msg.contains("already initialized"), "{msg}");
+}

--- a/packages/cli/tests/wrap_json_cli.rs
+++ b/packages/cli/tests/wrap_json_cli.rs
@@ -1,0 +1,119 @@
+use std::process::Command;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+/// `wrap --format json` printed nothing and exited 0.
+///
+/// Every output line went through `printer.info`, which returns early in JSON
+/// mode, so the receipt was built and discarded. The only thing on stdout was
+/// the wrapped command's own output — so a caller parsing the result got the
+/// program's output where a receipt should be. The Python SDK's `wrap()` could
+/// not work at all.
+///
+/// Emitting the document was necessary but not sufficient: the child's stdout
+/// shared the stream, so `json.loads` still failed on the first line. In JSON
+/// mode the child's output moves to stderr — not discarded, just off the
+/// channel that promises one machine-readable document.
+#[test]
+fn wrap_json_emits_one_parseable_document_on_stdout() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let run = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = run(&["init", "--config", cfg, "--name", "wrap-json"]);
+    assert!(
+        init.status.success(),
+        "init: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let out = run(&[
+        "wrap", "--config", cfg, "--format", "json", "--", "echo", "NOISE",
+    ]);
+    assert!(
+        out.status.success(),
+        "wrap: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.trim().is_empty(),
+        "`--format json` produced no output; exit 0 with an empty document is \
+         the shape that made this bug invisible"
+    );
+
+    // The load-bearing assertion: stdout parses whole. Before the fix it began
+    // with the wrapped program's output and failed here.
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("stdout must be exactly one JSON document, got {e}:\n{stdout}"));
+
+    assert!(
+        json["artifact_id"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("art_")),
+        "artifact_id is what an SDK reads off this call: {json}"
+    );
+    assert!(json["digest"].as_str().is_some(), "{json}");
+    assert_eq!(json["exit_code"], 0, "{json}");
+    assert_eq!(json["succeeded"], true, "{json}");
+
+    // The child's output is moved, not dropped. A caller running --format json
+    // interactively must still see what their command printed.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("NOISE"),
+        "the wrapped command's output must still reach the user on stderr: {stderr}"
+    );
+    // Not `!stdout.contains("NOISE")` -- that fails on the correct output,
+    // because the argv is legitimately in the document as `command`. The real
+    // property is that stdout holds NOTHING but the document: no bare line
+    // before it. Parsing whole (above) proves that; this pins the reason.
+    assert_eq!(
+        json["command"],
+        serde_json::json!(["echo", "NOISE"]),
+        "the argv belongs in the document; the child's stdout does not: {json}"
+    );
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "stdout must begin with the document, not the wrapped program's output: {stdout}"
+    );
+}
+
+/// Human mode is unchanged: the child's output belongs on stdout there.
+#[test]
+fn wrap_human_mode_still_passes_child_stdout_through() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path();
+    let config = root.join(".treeship/config.json");
+    let cfg = config.to_str().unwrap();
+
+    let run = |args: &[&str]| {
+        let mut cmd = Command::new(cli_path());
+        cmd.current_dir(root).env("HOME", root).args(args);
+        cmd.output().expect("run treeship")
+    };
+
+    let init = run(&["init", "--config", cfg, "--name", "wrap-human"]);
+    assert!(init.status.success());
+
+    let out = run(&["wrap", "--config", cfg, "--", "echo", "VISIBLE"]);
+    assert!(
+        out.status.success(),
+        "wrap: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("VISIBLE"),
+        "human mode must keep the child's output on stdout"
+    );
+}


### PR DESCRIPTION
```
$ cd /a/brand/new/dir && treeship init
✗ already initialized at /Users/you/.treeship/config.json
```

**Nothing about that directory was initialized.** `default_config_path` walks up for a project-local config and falls back to `~/.treeship/config.json` when it finds none — so in a new directory the fallback resolves to the global, the guard sees a file there, and init refuses, naming the *home* config as though it were this directory's.

The consequence is quieter than the message: every command run there then uses the home workspace **without saying so**, so receipts from unrelated projects share one store and `--config` becomes the only way to separate them.

## Correcting #321's diagnosis

#321 reported this as *"`init` walks up to an ancestor `.treeship`, so a fresh directory silently joins that workspace."*

**The walk is not the problem.** `walk_up_for_project_config` deliberately skips the global path, with a comment explaining exactly why — it never returns the home config as project-local. The bug is this guard, which conflates *"a config exists somewhere"* with *"this location is initialized."*

Fixing the walk would have broken working behaviour and left the actual bug in place. Worth flagging because the reported cause and the real one point at different files.

## The fix, narrowed

When the target came from the **global fallback** and the caller passed neither `--config` nor `--global`:

```
✗ no Treeship workspace here, and the global one at
  /Users/you/.treeship/config.json is not this directory's.

  Create a project-local workspace:  treeship init --config .treeship/config.json
  Or use the global workspace:       treeship init --global

  Commands run here would otherwise use the global workspace, so receipts
  from unrelated projects share one store.
```

Every other path untouched — verified: `--config` on an existing project still refuses, `--global` still reports the global as initialized, first init still succeeds, isolated HOME still works.

The second test pins the case this was carved out of. A narrowing that silently stopped refusing real re-inits would be worse than the bug.

Clippy clean, full CLI suite green.