### PR TITLE
fix(core-wasm): refuse to package a nodejs build that does not load

### DIFF
--- a/packages/core-wasm/build-npm.sh
+++ b/packages/core-wasm/build-npm.sh
@@ -70,6 +70,51 @@ else
   echo "wasm-opt not found; skipping (binary will still be small enough)."
 fi
 
+# Prove the nodejs build actually loads before anyone can publish it.
+#
+# v0.25.0 added the nodejs target to fix a Node load failure, and v0.25.1
+# shipped with that failure still present, because the artifact CI built was
+# not the artifact CI tested. Every gate packed a locally built pkg; nothing
+# loaded the one the release job produced.
+#
+# The failure is a miscompile, not a config mistake. In the release build the
+# export named `__wbindgen_externrefs` is bound to the funcref table -- which
+# wasm-pack emits with min == max, so it cannot grow -- instead of the
+# externref table. The loader's `table.grow(4)` then throws
+#
+#     RangeError: WebAssembly.Table.grow(): failed to grow table by 4
+#
+# on first use. Same rustc, same wasm-bindgen 0.2.114, same wasm-pack 0.14.0
+# as a local build that works; the difference is the host platform, so it is
+# invisible to anyone building on a Mac and fatal to everything published.
+#
+# Hence an end-to-end load here rather than an inspection of the toolchain:
+# the question that matters is "does this file work", and it is cheap to ask
+# directly. A structural assertion follows it so the failure names its own
+# cause instead of only its symptom.
+echo "Verifying the nodejs build loads..."
+node -e '
+  const path = require("path");
+  const mod = require(path.resolve("pkg/node/treeship_core_wasm.js"));
+  if (typeof mod.version !== "function") {
+    console.error("  err   nodejs build exposes no version(); it did not initialise");
+    process.exit(1);
+  }
+  // The wasm initialises on first call, not on require.
+  const v = mod.version();
+  if (!v) {
+    console.error("  err   version() returned nothing");
+    process.exit(1);
+  }
+  console.log("    nodejs build loads and runs: " + v);
+' || {
+  echo "  err   the nodejs build does not load in Node. Refusing to package it." >&2
+  echo "        If this is the externref table bug, the export named" >&2
+  echo "        __wbindgen_externrefs is bound to a non-growable funcref table." >&2
+  echo "        Inspect with: wasm-dis pkg/node/treeship_core_wasm_bg.wasm | grep -E '\(table|__wbindgen_externrefs'" >&2
+  exit 1
+}
+
 # Rewrite package.json with npm-ready metadata.
 node - "$VERSION" <<'EOF'
 const fs = require('fs');


### PR DESCRIPTION
## The bug

`@treeship/verify@0.25.1` cannot verify anything in Node:

```
RangeError: WebAssembly.Table.grow(): failed to grow table by 4
```

Clean install, reproduced on Node **20.19.5, 22.17.1, 22.20.0, 22.23.1, 23.2.0**.
This is the failure v0.25.0 was released to fix. #320's structural half worked
— `require()` resolves to the nodejs target rather than a bundler-only build —
but the binary it lands on is broken, so nothing changed for users.

## Root cause

The export is bound to the wrong table:

```
published:  (export "__wbindgen_externrefs" (table $0))   ; 250 250 funcref
local:      (export "__wbindgen_externrefs" (table $1))   ; 1024 externref
```

wasm-pack emits the funcref table with `min == max`, so it **cannot grow**.
The loader's `table.grow(4)` — on what it believes is the externref table —
throws on first use.

Same rustc (`e408947b`), same wasm-bindgen `0.2.114`, same wasm-pack `0.14.0`
as a local build that works. The difference is the **host platform**:
invisible to anyone building on a Mac, fatal to everything published from
Linux CI. wasm-opt was the obvious suspect and is **not** the cause — it only
touches `pkg/*.wasm`, never `pkg/node/`, and `-Oz`/`-O2`/`--enable-reference-types`
all produce working binaries locally.

## What this PR does

**It does not fix the miscompile.** It makes it unshippable.

`build-npm.sh` now loads its own nodejs output and calls into it before
packaging, failing the build if that throws. End-to-end rather than a
toolchain assertion, because the question that matters is *does this file
work*, and it's cheap to ask directly.

Verified **both directions**:

| binary | exit |
|---|---|
| published 0.25.1 (known broken) | **1** — build refuses |
| good local build | **0** — build proceeds |

A check that only passed on the good build would prove nothing.

## Why ten green gates missed it

Every check tested an artifact that was not the published one:

- `check-verify-js-loads.sh` — runs `build-npm.sh`, `npm pack`s the result, installs the tarball. **CI's own build.**
- `publish-smoke.sh` — installs the published **CLI**, a Rust binary that never touches the wasm.

Third time in this shape: v0.24.0 shipped bundler-only because the only
exercised consumer was the website; #320 fixed core-wasm and tested
core-wasm rather than the package users install; now the tested artifact is
the one CI built rather than the one CI published.

## Ships with

**#340** is the post-publish half (installs `@treeship/verify` from the
registry and calls it). This is the pre-publish half — the one that stops a
bad artifact existing at all. Both should land before 0.25.2 is tagged.

**The real test is CI.** If the release job still produces a mis-bound
export, this build now fails loudly there instead of publishing — and we
diagnose with CI logs rather than guessing at a platform I can't reproduce.