### PR TITLE
Release v0.25.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.25.2"
+    "version": "0.25.3"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,38 @@ jobs:
       # @treeship/verify, which pins core-wasm EXACTLY -- so a green core-wasm
       # gate can sit beside a broken user install indefinitely. This exercises
       # the package a user actually gets.
+      # Install binaryen so CI's build follows the same path as the release
+      # job's. release.yml installs it; ci.yml did not, so the two pipelines
+      # produced different artifacts and the gates ran against the one that
+      # was never published -- a build step present in one pipeline and absent
+      # in the other is how an artifact difference stays invisible.
+      #
+      # Note this is NOT build-npm.sh's own `wasm-opt -Oz`, which globs
+      # pkg/*.wasm and never matches pkg/node/. wasm-pack runs wasm-opt itself
+      # on the package it just built whenever binaryen is on PATH. That is the
+      # invocation that broke 0.25.1, and core-wasm's Cargo.toml now disables
+      # it. binaryen is still installed here for the bundler build's -Oz pass,
+      # and pinned so both pipelines optimize with the same tool.
+      # Pin binaryen the way wasm-pack is pinned two steps up. Ubuntu's apt
+      # binaryen is 108-1, a 2022 build that predates the `bulk-memory-opt`
+      # and `call-indirect-overlong` features core-wasm declares; it lowered
+      # the externref table to a non-growable one and shipped a
+      # @treeship/core-wasm that threw on require() in 0.25.0 and 0.25.1.
+      # `cargo install --locked` was chosen for wasm-pack so the job would not
+      # run "whatever the CDN served at job runtime" -- installing the tool
+      # that rewrites the artifact from an unpinned distro package left that
+      # same hole open. Checksummed so the release job, which holds
+      # id-token: write, cannot be handed a substituted tarball.
+      - name: Install wasm-opt (binaryen, pinned)
+        run: |
+          set -euo pipefail
+          V=132
+          URL="https://github.com/WebAssembly/binaryen/releases/download/version_${V}/binaryen-version_${V}-x86_64-linux.tar.gz"
+          curl -fsSL --retry 5 --retry-connrefused -o /tmp/binaryen.tar.gz "$URL"
+          echo "195ddc94f9bc89f45abdabb0b9eea86023d727ba90eac8b35b80f2544fc30572  /tmp/binaryen.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/binaryen.tar.gz -C /opt
+          echo "/opt/binaryen-version_${V}/bin" >> "$GITHUB_PATH"
+
       - name: "@treeship/verify installs and verifies under Node"
         run: |
           cargo install wasm-pack --version 0.14.0 --locked || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,10 +369,25 @@ jobs:
         # that holds `id-token: write` for npm trusted publishing.
         run: cargo install wasm-pack --version 0.14.0 --locked
 
-      - name: Install wasm-opt (binaryen)
+      # Pin binaryen the way wasm-pack is pinned two steps up. Ubuntu's apt
+      # binaryen is 108-1, a 2022 build that predates the `bulk-memory-opt`
+      # and `call-indirect-overlong` features core-wasm declares; it lowered
+      # the externref table to a non-growable one and shipped a
+      # @treeship/core-wasm that threw on require() in 0.25.0 and 0.25.1.
+      # `cargo install --locked` was chosen for wasm-pack so the job would not
+      # run "whatever the CDN served at job runtime" -- installing the tool
+      # that rewrites the artifact from an unpinned distro package left that
+      # same hole open. Checksummed so the release job, which holds
+      # id-token: write, cannot be handed a substituted tarball.
+      - name: Install wasm-opt (binaryen, pinned)
         run: |
-          sudo apt-get update
-          sudo apt-get install -y binaryen
+          set -euo pipefail
+          V=132
+          URL="https://github.com/WebAssembly/binaryen/releases/download/version_${V}/binaryen-version_${V}-x86_64-linux.tar.gz"
+          curl -fsSL --retry 5 --retry-connrefused -o /tmp/binaryen.tar.gz "$URL"
+          echo "195ddc94f9bc89f45abdabb0b9eea86023d727ba90eac8b35b80f2544fc30572  /tmp/binaryen.tar.gz" | sha256sum -c -
+          sudo tar -xzf /tmp/binaryen.tar.gz -C /opt
+          echo "/opt/binaryen-version_${V}/bin" >> "$GITHUB_PATH"
 
       - name: Build and publish @treeship/core-wasm
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.25.3 (2026-08-31)
+
+**Upgrade if you use `@treeship/verify`, `@treeship/sdk`, or any npm package
+that verifies in Node.** 0.25.2 never reached npm: the gate added in 0.25.2
+caught that the artifact still did not load and refused to publish it, so npm
+remained on the broken 0.25.1 while crates.io and PyPI moved to 0.25.2. This
+release fixes the underlying cause and brings every registry back in line.
+
+### Fixed
+
+- **`@treeship/core-wasm` was rewritten by whatever `wasm-opt` the build
+  machine happened to have.** `wasm-pack` runs `wasm-opt` on the package it
+  just built whenever binaryen is on `PATH`. The release workflow installed
+  binaryen from apt, which on Ubuntu noble is `108-1` -- a 2022 build
+  predating the `bulk-memory-opt` and `call-indirect-overlong` features the
+  module declares. It lowered the externref table to a non-growable one, so
+  `require()` threw `WebAssembly.Table.grow(): failed to grow table by 4` on
+  first use. A machine with no `wasm-opt`, or a current one, built the same
+  commit correctly, which is why 0.25.0 and 0.25.1 both shipped broken.
+
+  `wasm-pack`'s `wasm-opt` pass is now disabled for `core-wasm`, so the
+  published nodejs artifact is `wasm-bindgen`'s output and nothing else.
+
+### Changed
+
+- The release and CI workflows install a checksummed binaryen 132 tarball
+  instead of an unpinned apt package. `wasm-pack` was already pinned with
+  `cargo install --locked` specifically so the release job would not run
+  whatever a CDN served at job runtime; the tool that rewrites the artifact
+  is now pinned to the same standard.
+- CI installs binaryen at all, which it previously did not. The two pipelines
+  built differently, so every gate ran against an artifact that was never the
+  one published.
+- `rust-toolchain.toml` pins `wasm32-unknown-unknown`. This did not cause the
+  failure above, but it was the other unpinned input feeding the same
+  artifact.
+
 ## 0.25.2 (2026-08-30)
 
 **Upgrade if you use `@treeship/verify`, `@treeship/sdk`, or any npm package

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "base64",
  "clap",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.2"
+        "@treeship/core-wasm": "0.25.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.2"
+    "@treeship/core-wasm": "0.25.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.25.2",
+        "@treeship/core-wasm": "0.25.3",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.25.2",
+    "@treeship/core-wasm": "0.25.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.25.2",
-    "@treeship/cli-linux-arm64": "0.25.2",
-    "@treeship/cli-darwin-arm64": "0.25.2",
-    "@treeship/cli-darwin-x64": "0.25.2"
+    "@treeship/cli-linux-x64": "0.25.3",
+    "@treeship/cli-linux-arm64": "0.25.3",
+    "@treeship/cli-darwin-arm64": "0.25.3",
+    "@treeship/cli-darwin-x64": "0.25.3"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.25.2", path = "../core" }
+treeship-core = { version = "0.25.3", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -39,5 +39,24 @@ zk = ["ark-groth16", "ark-bn254", "ark-serialize", "ark-ec", "ark-ff"]
 # is silently ignored in a workspace, so we avoid putting it here to prevent
 # future readers from assuming it takes effect.
 
+# wasm-pack runs `wasm-opt` on the package it just built whenever binaryen is
+# anywhere on PATH, before build-npm.sh ever sees the output. That made the
+# published artifact a function of whatever binaryen the environment happened
+# to have. release.yml installed Ubuntu's apt binaryen -- 108-1, a 2022 build
+# that predates the `bulk-memory-opt` and `call-indirect-overlong` features
+# this module declares. It lowered the externref table to a non-growable one,
+# so `__wbindgen_init_externref_table` threw `WebAssembly.Table.grow(): failed
+# to grow table by 4` on require(). 0.25.0 and 0.25.1 shipped that way. A
+# developer machine with no wasm-opt, or a modern one, produced a working
+# build from the same commit, which is why it stayed invisible for two
+# releases.
+#
+# Turning it off here means the artifact is wasm-bindgen's output and nothing
+# else. build-npm.sh still runs its own pinned `wasm-opt -Oz` over pkg/*.wasm
+# for the bundler build; the nodejs build is not size-critical and is the one
+# that broke.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [lints]
 workspace = true

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.25.2"
+version = "0.25.3"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.25.2", path = "../core" }
+treeship-core = { version = "0.25.3", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.25.2"
+version = "0.25.3"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.2"
+        "@treeship/core-wasm": "0.25.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.2"
+    "@treeship/core-wasm": "0.25.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.2"
+        "@treeship/core-wasm": "0.25.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.2"
+    "@treeship/core-wasm": "0.25.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -18,6 +18,14 @@
 # pinned channel on first cargo invocation, so local devs do not need to run
 # `rustup component add` manually.
 #
+# wasm32-unknown-unknown is listed for the same reason. Without it the wasm
+# target's stdlib is whatever each environment installs on demand, so the one
+# artifact whose correctness is platform-sensitive was the one target not
+# pinned. This is not what broke 0.25.0 and 0.25.1 -- that was an unpinned
+# binaryen rewriting the externref table, fixed in core-wasm's Cargo.toml and
+# the two workflows. It is pinned here so the next difference between a
+# developer build and a release build is not discovered the same way.
+#
 # Targets: the release workflow cross-compiles for x86_64-apple-darwin
 # (from macOS arm64 runners), aarch64-apple-darwin (native), and
 # x86_64-unknown-linux-musl and aarch64-unknown-linux-musl on native
@@ -31,4 +39,4 @@
 channel    = "1.94.1"
 components = ["clippy", "rustfmt"]
 profile    = "minimal"
-targets    = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
+targets    = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "wasm32-unknown-unknown"]

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
-        "@treeship/verify": "0.25.2"
+        "@treeship/verify": "0.25.3"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.25.2"
+    "@treeship/verify": "0.25.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
-        "@treeship/verify": "0.25.2"
+        "@treeship/verify": "0.25.3"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.2"
+    "@treeship/verify": "0.25.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "dependencies": {
-        "@treeship/verify": "0.25.2"
+        "@treeship/verify": "0.25.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.2"
+    "@treeship/verify": "0.25.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Why this release exists

v0.25.2 **never reached npm.** The gate added in #341 caught that the built
artifact still did not load and refused to publish it — so npm stayed on the
broken 0.25.1 while crates.io and PyPI moved to 0.25.2. The gate did its job;
the underlying build bug was still there.

```
RangeError: WebAssembly.Table.grow(): failed to grow table by 4
    at __wbindgen_init_externref_table
```

## Root cause

`wasm-pack` runs `wasm-opt` on the package it just built whenever binaryen is
anywhere on `PATH`, before `build-npm.sh` ever sees the output. `release.yml`
installed binaryen from apt, which on Ubuntu noble is **`108-1`** — a 2022
build predating the `bulk-memory-opt` and `call-indirect-overlong` features
`core-wasm` declares. It lowered the externref table to a non-growable one.

A machine with no `wasm-opt`, or a current one, built the same commit
correctly. That asymmetry is why 0.25.0 and 0.25.1 both shipped broken and
looked fine locally.

This is **not** `build-npm.sh`'s own `wasm-opt -Oz`, which globs `pkg/*.wasm`
and never matches `pkg/node/`. That distinction is what made the artifact path
easy to misread.

## Changes

- **`core-wasm/Cargo.toml` disables `wasm-pack`'s `wasm-opt`.** The published
  nodejs artifact is now `wasm-bindgen`'s output and nothing else. No binaryen
  version can touch it.
- **Both workflows install a checksummed binaryen 132 tarball** instead of an
  unpinned apt package. `release.yml` already pinned `wasm-pack` with
  `cargo install --locked` so the job would not run "whatever the CDN served at
  job runtime" — the tool that *rewrites the artifact* is now held to the same
  standard, in a job holding `id-token: write`.
- **`ci.yml` installs binaryen at all**, which it did not before. The two
  pipelines built differently, so every gate ran against an artifact that was
  never the one published.
- **`rust-toolchain.toml` pins `wasm32-unknown-unknown`.** Not the cause here,
  but the other unpinned input feeding the same artifact.

## Verification

Reproduced locally by installing binaryen (absent on this machine, which is
itself the asymmetry). Before the fix, `wasm-pack` logs `found wasm-opt` →
`Optimizing wasm binaries`. After, those lines are gone, `build-npm.sh`'s own
`-Oz` pass still runs over the bundler build, and the nodejs build loads:

```
Verifying the nodejs build loads...
    nodejs build loads and runs: treeship-core-wasm
```

Local gates: 43/43 version sites, lockfile sync, conflict markers all pass.

## After merge

Tag `v0.25.3` to publish, then `scripts/release.sh refresh-lockfiles` — `main`
is currently red on `check-lockfile-sync` because the declared `0.25.2` cannot
resolve against npm, and that clears once a version actually publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YiJqtp9p7gUiQjA8pc5Ty