### PR TITLE
docs(commerce): install treeship-commerce from PyPI

### DIFF
--- a/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
+++ b/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
@@ -97,8 +97,7 @@ After that, the checkout hand-off: a signed digest of exactly the cart that went
 ```bash
 # in a clone of anthropics/commerce-agents
 pip install -r requirements.txt
-pip install treeship-sdk
-pip install "treeship-commerce @ git+https://github.com/zerkerlabs/treeship.git#subdirectory=integrations/commerce-agents"
+pip install treeship-sdk treeship-commerce
 curl -fsSL https://treeship.dev/install | sh && treeship init
 python -m treeship_commerce.demo
 ```

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -178,7 +178,7 @@ Offline, from the CLI, against your own trust roots:
 
 ```bash
 treeship verify art_44180341eaeafa79d472115c7c38b03a       # the chain head
-#   ✓ verified  (13 artifacts . chain intact)
+#   ✓ verified  (11 artifacts . chain intact)
 treeship package verify .treeship/sessions/ssn_a52cd0de94f479d3.treeship
 #   18 passed, 0 failed, 1 warnings
 #   ✓ package verified

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -178,7 +178,7 @@ Offline, from the CLI, against your own trust roots:
 
 ```bash
 treeship verify art_44180341eaeafa79d472115c7c38b03a       # the chain head
-#   ✓ verified  (11 artifacts . chain intact)
+#   ✓ verified  (13 artifacts . chain intact)
 treeship package verify .treeship/sessions/ssn_a52cd0de94f479d3.treeship
 #   18 passed, 0 failed, 1 warnings
 #   ✓ package verified
@@ -186,7 +186,7 @@ treeship package verify .treeship/sessions/ssn_a52cd0de94f479d3.treeship
 
 `--format json` gives a CI-consumable document: every check by artifact id, `chain_linkage_ok`, and the outcome. A published session renders at `treeship.dev/receipt/<id>` with the timeline and the same verifier running in the browser (`@treeship/verify`, WebAssembly); the hub stores bytes and serves proofs, it never issues a verdict.
 
-The demo's output, from a clean ship with the released 0.27.0 CLI and the SDK from PyPI (the `1 warnings` above is the package's always-on note that the narrative fields are not signature-bound; the artifacts and Merkle root are):
+The demo's output, from a clean ship with the released 0.28.0 CLI and the SDK from PyPI (the `1 warnings` above is the package's always-on note that the narrative fields are not signature-bound; the artifacts and Merkle root are):
 
 ```text
 tool calls        intent-id result-id

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -84,8 +84,7 @@ What is deliberately **not** in a receipt:
 ```bash
 # in a clone of anthropics/commerce-agents, with its venv active
 pip install -r requirements.txt                  # the reference's packages; unregistered on PyPI by design
-pip install treeship-sdk
-pip install "treeship-commerce @ git+https://github.com/zerkerlabs/treeship.git#subdirectory=integrations/commerce-agents"
+pip install treeship-sdk treeship-commerce
 curl -fsSL https://treeship.dev/install | sh     # the CLI does the signing
 treeship init
 ```
@@ -223,6 +222,6 @@ session           receipts=10 events=6 root_verified=True
 
 ## Reference
 
-- Package: [`integrations/commerce-agents/`](https://github.com/zerkerlabs/treeship/tree/main/integrations/commerce-agents); installs from the repository today, PyPI publication follows with the next release
+- Package: [`integrations/commerce-agents/`](https://github.com/zerkerlabs/treeship/tree/main/integrations/commerce-agents); on PyPI as `treeship-commerce`
 - Tests: eight cases on a real ship over the reference's retail mock, run in CI against the reviewed commit of the reference
 - Related: [Integration overview](/integrations/commerce-agents), [Agentic commerce](/commerce/overview), [Payment proofs](/commerce/payment-proofs), [Trust model](/concepts/trust-model)

--- a/docs/content/docs/integrations/commerce-agents.mdx
+++ b/docs/content/docs/integrations/commerce-agents.mdx
@@ -29,8 +29,7 @@ Never written: the arguments, the result text (fenced third-party content on the
 ```bash
 # from a clone of anthropics/commerce-agents, with its venv active
 pip install -r requirements.txt          # the reference's packages; unregistered on PyPI by design
-pip install treeship-sdk
-pip install "treeship-commerce @ git+https://github.com/zerkerlabs/treeship.git#subdirectory=integrations/commerce-agents"
+pip install treeship-sdk treeship-commerce
 curl -fsSL https://treeship.dev/install | sh && treeship init
 ```
 

--- a/integrations/commerce-agents/README.md
+++ b/integrations/commerce-agents/README.md
@@ -35,8 +35,7 @@ can correlate and a reader cannot.
 ```bash
 # from a clone of anthropics/commerce-agents, with its venv active
 pip install -r requirements.txt            # their seven packages (unregistered on PyPI)
-pip install treeship-sdk
-pip install "treeship-commerce @ git+https://github.com/zerkerlabs/treeship.git#subdirectory=integrations/commerce-agents"   # PyPI publication follows the next release
+pip install treeship-sdk treeship-commerce
 curl -fsSL https://treeship.dev/install | sh && treeship init
 ```
 


### PR DESCRIPTION
v0.28.0 published `treeship-commerce` to PyPI by trusted publishing and the release installed it back from the registry and imported it. The guide, the post, the integration page and the README now say `pip install treeship-sdk treeship-commerce` instead of the repository install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K7KU5PGyspTMuLCLmg6Ps