### PR TITLE
chore: lock the JS workspaces to the published 0.28.0 tarballs

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
-      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.28.0.tgz",
+      "integrity": "sha512-2ODzLOkHfZAptb8rNp1euUZCwNBDBt11MRAKvjSoK7JMp7DXLygf49tJbHdzi9jysCnQhf7UBtcShC6wUKxYMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.27.0"
+        "@treeship/core-wasm": "0.28.0"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
-      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.28.0.tgz",
+      "integrity": "sha512-2ODzLOkHfZAptb8rNp1euUZCwNBDBt11MRAKvjSoK7JMp7DXLygf49tJbHdzi9jysCnQhf7UBtcShC6wUKxYMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.27.0"
+        "@treeship/core-wasm": "0.28.0"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.27.0.tgz",
-      "integrity": "sha512-yicvSnWIq/la0BZ0I/KDmNTfzF6kAdGGWu3da88wurUVjMYnAm3Y8Z4a1y+5VhM972Syf9nKLY9v5jtjz/Kpsw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.28.0.tgz",
+      "integrity": "sha512-EZv/DcVtRLFEXEsH3ASZxRwcXjOuF3VcGv6uBJhqPVm8bfIUbripqEAnRDOoowh3KX7brCiLtr1SROU1tW+gqA==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.27.0.tgz",
-      "integrity": "sha512-b1gqRpXmPSwTNcdPXYN+3TUvijqoLyNxqQJcX9AfUbs6fm0u1eGqiSlGGkUP1dQzji6yhaFoXUjrx6kJWm9mDg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.28.0.tgz",
+      "integrity": "sha512-2ODzLOkHfZAptb8rNp1euUZCwNBDBt11MRAKvjSoK7JMp7DXLygf49tJbHdzi9jysCnQhf7UBtcShC6wUKxYMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.27.0"
+        "@treeship/core-wasm": "0.28.0"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
The other half of the release-time lockfile fallback: `scripts/release.sh refresh-lockfiles` now that v0.28.0 is on npm. Seven lockfiles, resolved + integrity for `@treeship/core-wasm` and `@treeship/verify` 0.28.0, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K7KU5PGyspTMuLCLmg6Ps