### PR TITLE
Release v0.25.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.25.0"
+    "version": "0.25.1"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.25.1 (2026-08-21)
+
+**Upgrade if you use the Python SDK or `treeship wrap --format json`.** Two
+SDK entry points could not work at all — not misconfigured, structurally
+unable to succeed — which is the same shape as the bug that forced 0.25.0.
+
+### Fixed
+
+- **`attest_approval` in the Python SDK could not mint an approval.** It
+  forwarded none of the scoping arguments the CLI requires and passed
+  `expires_in` where the CLI takes `expires_at`, so every call that reached the
+  subprocess was rejected. The scoping arguments (`allowed_actions`,
+  `allowed_actors`, `allowed_subjects`, `max_uses`, `unscoped`) are now
+  forwarded, and an unscoped approval must say so explicitly rather than
+  becoming one by omission. (#331)
+- **`treeship wrap --format json` printed nothing parseable.** It emitted the
+  result through a path that returns early in JSON mode, and interleaved the
+  wrapped command's own stdout into the document, so callers got either an
+  empty string or invalid JSON. The result is now emitted as JSON and the child
+  process's stdout is routed to stderr, leaving stdout a single document. (#332)
+- **`treeship attest --expires 1h` signed a timestamp already in the past.**
+  `--expires` takes an absolute RFC 3339 time; a duration parsed to epoch zero
+  and was signed into the artifact, producing an approval born expired with a
+  valid signature. Durations are now refused with a message naming the expected
+  form. (#328)
+- **`treeship init` told a fresh directory it was "already initialized."** The
+  guard tested the resolved config path, which falls back to the global config,
+  so any directory on a machine with a global Treeship config was reported as
+  already set up. It now distinguishes a local workspace from the global
+  fallback. (#333)
+- **`treeship setup --help` promised a verdict the command does not produce.**
+  It documented promoting cards to `Verified`; the code deliberately sets
+  `Active`. (#330)
+- **`release.sh prepare` could not update the npm lockfiles it exists to
+  update.** `npm install --package-lock-only` resolves against the registry, so
+  it failed on the version being released, which is not published yet — the
+  step added to prevent v0.25.0's out-of-sync lockfiles could never run during
+  a release. Prepare now writes the declared range offline and
+  `release.sh refresh-lockfiles` fills in resolved entries after publish. The
+  sync check also covered only four hardcoded packages; it now discovers all
+  ten, which surfaced three runtime-acceptance lockfiles five releases behind.
+
+### Documentation
+
+- Documentation QA pass across 127 pages, plus eight gates that keep the docs
+  and the CLI from drifting apart: internal links, API routes, verify rows,
+  event types, predicates, command names, flags, and option tables. Four of the
+  fixes above were found by those gates. (#321)
+
 ## 0.25.0 (2026-08-19)
 
 **Upgrade if you use any npm package. `@treeship/core-wasm@0.24.0` cannot be

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "base64",
  "clap",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.0"
+        "@treeship/core-wasm": "0.25.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.0"
+    "@treeship/core-wasm": "0.25.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.25.0",
+        "@treeship/core-wasm": "0.25.1",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.25.0",
+    "@treeship/core-wasm": "0.25.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.25.0",
-    "@treeship/cli-linux-arm64": "0.25.0",
-    "@treeship/cli-darwin-arm64": "0.25.0",
-    "@treeship/cli-darwin-x64": "0.25.0"
+    "@treeship/cli-linux-x64": "0.25.1",
+    "@treeship/cli-linux-arm64": "0.25.1",
+    "@treeship/cli-darwin-arm64": "0.25.1",
+    "@treeship/cli-darwin-x64": "0.25.1"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.25.0", path = "../core" }
+treeship-core = { version = "0.25.1", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.25.0", path = "../core" }
+treeship-core = { version = "0.25.1", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.25.0"
+version = "0.25.1"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.0"
+        "@treeship/core-wasm": "0.25.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.0"
+    "@treeship/core-wasm": "0.25.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.0"
+        "@treeship/core-wasm": "0.25.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.0"
+    "@treeship/core-wasm": "0.25.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/scripts/check-lockfile-sync.py
+++ b/scripts/check-lockfile-sync.py
@@ -24,12 +24,26 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
-PACKAGES = [
-    "packages/verify-js",
-    "packages/sdk-ts",
-    "bridges/mcp",
-    "bridges/a2a",
-]
+# Every directory with both a package.json and a package-lock.json is in
+# scope. An explicit list looks safer and is not: this list originally held
+# only the four packages whose CI jobs broke at v0.25.0, so the three
+# runtime-acceptance lockfiles drifted five releases behind on
+# @treeship/verify with the gate reporting "4 package(s)" and passing.
+#
+# Discovering them means a new package is covered the day it is added rather
+# than the day someone remembers to extend this list.
+SKIP_DIRS = {"node_modules", ".git", "target", "dist", "pkg"}
+
+
+def discover(root: Path):
+    found = []
+    for lock in sorted(root.rglob("package-lock.json")):
+        rel = lock.relative_to(root)
+        if any(part in SKIP_DIRS for part in rel.parts):
+            continue
+        if (lock.parent / "package.json").is_file():
+            found.append(str(rel.parent))
+    return found
 
 
 def declared(pkg: Path) -> dict:
@@ -54,7 +68,7 @@ def locked(pkg: Path) -> dict:
 def main() -> int:
     checked = 0
     bad = []
-    for rel in PACKAGES:
+    for rel in discover(ROOT):
         pkg = ROOT / rel
         if not (pkg / "package.json").is_file() or not (pkg / "package-lock.json").is_file():
             continue

--- a/scripts/lockfile-pin.py
+++ b/scripts/lockfile-pin.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Update a lockfile's declared dependency range without touching the network.
+
+`npm install --package-lock-only` still resolves against the registry. At
+`release.sh prepare` time the version being released does not exist yet, so
+that command cannot succeed -- it fails ETARGET on the very pin it is meant
+to write:
+
+    npm error notarget No matching version found for @treeship/core-wasm@0.25.1
+
+which is how the 0.25.1 prepare died. The lockfile step added after v0.25.0
+shipped out-of-sync lockfiles was itself unrunnable during a release, so the
+bug it existed to prevent was still one forgotten manual step away.
+
+This writes the one field `npm ci` compares against package.json:
+
+    packages[""].dependencies[<name>]
+
+The resolved entry (`packages["node_modules/<name>"]`) keeps its old version,
+`resolved` and `integrity`. That is deliberate. Those three describe a tarball
+that has been fetched and hashed; the new one does not exist yet, so there is
+no honest value to write. Inventing one, or copying the previous release's
+hash forward, would put a wrong integrity hash in a lockfile -- the failure
+this repo cares about most.
+
+npm handles the resulting state correctly: the sync check passes (no EUSAGE),
+and because the resolved entry no longer satisfies the declared range npm
+re-resolves from the registry rather than silently installing the stale
+version. Before publish that is a loud ETARGET; after publish it fetches the
+right tarball. `release.sh refresh-lockfiles` then rewrites the resolved
+entries for real, with hashes of tarballs that exist.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv):
+    if len(argv) != 3:
+        print("usage: lockfile-pin.py <package-dir> <version>", file=sys.stderr)
+        return 2
+    pkg_dir, version = Path(argv[1]), argv[2]
+    lock_path = pkg_dir / "package-lock.json"
+    if not lock_path.is_file():
+        print(f"  err   {lock_path} does not exist", file=sys.stderr)
+        return 1
+
+    with open(lock_path, encoding="utf-8") as f:
+        text = f.read()
+    lock = json.loads(text)
+
+    root = lock.get("packages", {}).get("")
+    if root is None:
+        print(f"  err   {lock_path} has no root package entry", file=sys.stderr)
+        return 1
+
+    # Every workspace-internal package releases at one version -- that is what
+    # check-release-versions.py enforces across its 43 sites. So the pin to
+    # rewrite is any @treeship/* dep, not one hardcoded name. Hardcoding
+    # @treeship/core-wasm is how three runtime-acceptance lockfiles sat five
+    # releases behind on @treeship/verify without anything noticing.
+    moved = []
+    for section in ("dependencies", "peerDependencies"):
+        deps = root.get(section)
+        if not isinstance(deps, dict):
+            continue
+        for name in deps:
+            if name.startswith("@treeship/") and deps[name] != version:
+                moved.append(f"{name} {deps[name]} -> {version}")
+                deps[name] = version
+
+    if not moved:
+        return 0
+
+    # Match npm's own formatting so the diff is one line, not the whole file.
+    indent = 2
+    trailing = "\n" if text.endswith("\n") else ""
+    with open(lock_path, "w", encoding="utf-8") as f:
+        json.dump(lock, f, indent=indent)
+        f.write(trailing)
+    for m in moved:
+        print(f"  ✓ {pkg_dir}/package-lock.json: {m} (declared range only)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,13 +66,25 @@ cmd_prepare() {
   # shipped that way and blocked four PRs until it was noticed. `--package-lock-only`
   # updates the lockfile without touching node_modules or the network beyond
   # metadata.
+  # `--package-lock-only` still resolves against the registry, so during a
+  # prepare it fails ETARGET on the version being released -- it does not
+  # exist yet. Fall back to writing the one field `npm ci` compares against
+  # package.json. See scripts/lockfile-pin.py for why the resolved entry and
+  # its integrity hash are deliberately left alone until after publish.
   echo "Updating npm lockfiles..."
-  for pkg in packages/verify-js packages/sdk-ts bridges/mcp bridges/a2a; do
+  for pkg in packages/verify-js packages/sdk-ts bridges/mcp bridges/a2a \
+           tests/runtime-acceptance/aws-lambda \
+           tests/runtime-acceptance/cloudflare-worker \
+           tests/runtime-acceptance/vercel-edge; do
     if [ -f "$pkg/package-lock.json" ]; then
-      ( cd "$pkg" && npm install --package-lock-only --no-audit --no-fund --silent ) \
-        || { echo "lockfile update failed in $pkg" >&2; exit 1; }
+      if ! ( cd "$pkg" && npm install --package-lock-only --no-audit --no-fund --silent 2>/dev/null ); then
+        python3 "$(dirname "$0")/lockfile-pin.py" "$pkg" "$VERSION" \
+          || { echo "lockfile update failed in $pkg" >&2; exit 1; }
+      fi
     fi
   done
+  echo "  note: resolved entries are refreshed by 'release.sh refresh-lockfiles'"
+  echo "        once @treeship/core-wasm@$VERSION is on the registry."
 
   echo
   echo "Running release version preflight..."
@@ -191,6 +203,38 @@ EOF
   echo "  git push origin v${VERSION}"
 }
 
+# ---------- refresh-lockfiles ----------------------------------------------
+
+# The other half of the prepare-time lockfile fallback. Prepare can only write
+# the declared range, because at that point the version has no tarball and so
+# no honest integrity hash. Once it is published there is one, and the
+# lockfiles should carry it -- a lockfile whose resolved entry points at the
+# previous release is not locking anything.
+cmd_refresh_lockfiles() {
+  local failed=0
+  for pkg in packages/verify-js packages/sdk-ts bridges/mcp bridges/a2a \
+           tests/runtime-acceptance/aws-lambda \
+           tests/runtime-acceptance/cloudflare-worker \
+           tests/runtime-acceptance/vercel-edge; do
+    [ -f "$pkg/package-lock.json" ] || continue
+    if ( cd "$pkg" && npm install --package-lock-only --no-audit --no-fund --silent ); then
+      echo "  ✓ $pkg"
+    else
+      echo "  err   $pkg: still unresolvable -- is the version published yet?" >&2
+      failed=1
+    fi
+  done
+  [ "$failed" -eq 0 ] || exit 1
+  echo
+  if git diff --quiet -- '*package-lock.json'; then
+    echo "Lockfiles already current; nothing to commit."
+  else
+    git --no-pager diff --stat -- '*package-lock.json'
+    echo
+    echo "Review the diff, then commit these lockfiles."
+  fi
+}
+
 # ---------- usage / dispatch -----------------------------------------------
 
 usage() {
@@ -204,6 +248,10 @@ Treeship release script.
       Create the annotated tag. Required after the prepare PR has merged
       and you have explicit approval to release.
 
+  scripts/release.sh refresh-lockfiles
+      Rewrite npm lockfile resolved entries + integrity hashes. Run after
+      the release is published; prepare can only write the declared range.
+
 The default invocation (no subcommand) intentionally errors out so a stray
 \`scripts/release.sh 0.9.7\` cannot retain its old "do everything" semantics.
 
@@ -216,6 +264,7 @@ EOF
 case "${1:-}" in
   prepare) shift; cmd_prepare "$@" ;;
   tag)     shift; cmd_tag "$@" ;;
+  refresh-lockfiles) shift; cmd_refresh_lockfiles "$@" ;;
   ""|-h|--help|help) usage; exit 0 ;;
   *)
     cat >&2 <<EOF

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -8,7 +8,7 @@
       "name": "treeship-aws-lambda-acceptance",
       "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.25.0"
+        "@treeship/verify": "0.25.1"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.20.0"
+        "@treeship/verify": "0.25.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.25.0"
+    "@treeship/verify": "0.25.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -8,7 +8,7 @@
       "name": "treeship-cloudflare-worker-acceptance",
       "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.25.0"
+        "@treeship/verify": "0.25.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.20.0"
+        "@treeship/verify": "0.25.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.0"
+    "@treeship/verify": "0.25.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -8,7 +8,7 @@
       "name": "treeship-vercel-edge-acceptance",
       "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.25.0"
+        "@treeship/verify": "0.25.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "dependencies": {
-        "@treeship/verify": "0.20.0"
+        "@treeship/verify": "0.25.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.0"
+    "@treeship/verify": "0.25.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Patch release. Two SDK entry points in 0.25.0 could not work at all — not
misconfigured, structurally unable to succeed. That is the same shape as the
`@treeship/core-wasm` load failure that forced 0.25.0, and the same argument
for not waiting.

## What's in it

Five fixes, already on main:

| PR | Fix |
|----|-----|
| #331 | `attest_approval` (Python SDK) forwarded no scoping args and passed `expires_in` where the CLI takes `expires_at` — every call was rejected |
| #332 | `wrap --format json` emitted through a path that returns early in JSON mode, and interleaved the child's stdout into the document |
| #328 | `attest --expires 1h` parsed a duration to epoch zero and signed it — an approval born expired, with a valid signature |
| #333 | `init` reported a fresh directory as "already initialized" whenever a global config existed |
| #330 | `setup --help` documented promoting to `Verified`; the code sets `Active` |

Plus #321: a docs QA pass over 127 pages and eight drift gates. Four of the
five fixes above came out of those gates.

## Not in it

#324 (Reason authorization) is reviewed and sound, but it adds a new signing
surface. A patch release is the wrong vehicle for that — it lands in 0.26.0.

## The release-tooling commit

`release.sh prepare` died partway through this release. The lockfile step
added after v0.25.0 shipped four out-of-sync lockfiles could never have run
during a release: `npm install --package-lock-only` still resolves against the
registry, so it fails on the version being released, which does not exist yet.

Prepare now writes the one field `npm ci` compares against package.json. The
resolved entry keeps its old `version`/`resolved`/`integrity` — those describe
a fetched, hashed tarball and the new one has none, so there is no honest value
to write; copying the previous release's hash forward would put a wrong
integrity hash in a lockfile. Verified npm handles the in-between state
correctly: the sync check passes and npm re-resolves rather than silently
installing the stale version (ETARGET, not EUSAGE).

**After publish, run `scripts/release.sh refresh-lockfiles`** to rewrite the
resolved entries against the real tarballs, and commit the result.

Two scope bugs surfaced while fixing it:

- the fallback keyed on a hardcoded `@treeship/core-wasm`, but workspace
  packages release in lockstep, so any `@treeship/*` pin needs rewriting;
- `check-lockfile-sync.py` listed only the four packages whose jobs broke at
  v0.25.0. It reported "4 package(s)" and passed while three
  runtime-acceptance lockfiles sat five releases behind on `@treeship/verify`.
  It now discovers every package.json/lockfile pair — ten, not four.

The two commits are separately consistent; the tooling commit pins to 0.25.0
so it passes its own widened gate, and the release commit bumps everything.

## Follow-up, not fixed here

`tests/runtime-acceptance/{aws-lambda,cloudflare-worker,vercel-edge}` are
referenced by no workflow. That is why nothing noticed their lockfiles rotting
for five releases. Wiring them up is out of scope for a patch release.

## Verification

- `release.sh prepare 0.25.1` runs clean end to end: 43/43 version sites, all
  seven lockfiles updated
- `check-lockfile-sync.py` ✓ 10 packages · `check-release-versions.py
  --consistency` ✓ 43/43 · `check-conflict-markers.py` ✓ 766 files
- both commits verified in isolated worktrees

Do not tag until CI is green and you've approved the release.