### PR TITLE
chore(release): refresh lockfiles against published 0.27.0

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
-      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
+      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.26.0"
+        "@treeship/core-wasm": "0.27.0"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
-      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
+      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.26.0"
+        "@treeship/core-wasm": "0.27.0"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.26.0.tgz",
-      "integrity": "sha512-csDuXonI6qUbEi8DlLsAWHKsa9IZg0/ms5oTDDBU7WJs2VAOhYpmXlFoEcmHVG4O1h8Frme3fAGD6nabC7urTw==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
+      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.26.0.tgz",
-      "integrity": "sha512-kNlhB8xydjtfR9YbaJyaiwv4Eqxa68rFNj/RUuMWl6XRtp4Go0ra+0pW/29b4YE16Za0QYCIazA9LhQMAodQNA==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
+      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.26.0"
+        "@treeship/core-wasm": "0.27.0"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
Unblocks every open PR's JS tests, same shape as #346 and #354: the lockfiles' installed entries could not name 0.27.0 until it was published. It is now on npm (`treeship`, `@treeship/verify`, `@treeship/core-wasm`, `@treeship/mcp`, `@treeship/sdk`, `@treeship/a2a` all 0.27.0), so they can. `check-lockfile-sync` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K7KU5PGyspTMuLCLmg6Ps
