### PR TITLE
fix(ci): nothing tested the published @treeship/verify, and it is broken

### DIFF
--- a/.github/scripts/publish-smoke-verify-js.sh
+++ b/.github/scripts/publish-smoke-verify-js.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Fail when the PUBLISHED @treeship/verify cannot verify in Node.
+#
+# Every existing check tests a locally built artifact. scripts/
+# check-verify-js-loads.sh runs build-npm.sh, `npm pack`s the result, and
+# installs the tarball; publish-smoke.sh installs the published CLI, which is
+# a Rust binary and cannot exercise the wasm at all. So nothing installs
+# @treeship/verify from the registry and calls it.
+#
+# That gap is not theoretical. As of v0.25.1 the published core-wasm throws
+#
+#   RangeError: WebAssembly.Table.grow(): failed to grow table by 4
+#
+# on first use in Node, while a local build of the same commit loads and
+# verifies fine. The JS loaders are byte-identical; only the .wasm differs.
+# Every gate was green because every gate tested the binary that works.
+#
+# This is the third time the same shape has bitten: v0.24.0 shipped a
+# bundler-only build because the only exercised consumer was the website;
+# #320 fixed core-wasm and tested core-wasm rather than the package users
+# install; and now the artifact under test is the one CI built rather than
+# the one CI published. A check is only worth the distance between what it
+# runs and what a user gets.
+#
+# Runs after publish, against the registry, on the same Node the smoke job
+# uses. It calls a verify function, because the wasm loads lazily and an
+# import proves nothing.
+set -euo pipefail
+
+VERSION="${1:?usage: publish-smoke-verify-js.sh <version>}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+npm init -y >/dev/null 2>&1
+
+echo "--- npm install @treeship/verify@${VERSION} (from the registry)"
+npm install "@treeship/verify@${VERSION}" --no-audit --no-fund >/dev/null
+
+cat > t.mjs <<'JS'
+const m = await import('@treeship/verify');
+const fn = m.verifyReceipt ?? m.verify_receipt;
+if (typeof fn !== 'function') {
+  console.error('  err   published @treeship/verify exposes no verifyReceipt; exports:',
+    Object.keys(m).join(', '));
+  process.exit(1);
+}
+// The wasm loads lazily. Importing proves nothing -- call it.
+let out;
+try {
+  out = await fn(JSON.stringify({
+    payload: 'e30',
+    payloadType: 'application/vnd.treeship.receipt+json;v=1',
+    signatures: [{ sig: 'AAAA', keyid: 'k' }],
+  }));
+} catch (e) {
+  console.error('  err   published @treeship/verify threw before producing a verdict:');
+  console.error('        ' + String(e).slice(0, 200));
+  console.error('        A local build of the same commit may work; this tests what users install.');
+  process.exit(1);
+}
+const verdict = typeof out === 'string' ? JSON.parse(out) : out;
+if (verdict && verdict.valid === true) {
+  console.error('  err   a tampered receipt verified; the published module is not doing the work');
+  process.exit(1);
+}
+console.log('    published @treeship/verify rejected a tampered receipt');
+JS
+
+node t.mjs
+echo "  ✓ @treeship/verify@${VERSION} verifies from the registry under $(node --version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -761,3 +761,9 @@ jobs:
 
       - name: Fresh-install publish smoke (npm + PyPI)
         run: bash .github/scripts/publish-smoke.sh "${GITHUB_REF_NAME#v}"
+
+      # The step above installs the published CLI, which is a Rust binary and
+      # never touches the wasm. This one installs the published JS verifier
+      # and calls it -- the artifact users get, not the one CI built.
+      - name: Published @treeship/verify verifies in Node
+        run: bash .github/scripts/publish-smoke-verify-js.sh "${GITHUB_REF_NAME#v}"


### PR DESCRIPTION
## @treeship/verify@0.25.1 cannot verify anything in Node

```
$ npm install @treeship/verify@0.25.1
$ node --input-type=module -e "
    const m = await import('@treeship/verify');
    await m.verifyReceipt(...)"

RangeError: WebAssembly.Table.grow(): failed to grow table by 4
```

Reproduced from a clean install on Node **20.19.5, 22.17.1, 22.20.0, 22.23.1,
23.2.0**. This is the failure v0.25.0 was released to fix. The structural half
of #320 worked — `require()` now resolves to the node target rather than a
bundler-only build — but the binary it resolves to is broken, so nothing
changed for users.

| version | `require()` result |
|---|---|
| 0.23.0 | bundler-only error |
| 0.24.0 | bundler-only error |
| 0.25.0 | **Table.grow** |
| 0.25.1 | **Table.grow** |

## The published binary differs from the built one

| | result |
|---|---|
| local build of the same commit | **OK** — `version()` returns `treeship-core-wasm 0.25.1` |
| published `.wasm`, same harness | **FAIL** |
| loader `.js`, local vs published | **byte-identical** |

Swapping only the `.wasm` flips the outcome.

**wasm-opt was the obvious suspect and is not the cause.** `-Oz` (what
`release.yml` runs), `-O2`, and `-Oz --enable-reference-types` all produce
*working* binaries locally. The remaining difference is the toolchain in the
release job, and **that is still open** — I have not found it.

## Why ten green gates missed it

Every check tests an artifact that is not the one users install:

- `check-verify-js-loads.sh` runs `build-npm.sh`, `npm pack`s the result, installs the tarball — **CI's own build**, never the registry's.
- `publish-smoke.sh` installs the published **CLI**, a Rust binary that cannot exercise the wasm.
- `ci.yml` installs no binaryen at all, so its build doesn't even follow the release job's path.

Nothing anywhere installs `@treeship/verify` from npm and calls it.

That's the same shape three times now: v0.24.0 shipped bundler-only because
the only exercised consumer was the website; #320 fixed core-wasm and tested
core-wasm rather than the package users install; now the artifact under test
is the one CI built rather than the one CI published. **A check is only worth
the distance between what it runs and what a user gets.**

## What this PR does

Adds a post-publish step that installs `@treeship/verify` **from the registry**
and calls a verify function — the wasm loads lazily, so an import proves
nothing.

Verified it **fails with exit 1** against the currently published 0.25.1. A
gate that passed on the known-broken artifact would be worth nothing.

## What this PR does not do

**It does not fix the bug.** 0.25.1 remains broken for JS consumers in Node
until the artifact difference is found. Unaffected: the CLI, the Rust crates,
the Python SDK, and the website (which vendors and bundles its own wasm).