### PR TITLE
docs(release): npm bootstrap is two steps, and the docs only named one

### DIFF
--- a/.github/scripts/npm-publish-if-needed.sh
+++ b/.github/scripts/npm-publish-if-needed.sh
@@ -5,13 +5,30 @@
 #
 # Usage: npm-publish-if-needed.sh <pkg_name> <version>
 #
-# Why: a scope-new package (e.g. @treeship/core-wasm in the 0.9.x window)
-# must be bootstrapped once with `npm publish --access public --auth-type=web`
-# before the OIDC trusted publisher in CI can take over. If the manual
-# bootstrap lands at the same version the workflow is about to publish,
-# the workflow's own `npm publish` would fail with "You cannot publish
-# over the previously published versions" and unwind the release. This
-# helper treats "exact version already live" as a pass.
+# Why: a scope-new package must be bootstrapped once with
+# `npm publish --access public --auth-type=web` before the OIDC trusted
+# publisher in CI can take over. If the manual bootstrap lands at the same
+# version the workflow is about to publish, the workflow's own `npm publish`
+# would fail with "You cannot publish over the previously published
+# versions" and unwind the release. This helper treats "exact version
+# already live" as a pass.
+#
+# Note what that skip does NOT prove. Bootstrapping is two steps -- publish
+# once by hand, THEN configure the trusted publisher on npmjs.com -- and this
+# helper cannot tell them apart. If only the first was done, the package is
+# live, this helper skips it, and the release goes green having never
+# exercised CI's permission to write it.
+#
+# That is the v0.25.0/v0.25.1 sequence exactly. @treeship/cli-linux-arm64 was
+# new in 0.25.0; attempt 1 of the release 404'd on it; it was bootstrapped by
+# hand; attempt 2 reached this helper, saw it live, skipped, and went green.
+# The trusted publisher was never configured, and nothing said so until
+# v0.25.1 tried to publish a version that was not already there -- six
+# packages into the job, leaving a partial release across three registries.
+#
+# The preflight in release.yml now checks provenance for exactly this reason:
+# a green release that skipped a package is not evidence the package is
+# publishable.
 
 set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,7 +343,9 @@ jobs:
           FAIL=0
           if [ ${#MISSING[@]} -gt 0 ]; then
             echo "::error::${#MISSING[@]} package(s) missing: ${MISSING[*]}"
-            echo "::error::Bootstrap each with: npm publish --access public --auth-type=web"
+            echo "::error::Bootstrap is TWO steps, both required:"
+            echo "::error::  1. npm publish --access public --auth-type=web"
+            echo "::error::  2. configure the trusted publisher on npmjs.com (see below)"
             FAIL=1
           fi
           if [ ${#UNTRUSTED[@]} -gt 0 ]; then


### PR DESCRIPTION
## Why this exists

"I thought we already set this up" — you did, and you followed the repo's
instructions exactly. They were incomplete.

The v0.25.0 run history:

```
00:54:22  v0.25.0 attempt 1 starts
          publish-npm FAILS — 404 on @treeship/cli-linux-arm64
          (new in 0.25.0, for the linux-arm64 build)
01:06:30  package created on npm by hand  ← the documented bootstrap
01:12:03  attempt 2 → npm-publish-if-needed.sh:
          "✓ @treeship/cli-linux-arm64@0.25.0 already live; skipping"
          job goes green ✅
```

The instruction in this repo said: publish once by hand, and *"once the
package name exists on the registry at any version, this check passes and
future automated publishes work."*

The second half is false. Existing on the registry lets the **preflight**
pass; it does not grant CI **permission to write**. That requires a trusted
publisher configured on npmjs.com — a second step the docs never named.

## Why it stayed hidden for a whole release

The only run after the bootstrap **published nothing** for that package — the
helper skipped it as already live. So the misconfiguration survived a green
release without ever being exercised.

**A skip is not a publish, and a green release that skipped a package is not
evidence the package is publishable.** v0.25.1 was the first run that
actually had to write it, and it 404'd six packages in, splitting the release
across three registries.

## What changes

Both instruction sites now say bootstrap is two steps. `npm-publish-if-needed.sh`
records what its own skip does *not* prove, since that skip is precisely what
let this survive.

#335 stops the next occurrence before anything publishes. This is the
documentation half — so the next person doesn't believe step one was the
whole job.

No functional change; comments and error text only.