### PR TITLE
Release v0.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.25.3"
+    "version": "0.26.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.26.0 (2026-09-01)
+
 ### Added
 
 - **`treeship workflow verify`: one fail-closed path from a signed declaration
@@ -29,6 +31,39 @@
   so the pass/fail policy belongs to the caller and the substrate reports the
   file. Path, authority, and loop findings stay on separate axes in both the
   text and `--format json` output; one never summarizes another.
+
+- **Observation sets can be derived from verified actions instead of typed by
+  hand.** `treeship workflow verify --run` read a file somebody wrote, which
+  meant the attribution rule -- which declared node an action belongs to --
+  lived outside the trust boundary entirely. `derive_observed_run` builds the
+  observation set from verified actions, so that rule is now code with tests
+  against it.
+
+  Attribution is by admissibility, never by label. A node admits an action when
+  its executor matches the signed actor (or a capability the verified mandate
+  carried) and its `allowed_tools` covers the signed action label. Exactly one
+  admitting node is the only case that earns `checked`, and a recorded node
+  label is not consulted there at all: a runtime cannot relabel work the
+  declaration already places. A label may only pick within an already
+  admissible set, which caps that attempt at `captured`, and a label naming a
+  node that cannot admit the action is reported rather than used as a
+  tiebreak.
+
+  Two ways this could have reported a clean run for a dirty one, both now
+  regression tests. Dropping an action that no node's `allowed_tools` covers
+  would have hidden an out-of-scope tool, so such an action stays attributed by
+  executor match and the authority axis still reports it. Accepting a repeated
+  action reference would have let one action pay twice against a loop's
+  `budget.max_actions`, which counts unique signed-action references, so
+  duplicates are refused during derivation -- `validate_run` only dedupes
+  within a single attempt.
+
+  Derivation leaves `pre_existence` asserted. `verify_workflow_run` remains the
+  only place that grades ordering.
+
+- **The recovered workflow conformance verifier.** `workflow_conformance.rs`,
+  its golden fixtures, and the `workflow.v1` predicate schema had existed only
+  in a local stash since 2026-08-18. They are on main.
 
 ## 0.25.3 (2026-08-31)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "base64",
  "clap",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.3"
+    "@treeship/core-wasm": "0.26.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.25.3",
+        "@treeship/core-wasm": "0.26.0",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.25.3",
+    "@treeship/core-wasm": "0.26.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.25.3",
-    "@treeship/cli-linux-arm64": "0.25.3",
-    "@treeship/cli-darwin-arm64": "0.25.3",
-    "@treeship/cli-darwin-x64": "0.25.3"
+    "@treeship/cli-linux-x64": "0.26.0",
+    "@treeship/cli-linux-arm64": "0.26.0",
+    "@treeship/cli-darwin-arm64": "0.26.0",
+    "@treeship/cli-darwin-x64": "0.26.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.25.3", path = "../core" }
+treeship-core = { version = "0.26.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.25.3", path = "../core" }
+treeship-core = { version = "0.26.0", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.25.3"
+version = "0.26.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.3"
+    "@treeship/core-wasm": "0.26.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.25.3"
+    "@treeship/core-wasm": "0.26.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "dependencies": {
-        "@treeship/verify": "0.25.3"
+        "@treeship/verify": "0.26.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.25.3"
+    "@treeship/verify": "0.26.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "dependencies": {
-        "@treeship/verify": "0.25.3"
+        "@treeship/verify": "0.26.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.3"
+    "@treeship/verify": "0.26.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "dependencies": {
-        "@treeship/verify": "0.25.3"
+        "@treeship/verify": "0.26.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.25.3"
+    "@treeship/verify": "0.26.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Cuts v0.26.0. Minor bump rather than patch: this release adds a new CLI command and new public core API, matching the 0.24.0 → 0.25.0 convention.

## What ships

**`treeship workflow verify`** — one fail-closed path from a signed declaration to a conformance report. The three verification pieces existed separately and nothing composed them; `verify_workflow_run` does, and it is now the only place the pre-existence grade is decided.

**`derive_observed_run`** — observation sets can be derived from verified actions instead of typed by hand, which moves the attribution rule inside the trust boundary. Attribution is by admissibility, never by label: one admitting node earns `checked`, a recorded label may only pick within an already-admissible set and caps at `captured`, and ambiguity is reported rather than guessed.

**The recovered conformance verifier** — `workflow_conformance.rs`, its golden fixtures, and the `workflow.v1` predicate schema existed only in a local stash since 2026-08-18. They are on main.

Merged since v0.25.3: #347, #350, #348, #349, #351.

## Release mechanics

`scripts/release.sh prepare 0.26.0` stamped 43 version sites across Cargo, npm, PyPI, and plugin manifests. CHANGELOG's `Unreleased` section is dated as `0.26.0 (2026-09-01)` with a fresh empty `Unreleased` above it.

**Lockfiles are intentionally not regenerated here.** `--package-lock-only` still resolves against the registry and 0.26.0 has no tarball yet, so `check-lockfile-sync` relaxes the installed-entry half on `release/v*` — verified locally, it reports the declared ranges agreeing across 10 packages. Per #346, main goes red on that check between merge and publish; `scripts/release.sh refresh-lockfiles` closes it afterward.

**Merging this does not release anything.** `release.yml` triggers on `push: tags: v*`, so this needs an explicit `scripts/release.sh tag 0.26.0 --sha <merged-main-sha>` followed by `git push origin v0.26.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH9paxzY6ZJtXKJ5KNgRBA