### PR TITLE
fix(keys): keystore recovery advice named the wrong keystore, and over-promised

### DIFF
--- a/packages/core/src/keys/mod.rs
+++ b/packages/core/src/keys/mod.rs
@@ -801,11 +801,52 @@ impl Store {
              corrupted."
         };
 
-        // Resolve the user's ~/.treeship path for the recovery command, so
-        // we give a copy-pasteable command rather than a generic instruction.
-        let ts_dir = std::env::var("HOME")
-            .map(|h| format!("{h}/.treeship"))
-            .unwrap_or_else(|_| "~/.treeship".into());
+        // Name the keystore that actually failed, not the default one.
+        //
+        // This used to read $HOME/.treeship unconditionally, which is the
+        // store root only in the default layout. `self.dir` is the keys
+        // directory (KeyStore::open is always called with cfg.keys_dir), so
+        // under `--config`, or any custom keys_dir, the old message told the
+        // user to move a keystore that was working and leave the broken one
+        // in place: advice that damages a good store and fixes nothing.
+        //
+        // `mv` on a store directory is exactly the operation that has
+        // scrambled state here before -- see resolve_dirs in the CLI's
+        // config.rs, where one machine reached six .bak directories and
+        // three ship identities. Aiming it at the wrong directory is not a
+        // cosmetic flaw in the message; it is the message handing over a
+        // footgun pointed somewhere else.
+        let keys_dir = self.dir.display().to_string();
+
+        // A non-default store needs --config on the way back in, or
+        // `treeship init` re-creates the *default* store and the user is
+        // still broken, now with an extra keystore.
+        //
+        // --force is required rather than optional: moving the keys aside
+        // leaves config.json behind, and plain `init` then refuses with
+        // "already initialized" while `attest` says "no default key -- run
+        // treeship init". Verified: without --force the two commands send
+        // the user in a circle.
+        // Compare canonicalized paths, not strings: on macOS $HOME and the
+        // resolved store path can differ by the /tmp -> /private/tmp symlink,
+        // and a string compare then reports a default store as custom. The
+        // custom branch is still correct when that happens (it just names a
+        // --config that was already implied), so this only sharpens the
+        // message; it cannot make it wrong.
+        let canon = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        let default_keys = std::env::var("HOME")
+            .ok()
+            .map(|h| canon(&PathBuf::from(h).join(".treeship").join("keys")));
+        let init_cmd = if default_keys.as_deref() == Some(canon(&self.dir).as_path()) {
+            "treeship init --force".to_string()
+        } else {
+            let root = self
+                .dir
+                .parent()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| keys_dir.clone());
+            format!("treeship --config {root}/config.json init --force")
+        };
 
         // The outer KeyError::Crypto Display impl already prepends
         // "keys crypto: "; don't double it. Start with the raw MAC error
@@ -814,11 +855,15 @@ impl Store {
         let msg = format!(
             "{raw}\n\n  \
              Diagnosis: {diagnosis}\n\n  \
-             Recovery (nondestructive -- the old keystore is moved aside, \
-             not deleted; any sealed .treeship packages you produced remain \
-             verifiable since their receipts embed the old public key):\n\n    \
-             mv {ts_dir} {ts_dir}.bak.$(date +%s)\n    \
-             treeship init\n"
+             Recovery (reversible -- the old keystore is moved aside, not \
+             deleted, and moving it back restores the previous state):\n\n    \
+             mv {keys_dir} {keys_dir}.bak.$(date +%s)\n    \
+             {init_cmd}\n\n  \
+             After this you sign under a new key. Receipts already signed by \
+             the old key verify as `unknown key` until that keystore is \
+             restored, so keep the .bak directory. Sealed .treeship packages \
+             are unaffected -- they embed the public key they were signed \
+             with.\n"
         );
 
         KeyError::Crypto(msg)

--- a/tests/adversarial/verify_probes.py
+++ b/tests/adversarial/verify_probes.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Adversarial probe of the Treeship CLI's trust surface.
+
+Usage: verify_probes.py <path-to-treeship> <workspace-dir>
+  where <workspace-dir> holds a config.json created by
+  `treeship --config <dir>/config.json init`.
+
+Written from the hostile reviewer's stance: do NOT check that good input
+passes -- check that bad input fails, loudly, on both channels a caller can
+read (stdout document, exit code).
+
+The failure classes probed here are the silent ones. A loud bug (unparseable
+output) announces itself; a silent one (Ok for the wrong reason) is what a
+trust tool cannot afford. Each probe states what a PASS means so a green run
+cannot be mistaken for "we ran something".
+"""
+import base64, json, os, shutil, subprocess, sys, tempfile
+
+def b64d(x):
+    # DSSE payloads here are stored without '=' padding.
+    return base64.b64decode(x + "=" * (-len(x) % 4))
+
+BIN = sys.argv[1]
+WS = sys.argv[2]
+results = []
+
+def run(args, env=None):
+    # Do NOT override HOME: it feeds the machine-key derivation, and changing
+    # it makes the keystore undecryptable in a way that looks like a tool bug.
+    e = dict(os.environ)
+    if env: e.update(env)
+    p = subprocess.run([BIN, "--config", os.path.join(WS, "config.json")] + args,
+                       capture_output=True, text=True, env=e, cwd=WS)
+    return p.returncode, p.stdout, p.stderr
+
+def record(name, ok, detail=""):
+    results.append((ok, name, detail))
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  -- {detail}" if detail else ""))
+
+def art_path(aid):
+    # Store root is the parent of the --config file, not HOME/.treeship.
+    return os.path.join(WS, "artifacts", f"{aid}.json")
+
+def load(aid):
+    with open(art_path(aid)) as f: return json.load(f)
+
+def save(aid, d):
+    with open(art_path(aid), "w") as f: json.dump(d, f)
+
+def mutate(aid, fn):
+    """Apply fn to the decoded inner payload, re-encode, return restore()."""
+    orig = open(art_path(aid)).read()
+    d = json.loads(orig)
+    inner = json.loads(b64d(d["envelope"]["payload"]))
+    fn(inner, d)
+    d["envelope"]["payload"] = base64.b64encode(json.dumps(inner).encode()).decode()
+    save(aid, d)
+    return lambda: open(art_path(aid), "w").write(orig)
+
+def verify_json(aid):
+    rc, out, err = run(["verify", aid, "--format", "json"])
+    try: doc = json.loads(out)
+    except Exception: doc = None
+    return rc, doc, out, err
+
+# ---------------------------------------------------------------- mint
+rc, out, _ = run(["attest", "action", "--actor", "agent:probe",
+                  "--action", "probe.baseline", "--format", "json"])
+AID = json.loads(out)["id"]
+print(f"\nbaseline artifact: {AID}\n")
+
+# 1. baseline sanity -- if this fails every later probe is meaningless
+rc, doc, out, _ = verify_json(AID)
+record("baseline verifies and exits 0",
+       rc == 0 and doc and doc.get("outcome") == "pass",
+       f"rc={rc} outcome={doc.get('outcome') if doc else None}")
+
+# 2. stdout carries exactly one JSON document, no leading/trailing noise
+record("verify --format json stdout is exactly one document",
+       out.strip().startswith("{") and out.strip().endswith("}")
+       and out.count("\n{") == 0,
+       f"{len(out)} bytes")
+
+# 3-6. tamper each signed field -> must fail AND exit nonzero
+for field, val in [("actor", "agent:ATTACKER"), ("action", "probe.ESCALATED"),
+                   ("timestamp", "2099-01-01T00:00:00Z"), ("type", "treeship/action/v99")]:
+    restore = mutate(AID, lambda i, d, f=field, v=val: i.__setitem__(f, v))
+    rc, doc, _, _ = verify_json(AID)
+    record(f"tampered {field!r} is rejected",
+           rc != 0 and doc and doc.get("outcome") != "pass",
+           f"rc={rc} outcome={doc.get('outcome') if doc else 'UNPARSEABLE'}")
+    restore()
+
+# 7. strip signatures entirely -> must NOT pass vacuously ("0 checks, all green")
+orig = open(art_path(AID)).read()
+d = json.loads(orig); d["envelope"]["signatures"] = []
+save(AID, d)
+rc, doc, _, _ = verify_json(AID)
+record("empty signature array does not pass vacuously",
+       rc != 0 and doc and doc.get("outcome") != "pass",
+       f"rc={rc} outcome={doc.get('outcome') if doc else 'UNPARSEABLE'} passed={doc.get('passed') if doc else '?'}")
+open(art_path(AID), "w").write(orig)
+
+# 8. flip a single byte of the signature -> must fail
+restore_raw = open(art_path(AID)).read()
+d = json.loads(restore_raw)
+sig = d["envelope"]["signatures"][0]["sig"]
+flipped = ("A" if sig[0] != "A" else "B") + sig[1:]
+d["envelope"]["signatures"][0]["sig"] = flipped
+save(AID, d)
+rc, doc, _, _ = verify_json(AID)
+record("corrupted signature is rejected",
+       rc != 0 and doc and doc.get("outcome") != "pass",
+       f"rc={rc} outcome={doc.get('outcome') if doc else 'UNPARSEABLE'}")
+open(art_path(AID), "w").write(restore_raw)
+
+# 9. truncated JSON -> must error, never pass
+open(art_path(AID), "w").write(restore_raw[: len(restore_raw) // 2])
+rc, doc, _, _ = verify_json(AID)
+record("truncated artifact is rejected",
+       rc != 0 and (doc is None or doc.get("outcome") != "pass"), f"rc={rc}")
+open(art_path(AID), "w").write(restore_raw)
+
+# 10. empty file -> must error, never pass
+open(art_path(AID), "w").write("")
+rc, doc, _, _ = verify_json(AID)
+record("empty artifact file is rejected",
+       rc != 0 and (doc is None or doc.get("outcome") != "pass"), f"rc={rc}")
+open(art_path(AID), "w").write(restore_raw)
+
+# 11. nonexistent artifact -> must error, never pass
+rc, doc, _, _ = verify_json("art_deadbeefdeadbeef")
+record("nonexistent artifact is rejected",
+       rc != 0 and (doc is None or doc.get("outcome") != "pass"), f"rc={rc}")
+
+# 12. restored artifact still verifies -- proves the probes were reversible
+#     and that a PASS above was not just "everything fails now"
+rc, doc, _, _ = verify_json(AID)
+record("baseline still verifies after all probes",
+       rc == 0 and doc and doc.get("outcome") == "pass", f"rc={rc}")
+
+print()
+bad = [r for r in results if not r[0]]
+print(f"{len(results) - len(bad)}/{len(results)} probes passed")
+sys.exit(1 if bad else 0)


### PR DESCRIPTION
Found by probing the CLI the way FarukGroqAgent would — not *"does good input
pass"* but *"does bad input fail, loudly, on every channel a caller reads"*.

## The verification core came through clean

12/12 probes against a 0.25.1 build:

| probe | result |
|---|---|
| tamper `actor` / `action` / `timestamp` / `type` in the signed payload | rejected, exit 1 |
| empty signature array | **does not pass vacuously** — fail, exit 1 |
| single flipped signature byte | rejected, exit 1 |
| truncated artifact / empty file / nonexistent id | rejected, exit 1 |
| corrupted `enc_priv_key` | fails closed, exit 3, **no silent key regeneration** |
| `verify --format json` stdout | exactly one document |
| baseline after all probes | still verifies |

Also worth stating for the record: `verify` never spawns a subprocess, so the
`wrap` stdout-collision class is structurally absent from the verification
path rather than merely fixed there.

## The error path did not

**1. It named the wrong keystore.** The path came from `$HOME/.treeship`,
which is the store root only in the default layout. `self.dir` is the *keys*
directory (`KeyStore::open` is always called with `cfg.keys_dir`), so under
`--config` a user whose isolated keystore failed was told to `mv` their
**global** one — moving a working store, leaving the broken one, fixing
nothing.

That's not a neutral suggestion. `resolve_dirs` in `config.rs` documents a
machine that reached *"six .bak directories and three ship identities"* doing
exactly this. Pointing it at the wrong directory is the message handing over
a footgun aimed somewhere else.

**2. The command didn't work even with the right path.** Moving the keys
aside leaves `config.json`, so plain `init` refuses with "already
initialized" while `attest` says "no default key — run treeship init". A
circle. Now `init --force`, plus `--config` for non-default stores.

**3. The reassurance was false for the artifacts people have.** The old text
promised sealed packages "remain verifiable since their receipts embed the
old public key" — true, and beside the point. Local receipts reference the
key by id and resolve it through the keystore, so after recovery they verify
as `unknown key: key_...`. Confirmed by mint → corrupt → recover → re-verify.

`nondestructive` → `reversible`, which is the claim that survives testing:

```
after recovery:                fail
after restoring old keystore:  pass
```

## Verification

Every command in the new message was **executed verbatim** against both
layouts, and both recover:

```
default:  mv $HOME/.treeship/keys ...bak.$(date +%s)
          treeship init --force
custom:   mv /tmp/final2/keys ...bak.$(date +%s)
          treeship --config /tmp/final2/config.json init --force
```

Path comparison is canonicalized so the `/tmp` → `/private/tmp` symlink can't
misclassify a default store; the fallback branch is the always-correct one.

558 core tests pass. `tests/adversarial/verify_probes.py` is committed so
these classes stay covered.