### PR TITLE
chore(release): refresh lockfiles against published 0.26.0

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
-      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
+      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
-      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
+      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.25.3.tgz",
-      "integrity": "sha512-VlFlACfxIVEQ1gVZ3N4gLIN/+FX0wYEZMZEvzK7r6EybtWc9WoJHWPdUxuQ5DdvlmtPjxEmY4fN7M5m9WgpJaQ==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
+      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.25.3",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.25.3.tgz",
-      "integrity": "sha512-qzLQ8yroRnmjwEU4nk/8mUWberrbyxS1/cXx1FE3jtwVM8dco3Tmjx+wv1wEtO+X8PA7Dt6GiUmHO0E4Y3U9Qw==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
+      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.25.3"
+        "@treeship/core-wasm": "0.26.0"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
Unblocks every open PR's JS tests.

`release.sh prepare` stamps `package.json` but cannot update the lockfiles: `--package-lock-only` resolves against the registry, and the version being released has no tarball yet. `check-lockfile-sync` relaxes the installed-entry half on `release/v*` for exactly that reason, which is why #352 went green and the push to main went red.

0.26.0 is published now, so the lockfiles can name it.

**Why this is urgent rather than tidy:** `npm ci` currently refuses on every open PR, and the failure reads as a per-PR problem. On #353 it surfaced as three failing checks — JS tests for `bridges/a2a`, `bridges/mcp`, and `packages/verify-js` — all failing at the **Install** step, none of which touched a lockfile.

Same shape as #346 after 0.25.3. Eleven packages now agree; `check-lockfile-sync` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MH9paxzY6ZJtXKJ5KNgRBA