### PR TITLE
Release v0.25.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.25.1"
+    "version": "0.25.2"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.25.2 (2026-08-30)
+
+**Upgrade if you use `@treeship/verify`, `@treeship/sdk`, or any npm package
+that verifies in Node.** Those packages could not verify anything at all in
+0.25.1 or 0.25.0.
+
+### Fixed
+
+- **`@treeship/verify` threw on first use in Node.** `WebAssembly.Table.grow():
+  failed to grow table by 4`, from a clean install, on Node 20.19.5, 22.17.1,
+  22.20.0, 22.23.1 and 23.2.0. This is the failure 0.25.0 was released to fix.
+  The structural half of that fix worked — `require()` resolves to the nodejs
+  build rather than a bundler-only one — but the binary it resolved to was
+  miscompiled: the export named `__wbindgen_externrefs` was bound to the
+  funcref table, which wasm-pack emits with `min == max` and therefore cannot
+  grow. Same rustc, same wasm-bindgen, same wasm-pack as a local build that
+  works; the difference is the host platform, which made it invisible to
+  anyone building on a Mac and fatal to everything published from Linux CI.
+  `build-npm.sh` now loads its own nodejs output and calls into it before
+  packaging, so a build that does not work cannot be packaged. (#341)
+- **Nothing tested the published packages.** Every check ran against an
+  artifact CI had just built: `check-verify-js-loads.sh` packs a local build,
+  and the post-publish smoke installs the published CLI — a Rust binary that
+  never touches the wasm. So a broken `@treeship/verify` shipped twice under
+  green checks. The release now installs `@treeship/verify` from the registry
+  after publishing and calls a verify function, because the wasm loads lazily
+  and an import proves nothing. (#340)
+- **`release.sh prepare` could not update the lockfiles it exists to update,
+  and `npm ci` then failed on main.** `--package-lock-only` resolves against
+  the registry, so it failed on the unpublished version being released.
+  Prepare now writes the declared range offline; `refresh-lockfiles` fills in
+  resolved entries after publish. The sync check also compared only the
+  declared range, not the installed entry `npm ci` actually rejects on, so it
+  reported green on a tree where every JS job failed. (#337)
+- **The npm preflight checked that packages exist, not that CI can publish
+  them.** `npm view` is an unauthenticated read; npm returns 404 rather than
+  403 for an unauthorized write. A package bootstrapped by hand but never
+  given a trusted publisher passed the check and then failed mid-publish,
+  leaving 0.25.1 split across three registries. Preflight now checks
+  provenance, which is the observable trace of a successful CI publish. (#335)
+- **Keystore recovery advice named the wrong keystore.** The path came from
+  `$HOME/.treeship`, but that is the store root only in the default layout, so
+  under `--config` a user was told to move their global keystore while the
+  broken one stayed in place. The command also did not work — moving keys
+  aside leaves `config.json`, so `init` refused as "already initialized" while
+  `attest` said to run `init`. And it promised existing receipts stay
+  verifiable; they report `unknown key` until the old keystore is restored.
+  All three corrected, and every command in the message is now executed
+  verbatim in testing. (#338)
+
 ## 0.25.1 (2026-08-21)
 
 **Upgrade if you use the Python SDK or `treeship wrap --format json`.** Two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "base64",
  "clap",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.1"
+    "@treeship/core-wasm": "0.25.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.25.1",
+        "@treeship/core-wasm": "0.25.2",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.25.1",
+    "@treeship/core-wasm": "0.25.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.25.1",
-    "@treeship/cli-linux-arm64": "0.25.1",
-    "@treeship/cli-darwin-arm64": "0.25.1",
-    "@treeship/cli-darwin-x64": "0.25.1"
+    "@treeship/cli-linux-x64": "0.25.2",
+    "@treeship/cli-linux-arm64": "0.25.2",
+    "@treeship/cli-darwin-arm64": "0.25.2",
+    "@treeship/cli-darwin-x64": "0.25.2"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.25.1", path = "../core" }
+treeship-core = { version = "0.25.2", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.25.1", path = "../core" }
+treeship-core = { version = "0.25.2", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.25.1"
+version = "0.25.2"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.1"
+    "@treeship/core-wasm": "0.25.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.1"
+    "@treeship/core-wasm": "0.25.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/scripts/check-lockfile-sync.py
+++ b/scripts/check-lockfile-sync.py
@@ -31,6 +31,7 @@ real tool verifies will eventually pass something the real tool rejects.
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -45,6 +46,21 @@ ROOT = Path(__file__).resolve().parents[1]
 #
 # Discovering them means a new package is covered the day it is added rather
 # than the day someone remembers to extend this list.
+# Between `release.sh prepare` and publish, the resolved entries legitimately
+# lag the declared range: the version being released has no tarball yet, so
+# there is no honest integrity hash to write (see scripts/lockfile-pin.py).
+# On a release branch that is the expected state, not drift, and failing here
+# would make every release PR unmergeable by a check the release itself
+# created.
+#
+# Deliberately narrow: only the installed-entry half is relaxed, only on a
+# release branch. The declared-range half -- the one that made main
+# unbuildable at v0.25.0 -- still runs everywhere, and `refresh-lockfiles`
+# after publish restores the resolved entries so the full check applies to
+# main.
+_ref = os.environ.get("GITHUB_HEAD_REF") or os.environ.get("GITHUB_REF_NAME") or ""
+RELEASE_WINDOW = _ref.startswith("release/v")
+
 SKIP_DIRS = {"node_modules", ".git", "target", "dist", "pkg"}
 
 
@@ -117,7 +133,7 @@ def main() -> int:
             # Exact pins only. A range like ^1.2.0 is legitimately satisfied by
             # many versions, and deciding which needs a semver implementation;
             # every @treeship/* pin is exact, which is the case that broke.
-            if re.fullmatch(r"\d+\.\d+\.\d+", want):
+            if re.fullmatch(r"\d+\.\d+\.\d+", want) and not RELEASE_WINDOW:
                 res = inst.get(name)
                 if res is not None and res != want:
                     bad.append((rel, name, want, res, "installed entry"))
@@ -137,7 +153,14 @@ def main() -> int:
         )
         return 1
 
-    print(f"  ✓ package.json and lockfile agree in {checked} package(s)")
+    if RELEASE_WINDOW:
+        print(
+            f"  ✓ declared ranges agree in {checked} package(s); installed-entry "
+            f"check relaxed on release branch {_ref!r}"
+        )
+        print("        Run `scripts/release.sh refresh-lockfiles` after publish.")
+    else:
+        print(f"  ✓ package.json and lockfile agree in {checked} package(s)")
     return 0
 
 

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
-        "@treeship/verify": "0.25.1"
+        "@treeship/verify": "0.25.2"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.25.1"
+    "@treeship/verify": "0.25.2"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
-        "@treeship/verify": "0.25.1"
+        "@treeship/verify": "0.25.2"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.1"
+    "@treeship/verify": "0.25.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "dependencies": {
-        "@treeship/verify": "0.25.1"
+        "@treeship/verify": "0.25.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.1"
+    "@treeship/verify": "0.25.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
**`@treeship/verify` could not verify anything in Node in 0.25.0 or 0.25.1.**
That is the release.

```
npm install @treeship/verify@0.25.1
→ RangeError: WebAssembly.Table.grow(): failed to grow table by 4
```

Clean install, Node 20.19.5 / 22.17.1 / 22.20.0 / 22.23.1 / 23.2.0.

## Root cause (#341)

The export was bound to the wrong table:

```
published:  (export "__wbindgen_externrefs" (table $0))   ; 250 250 funcref
local:      (export "__wbindgen_externrefs" (table $1))   ; 1024 externref
```

wasm-pack emits the funcref table with `min == max`, so it cannot grow. Same
rustc, same wasm-bindgen 0.2.114, same wasm-pack 0.14.0 as a working local
build — the difference is the **host platform**. Invisible on a Mac, fatal
from Linux CI.

`build-npm.sh` now loads its own nodejs output and calls into it before
packaging. Verified both directions: **exit 1** on the published 0.25.1
binary, **exit 0** on a good build.

## Why it shipped twice (#340)

Every gate tested an artifact CI had just built, never the published one.
`check-verify-js-loads.sh` packs a local build; `publish-smoke.sh` installs
the published *CLI*, a Rust binary that never touches the wasm. The release
now installs `@treeship/verify` from the registry and calls it.

Third time in this shape: 0.24.0 shipped bundler-only because the only
exercised consumer was the website; #320 fixed core-wasm and tested
core-wasm rather than the package users install; now the tested artifact was
the one CI built rather than the one CI published.

## Also in it

| PR | Fix |
|----|-----|
| #337 | `npm ci` failed on all of main; the sync gate compared only the declared range, not the installed entry it actually rejects on |
| #335 | npm preflight checked existence, not writability — how 0.25.1 half-published |
| #338 | Keystore recovery advice named the wrong keystore, didn't work, and over-promised |

## The real test is the release run

If the release job still produces a mis-bound export, the build now **fails
loudly instead of publishing**, and we diagnose from CI logs rather than
guessing at a platform that can't be reproduced locally. Either outcome is
better than 0.25.1's.

Do not tag until CI is green and you've approved the release.