### PR TITLE
fix(ci): main is unbuildable for JS, and the check for it reports green

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
-      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
-      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
-      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.0.tgz",
-      "integrity": "sha512-QMYBdUZ4wzHgao7pcu4gzYFT8RlWh8ACZjJ1oZfSog4MbTjwMt3KG6KIkbPJeWnVm9B+CzoUU4D7vGa1Fu4S3A==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/scripts/check-lockfile-sync.py
+++ b/scripts/check-lockfile-sync.py
@@ -16,9 +16,22 @@ with each PR rather than with main.
 Checked here rather than left to `npm ci` because the CI error names the
 symptom and not the cause: a reader sees "your lockfile is out of date" on a
 PR that never touched a lockfile.
+
+Two fields have to agree, not one. `npm ci` compares package.json against
+BOTH the declared range in packages[""] and the version of the installed
+entry in packages["node_modules/<name>"]:
+
+    npm error Invalid: lock file's @treeship/core-wasm@0.25.0
+              does not satisfy @treeship/core-wasm@0.25.1
+
+v0.25.1 checked only the first and passed on a tree where `npm ci` failed in
+every JS package on main -- the same outage as v0.25.0, reported green by the
+check written to prevent it. A gate that verifies a strict subset of what the
+real tool verifies will eventually pass something the real tool rejects.
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -56,12 +69,34 @@ def declared(pkg: Path) -> dict:
 
 
 def locked(pkg: Path) -> dict:
+    """The declared ranges recorded in the lockfile's root entry."""
     with open(pkg / "package-lock.json", encoding="utf-8") as f:
         d = json.load(f)
     root = d.get("packages", {}).get("", {})
     out = {}
     for key in ("dependencies", "peerDependencies"):
         out.update(root.get(key, {}))
+    return out
+
+
+def installed(pkg: Path) -> dict:
+    """The concrete version of each entry the lockfile would install.
+
+    This is the half `npm ci` rejects on and the half the check used to miss.
+    """
+    with open(pkg / "package-lock.json", encoding="utf-8") as f:
+        d = json.load(f)
+    out = {}
+    for path, entry in d.get("packages", {}).items():
+        if not path.startswith("node_modules/"):
+            continue
+        name = path[len("node_modules/") :]
+        # Nested paths (a/node_modules/b) describe a dependency's own tree,
+        # not this package's top-level resolution.
+        if "/node_modules/" in path:
+            continue
+        if "version" in entry:
+            out[name] = entry["version"]
     return out
 
 
@@ -73,11 +108,19 @@ def main() -> int:
         if not (pkg / "package.json").is_file() or not (pkg / "package-lock.json").is_file():
             continue
         checked += 1
-        dec, lck = declared(pkg), locked(pkg)
+        dec, lck, inst = declared(pkg), locked(pkg), installed(pkg)
         for name, want in dec.items():
             got = lck.get(name)
             if got != want:
-                bad.append((rel, name, want, got))
+                bad.append((rel, name, want, got, "declared range in the lockfile"))
+                continue
+            # Exact pins only. A range like ^1.2.0 is legitimately satisfied by
+            # many versions, and deciding which needs a semver implementation;
+            # every @treeship/* pin is exact, which is the case that broke.
+            if re.fullmatch(r"\d+\.\d+\.\d+", want):
+                res = inst.get(name)
+                if res is not None and res != want:
+                    bad.append((rel, name, want, res, "installed entry"))
 
     if not checked:
         # A check that examined nothing passes vacuously and reads as a pass.
@@ -85,8 +128,8 @@ def main() -> int:
         return 1
 
     if bad:
-        for rel, name, want, got in bad:
-            print(f"  err   {rel}: {name} is {want!r} in package.json but {got!r} in the lockfile")
+        for rel, name, want, got, where in bad:
+            print(f"  err   {rel}: {name} is {want!r} in package.json but {got!r} in the {where}")
         print()
         print(
             f"{len(bad)} mismatch(es). `npm ci` will refuse on every PR until the "

--- a/scripts/lockfile-pin.py
+++ b/scripts/lockfile-pin.py
@@ -23,12 +23,26 @@ no honest value to write. Inventing one, or copying the previous release's
 hash forward, would put a wrong integrity hash in a lockfile -- the failure
 this repo cares about most.
 
-npm handles the resulting state correctly: the sync check passes (no EUSAGE),
-and because the resolved entry no longer satisfies the declared range npm
-re-resolves from the registry rather than silently installing the stale
-version. Before publish that is a loud ETARGET; after publish it fetches the
-right tarball. `release.sh refresh-lockfiles` then rewrites the resolved
-entries for real, with hashes of tarballs that exist.
+The resulting lockfile is deliberately incomplete, and `npm ci` rejects it:
+
+    npm error Invalid: lock file's @treeship/core-wasm@0.25.0
+              does not satisfy @treeship/core-wasm@0.25.1
+
+That is not a side effect to tolerate -- it is the point. The alternative is
+a lockfile that claims to pin a version while resolving to a different one,
+which installs the wrong bytes quietly. Refusing loudly is correct.
+
+But it means the tree between `prepare` and publish does not build for JS,
+so `release.sh refresh-lockfiles` is a required step of the release and not
+a cleanup task. Run it as soon as the packages are on the registry; it
+rewrites the resolved entries with real hashes of tarballs that exist.
+
+(An earlier version of this comment claimed npm accepted the intermediate
+state, on the strength of a pre-publish test that returned ETARGET. The
+ETARGET came from registry resolution and masked the EUSAGE underneath;
+once the version was published, the EUSAGE surfaced and broke `npm ci` in
+every JS package on main. Testing the failure path proved nothing about the
+success path.)
 """
 
 import json

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,8 +83,13 @@ cmd_prepare() {
       fi
     fi
   done
-  echo "  note: resolved entries are refreshed by 'release.sh refresh-lockfiles'"
-  echo "        once @treeship/core-wasm@$VERSION is on the registry."
+  echo
+  echo "  IMPORTANT: these lockfiles are now incomplete on purpose -- the resolved"
+  echo "  entries still name the previous version, because $VERSION has no tarball"
+  echo "  to hash yet. 'npm ci' will refuse until you run, after publish:"
+  echo "        scripts/release.sh refresh-lockfiles"
+  echo "  That is a required release step, not cleanup. Skipping it leaves main"
+  echo "  unbuildable for JS."
 
   echo
   echo "Running release version preflight..."

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.20.0.tgz",
-      "integrity": "sha512-P+L8VUej/28ofa2OnfSmQ+4uVaAeEdGoLN1YLgUH5Zw8Ot+2c1ZNJ5i8Qv2GR2IlWmHdK4i1rrn2IPU64C6R3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.20.0.tgz",
-      "integrity": "sha512-hzNCwyeqSjWuBnGApItH6Jqce57TJMWqQDXXFZK2VHdGoDxvww/nCTT13XDFoF4/zmPv9Yeua7k5IPIjBcFChw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
+      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.20.0"
+        "@treeship/core-wasm": "0.25.1"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.20.0.tgz",
-      "integrity": "sha512-P+L8VUej/28ofa2OnfSmQ+4uVaAeEdGoLN1YLgUH5Zw8Ot+2c1ZNJ5i8Qv2GR2IlWmHdK4i1rrn2IPU64C6R3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.20.0.tgz",
-      "integrity": "sha512-hzNCwyeqSjWuBnGApItH6Jqce57TJMWqQDXXFZK2VHdGoDxvww/nCTT13XDFoF4/zmPv9Yeua7k5IPIjBcFChw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
+      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.20.0"
+        "@treeship/core-wasm": "0.25.1"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.20.0.tgz",
-      "integrity": "sha512-P+L8VUej/28ofa2OnfSmQ+4uVaAeEdGoLN1YLgUH5Zw8Ot+2c1ZNJ5i8Qv2GR2IlWmHdK4i1rrn2IPU64C6R3w==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
+      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.20.0.tgz",
-      "integrity": "sha512-hzNCwyeqSjWuBnGApItH6Jqce57TJMWqQDXXFZK2VHdGoDxvww/nCTT13XDFoF4/zmPv9Yeua7k5IPIjBcFChw==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
+      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.20.0"
+        "@treeship/core-wasm": "0.25.1"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
## Main is broken right now

Every JS job on main fails:

```
npm error Invalid: lock file's @treeship/core-wasm@0.25.0
          does not satisfy @treeship/core-wasm@0.25.1
```

This is the **v0.25.0 outage again, reintroduced by the commit that fixed it**
(#334). It's blocking #335 and will block every PR until this lands.

## What happened

v0.25.1's `prepare` wrote the declared range into each lockfile and left the
resolved entry on the old version — correct at the time, since 0.25.1 had no
tarball to hash yet. The step that fills those in, `refresh-lockfiles`, was
documented as a post-publish task and then not run.

## Two things were wrong, and only one is the lockfiles

**The check was verifying a subset of what npm verifies.**
`check-lockfile-sync.py` compared package.json against the declared range in
`packages[""]` and stopped. `npm ci` compares against that **and** the version
of the installed entry in `packages["node_modules/<name>"]`. So it passed on a
tree where `npm ci` failed in all four JS packages — a green report on the
exact outage it exists to prevent.

Now it checks the installed entry too, for exact pins only (a caret range is
legitimately satisfied by many versions; every `@treeship/*` pin is exact, and
that's the case that broke).

| | old gate | new gate |
|---|---|---|
| broken main | ✅ "agree in 10 package(s)" | ❌ 7 mismatches |
| fixed tree | ✅ | ✅ |

**The claim in the comment was false.** `lockfile-pin.py` asserted npm accepted
the intermediate state — *"the sync check passes (no EUSAGE)"*. I based that on
a pre-publish test that returned ETARGET. The ETARGET came from registry
resolution and **masked the EUSAGE behind it**; when 0.25.1 was published the
mask came off. Testing the failure path proved nothing about the success path,
and the wrong conclusion got written down as documentation that the next
person would trust.

The comment now says what's true: the intermediate lockfile is incomplete on
purpose, npm rejects it on purpose, and `refresh-lockfiles` is a **required
release step**, not cleanup. `prepare` now prints that at the point where it
creates the state, rather than a mild "note:".

## Verification

- lockfiles regenerated with real resolved entries + integrity hashes
- `npm ci` verified working: `packages/verify-js` (55 packages), `bridges/mcp` (146)
- new gate verified to fail on broken main and pass here — a gate that passes
  on both would be worth nothing

## Merge order

This first, then #335 (its JS failures are this bug, not its own).