### PR TITLE
chore(release): refresh lockfiles against published 0.25.3

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
-      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
+      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.3"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
-      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
+      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.3"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.1.tgz",
-      "integrity": "sha512-WrimxgRTQ6YIvABc9925rcDHIh92rpfRo98tV53OGMabKURJzrqs7890aRvpVzTQTcYXlwSR+eJDFD6JzYb/2A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
+      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.1.tgz",
-      "integrity": "sha512-z5mZ1Mj+wU442JH83AmlHoV7yPa3KRkh3I8GWNstXsQhjXjhgkEasDjAox8h/vdhmaI5XXP89LaGDHqswM5G4A==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
+      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.1"
+        "@treeship/core-wasm": "0.25.3"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
`main` is red on `check-lockfile-sync`: package.json declares `0.25.3` while
the installed entries still say `0.25.1`/`0.25.2`.

That is the expected post-release state, not drift. `release.sh prepare`
stamps package.json but cannot update lockfiles — `--package-lock-only` still
resolves against the registry, and the version being released has no tarball
yet. The gate relaxes its installed-entry half on `release/v*` for that
reason, which is why #345 passed and the push to `main` failed.

`@treeship/core-wasm@0.25.3` and `@treeship/verify@0.25.3` are on npm now, so
the entries resolve. Generated with `scripts/release.sh refresh-lockfiles` —
the post-publish step the gate's own failure message asks for.

Verified locally under `main`'s conditions (no release-branch relaxation):

```
✓ package.json and lockfile agree in 10 package(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YiJqtp9p7gUiQjA8pc5Ty