### PR TITLE
docs(specs): two specs said "not implemented" for shipped features

### DIFF
--- a/docs/quality/capability-index.md
+++ b/docs/quality/capability-index.md
@@ -166,3 +166,29 @@ applied to receipts.
 Route scanning matches chi registrations by literal string. A route built at
 runtime from a variable will not be found, and will surface as reverse drift
 only if it is *also* undocumented. Adding one is fine; it just needs its entry.
+
+**Design specs under `docs/specs/` are not covered by this index, and they
+drift the dangerous direction.** Nothing cross-checks a spec's `**Status:**`
+line against the feature it describes, so a spec can go on saying "draft, not
+implemented" for releases after the thing shipped. That is worse than an
+out-of-date doc: the standing rule above says "this does not exist" is a claim
+requiring evidence, and a stale spec *is* that claim, stated in the repo's own
+voice, where an agent will find it and rebuild something that already works.
+
+Two were corrected on 2026-08-31 after exactly that near-miss:
+`per-actor-signing.md` said "draft, not implemented" for the feature this
+index records as shipped in v0.13, and `merkle-consistency.md` said "NOT
+implemented — deliberately deferred" for `merkle-consistency` (status:
+stable, shipped v0.15). Both were verified before editing — per-actor signing
+by onboarding an agent and observing `actor proof: proven (key-bound)`, merkle
+consistency by locating `consistency_proof` in `tree.rs`.
+
+Nine further specs still say "draft, not implemented" while naming CLI
+commands or feature ids this index lists: `agent-capability-cards`,
+`agent-resolver`, `transparency-log`, `work-history`, `receipt-system`,
+`capability-provenance`, `time-anchoring`, `protocol-integration`,
+`registry-topology`, `agent-invitations-rooms`. Keyword overlap is not proof —
+a spec may legitimately describe more than what shipped — so each needs
+checking individually before its status is changed. Until a spec declares the
+inventory ids it corresponds to, this cannot be automated the way the rest of
+the index is.

--- a/docs/specs/merkle-consistency.md
+++ b/docs/specs/merkle-consistency.md
@@ -1,8 +1,12 @@
 # Merkle Consistency Proofs (transparency-log slice 3)
 
-**Status:** draft, NOT implemented — deliberately deferred to a careful, dedicated build
+**Status:** SHIPPED in v0.15. Kept as the design record; it is no longer a plan.
+Tracked in `docs/feature-inventory.yml` as `merkle-consistency` (status: stable).
+**Implementation:** `consistency_proof` / `verify_consistency` in
+`packages/core/src/merkle/tree.rs`, `POST /v1/merkle/consistency` on the Hub,
+and `treeship merkle publish`. The audit chain walks the proofs offline.
 **Pairs with:** [transparency-log](./transparency-log.md), `packages/core/src/merkle/tree.rs`
-**Last updated:** 2026-06-24
+**Last updated:** 2026-08-31
 
 ## What this is
 

--- a/docs/specs/per-actor-signing.md
+++ b/docs/specs/per-actor-signing.md
@@ -1,12 +1,32 @@
-# Per-Actor Signing — design draft
+# Per-Actor Signing
 
-**Status:** draft, not implemented
-**Pairs with:** capability cards (`verify-capability` key-bound check), `TrustRootKind::AgentCert`, `treeship agent register`
-**Last updated:** 2026-06-24
+**Status:** SHIPPED in v0.13. This document is the design record, kept because
+the reasoning is still load-bearing; it is no longer a plan.
+**Implementation:** `resolve_actor_signer` in `packages/cli/src/commands/attest.rs`
+(actor → key resolution + the AgentCert pin check), `registered_key_for_actor`
+in `packages/cli/src/commands/cards.rs` (the `actor → key_id` lookup),
+`treeship onboard` (mints the per-agent key and pins it), and the
+`proven (key-bound)` / `asserted` labels in `packages/cli/src/commands/verify.rs`.
+**Pairs with:** capability cards (`verify-capability` key-bound check), `TrustRootKind::AgentCert`
+**Last updated:** 2026-08-31
+
+## Verifying it yourself
+
+```
+treeship onboard my-agent
+treeship attest action --actor agent://my-agent --action demo
+treeship verify <artifact-id>      # actor proof: proven (key-bound)
+```
+
+An actor that was never onboarded still signs with the ship's default key and
+grades `asserted`. That is the designed fallback, not a defect — but it does
+mean an integration that attests under an actor nobody registered produces
+`asserted` artifacts silently, and the fix is to onboard the actor, not to
+change any code.
 
 ## The shift
 
-Today every action in a Treeship is signed by the **single default key**. `agent://deployer` and `agent://planner` working in the same Treeship both produce receipts signed by that one key, and the `actor` field is a free string. So actor identity is **asserted, not proven**: a compromised `agent://deployer` can label its actions `agent://planner` and the signature still verifies. This is the actor-forgery gap, and it is the gap the capability card's `key-bound` status is waiting on, today every card is `self-asserted` because nothing pins a per-agent key.
+Before v0.13, every action in a Treeship was signed by the **single default key**. `agent://deployer` and `agent://planner` working in the same Treeship both produced receipts signed by that one key, and the `actor` field was a free string. So actor identity was **asserted, not proven**: a compromised `agent://deployer` can label its actions `agent://planner` and the signature still verifies. That was the actor-forgery gap, and the gap the capability card's `key-bound` status was waiting on: before v0.13 every card was `self-asserted` because nothing pinned a per-agent key.
 
 Per-actor signing closes it: **each agent signs its own actions with its own key, certified by the ship.** Then the `actor` becomes provable (the receipt's signing key is the agent's pinned `AgentCert` key), and `verify-capability` lights up `key-bound: yes`.
 
@@ -33,7 +53,7 @@ agent_key_A  --signs-->  every action receipt for agent://deployer
 verify: action.signer == agent_key_A == cert.key, cert issued by a trusted ship  =>  actor PROVEN
 ```
 
-## What changes
+## What changed
 
 1. **`treeship agent register --actor agent://deployer`** generates a *new* per-agent key (or adopts a named one), issues a ship-signed `AgentCertificate` binding the actor URI to that key, pins the agent key under `AgentCert`, and records the `actor → key_id` mapping on the agent card.
 2. **`treeship attest action --actor agent://deployer`** resolves the actor URI to its registered key id and signs with `keys.signer(key_id)`. If the actor has no registered per-agent key, it signs with `default_signer()` exactly as today (backward compatible).
@@ -57,6 +77,10 @@ Per-actor signing is what moves `actor` from the asserted column to the proven c
 
 Strictly additive. An agent with no registered per-agent key signs with the default key, byte-for-byte as today. Existing certs (which certify the default key) keep verifying. The only new behavior is *opt-in* per-agent keys.
 
+## Slices — all shipped
+
+All three landed in v0.13. Kept for the record of how it was sequenced.
+
 ## Slices
 
 1. **`agent register` mints + binds a per-agent key.** Generate a key, issue the ship-signed cert over *that* key, pin it `AgentCert`, store `actor → key_id` on the agent card. (The cert-issuance and pinning code largely exists; the change is generating/using a per-agent key instead of the default.)
@@ -68,6 +92,18 @@ Strictly additive. An agent with no registered per-agent key signs with the defa
 1. **Where the `actor → key_id` map lives.** Proposal: a `key_id` field on the `AgentCard` (it already carries `certificate_digest`), so `attest` resolves via the card store. Alternative: derive from the pinned `AgentCert` roots by matching the cert's `agent` URI.
 2. **Key rotation.** When an agent rotates keys, a new cert supersedes the old; past receipts stay valid under the old (still-trusted-at-the-time) key. Needs the same resolution semantics as capability-card `supersedes`.
 3. **Default-key actions after registration.** If an agent is registered but a tool path still calls `default_signer`, the receipt is shared-key (asserted) even though the agent has a key. Decide whether to warn, or to make the resolved-key path the default once a per-agent key exists.
+
+## Resolved open questions
+
+1. **Where the `actor → key_id` map lives.** The proposal was taken: `key_id`
+   on the `AgentCard`, resolved through the card store by
+   `registered_key_for_actor`. It picks the newest matching card
+   deterministically, so filesystem iteration order cannot decide which key an
+   actor signs with.
+2. **Default-key actions after registration.** Resolution is automatic: an
+   actor with a registered, AgentCert-pinned key signs with it; everything else
+   falls back to the default. No warning is emitted, which is the one rough
+   edge — see "Verifying it yourself" above.
 
 ## First slice to build
 


### PR DESCRIPTION
## What happened

I was about to implement per-actor signing. `docs/specs/per-actor-signing.md`
said **"Status: draft, not implemented"**, named the first slice to build, and
described `resolve_actor_signer` as future work.

It shipped in **v0.13**. This repo's own capability index records it:

> Registered agents sign with their own Ed25519 key, bound by a ship-issued
> `agent_cert.v1` — the `proven (key-bound)` actor grade. Shipped v0.13.

`resolve_actor_signer` is already in `packages/cli/src/commands/attest.rs`,
with the AgentCert pin check and the default-key fallback the spec describes as
work remaining. The only reason I didn't rebuild it is CLAUDE.md's rule to
check the capability index first — *"this does not exist is a claim requiring
evidence."*

Which is the point: **a spec marked not-implemented is that claim**, stated in
the repo's own voice, in the file an agent reads before building.

## Verified, not inferred

```
treeship onboard zerker-gateway
treeship attest action --actor agent://zerker-gateway --action demo
treeship verify <id>     # actor proof: proven (key-bound)
```

An actor nobody onboarded still grades `asserted`. That's the designed
fallback — and it explains why an integration attesting under an unregistered
actor produces `asserted` artifacts with no warning. Noted in the spec, because
the fix is to onboard the actor, not to change code.

`merkle-consistency.md` had the same defect: *"NOT implemented — deliberately
deferred to a careful, dedicated build"* for a feature the index lists as
`merkle-consistency`, **status: stable, shipped v0.15**, with
`consistency_proof` at `tree.rs:427` and `POST /v1/merkle/consistency` on the
Hub.

Both are rewritten as design records with implementation pointers, so the
reasoning survives without the false claim.

## The blind spot

Nothing cross-checks a spec's `**Status:**` line against the feature it
describes, so this drift is invisible to every guard the repo has — and it
drifts in the direction that causes rework. Documented under
`capability-index.md` → Limits.

**Nine further specs** say "draft, not implemented" while naming CLI commands
or feature ids the index lists: `agent-capability-cards`, `agent-resolver`,
`transparency-log`, `work-history`, `receipt-system`, `capability-provenance`,
`time-anchoring`, `protocol-integration`, `registry-topology`,
`agent-invitations-rooms`.

They are **named, not edited.** Keyword overlap is not proof — a spec may
legitimately describe more than what shipped — and correcting a status without
verifying it is the same error in the opposite direction. Each needs its own
check.

Automating this needs specs to declare the inventory ids they correspond to;
worth doing if the list is as wrong as it looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YiJqtp9p7gUiQjA8pc5Ty