### PR TITLE
feat(claude-code): record the human's answer, and never invent an approver

### DIFF
--- a/integrations/claude-code-plugin/README.md
+++ b/integrations/claude-code-plugin/README.md
@@ -38,6 +38,8 @@ The plugin requires the `treeship` CLI binary on your PATH and a `.treeship/` di
 - **Every tool call is captured.** MCP tool calls flow through the bundled Treeship MCP server (`@treeship/mcp`); built-in Claude Code tools (Read, Write, Edit, Bash, Grep, Glob, etc.) flow through a PostToolUse hook. Combined: full timeline.
 - **Sessions seal automatically.** When the Claude Code session ends, a SessionEnd hook closes the session and surfaces the shareable session report URL back into the conversation. You don't have to ask.
 - **Live status while you work.** A background monitor streams the receipt counter (`receipts=N events=M`) into Claude's context every few seconds, so the agent knows the receipt is being built.
+- **Human answers are recorded, not just counted.** When Claude asks you something through `AskUserQuestion` -- often the moment you authorize something irreversible -- the hook records the question and the option you chose. Previously this was stored as a bare tool name, so the most consequential moment in a session was the one the receipt said least about.
+
 - **Three skills for the moments that need agency.** `treeship-session` for closing with a real headline before SessionEnd auto-closes. `treeship-verify` for confirming a receipt someone shared with you. `treeship-report` for explicitly publishing a session report URL.
 
 ## Design rationale
@@ -61,6 +63,34 @@ The brief was: zero configuration, sessions start and close themselves, the URL 
 **No `settings.json`.** The Claude Code plugin settings layer currently only takes `agent` and `subagentStatusLine` keys. Treeship doesn't ship a custom agent or status line, so a settings file would be empty noise.
 
 **Why hooks instead of asking the model nicely.** The brief is explicit: zero configuration, sessions should start and close automatically. Hooks are deterministic — they fire on every session regardless of which model is running, what's in the system prompt, or what the user remembered to ask for. A model-prompted approach would drift the moment someone forgets to mention Treeship, or runs a small model that ignores the instruction, or is mid-session when behavior changes. Hooks are the right primitive for any guarantee that has to hold every time.
+
+### Signing approvals: `TREESHIP_APPROVER`
+
+By default the hook records what was asked and answered, and mints nothing.
+It deliberately stops short of a signed approval artifact, because it cannot
+prove *who* answered -- it only knows someone at this terminal chose an
+option. Deriving an approver from `$USER` or your git config would put a
+manufactured identity claim into a signed, publishable record.
+
+Set an approver to opt in:
+
+```bash
+export TREESHIP_APPROVER="human://alice"
+```
+
+With it set, each answer also mints a signed `approval.v1` artifact naming
+that approver. You are asserting that answers given in this session are
+yours and may be recorded as authorization records; the artifact rests on
+that assertion, not on anything the hook independently verified.
+
+Two limits worth stating plainly:
+
+- `AskUserQuestion` is a general-purpose question tool, not an approval gate.
+  Most answers authorize nothing, so the artifact records only that you
+  answered X to question Y -- never that the answer authorized a specific
+  action.
+- The approval is minted after the fact. It witnesses your answer; it does
+  not gate the action Claude takes next.
 
 ## File tree
 

--- a/integrations/claude-code-plugin/scripts/post-tool-use.sh
+++ b/integrations/claude-code-plugin/scripts/post-tool-use.sh
@@ -13,6 +13,8 @@
 #   NotebookEdit       ->  agent.wrote_file --file <path>
 #   Bash               ->  agent.completed_process --tool <cmd> --exit-code <N>
 #   WebFetch           ->  agent.connected_network --destination <host>
+#   AskUserQuestion    ->  agent.called_tool + the question and the operator's
+#                          answer, and (opt-in) a signed approval artifact
 #   *                  ->  agent.called_tool --tool <name>
 #
 # Without the dispatch, every tool was emitted as agent.called_tool only, so
@@ -211,6 +213,71 @@ case "$TOOL_NAME" in
       emit_called_tool
     fi
     ;;
+  AskUserQuestion)
+    # The one place a human's judgement enters the session. Previously this
+    # fell through to the catch-all, so a session in which an operator
+    # approved an irreversible action recorded exactly:
+    #
+    #   {"type": "agent.called_tool", "tool_name": "AskUserQuestion"}
+    #
+    # -- no question, no answer, no approver. The decision that mattered most
+    # in the run was the one the receipt said least about.
+    #
+    # Two things happen here, and they claim very different amounts.
+    QUESTION=$(extract tool_input.questions)
+    ANSWERS=$(extract tool_response.answers)
+    [ -z "$ANSWERS" ] && ANSWERS=$(extract tool_response)
+
+    # (a) Always: record the exchange in the timeline. Redacted first --
+    #     this string can reach a published, no-auth receipt (AUD-26) -- then
+    #     capped, because option descriptions run long and the timeline is not
+    #     the place for a full prompt.
+    Q_SAFE=$(redact_secrets "${QUESTION:-}" | cut -c1-400)
+    A_SAFE=$(redact_secrets "${ANSWERS:-}" | cut -c1-400)
+    META=$(python3 -c "
+import json, sys
+print(json.dumps({'question': sys.argv[1], 'answer': sys.argv[2]}))
+" "$Q_SAFE" "$A_SAFE" 2>/dev/null)
+
+    if [ -n "$META" ]; then
+      treeship session event \
+        --type "agent.called_tool" \
+        --tool "$TOOL_NAME" \
+        --agent-name "claude-code" \
+        --meta "$META" \
+        >/dev/null 2>&1 || emit_called_tool
+    else
+      emit_called_tool
+    fi
+
+    # (b) Opt-in only: mint a signed approval artifact.
+    #
+    # Fail-closed on identity. The hook observes that *someone* at this
+    # terminal chose an option; it cannot prove who. Deriving an approver from
+    # $USER or a git config would manufacture an identity claim the evidence
+    # does not support, which is exactly the failure mode this repo's policy
+    # names. So: no configured approver, no artifact. The timeline entry above
+    # still records what happened.
+    #
+    # Setting TREESHIP_APPROVER is the operator asserting "answers I give in
+    # this session are mine, and may be recorded as authorization records."
+    # That assertion is theirs to make, and it is what the artifact rests on.
+    #
+    # Note also that AskUserQuestion is a general-purpose question tool, not an
+    # approval gate -- most answers authorize nothing. The description below
+    # therefore states only what was observed (operator answered X to question
+    # Y) and never that the answer authorized any particular action.
+    if [ -n "${TREESHIP_APPROVER:-}" ]; then
+      DESC=$(printf 'operator answered %s | question: %s' "$A_SAFE" "$Q_SAFE" | cut -c1-500)
+      treeship attest approval \
+        --approver "$TREESHIP_APPROVER" \
+        --description "$DESC" \
+        --unscoped \
+        --quiet \
+        >/dev/null 2>&1 || true
+    fi
+    ;;
+
   *)
     # Glob, Grep, Task, TodoWrite, ScheduleWakeup, etc. -- generic call.
     emit_called_tool

--- a/tests/acceptance/trust-fabric.sh
+++ b/tests/acceptance/trust-fabric.sh
@@ -156,6 +156,82 @@ test_smoke_session_roundtrip() {
 # test, and assert on the package/verify output. Add new run_test() lines in
 # main() once each test function lands.
 
+# T1: The Claude Code PostToolUse hook must record a human's answer, and must
+# NOT invent an approver.
+#
+# Background: AskUserQuestion used to fall through to the generic branch, so a
+# session where an operator authorized an irreversible publish recorded only
+# {"type":"agent.called_tool","tool_name":"AskUserQuestion"} -- the most
+# consequential moment in the run, stored with the least detail.
+#
+# Two properties are release-breaking here and both are asserted:
+#
+#   1. Without TREESHIP_APPROVER, no approval artifact is minted. The hook can
+#      see that someone answered; it cannot see who. Deriving an approver from
+#      $USER or git config would manufacture an identity claim the evidence
+#      does not support. Fail-closed: no configured approver, no artifact.
+#   2. With TREESHIP_APPROVER, exactly one approval artifact is minted and it
+#      verifies, carrying the configured approver.
+#
+# A regression on (1) is the dangerous direction: it would put a fabricated
+# human identity into a signed, publishable record.
+test_askuserquestion_approval_capture() {
+  local hook payload before after out
+  hook="${REPO_ROOT}/integrations/claude-code-plugin/scripts/post-tool-use.sh"
+  [[ -x "${hook}" || -f "${hook}" ]] || { echo "   hook not found: ${hook}" >&2; return 1; }
+
+  payload='{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Publish to npm? Irreversible.","header":"Release"}]},"tool_response":{"answers":{"Publish to npm?":"Yes, publish"}}}'
+
+  # The hook resolves `treeship` from PATH and the project from cwd, and it
+  # exits early unless a session is open -- it is a session recorder, so no
+  # session means nothing to record against.
+  export PATH="$(dirname "${CLI}"):${PATH}"
+  export TREESHIP_PROJECT_ROOT="${WORKSPACE}"
+  "${CLI}" session start --config "${CONFIG}" --name approval-capture >/dev/null 2>&1 || true
+
+  count_artifacts() {
+    find "${WORKSPACE}/.treeship/artifacts" -name 'art_*.json' 2>/dev/null | wc -l | tr -d ' '
+  }
+
+  # (1) approver unset -> no artifact minted
+  before="$(count_artifacts)"
+  printf '%s' "${payload}" | env -u TREESHIP_APPROVER sh "${hook}" >/dev/null 2>&1 || true
+  after="$(count_artifacts)"
+  if [[ "${before}" != "${after}" ]]; then
+    echo "   minted an approval with no TREESHIP_APPROVER set (${before} -> ${after})" >&2
+    echo "   the hook must never invent an approver identity" >&2
+    return 1
+  fi
+
+  # (2) approver set -> exactly one artifact, and it verifies
+  printf '%s' "${payload}" | TREESHIP_APPROVER="human://acceptance" sh "${hook}" >/dev/null 2>&1 || true
+  after="$(count_artifacts)"
+  if [[ "${after}" != "$((before + 1))" ]]; then
+    echo "   expected exactly one new approval artifact (${before} -> ${after})" >&2
+    return 1
+  fi
+
+  # Verify every approval artifact in the store and require that one of them
+  # names the configured approver. Selecting "the newest file" is not stable
+  # across filesystems, and a test that verifies the wrong artifact would go
+  # green for the wrong reason.
+  local found=0 art_id
+  while IFS= read -r art_path; do
+    [[ -n "${art_path}" ]] || continue
+    art_id="$(basename "${art_path}" .json)"
+    out="$("${CLI}" verify --config "${CONFIG}" "${art_id}" 2>&1 || true)"
+    if echo "${out}" | grep -Fq "human://acceptance"; then
+      found=1
+      break
+    fi
+  done < <(find "${WORKSPACE}/.treeship/artifacts" -name 'art_*.json' 2>/dev/null)
+
+  if [[ "${found}" -ne 1 ]]; then
+    echo "   no minted artifact verified with approver human://acceptance" >&2
+    return 1
+  fi
+}
+
 # ---------- runner ----------
 
 main() {
@@ -166,6 +242,7 @@ main() {
 
   local filter="${1:-}"
   run_test "smoke"   test_smoke_session_roundtrip "${filter}"
+  run_test "approval-capture" test_askuserquestion_approval_capture "${filter}"
 
   echo "================================"
   echo "  passed: ${PASS}    failed: ${FAIL}"


### PR DESCRIPTION
## The gap

`AskUserQuestion` fell through to the generic branch of the PostToolUse
dispatch. A session in which an operator authorized an irreversible publish
to three package registries recorded exactly this:

```json
{"type": "agent.called_tool", "tool_name": "AskUserQuestion"}
```

No question, no answer, no approver. The moment that mattered most in the run
was the one the receipt said least about — while `ApprovalStatement`, with
approver, single-use nonce, expiry, `policyRef` and irreversibility class, sat
unused in the same codebase.

This is the first of the "emit the artifacts we already have" items. No new
protocol, no new statement type — wiring only.

## What changed

**Always.** The question and the selected option are recorded in the timeline.
Redacted before it is stored (AUD-26 — this string can reach a published,
no-auth receipt), then capped, because option descriptions run long.

**Opt-in, via `TREESHIP_APPROVER`.** A signed `approval.v1` artifact naming
that approver.

## Fail-closed on identity

The hook can see that *someone* at this terminal answered. It cannot see who.

Deriving an approver from `$USER` or a git config would manufacture an identity
claim the evidence does not support — precisely what
`docs/quality/ai-assisted-development.md` exists to catch. So: no configured
approver, no artifact. The timeline entry still records what happened.

Setting `TREESHIP_APPROVER` is the operator asserting "answers I give in this
session are mine, and may be recorded as authorization records." The artifact
rests on that assertion, not on anything the hook independently verified.

## Limits stated rather than papered over

- `AskUserQuestion` is a general-purpose question tool, **not** an approval
  gate. Most answers authorize nothing, so the description records only that
  the operator answered X to question Y — never that it authorized a specific
  action.
- The artifact is minted **after the fact**. It witnesses the answer; it does
  not gate what Claude does next.

## Test

`tests/acceptance/trust-fabric.sh approval-capture` asserts both directions,
and the dangerous one is the absence:

1. Without `TREESHIP_APPROVER` → no artifact minted.
2. With it → exactly one artifact, and it verifies carrying the approver.

Checked against a deliberately reintroduced regression — patching the hook to
default the approver to `human://$(whoami)`:

```
   minted an approval with no TREESHIP_APPROVER set (1 -> 2)
   the hook must never invent an approver identity
   ✗ approval-capture
```

Artifact selection verifies every approval in the store rather than guessing
the newest file, so the test cannot go green by verifying the wrong one. Stable
across repeated runs; full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YiJqtp9p7gUiQjA8pc5Ty