### PR TITLE
feat(commerce): signed single-use operator approvals on the merchant apply_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+### Added
+
+- **`treeship-commerce`: signed single-use operator approvals on the merchant
+  `apply_change`.** The reference gates `apply_change` on an in-process set the
+  host fills from its y/N; the set leaves no record and cannot refuse a second
+  apply inside the same window. `MerchantApprovals.grant(change_id)` mints a
+  signed Approval Grant scoped to one actor, one action, and
+  `change://<change_id>` with `max_uses=1`; `approved(receipted(
+  MerchantToolExecutor), approvals)` signs the apply's intent receipt with the
+  grant's nonce, so the CLI reserves a use in the Approval Use Journal before
+  it signs. A replay finds the grant spent; a grant for another change is
+  refused by scope, because the action's subject is taken from the call's own
+  arguments and never from the grant. The receipt says `approval: "proven"` or
+  `"unproven"` with the CLI's reason. Recording only by default; `enforce=True`
+  holds an unproven apply in the reference's own held-outcome shape, and the
+  hold is itself a signed refusal. On an SDK without `subject` it warns once
+  and mints nothing. `approving(toolset, approvals)` wraps the Agent SDK
+  `MerchantToolset`'s `host_approve` / `host_clear` in place, so the reference
+  console's y/N loop mints and forgets grants unchanged. Merchant demo
+  `demo_merchant.py` (`--enforce` for the gating mode); twelve tests,
+  including the replay and wrong-change refusals and the merchant side on all
+  three runtimes through `executor_class`.
+
+- **`treeship-commerce`: arguments that are not JSON-native no longer break
+  the tool.** The reference's MCP server hands the executor parsed pydantic
+  models; the argument digest called `json.dumps` on them outside the guarded
+  path and the stage call died inside the recorder. The digest is now total
+  (pydantic v1/v2, dataclasses, sets, bytes, datetimes, Decimal, Enum, paths,
+  and a typed repr for anything else) and equal to the digest of the same
+  arguments as plain dicts, and nothing raised while describing a call can
+  reach the tool.
+
+- **Python SDK: `attest_action(..., subject=)`.** Sets the action's
+  `subject.uri`, the field an approval's `allowed_subjects` scope is matched
+  against. Without it a subject-scoped grant refused every action from the
+  SDK; the CLI has taken `--subject` since the scope check existed.
+
 ## 0.28.0 (2026-09-07)
 
 **Upgrade if you build on Anthropic's commerce-agents reference, or use the

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -207,6 +207,64 @@ session           receipts=10 events=6 root_verified=True
 
 **Trust boundary.** The signing key lives on the machine that runs the executor. That is the right place for a deployment's own record of its agent, and it is a boundary: root on that machine can sign anything. A counterparty who wants to trust these receipts pins your ship key once (`treeship keys export` prints the line) and verifies against it.
 
+## Approvals: the operator's yes, spendable once
+
+The merchant side has one tool that mutates a merchant's system of record, `apply_change`, and the reference already gates it well: the change must have been staged in this session, must pass the configured guardrails, and, when `require_host_approval` is on, must be in `state.approved_change_ids`. The console's y/N puts it there with `toolset.host_approve(change_id)` and takes it out with `host_clear` when the apply turn returns.
+
+That set is an in-process boolean. It is right while the process runs and gone afterwards, so it cannot answer the two questions an operator is asked later: *did a human approve this, and when?* and *was that approval used more than once?* `MerchantApprovals` answers both. When the operator says yes it mints a signed Approval Grant scoped to one actor, one action, and one change, with `max_uses=1`. The apply's intent receipt is then signed with that grant's nonce, which makes the CLI reserve a use in the local Approval Use Journal before it will sign. A second apply of the same change finds the grant spent. A grant for one change cannot be spent on another, because the action names `change://<change_id>` as its subject and the grant's scope names the same URI. The subject comes from the call's own arguments, never from the grant, so the scope check cannot compare a grant against itself.
+
+```python
+from treeship_commerce import MerchantApprovals, approved, receipted
+from merchant_agent.executor import MerchantToolExecutor
+
+approvals = MerchantApprovals(ts, approver="human://operator", actor="agent://merchant")
+Executor = approved(receipted(MerchantToolExecutor, recorder=make_recorder), approvals)
+
+# in the host's y/N loop, where it currently calls host_approve alone:
+approvals.grant(change.change_id, summary=change.summary)   # the evidence
+toolset.host_approve(change.change_id)                      # the reference's own gate
+```
+
+Both calls, because they answer different questions: the mark lets the apply run, the grant proves it was allowed to. The apply's intent receipt then carries `approval: "proven"`, the grant's artifact id, and the change id. When a grant is missing, spent, expired, or scoped to another change, the receipt is still written and says `approval: "unproven"` with the CLI's reason (`would exceed max_uses (1/1)`, `scope refused this action: subject ...`). The tool still runs into the reference's `check_apply_change`, which is what holds it. Pass `enforce=True` to `approved(...)` to hold an unproven apply before the tool runs, using the reference's own held-outcome shape.
+
+```bash
+treeship approval uses <grant-id>       # the journal's record of the one use
+treeship approval journal verify        # the journal's own hash chain
+```
+
+`treeship package verify` on the sealed session reports the same evidence as a check of its own: `PASS replay-local-journal -- local Approval Use Journal passed, use 1/1`.
+
+### Per runtime
+
+The three runtimes differ in *where* the human's yes enters the process, so they differ in what can be signed.
+
+- **Agent SDK.** `MerchantToolset` is the approval surface: the console calls `host_approve` on yes and `host_clear` when the apply turn returns. `approving(toolset, approvals)` wraps those two methods on the toolset you already built, so the console's loop is unchanged and every yes mints a grant, every clear forgets it:
+
+  ```python
+  from treeship_commerce import MerchantApprovals, approved, approving, receipted
+
+  approvals = MerchantApprovals(ts, approver="human://operator")
+  toolset = approving(
+      MerchantToolset(backend=backend, executor_class=approved(
+          receipted(MerchantToolExecutor, recorder=make_recorder), approvals)),
+      approvals,
+  )
+  # main.py's confirm_staged_changes() runs as-is.
+  ```
+
+- **Messages API.** `MerchantAgent` leaves `state.approved_change_ids` to the host. Where the host adds the id, it also calls `approvals.grant(change_id, summary=...)`. The executor the orchestrator builds per turn picks the grant up through `executor_class`.
+- **Managed Agents.** The MCP server runs with `require_host_approval=False` because the platform's `always_ask` prompt is the approval surface, and that click happens outside the process. Nothing here can sign it. An apply there is receipted, and its receipt carries no approval claim rather than a fabricated one; `enforce=True` on that runtime would hold every apply, which is the honest reading of "no signed approval".
+
+All three are exercised in the test suite through each runtime's own `executor_class` seam, the way a deployment wires them.
+
+Requires a `treeship-sdk` whose `attest_action` takes `subject` (added after 0.28.0). On an older SDK `grant()` warns once and mints nothing, and the apply stays gated exactly as the unwrapped reference gates it.
+
+The merchant demo runs all of it with no model and no API key: a staged price change held unapproved, applied once under a signed grant, and refused on replay while the reference's own mark is still set.
+
+```bash
+python -m treeship_commerce.demo_merchant
+```
+
 ## Operating it
 
 - **Recording never breaks the agent path.** A receipt that cannot be written (CLI missing, ship not initialized, disk full) warns once, the tool runs anyway, and `TreeshipReceipts.dropped` counts it. A result whose intent is missing says `intent_recorded: false` and chains from the previous head; no id is ever invented.
@@ -216,12 +274,11 @@ session           receipts=10 events=6 root_verified=True
 
 ## What comes next
 
-- **Approvals.** The merchant `apply_change` gate passes only for a change id the host marked approved, a mark set just before the click and cleared just after. The next piece turns that mark into a signed, scoped, single-use Treeship approval: `attest approval --allowed-actions apply_change --allowed-subjects <change_id> --max-uses 1`, the apply receipt echoing the nonce, and the Approval Use Journal making it unspendable twice. The reference's `StagedChange` already carries the operator principal, so the approver is never invented.
 - **Checkout hand-off.** `checkout_handoff` returns a hosted URL the model never sees. Signing the cart digest and the URL digest at that moment, chained to the host's order placement, gives the customer a receipt for exactly the cart that went to checkout. See [Payment Proofs](/commerce/payment-proofs) for the pattern.
 - **A plugin command** in the reference's own marketplace format, alongside its `/add-commerce-flow`.
 
 ## Reference
 
 - Package: [`integrations/commerce-agents/`](https://github.com/zerkerlabs/treeship/tree/main/integrations/commerce-agents); on PyPI as `treeship-commerce`
-- Tests: eight cases on a real ship over the reference's retail mock, run in CI against the reviewed commit of the reference
+- Tests: twenty-eight cases on a real ship over the reference's retail and merchant mocks, run in CI against the reviewed commit of the reference; eight cover approvals, including the replay and the wrong-change refusals, and four drive the merchant side through each runtime's `executor_class` seam
 - Related: [Integration overview](/integrations/commerce-agents), [Agentic commerce](/commerce/overview), [Payment proofs](/commerce/payment-proofs), [Trust model](/concepts/trust-model)

--- a/docs/content/docs/integrations/commerce-agents.mdx
+++ b/docs/content/docs/integrations/commerce-agents.mdx
@@ -91,7 +91,7 @@ session           receipts=10 events=6 root_verified=True
 
 - **Gate.** The reference's provenance gates, caps, and host approval decide what runs. This records the decision.
 - **Prove the work is correct.** A receipt is evidence of what ran and what the gates said. A wrong answer with a perfect receipt is still wrong.
-- **Approvals, yet.** The merchant `apply_change` gate checks a mark the host sets and clears around the click. Turning that mark into a signed, single-use Treeship approval, with the apply receipt echoing the nonce, is the next piece.
+- **Gate on approvals, by default.** The merchant side mints a signed single-use grant when the operator says yes, and the apply's receipt is signed with its nonce so the Approval Use Journal refuses a replay. A missing or spent grant is recorded as unproven; it holds the call only with `enforce=True`. See the guide's approvals section.
 - **The checkout hand-off, yet.** Signing the cart digest and the hosted-checkout URL digest at `checkout_handoff`, chained to the host's order placement, follows.
 
 Full guide, with wiring for each runtime, a decoded receipt, and the trust boundary: [Claude Commerce Agents](/commerce/commerce-agents). Source: [`integrations/commerce-agents/`](https://github.com/zerkerlabs/treeship/tree/main/integrations/commerce-agents).

--- a/docs/feature-inventory.yml
+++ b/docs/feature-inventory.yml
@@ -600,7 +600,9 @@
     - docs/content/docs/integrations/commerce-agents.mdx
   tests:
     - integrations/commerce-agents/tests/test_receipts.py
-  notes: "Wraps the one executor every tool call passes through in anthropics/commerce-agents (Messages API, Agent SDK, Managed Agents): a signed intent receipt before dispatch, a signed result receipt after, chained from the Treeship session root. Held calls are signed as blocked with the gate's name. Receipts carry digests and the reference's own session tag, never arguments, result text, or the session id. Records only; the reference's gates still decide what runs. Approvals and the checkout hand-off receipt are next."
+    - integrations/commerce-agents/tests/test_approvals.py
+    - integrations/commerce-agents/tests/test_merchant_runtimes.py
+  notes: "Wraps the one executor every tool call passes through in anthropics/commerce-agents (Messages API, Agent SDK, Managed Agents): a signed intent receipt before dispatch, a signed result receipt after, chained from the Treeship session root. Held calls are signed as blocked with the gate's name. Receipts carry digests and the reference's own session tag, never arguments, result text, or the session id. Records only; the reference's gates still decide what runs. Merchant side: MerchantApprovals mints a signed single-use grant scoped to change://<id> when the operator approves; the apply's intent receipt is signed with its nonce so the Approval Use Journal refuses a replay, and a grant for another change is refused by scope. The checkout hand-off receipt is next."
 
 - id: npm-binary-integrity
   name: npm binary SHA-256 integrity check

--- a/integrations/commerce-agents/README.md
+++ b/integrations/commerce-agents/README.md
@@ -84,11 +84,33 @@ Runs the reference's shopping executor over the retail mock with no model and no
 a search, a product read, an add, an add the provenance gate holds, a checkout hand-off.
 Prints every receipt id, seals the session, and shows the `treeship verify` command.
 
+```bash
+TREESHIP_BIN=... python -m treeship_commerce.demo_merchant
+```
+
+The merchant side: a staged price change, held while unapproved, applied once under a
+signed single-use operator approval, then refused on replay while the reference's own
+in-process approval mark is still set. Prints the grant id and the journal's record of
+its one use.
+
+## Approvals
+
+`MerchantApprovals` turns the host's y/N into a signed Approval Grant scoped to one actor,
+one action, and one change (`change://<change_id>`), `max_uses=1`. `approved(receipted(
+MerchantToolExecutor), approvals)` signs the apply's intent receipt with the grant's nonce,
+so the CLI reserves a use in the Approval Use Journal before signing. A second apply finds
+the grant spent; a grant for another change is refused by scope. The receipt says
+`approval: "proven"` or `"unproven"` with the reason. Recording only, unless
+`enforce=True`. Needs a `treeship-sdk` whose `attest_action` takes `subject`.
+
+On the Agent SDK runtime, `approving(toolset, approvals)` wraps `MerchantToolset.host_approve`
+and `host_clear` in place, so the reference console's y/N loop mints and forgets grants with
+no edits. On the Messages API the host calls `approvals.grant()` beside its own mark. On
+Managed Agents the platform's prompt is the approval surface and the click is outside the
+process; an apply there is receipted with no approval claim, never an invented one.
+
 ## What this does not do (yet)
 
-- **Approvals.** The merchant `apply_change` gate checks a mark the host sets. Turning that
-  mark into a signed, single-use Treeship approval (nonce echoed by the apply receipt,
-  enforced by the Approval Use Journal) is the next piece.
 - **Checkout hand-off receipt.** Signing the cart digest and hosted-checkout URL digest at
   `checkout_handoff`, chained to the host's order placement.
 - **Prove the work is correct.** A receipt is evidence of what ran and what the gates
@@ -100,7 +122,11 @@ Prints every receipt id, seals the session, and shows the `treeship verify` comm
 TREESHIP_BIN=/path/to/treeship python -m pytest
 ```
 
-Six cases on a real isolated ship and the real retail mock: chain order and linkage, a held
-call signed as blocked with its gate, digests-only content, recording failure leaving the
-tool untouched, `TREESHIP_DISABLE`, and `attach` refusing an executor that would record
-nothing.
+Twenty-eight cases on a real isolated ship over the real retail and merchant mocks: chain
+order and linkage, a held call signed as blocked with its gate, digests-only content,
+recording failure leaving the tool untouched, `TREESHIP_DISABLE`, `attach` refusing an
+executor that would record nothing, one per runtime, and the approval properties: a grant
+binds to its receipt, is spendable once, is refused for another change, `enforce=True`
+holds an unapproved apply, the receipt note is the CLI's reason rather than the SDK's
+wrapper, the merchant side on all three runtimes through `executor_class`, and arguments
+that arrive as parsed pydantic models (the MCP server's shape) digesting like their dicts.

--- a/integrations/commerce-agents/tests/conftest.py
+++ b/integrations/commerce-agents/tests/conftest.py
@@ -144,3 +144,55 @@ def executor(ship: Ship):
         parent_id=ship.session_root,
     )
     return attach(ex, receipts)
+
+
+MERCHANT_SESSION_ID = "m-secret-session-3d81"
+
+
+def _merchant_executor(ship: Ship, *, enforce: bool):
+    """A receipted merchant executor over the ACME mock, with a signed
+    approval surface bound to its apply tool."""
+    from commerce_common.memory import InMemoryMemoryStore
+    from commerce_common.skills import SkillRegistry
+    from merchant_agent import MerchantAgentConfig, MerchantSessionContext, MerchantSessionState
+    from merchant_agent.executor import MerchantToolExecutor, build_memory
+    from merchant_agent_sdk import load_mock_backend
+
+    from treeship_commerce import MerchantApprovals, approved
+
+    config = MerchantAgentConfig()
+    approvals = MerchantApprovals(
+        ship.client, approver="human://operator", actor="agent://merchant"
+    )
+    cls = approved(receipted(MerchantToolExecutor), approvals, enforce=enforce)
+    ex = cls(
+        backend=load_mock_backend(),
+        config=config,
+        skills=SkillRegistry([]),
+        session=MerchantSessionContext(
+            session_id=MERCHANT_SESSION_ID, merchant_id="m-1", operator="human://operator"
+        ),
+        state=MerchantSessionState(),
+        memory=build_memory(config, InMemoryMemoryStore()),
+    )
+    attach(
+        ex,
+        TreeshipReceipts(
+            ship.client,
+            actor="agent://merchant",
+            session_id=MERCHANT_SESSION_ID,
+            role="merchant",
+            parent_id=ship.session_root,
+        ),
+    )
+    return ex, approvals
+
+
+@pytest.fixture
+def merchant(ship: Ship):
+    return _merchant_executor(ship, enforce=False)
+
+
+@pytest.fixture
+def merchant_enforcing(ship: Ship):
+    return _merchant_executor(ship, enforce=True)

--- a/integrations/commerce-agents/tests/test_approvals.py
+++ b/integrations/commerce-agents/tests/test_approvals.py
@@ -1,0 +1,256 @@
+# The merchant side. Every test here names the property it exists for, and
+# each one is written so that removing the feature makes it fail for the right
+# reason -- an approval test that passes because nothing was checked is worse
+# than no approval test.
+
+from __future__ import annotations
+
+import pytest
+
+from treeship_commerce import TreeshipReceipts
+from treeship_commerce.approvals import change_subject
+from treeship_commerce.receipts import _refusal_reason, sdk_supports_subject
+
+from .conftest import Ship, needs_cli
+
+pytestmark = [
+    needs_cli,
+    pytest.mark.skipif(
+        not sdk_supports_subject(),
+        reason="installed treeship-sdk cannot name an action subject",
+    ),
+]
+
+MERCHANT_SESSION_ID = "m-secret-session-3d81"
+
+
+async def stage_a_change(executor) -> str:
+    """Drive the merchant executor until it has one staged change, and return
+    its id. Staging is the reference's own path; nothing is faked."""
+    listings = await executor.execute("search_listings", {"query": ""})
+    assert not listings.refused, listings.result_text
+    seen = executor._state.seen_listings
+    assert seen, "the merchant mock returned no listings"
+    listing_id, listing = next(
+        (lid, item) for lid, item in seen.items() if not item.has_options
+    )
+    # A shallow markdown: deep enough to be a real change, shallow enough to
+    # clear the mock's cost floor and promotion-depth guardrails, which are the
+    # reference's gates and not what these tests are about.
+    outcome = await executor.execute(
+        "stage_price_update",
+        {
+            "items": [{"listing_id": listing_id, "new_price": round(listing.price * 0.97, 2)}],
+            "note": "clearance",
+        },
+    )
+    assert not outcome.refused, outcome.result_text
+    staged = list(executor._state.seen_changes)
+    assert staged, f"no change staged: {outcome.result_text}"
+    return staged[0]
+
+
+def operator_approves(executor, approvals, change_id: str):
+    """What a host does when the human says yes: mint the signed grant and set
+    the reference's own approval mark. Both, because they answer different
+    questions -- the mark lets the apply through, the grant proves it was
+    allowed to."""
+    grant = approvals.grant(change_id, summary="operator approved in test")
+    executor._state.approved_change_ids.add(change_id)
+    return grant
+
+
+async def test_apply_without_a_grant_records_no_approval_evidence(ship: Ship, merchant):
+    """The baseline the rest is measured against: with no grant, the apply's
+    receipt carries no approval claim at all -- not a false one."""
+    executor, approvals = merchant
+    change_id = await stage_a_change(executor)
+    await executor.execute("apply_change", {"change_id": change_id})
+
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    intents = [
+        c["statement"]
+        for c in ship.chain(receipts.head)
+        if c["statement"].get("action") == "commerce.tool.apply_change.intent"
+    ]
+    assert len(intents) == 1
+    meta = intents[0].get("meta") or {}
+    assert "approval" not in meta
+    assert "approval_grant" not in meta
+    assert approvals.minted == []
+
+
+async def test_operator_approval_is_signed_and_binds_to_the_receipt(ship: Ship, merchant):
+    """The operator's yes produces a signed grant, and the apply's receipt
+    names it and claims the approval was proven."""
+    executor, approvals = merchant
+    change_id = await stage_a_change(executor)
+
+    grant = operator_approves(executor, approvals, change_id)
+    assert grant is not None
+    assert grant.change_id == change_id
+    assert grant.subject == change_subject(change_id)
+    assert approvals.minted == [grant.artifact_id]
+    # The nonce is a capability; it must not leak through the repr that ends
+    # up in operator logs.
+    assert grant.nonce not in repr(grant)
+
+    await executor.execute("apply_change", {"change_id": change_id})
+
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    intents = [
+        c["statement"]
+        for c in ship.chain(receipts.head)
+        if c["statement"].get("action") == "commerce.tool.apply_change.intent"
+    ]
+    assert len(intents) == 1
+    meta = intents[0]["meta"]
+    assert meta["approval"] == "proven"
+    assert meta["approval_grant"] == grant.artifact_id
+    assert meta["change_id"] == change_id
+    assert receipts.dropped == 0
+
+    # The journal, not our bookkeeping, is the authority on the use.
+    uses = ship.cli_json("approval", "uses", grant.artifact_id)
+    assert uses["uses"], uses
+    assert len(uses["uses"]) == 1
+
+
+async def test_a_grant_is_spendable_once(ship: Ship, merchant):
+    """The property the in-process approval set cannot provide: a second apply
+    of the same approved change gets no approval evidence, because the journal
+    refuses the second use."""
+    executor, approvals = merchant
+    change_id = await stage_a_change(executor)
+    grant = operator_approves(executor, approvals, change_id)
+    assert grant is not None
+
+    first = await executor.execute("apply_change", {"change_id": change_id})
+    assert not first.refused, first.result_text
+    # The host would normally re-approve; here the same grant is offered twice
+    # on purpose, which is exactly the replay the journal has to refuse.
+    approvals._grants[change_id] = grant
+    await executor.execute("apply_change", {"change_id": change_id})
+
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    intents = [
+        c["statement"]
+        for c in ship.chain(receipts.head)
+        if c["statement"].get("action") == "commerce.tool.apply_change.intent"
+    ]
+    assert len(intents) == 2
+    assert intents[0]["meta"]["approval"] == "proven"
+    note = intents[1]["meta"]["approval_note"]
+    assert "max_uses" in note
+    # The reason, not the SDK's transport wrapper around it.
+    assert "attest action failed" not in note
+    # Still one use in the journal, not two.
+    uses = ship.cli_json("approval", "uses", grant.artifact_id)
+    assert len(uses["uses"]) == 1
+
+
+async def test_a_grant_cannot_be_spent_on_a_different_change(ship: Ship, merchant):
+    """Scope, not just counting: a grant minted for one change is refused when
+    offered for another, so approvals cannot be shuffled between changes."""
+    executor, approvals = merchant
+    change_id = await stage_a_change(executor)
+    other = approvals.grant("chg_not_this_one")
+    assert other is not None
+
+    # Offer the wrong change's grant for this apply. The nonce is valid and
+    # unspent; only the subject differs, so the scope check is the only thing
+    # that can refuse it.
+    approvals._grants[change_id] = other
+    await executor.execute("apply_change", {"change_id": change_id})
+
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    intents = [
+        c["statement"]
+        for c in ship.chain(receipts.head)
+        if c["statement"].get("action") == "commerce.tool.apply_change.intent"
+    ]
+    assert intents[-1]["meta"]["approval"] == "unproven"
+    assert "scope" in intents[-1]["meta"]["approval_note"].lower()
+    uses = ship.cli_json("approval", "uses", other.artifact_id)
+    assert uses["uses"] == []
+
+
+async def test_enforce_holds_the_call_when_there_is_no_grant(ship: Ship, merchant_enforcing):
+    """Opt-in enforcement: an unapproved apply is held before the tool runs,
+    the hold is the reference's own outcome shape, and the hold is itself a
+    signed refusal -- an intent and a blocked result -- never a call that
+    left no trace."""
+    executor, _ = merchant_enforcing
+    change_id = await stage_a_change(executor)
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    before = len(receipts.recorded)
+
+    outcome = await executor.execute("apply_change", {"change_id": change_id})
+    assert outcome.refused
+    assert outcome.blocked == "approval"
+    assert change_id in outcome.result_text
+    assert "no signed approval grant" in outcome.result_text
+
+    assert len(receipts.recorded) == before + 2
+    result = ship.artifacts()[receipts.head]["statement"]
+    assert result["action"] == "commerce.tool.apply_change.result"
+    assert result["meta"]["status"] == "blocked"
+    assert result["meta"]["gate"] == "approval"
+
+
+async def test_enforce_holds_a_replay_of_a_spent_grant(ship: Ship, merchant_enforcing):
+    """Under enforce, a grant that would not spend holds the call even though
+    the reference's own mark is still set -- the journal is the authority."""
+    executor, approvals = merchant_enforcing
+    change_id = await stage_a_change(executor)
+    grant = operator_approves(executor, approvals, change_id)
+    assert grant is not None
+
+    first = await executor.execute("apply_change", {"change_id": change_id})
+    assert not first.refused, first.result_text
+
+    approvals._grants[change_id] = grant  # offer the spent grant again
+    replay = await executor.execute("apply_change", {"change_id": change_id})
+    assert replay.refused
+    assert replay.blocked == "approval"
+    assert "would not spend" in replay.result_text
+
+    intents = [
+        c["statement"]
+        for c in ship.chain(executor.treeship_receipts.head)
+        if c["statement"].get("action") == "commerce.tool.apply_change.intent"
+    ]
+    assert [i["meta"]["approval"] for i in intents] == ["proven", "unproven"]
+
+
+async def test_recording_off_mints_nothing_and_changes_nothing(ship: Ship, merchant, monkeypatch):
+    """TREESHIP_DISABLE is absolute: no grant is minted, and the apply behaves
+    exactly as the unwrapped reference does -- allowed when the host approved
+    it, held by the reference's own gate when it did not."""
+    executor, approvals = merchant
+    change_id = await stage_a_change(executor)
+    monkeypatch.setenv("TREESHIP_DISABLE", "1")
+
+    assert approvals.grant(change_id) is None
+    assert approvals.minted == []
+
+    held = await executor.execute("apply_change", {"change_id": change_id})
+    assert held.refused
+    assert held.blocked == "approval"  # the reference's gate, not ours
+
+    executor._state.approved_change_ids.add(change_id)
+    allowed = await executor.execute("apply_change", {"change_id": change_id})
+    assert not allowed.refused, allowed.result_text
+
+
+def test_the_refusal_reason_is_the_cli_reason_not_the_wrapper():
+    """The note is signed evidence, so it carries why the grant would not
+    spend -- not the SDK's ``failed (exit=1)`` envelope around it."""
+    wrapped = RuntimeError(
+        'treeship attest action failed (exit=1): '
+        '{"error":"approval grant art_x would exceed max_uses (1/1)","status":"error"}'
+    )
+    assert _refusal_reason(wrapped) == "approval grant art_x would exceed max_uses (1/1)"
+    # Anything that is not that shape is still recorded rather than swallowed.
+    assert _refusal_reason(RuntimeError("plain failure\nsecond line")) == "plain failure"
+    assert _refusal_reason(RuntimeError("")) == "RuntimeError"

--- a/integrations/commerce-agents/tests/test_merchant_runtimes.py
+++ b/integrations/commerce-agents/tests/test_merchant_runtimes.py
@@ -1,0 +1,244 @@
+# The merchant side on all three of the reference's runtimes, through the
+# `executor_class` seam each one exposes -- the path a deployment actually
+# uses, where the runtime constructs the executor and there is nothing to
+# attach() to. Each test drives the runtime the way the reference's own tests
+# do and reads the receipts back, so the approval story is tested per runtime
+# rather than inferred from the hand-built executor in test_approvals.py.
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from treeship_commerce import MerchantApprovals, TreeshipReceipts, approved, approving, receipted
+from treeship_commerce.receipts import sdk_supports_subject
+
+from .conftest import Ship, needs_cli
+
+pytestmark = [
+    needs_cli,
+    pytest.mark.skipif(
+        not sdk_supports_subject(),
+        reason="installed treeship-sdk cannot name an action subject",
+    ),
+]
+
+HEADPHONES_ID = "AR-1105"  # returned by a "headphones" search of the retail fixture
+RESTOCK = {"items": [{"listing_id": HEADPHONES_ID, "action": "restock", "quantity": 24}]}
+
+
+def _recorder(ship: Ship, made: list[TreeshipReceipts], executors: list | None = None):
+    def make(executor) -> TreeshipReceipts:
+        r = TreeshipReceipts(
+            ship.client,
+            actor="agent://merchant",
+            session_id=executor._session.session_id,
+            role="merchant",
+            parent_id=ship.session_root,
+        )
+        made.append(r)
+        if executors is not None:
+            executors.append(executor)
+        return r
+
+    return make
+
+
+def _executor_class(
+    ship: Ship,
+    made: list[TreeshipReceipts],
+    approvals: MerchantApprovals,
+    executors: list | None = None,
+):
+    from merchant_agent.executor import MerchantToolExecutor
+
+    return approved(
+        receipted(MerchantToolExecutor, recorder=_recorder(ship, made, executors)), approvals
+    )
+
+
+def _apply_intents(ship: Ship, receipts: TreeshipReceipts) -> list[dict]:
+    arts = ship.artifacts()
+    return [
+        arts[i]["statement"]["meta"]
+        for i in receipts.recorded
+        if arts[i]["statement"]["action"] == "commerce.tool.apply_change.intent"
+    ]
+
+
+async def test_agent_sdk_toolset_signs_the_consoles_yes_through_approving(ship: Ship):
+    """The reference console calls host_approve / host_clear and nothing else.
+    approving() makes those two calls mint and forget the grant, so the
+    console's loop is unchanged and the apply's receipt still proves the
+    approval."""
+    from merchant_agent_sdk import MerchantToolset, build_merchant_sdk_tools, load_mock_backend
+
+    made: list[TreeshipReceipts] = []
+    approvals = MerchantApprovals(ship.client, approver="human://operator")
+    toolset = approving(
+        MerchantToolset(
+            backend=load_mock_backend(),
+            executor_class=_executor_class(ship, made, approvals),
+        ),
+        approvals,
+    )
+    toolset.config.require_host_approval = True
+    handlers = {t.name: t for t in build_merchant_sdk_tools(toolset)}
+
+    await handlers["search_listings"].handler({"query": "headphones"})
+    await handlers["stage_inventory_action"].handler(RESTOCK)
+    change_id = next(iter(toolset.state.seen_changes))
+    assert [c.change_id for c in toolset.pending_host_approvals()] == [change_id]
+
+    # Exactly the reference's own sequence, from its test of this API.
+    held = await handlers["apply_change"].handler({"change_id": change_id})
+    assert toolset.config.approval_surface in _text(held)
+    assert approvals.minted == [], "no yes yet, so nothing signed"
+
+    toolset.host_approve(change_id)
+    assert len(approvals.minted) == 1, "the console's yes minted the grant"
+    grant_id = approvals.minted[0]
+    applied = await handlers["apply_change"].handler({"change_id": change_id})
+    assert "is_error" not in applied, _text(applied)
+    toolset.host_clear(change_id)
+    assert approvals.get(change_id) is None, "host_clear dropped the grant handle"
+
+    assert len(made) == 1, "one executor per toolset, one recorder"
+    intents = _apply_intents(ship, made[0])
+    assert [i.get("approval") for i in intents] == [None, "proven"]
+    assert intents[1]["approval_grant"] == grant_id
+    assert ship.cli_json("approval", "uses", grant_id)["uses"]
+    assert ship.cli_json("verify", made[0].head)["outcome"] == "pass"
+
+
+async def test_agent_sdk_toolset_a_cleared_mark_offers_no_nonce(ship: Ship):
+    """The reference's rule: a cleared mark approves nothing. Ours matches --
+    after host_clear the grant handle is gone, so a later apply cannot even
+    offer the nonce, and its receipt carries no approval claim."""
+    from merchant_agent_sdk import MerchantToolset, build_merchant_sdk_tools, load_mock_backend
+
+    made: list[TreeshipReceipts] = []
+    approvals = MerchantApprovals(ship.client)
+    toolset = approving(
+        MerchantToolset(
+            backend=load_mock_backend(), executor_class=_executor_class(ship, made, approvals)
+        ),
+        approvals,
+    )
+    toolset.config.require_host_approval = True
+    handlers = {t.name: t for t in build_merchant_sdk_tools(toolset)}
+    await handlers["search_listings"].handler({"query": "headphones"})
+    await handlers["stage_inventory_action"].handler(RESTOCK)
+    change_id = next(iter(toolset.state.seen_changes))
+
+    toolset.host_approve(change_id)
+    toolset.host_clear(change_id)
+    held = await handlers["apply_change"].handler({"change_id": change_id})
+    assert toolset.config.approval_surface in _text(held)
+
+    (intent,) = _apply_intents(ship, made[0])
+    assert "approval" not in intent
+    # The grant was minted and never spent; the journal agrees.
+    assert ship.cli_json("approval", "uses", approvals.minted[0])["uses"] == []
+
+
+async def test_messages_api_orchestrator_records_the_hosts_grant(ship: Ship):
+    """The Messages API runtime leaves the approval mark to the host. A host
+    that also calls grant() gets a proven apply receipt out of an executor the
+    orchestrator built itself, with a scripted model and no API key."""
+    from commerce_common.skills import SkillRegistry
+    from commerce_common.testing import FakeClient, text_message, tool_use_message
+    from merchant_agent import MerchantSessionContext, MerchantSessionState
+    from merchant_agent_runtime import MerchantAgent
+    from merchant_agent_sdk import load_mock_backend
+
+    made: list[TreeshipReceipts] = []
+    approvals = MerchantApprovals(ship.client, approver="human://operator")
+    session = MerchantSessionContext(
+        session_id="messages-api-merchant", merchant_id="m-1", operator="human://operator"
+    )
+    state = MerchantSessionState()
+
+    # Turn 1: the model reads and stages. Turn 2: the host approved; the model applies.
+    agent = MerchantAgent(
+        backend=load_mock_backend(),
+        skills=SkillRegistry([]),
+        client=FakeClient(
+            [
+                tool_use_message("search_listings", {"query": "headphones"}),
+                tool_use_message("stage_inventory_action", RESTOCK),
+                text_message("Staged; approve it on the card."),
+            ]
+        ),
+        executor_class=_executor_class(ship, made, approvals),
+    )
+    agent.config = agent.config.model_copy(update={"require_host_approval": True})
+    async for _ in agent.stream_turn(
+        [{"role": "user", "content": "Restock the headphones by 24"}], session, state
+    ):
+        pass
+    change_id = next(iter(state.seen_changes))
+    assert not state.approved_change_ids
+
+    # The host's yes: its own mark, and the signed grant.
+    state.approved_change_ids.add(change_id)
+    grant = approvals.grant(change_id, summary=state.seen_changes[change_id].summary)
+    assert grant is not None
+
+    agent.client = FakeClient(
+        [tool_use_message("apply_change", {"change_id": change_id}), text_message("Applied.")]
+    )
+    async for _ in agent.stream_turn(
+        [{"role": "user", "content": f"Approved {change_id}; apply it."}], session, state
+    ):
+        pass
+
+    assert len(made) == 2, "the orchestrator builds one executor per turn"
+    intents = _apply_intents(ship, made[1])
+    assert [i["approval"] for i in intents] == ["proven"]
+    assert intents[0]["approval_grant"] == grant.artifact_id
+    assert state.seen_changes[change_id].status.value == "applied"
+    for r in made:
+        assert ship.cli_json("verify", r.head)["outcome"] == "pass"
+
+
+async def test_managed_agents_mcp_server_records_and_never_invents_an_approval(ship: Ship):
+    """On Managed Agents the platform's own prompt is the approval surface and
+    the click happens outside this process, so the reference runs the server
+    with require_host_approval off. Nothing here can sign that click: the
+    apply is receipted, and its receipt carries no approval claim at all --
+    not a fabricated one."""
+    from commerce_common.memory import InMemoryMemoryStore
+    from mcp.shared.memory import create_connected_server_and_client_session
+    from merchant_agent_sdk import REPO_ROOT
+
+    sys.path.insert(0, str(REPO_ROOT / "merchant-agent" / "managed-agents" / "merchant-mcp-server"))
+    from merchant_mcp_server import build_server
+
+    made: list[TreeshipReceipts] = []
+    executors: list = []  # the server builds one per connection; the recorder sees it
+    approvals = MerchantApprovals(ship.client)
+    server = build_server(
+        memory_store=InMemoryMemoryStore(),
+        executor_class=_executor_class(ship, made, approvals, executors),
+    )
+    async with create_connected_server_and_client_session(server._mcp_server) as client:
+        await client.call_tool("search_listings", {"query": "headphones"})
+        await client.call_tool("stage_inventory_action", RESTOCK)
+        (executor,) = executors
+        change_id = next(iter(executor._state.seen_changes))
+        result = await client.call_tool("apply_change", {"change_id": change_id})
+    assert not result.isError, result
+    assert len(made) == 1, "one executor, one recorder, per MCP connection"
+    (intent,) = _apply_intents(ship, made[0])
+    assert "approval" not in intent and "approval_grant" not in intent
+    assert approvals.minted == []
+    assert ship.cli_json("verify", made[0].head)["outcome"] == "pass"
+
+
+def _text(result: dict) -> str:
+    from commerce_common.testing import result_text
+
+    return result_text(result)
+

--- a/integrations/commerce-agents/tests/test_receipts.py
+++ b/integrations/commerce-agents/tests/test_receipts.py
@@ -268,3 +268,64 @@ async def test_a_client_that_raises_anything_never_breaks_the_tool(ship: Ship, e
     assert not outcome.refused
     assert executor.treeship_receipts.recorded == []
     assert executor.treeship_receipts.dropped >= 2
+
+
+def test_args_digest_is_total_over_non_json_arguments():
+    """The reference's MCP server hands the executor parsed pydantic models as
+    arguments. The digest must exist for those -- and be the same digest as
+    for the plain dicts the other runtimes pass -- or the recorder is the
+    thing that broke the tool."""
+    import dataclasses
+    import datetime
+    import decimal
+    import enum
+    import pathlib
+
+    from merchant_agent.types import InventoryActionItem
+
+    item = InventoryActionItem(listing_id="AR-1105", action="restock", quantity=24)
+    assert args_digest({"items": [item]}) == args_digest({"items": [item.model_dump(mode="json")]})
+
+    @dataclasses.dataclass
+    class Point:
+        x: int
+        y: int
+
+    class Colour(enum.Enum):
+        RED = "red"
+
+    weird = {
+        "dc": Point(1, 2),
+        "set": {3, 1, 2},
+        "bytes": b"\x00\x01",
+        "when": datetime.datetime(2026, 9, 7, 10, 0, tzinfo=datetime.timezone.utc),
+        "money": decimal.Decimal("9.99"),
+        "colour": Colour.RED,
+        "path": pathlib.PurePosixPath("/tmp/x"),
+        "opaque": object,  # a type: no dump, no dict, no dataclass
+    }
+    first = args_digest(weird)
+    assert first == args_digest(dict(reversed(list(weird.items())))), "order-independent"
+    assert first != args_digest({**weird, "set": {3, 1}})
+
+
+async def test_a_pydantic_argument_neither_breaks_the_tool_nor_the_receipt(ship: Ship):
+    """End to end on the merchant executor: a stage call whose items are
+    already-parsed models (the MCP server's shape) runs, stages, and gets a
+    signed intent and result like any other call."""
+    from merchant_agent.types import InventoryActionItem
+
+    from .conftest import _merchant_executor
+
+    executor, _ = _merchant_executor(ship, enforce=False)
+    await executor.execute("search_listings", {"query": "headphones"})
+    item = InventoryActionItem(listing_id="AR-1105", action="restock", quantity=24)
+    outcome = await executor.execute("stage_inventory_action", {"items": [item]})
+    assert not outcome.refused, outcome.result_text
+    assert executor._state.seen_changes, "the change was staged"
+    receipts: TreeshipReceipts = executor.treeship_receipts
+    assert receipts.dropped == 0
+    assert len(receipts.recorded) == 4
+    intent = ship.artifacts()[receipts.recorded[2]]["statement"]["meta"]
+    assert intent["tool"] == "stage_inventory_action"
+    assert intent["args_digest"] == args_digest({"items": [item.model_dump(mode="json")]})

--- a/integrations/commerce-agents/treeship_commerce/__init__.py
+++ b/integrations/commerce-agents/treeship_commerce/__init__.py
@@ -6,6 +6,14 @@ every call a signed intent receipt before it runs and a signed result
 receipt after, chained from the session's root. See ``receipts.py``.
 """
 
+from .approvals import (
+    Grant,
+    MerchantApprovals,
+    TreeshipApprovalMixin,
+    approved,
+    change_subject,
+)
+from .host import approving
 from .receipts import (
     TreeshipExecutorMixin,
     TreeshipReceipts,
@@ -16,10 +24,16 @@ from .receipts import (
 )
 
 __all__ = [
+    "Grant",
+    "MerchantApprovals",
+    "TreeshipApprovalMixin",
     "TreeshipExecutorMixin",
     "TreeshipReceipts",
+    "approved",
+    "approving",
     "args_digest",
     "attach",
+    "change_subject",
     "receipted",
     "text_digest",
 ]

--- a/integrations/commerce-agents/treeship_commerce/approvals.py
+++ b/integrations/commerce-agents/treeship_commerce/approvals.py
@@ -1,0 +1,368 @@
+"""The operator's yes, signed once and spendable once.
+
+The gap this closes
+-------------------
+On the merchant side the reference already gates the one tool that mutates a
+merchant's system of record. ``check_apply_change`` refuses unless the change
+was staged in this session, passes the configured guardrails, and -- when
+``require_host_approval`` is on -- appears in ``state.approved_change_ids``.
+The console's y/N puts it there through ``toolset.host_approve(change_id)``
+and takes it out again with ``host_clear`` once the apply turn returns.
+
+That set is an in-process boolean. It is correct while the process lives and
+it is gone afterwards, so it cannot answer the two questions an operator is
+actually asked later:
+
+* *Did a human approve this change, and when?* The set left no record.
+* *Was that approval spent more than once?* The set cannot say; ``host_approve``
+  is idempotent and a second apply inside the same window passes the same check.
+
+:class:`MerchantApprovals` answers both. The moment the operator says yes it
+mints a **signed Approval Grant** scoped to one actor, one action, and one
+change, with ``max_uses=1``. When the apply runs, its intent receipt is signed
+*with that grant's nonce*, which makes the CLI reserve a use in the local
+Approval Use Journal before it will sign. A second apply of the same change
+finds the grant spent and gets no receipt. A grant minted for one change
+cannot be spent on another: the action names ``change://<change_id>`` as its
+subject, and the grant's scope names the same URI.
+
+What this does not do
+---------------------
+It does not replace the reference's gate, and it is not a second gate by
+default. Recording stays off the critical path: if a grant is missing or
+already spent, the intent receipt is written *without* approval evidence and
+says so (``approval: "unproven"`` with a reason), and the tool still runs into
+the reference's own ``check_apply_change``, which is what holds it. Pass
+``enforce=True`` to :func:`approved` when you want the missing evidence to
+hold the call itself -- a deployment that has decided the receipt is the
+authority, not a record of it.
+
+Wiring it
+---------
+The host that asks the human is the host that mints::
+
+    approvals = MerchantApprovals(ts, approver="human://operator")
+    Executor = approved(receipted(MerchantToolExecutor, recorder=...), approvals)
+
+    # in the console's y/N loop, replacing the bare host_approve:
+    approvals.grant(change.change_id, summary=change.summary)
+    toolset.host_approve(change.change_id)
+
+``grant`` returns the :class:`Grant`; ``toolset.host_approve`` still runs the
+reference's own gate. The two together mean the change is both allowed to
+apply and provably approved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from treeship_sdk import Treeship
+
+from .receipts import TreeshipExecutorMixin, sdk_supports_subject
+
+logger = logging.getLogger("treeship_commerce")
+
+# The action label the apply's intent receipt carries, and the one a grant is
+# scoped to. Kept in one place because the scope match is exact: a grant that
+# names a different label refuses every action.
+APPLY_INTENT_ACTION = "commerce.tool.apply_change.intent"
+
+# The subject URI scheme for a staged change. The action carries it as
+# subject.uri and the grant's allowed_subjects names the same string, so a
+# grant for one change cannot be spent on another.
+SUBJECT_SCHEME = "change"
+
+
+def change_subject(change_id: str) -> str:
+    """``chg_7f2`` -> ``change://chg_7f2``, the URI both sides match on."""
+    return f"{SUBJECT_SCHEME}://{change_id}"
+
+
+@dataclass(frozen=True)
+class PendingApproval:
+    """What the recorder signs the next intent with.
+
+    ``subject`` is the subject of the *call about to happen*, derived from its
+    own arguments -- never copied from the grant. Taking it from the grant
+    would make the scope check compare the grant against itself and pass for
+    every change, which is the whole property gone.
+    """
+
+    nonce: str
+    grant_id: str
+    subject: str
+    change_id: str
+
+
+@dataclass(frozen=True)
+class Grant:
+    """A signed, single-use approval for one staged change."""
+
+    change_id: str
+    artifact_id: str
+    nonce: str
+    subject: str
+
+    def __repr__(self) -> str:  # nonce is a capability; keep it out of logs
+        return (
+            f"Grant(change_id={self.change_id!r}, artifact_id={self.artifact_id!r}, "
+            f"nonce=<{len(self.nonce)} chars>)"
+        )
+
+
+class MerchantApprovals:
+    """Mints one single-use grant per approved change and hands out its nonce.
+
+    ``client`` is a configured :class:`treeship_sdk.Treeship`. ``approver`` is
+    the human the grant names -- a URI, not a display name, since it is signed.
+    ``actor`` must equal the actor the receipts are written under, or the
+    grant's scope will refuse the action it was minted for.
+    """
+
+    def __init__(
+        self,
+        client: Treeship,
+        *,
+        approver: str = "human://operator",
+        actor: str = "agent://merchant",
+        action: str = APPLY_INTENT_ACTION,
+        expires_at: str | None = None,
+    ) -> None:
+        self.client = client
+        self.approver = approver
+        self.actor = actor
+        self.action = action
+        self.expires_at = expires_at
+        self._grants: dict[str, Grant] = {}
+        self.minted: list[str] = []
+        """Artifact ids of the grants minted, in order."""
+
+    @property
+    def disabled(self) -> bool:
+        return os.environ.get("TREESHIP_DISABLE") == "1"
+
+    def grant(self, change_id: str, *, summary: str = "") -> Grant | None:
+        """Sign that the operator approved ``change_id``. Once.
+
+        Returns the :class:`Grant`, or ``None`` when recording is disabled or
+        the grant could not be signed -- this is a recorder, so a failure here
+        warns and leaves the reference's own approval gate to do its work.
+        """
+        if self.disabled:
+            return None
+        if not sdk_supports_subject():
+            self._warn_old_sdk()
+            return None
+        description = f"apply change {change_id}"
+        if summary:
+            description = f"{description}: {summary}"
+        try:
+            result = self.client.attest_approval(
+                self.approver,
+                description,
+                allowed_actions=[self.action],
+                allowed_actors=[self.actor],
+                allowed_subjects=[change_subject(change_id)],
+                max_uses=1,
+                expires_at=self.expires_at,
+            )
+        except Exception as err:  # noqa: BLE001 -- minting must not break the console
+            logger.warning(
+                "treeship approval grant not written for %s: %s. The change is still "
+                "gated by the reference's own approval check; it just is not provable.",
+                change_id,
+                err,
+            )
+            return None
+        grant = Grant(
+            change_id=change_id,
+            artifact_id=result.artifact_id,
+            nonce=result.nonce,
+            subject=change_subject(change_id),
+        )
+        self._grants[change_id] = grant
+        self.minted.append(result.artifact_id)
+        return grant
+
+    def nonce_for(self, change_id: str) -> str | None:
+        grant = self._grants.get(change_id)
+        return grant.nonce if grant else None
+
+    def get(self, change_id: str) -> Grant | None:
+        return self._grants.get(change_id)
+
+    def _warn_old_sdk(self) -> None:
+        if getattr(self, "_old_sdk_warned", False):
+            return
+        self._old_sdk_warned = True
+        logger.warning(
+            "treeship-sdk cannot name an action's subject, so a single-use approval "
+            "grant would be refused by its own scope on every apply. No grant minted; "
+            "apply_change stays gated by the reference's own approval check. Upgrade "
+            "treeship-sdk to mint provable approvals."
+        )
+
+    def forget(self, change_id: str) -> None:
+        """Drop the local handle on a grant. The signed grant and any use of it
+        stay on disk; this only stops this object from offering the nonce
+        again. The journal, not this dict, is what makes a use single."""
+        self._grants.pop(change_id, None)
+
+
+def change_id_of(tool_input: Mapping[str, Any] | None) -> str | None:
+    """The change a tool call targets, or ``None``. The reference names the
+    argument ``change_id`` on both ``apply_change`` and ``discard_change``."""
+    if not tool_input:
+        return None
+    value = tool_input.get("change_id")
+    return str(value) if value else None
+
+
+class TreeshipApprovalMixin:
+    """Binds :class:`MerchantApprovals` to the apply tool's intent receipt.
+
+    Sits between :class:`~treeship_commerce.receipts.TreeshipExecutorMixin` and
+    the reference executor. It does not sign anything itself; it tells the
+    recorder which nonce and subject to sign the next intent with, so the CLI
+    reserves the use before the receipt exists.
+    """
+
+    treeship_approvals: MerchantApprovals | None = None
+    treeship_approvals_factory: Callable[[Any], MerchantApprovals] | None = None
+    treeship_apply_tool: str = "apply_change"
+    treeship_enforce_approval: bool = False
+    _treeship_apply_lock: asyncio.Lock | None = None
+
+    def _treeship_approvals(self) -> MerchantApprovals | None:
+        if self.treeship_approvals is None and self.treeship_approvals_factory is not None:
+            self.treeship_approvals = self.treeship_approvals_factory(self)
+        return self.treeship_approvals
+
+    def _treeship_is_apply(self, name: str) -> bool:
+        # Runtimes prefix tool names (``mcp__merchant__apply_change``), so the
+        # reference matches on the suffix and so do we.
+        return name.endswith(self.treeship_apply_tool)
+
+    def _treeship_hold(self, name: str, tool_input: dict[str, Any] | None) -> Any | None:
+        """Under ``enforce``, hold an apply whose approval is not proven. Runs
+        after the intent receipt, so the receipt already says *why*: no grant
+        was offered, or the grant would not spend (already used, expired, or
+        scoped to another change)."""
+        if not self.treeship_enforce_approval or not self._treeship_is_apply(name):
+            return None
+        approvals = self._treeship_approvals()
+        if approvals is None:
+            return None
+        change_id = change_id_of(tool_input)
+        receipts = self._treeship_recorder()
+        verdict = receipts.approval_outcome if receipts is not None else None
+        if verdict == "proven":
+            return None
+        if verdict == "unproven":
+            return _held_unapproved(change_id, spent=True)
+        # No grant was offered at all (or nothing records, so nothing was tried).
+        if change_id is None or approvals.get(change_id) is None:
+            return _held_unapproved(change_id, spent=False)
+        return None
+
+    async def execute(self, name: str, tool_input: dict[str, Any] | None) -> Any:
+        approvals = self._treeship_approvals()
+        if approvals is None or not self._treeship_is_apply(name):
+            return await super().execute(name, tool_input)  # type: ignore[misc]
+
+        # The pending approval rides on the recorder, which one executor shares
+        # across its calls. Applies are serialised per executor so two
+        # concurrent applies cannot read each other's grant; every other tool
+        # runs unserialised as before.
+        if self._treeship_apply_lock is None:
+            self._treeship_apply_lock = asyncio.Lock()
+        async with self._treeship_apply_lock:
+            change_id = change_id_of(tool_input)
+            grant = approvals.get(change_id) if change_id else None
+            receipts = self._treeship_recorder()
+
+            if receipts is not None and grant is not None and change_id is not None:
+                receipts.pending_approval = PendingApproval(
+                    nonce=grant.nonce,
+                    grant_id=grant.artifact_id,
+                    # From the call, not the grant.
+                    subject=change_subject(change_id),
+                    change_id=change_id,
+                )
+            try:
+                # TreeshipExecutorMixin signs the intent (consuming the grant),
+                # asks _treeship_hold, runs or holds, and signs the result.
+                return await super().execute(name, tool_input)  # type: ignore[misc]
+            finally:
+                if receipts is not None:
+                    receipts.pending_approval = None
+                    spent = receipts.take_approval_outcome()
+                    if spent is not None and grant is not None:
+                        # A grant is spendable once; drop the handle either
+                        # way, so a second apply cannot even offer the nonce.
+                        approvals.forget(grant.change_id)
+
+
+def _held_unapproved(change_id: str | None, *, spent: bool) -> Any:
+    """The reference's own held outcome, so an enforced refusal looks to the
+    model exactly like the gate it already knows how to talk about."""
+    from commerce_common.streaming import ToolOutcome
+
+    why = (
+        "its signed approval would not spend: it was already used, has expired, "
+        "or was minted for a different change"
+        if spent
+        else "it has no signed approval grant; the operator has not approved it"
+    )
+    return ToolOutcome.held(
+        "approval",
+        f"change {change_id} cannot be applied: {why}. Ask the operator to approve "
+        "it on their approval surface.",
+    )
+
+
+def approved(
+    executor_cls: type,
+    approvals: MerchantApprovals | Callable[[Any], MerchantApprovals],
+    *,
+    apply_tool: str = "apply_change",
+    enforce: bool = False,
+) -> type:
+    """``receipted(MerchantToolExecutor)`` in, approval-bound executor out.
+
+    Compose it around a receipted class -- the approval evidence rides on the
+    intent receipt, so there must be a recorder for it to ride on::
+
+        Executor = approved(
+            receipted(MerchantToolExecutor, recorder=make_recorder),
+            approvals,
+        )
+
+    ``enforce=True`` turns a missing or spent grant into a held outcome instead
+    of an unproven receipt. Leave it off to keep recording strictly off the
+    critical path, with the reference's ``check_apply_change`` doing the gating.
+    """
+    if not issubclass(executor_cls, TreeshipExecutorMixin):
+        raise TypeError(
+            f"{executor_cls.__name__} does not record receipts, so there is nothing for "
+            f"the approval to ride on. Wrap it first: "
+            f"approved(receipted({executor_cls.__name__}, recorder=...), approvals)."
+        )
+    body: dict[str, Any] = {
+        "treeship_apply_tool": apply_tool,
+        "treeship_enforce_approval": enforce,
+    }
+    if callable(approvals) and not isinstance(approvals, MerchantApprovals):
+        body["treeship_approvals_factory"] = staticmethod(approvals)
+    else:
+        body["treeship_approvals"] = approvals
+    return type(
+        f"Approved{executor_cls.__name__.removeprefix('Approved')}",
+        (TreeshipApprovalMixin, executor_cls),
+        body,
+    )

--- a/integrations/commerce-agents/treeship_commerce/demo_merchant.py
+++ b/integrations/commerce-agents/treeship_commerce/demo_merchant.py
@@ -1,0 +1,183 @@
+"""A receipted merchant session where the operator's approval is signed once.
+
+    python -m treeship_commerce.demo_merchant   # from a clone of commerce-agents, venv active
+
+Drives the reference's ``MerchantToolExecutor`` over ``examples/retail``'s mock
+merchant with no model and no API key: a listing search, a staged price update,
+then three attempts to apply it.
+
+    1. before approval       -- the reference's own gate holds it
+    2. after approval        -- the signed grant is consumed, the apply lands
+    3. the same again        -- the grant is spent; the journal refuses a second use
+
+The third is the one that matters. The reference's approval *gate* lets it
+through, because the host's in-process mark is still set for the rest of the
+turn; the mock backend then happens to refuse it as already applied, which is
+backend state, not evidence. The Approval Use Journal refuses it regardless of
+what the backend knows, before anything is signed, and the receipt says so.
+Every id printed is real; verify them with the commands printed at the end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+import uuid
+
+from treeship_sdk import Treeship
+
+from . import MerchantApprovals, TreeshipReceipts, approved, attach, receipted
+from .lifecycle import _run_json, close_session, session_status, start_session
+from .receipts import sdk_supports_subject
+
+ACTOR = "agent://merchant"
+APPROVER = "human://operator"
+
+
+def _build_executor(session_id: str, approvals: MerchantApprovals, *, enforce: bool):
+    try:
+        from commerce_common.memory import InMemoryMemoryStore
+        from commerce_common.skills import SkillRegistry
+        from merchant_agent import (
+            MerchantAgentConfig,
+            MerchantSessionContext,
+            MerchantSessionState,
+        )
+        from merchant_agent.executor import MerchantToolExecutor, build_memory
+        from merchant_agent_sdk import load_mock_backend
+    except ImportError as err:  # pragma: no cover - environment, not logic
+        sys.exit(
+            f"commerce-agents packages are not installed ({err}). From a clone of "
+            "anthropics/commerce-agents: pip install -r requirements.txt"
+        )
+    config = MerchantAgentConfig()
+    cls = approved(receipted(MerchantToolExecutor), approvals, enforce=enforce)
+    return cls(
+        backend=load_mock_backend(),
+        config=config,
+        skills=SkillRegistry([]),
+        session=MerchantSessionContext(
+            session_id=session_id, merchant_id="m-acme", operator=APPROVER
+        ),
+        state=MerchantSessionState(),
+        memory=build_memory(config, InMemoryMemoryStore()),
+    )
+
+
+async def run(*, enforce: bool) -> int:
+    if not sdk_supports_subject():
+        sys.exit(
+            "the installed treeship-sdk cannot name an action's subject, so a "
+            "single-use grant would be refused by its own scope. Upgrade treeship-sdk."
+        )
+    ts = Treeship()
+    commerce_session = f"demo-{uuid.uuid4().hex}"  # the reference treats this as a credential
+    root = start_session(ts, name="commerce:merchant-demo", actor=ACTOR)
+    approvals = MerchantApprovals(ts, approver=APPROVER, actor=ACTOR)
+    executor = attach(
+        _build_executor(commerce_session, approvals, enforce=enforce),
+        TreeshipReceipts(
+            ts, actor=ACTOR, session_id=commerce_session, role="merchant", parent_id=root
+        ),
+    )
+    receipts: TreeshipReceipts = executor.treeship_receipts
+
+    async def call(label: str, name: str, tool_input: dict):
+        before = len(receipts.recorded)
+        outcome = await executor.execute(name, tool_input)
+        status = (
+            "blocked:" + outcome.blocked
+            if outcome.blocked
+            else ("error" if outcome.is_error else "ok")
+        )
+        new = receipts.recorded[before:]
+        print(f"  {label:<26} {status:<22} {' '.join(new) or '(no receipt written)'}")
+        return outcome
+
+    tag = hashlib.sha256(commerce_session.encode()).hexdigest()[:12]
+    print(f"session root      {root}")
+    print(f"commerce session  sha256:{tag}  (tag; the id itself is never written)")
+    print("steps                      outcome                receipt ids")
+
+    await call("search_listings", "search_listings", {"query": ""})
+    listings = [
+        (lid, item) for lid, item in executor._state.seen_listings.items() if not item.has_options
+    ]
+    if not listings:
+        print("the merchant mock returned no simple listings; stopping")
+        return 1
+    listing_id, listing = listings[0]
+    await call(
+        "stage_price_update",
+        "stage_price_update",
+        {
+            "items": [{"listing_id": listing_id, "new_price": round(listing.price * 0.97, 2)}],
+            "note": "3% clearance",
+        },
+    )
+    staged = list(executor._state.seen_changes)
+    if not staged:
+        print("nothing staged; stopping")
+        return 1
+    change_id = staged[0]
+
+    # 1. Unapproved. The reference's own gate holds it.
+    await call("apply (not yet approved)", "apply_change", {"change_id": change_id})
+
+    # 2. The operator says yes. A host does both: the signed grant, which is the
+    #    evidence, and the reference's mark, which is what lets the apply run.
+    grant = approvals.grant(change_id, summary=f"3% clearance on {listing_id}")
+    executor._state.approved_change_ids.add(change_id)
+    print(f"  operator approves          grant signed           {grant.artifact_id}")
+    await call("apply (approved)", "apply_change", {"change_id": change_id})
+
+    # 3. The replay. The reference's mark is still set, so its gate allows this;
+    #    only the mock backend's "already applied" state stops it. The grant is
+    #    spent, so the receipt cannot claim approval whatever the backend says.
+    approvals._grants[change_id] = grant
+    await call("apply again (replay)", "apply_change", {"change_id": change_id})
+
+    uses = _run_json(ts, ["approval", "uses", grant.artifact_id])
+    print(f"\napproval          grant {grant.artifact_id}")
+    print(f"                  journal records {len(uses.get('uses', []))} use of it, max 1")
+
+    status = session_status(ts)
+    print(
+        f"session           receipts={status['receipts']} events={status['events']} "
+        f"root_verified={status['root_verified']}"
+    )
+    if receipts.dropped:
+        print(f"WARNING           {receipts.dropped} receipt(s) not written; the chain has gaps")
+    sealed = close_session(
+        ts,
+        summary=(
+            "Merchant demo: one price change staged, held unapproved, applied once under a "
+            "signed single-use approval, and refused on replay. Mock merchant, no live prices."
+        ),
+        headline="Receipted merchant session with a single-use operator approval",
+    )
+    print(f"package           {sealed.get('package')}")
+    print(f"verify            treeship verify {receipts.head}")
+    print(f"                  treeship approval uses {grant.artifact_id}")
+    print(f"                  treeship package verify {sealed.get('package')}")
+    return 0 if receipts.dropped == 0 else 2
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="hold an apply that has no signed grant, instead of recording it as unproven",
+    )
+    args = parser.parse_args()
+    if os.environ.get("TREESHIP_DISABLE") == "1":
+        sys.exit("TREESHIP_DISABLE=1 is set; this demo exists to write receipts")
+    sys.exit(asyncio.run(run(enforce=args.enforce)))
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/commerce-agents/treeship_commerce/host.py
+++ b/integrations/commerce-agents/treeship_commerce/host.py
@@ -1,0 +1,85 @@
+"""Drop-in for the reference's approval surface.
+
+The Agent SDK runtime's ``MerchantToolset`` *is* the host's approval surface:
+its console asks y/N per staged change and calls ``host_approve(change_id)``
+on yes, then ``host_clear(change_id)`` when the apply turn returns. That is
+the one place a human's decision enters the process, so it is the one place
+to sign it.
+
+:func:`approving` wraps those two methods on an existing toolset so the
+console's loop needs no edits::
+
+    toolset = approving(
+        MerchantToolset(backend=..., executor_class=Executor),
+        approvals,
+    )
+    # unchanged from the reference's main.py:
+    toolset.host_approve(change.change_id)     # now also mints the signed grant
+    ...
+    toolset.host_clear(change.change_id)       # now also drops the grant handle
+
+``host_approve`` still sets the reference's mark first, so the gate behaves
+exactly as before even if minting fails (it warns; see
+:meth:`MerchantApprovals.grant`). ``host_clear`` forgets the grant handle so a
+later turn cannot offer a nonce the operator's click did not cover -- the
+journal, not the handle, is what makes a use single; forgetting is hygiene.
+
+The other two runtimes have no in-process approval surface. The Messages API
+orchestrator leaves ``state.approved_change_ids`` to the host, so the host
+calls :meth:`MerchantApprovals.grant` alongside its own mark. The Managed
+Agents MCP server runs with ``require_host_approval=False`` because the
+platform's ``always_ask`` prompt is the approval surface; that click happens
+outside the process, so nothing here can sign it -- an apply there records
+no approval evidence rather than inventing some, and ``enforce=True`` would
+hold every apply, which is the honest reading of "no signed approval".
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+from .approvals import MerchantApprovals
+
+T = TypeVar("T")
+
+
+def approving(toolset: T, approvals: MerchantApprovals) -> T:
+    """Bind ``approvals`` to a toolset's ``host_approve`` / ``host_clear``.
+
+    The toolset must expose both methods, as the reference's ``MerchantToolset``
+    does. Returns the same object, so ``build_merchant_sdk_tools(toolset)`` and
+    everything else that holds it keep working. The summary the grant is minted
+    with is the staged change's own ``summary`` when the toolset can look it
+    up, so the operator's signed record reads the same as the card they
+    approved.
+    """
+    for name in ("host_approve", "host_clear"):
+        if not callable(getattr(toolset, name, None)):
+            raise TypeError(
+                f"{type(toolset).__name__} has no {name}(); approving() wraps the "
+                "reference's MerchantToolset approval surface, and this is not one."
+            )
+    original_approve = toolset.host_approve
+    original_clear = toolset.host_clear
+
+    def host_approve(change_id: str) -> None:
+        # The reference's mark first: the gate must behave exactly as before
+        # even when the grant cannot be signed.
+        original_approve(change_id)
+        approvals.grant(change_id, summary=_summary_of(toolset, change_id))
+
+    def host_clear(change_id: str) -> None:
+        original_clear(change_id)
+        approvals.forget(change_id)
+
+    toolset.host_approve = host_approve  # type: ignore[attr-defined]
+    toolset.host_clear = host_clear  # type: ignore[attr-defined]
+    toolset.treeship_approvals = approvals  # type: ignore[attr-defined]
+    return toolset
+
+
+def _summary_of(toolset: Any, change_id: str) -> str:
+    state = getattr(toolset, "state", None)
+    seen = getattr(state, "seen_changes", None) or {}
+    change = seen.get(change_id)
+    return str(getattr(change, "summary", "") or "")

--- a/integrations/commerce-agents/treeship_commerce/receipts.py
+++ b/integrations/commerce-agents/treeship_commerce/receipts.py
@@ -33,10 +33,17 @@ fabricated id. ``TREESHIP_DISABLE=1`` turns recording off entirely.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
+import datetime
+import decimal
+import enum
+import functools
 import hashlib
+import inspect
 import json
 import logging
 import os
+import pathlib
 import time
 from typing import Any, Callable, Mapping, Sequence
 
@@ -52,6 +59,23 @@ except ImportError:  # pragma: no cover - only when commerce-agents is absent
 
 logger = logging.getLogger("treeship_commerce")
 
+
+@functools.lru_cache(maxsize=1)
+def sdk_supports_subject() -> bool:
+    """Whether the installed SDK can name an action's subject.
+
+    Signed approvals need it: a grant scoped to ``change://<id>`` is matched
+    against the action's ``subject.uri``, so an action that carries no subject
+    is refused by the grant's own scope. SDKs before that parameter existed
+    cannot mint a usable grant at all, which is worth saying out loud rather
+    than discovering as a scope refusal on every apply.
+    """
+    try:
+        return "subject" in inspect.signature(Treeship.attest_action).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic client objects
+        return False
+
+
 INTENT_ACTION = "commerce.tool.{name}.intent"
 RESULT_ACTION = "commerce.tool.{name}.result"
 
@@ -60,9 +84,78 @@ RESULT_ACTION = "commerce.tool.{name}.result"
 _EXIT_CODES = {"ok": 0, "error": 1, "blocked": 2}
 
 
+
+def _refusal_reason(err: BaseException) -> str:
+    """Why an approval would not spend, in the words the CLI used.
+
+    The SDK wraps a CLI failure as ``treeship attest action failed (exit=1):
+    {"error": "..."}``. The useful half is inside that JSON; signing the
+    wrapper verbatim would put a transport detail in the evidence and bury
+    the reason. Falls back to the raw first line when the shape is anything
+    else, because an unrecognised error still has to be recorded.
+    """
+    text = str(err)
+    if not text:
+        return type(err).__name__
+    start = text.find("{")
+    if start != -1:
+        try:
+            payload = json.loads(text[start:])
+        except (ValueError, TypeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("error"), str):
+            return payload["error"][:200]
+    return text.splitlines()[0][:200]
+
+
+def _jsonable(value: Any) -> Any:
+    """What ``json.dumps`` calls for anything it cannot serialise itself.
+
+    Tool arguments are not always JSON-native by the time they reach the
+    executor: the reference's MCP server hands it parsed pydantic models
+    (``InventoryActionItem``, ``PriceUpdateItem``), and a deployment's own
+    runtime may pass dataclasses, sets, bytes, or timestamps. The digest has
+    to be the same for the same arguments however they arrived, and it has to
+    exist -- a recorder that raises on an argument type is a recorder that
+    broke the tool.
+    """
+    dump = getattr(value, "model_dump", None)  # pydantic v2
+    if callable(dump):
+        return dump(mode="json")
+    as_dict = getattr(value, "dict", None)  # pydantic v1
+    if callable(as_dict) and not isinstance(value, dict):
+        return as_dict()
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
+    if isinstance(value, (set, frozenset)):
+        # Order by canonical text, not by value: elements may be dicts or
+        # models, which Python will not compare, and the order must not
+        # depend on hash seeds.
+        members = [_jsonable(v) for v in value]
+        return sorted(members, key=lambda m: json.dumps(m, sort_keys=True, default=_jsonable))
+    if isinstance(value, (bytes, bytearray)):
+        return {"__bytes_sha256__": hashlib.sha256(bytes(value)).hexdigest()}
+    if isinstance(value, (datetime.date, datetime.datetime, datetime.time)):
+        return value.isoformat()
+    if isinstance(value, decimal.Decimal):
+        return str(value)
+    if isinstance(value, enum.Enum):
+        return _jsonable(value.value)
+    if isinstance(value, pathlib.PurePath):
+        return str(value)
+    # Last resort: name the type and its repr. Deterministic for anything with
+    # a stable repr, and it never raises. The receipt then still says *that*
+    # the call ran with *some* arguments of this shape.
+    return {"__type__": type(value).__qualname__, "__repr__": repr(value)}
+
+
 def _canonical(tool_input: Mapping[str, Any] | None) -> bytes:
     return json.dumps(
-        dict(tool_input or {}), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        dict(tool_input or {}),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=_jsonable,
     ).encode("utf-8")
 
 
@@ -125,6 +218,11 @@ class TreeshipReceipts:
         self.dropped = 0
         """Receipts that could not be written. Non-zero means the chain has
         gaps that ``intent_recorded: false`` on later results points at."""
+        self.pending_approval: Any = None
+        """Set by :class:`~treeship_commerce.approvals.TreeshipApprovalMixin`
+        just before an apply, so the next intent is signed with that grant's
+        nonce and subject. Cleared by the same mixin."""
+        self._approval_outcome: str | None = None
 
     @property
     def disabled(self) -> bool:
@@ -149,35 +247,114 @@ class TreeshipReceipts:
         elif os.environ.get("TREESHIP_DEBUG") == "1":
             logger.warning("treeship receipt not written (%s): %s", context, err)
 
-    async def _attest(self, action: str, meta: dict[str, Any], parent: str | None) -> str | None:
-        if self.disabled:
-            return None
-        try:
-            result = await asyncio.to_thread(
-                self.client.attest_action, self.actor, action, parent, None, meta
-            )
-        except Exception as err:  # noqa: BLE001 -- a recorder must never break the tool
-            self._warn(action, err)
-            return None
+    async def _sign(
+        self,
+        action: str,
+        meta: dict[str, Any],
+        parent: str | None,
+        *,
+        nonce: str | None = None,
+        subject: str | None = None,
+    ) -> str:
+        """Sign one receipt and advance the chain. Raises on failure; the
+        caller decides whether that failure is a dropped receipt or, for an
+        approval consume, a refusal worth recording in its own right."""
+        call = functools.partial(
+            self.client.attest_action, self.actor, action, parent, nonce, meta
+        )
+        if subject is not None:
+            call = functools.partial(call, subject=subject)
+        result = await asyncio.to_thread(call)
         async with self._lock:
             self._head = result.artifact_id
             self.recorded.append(result.artifact_id)
         return result.artifact_id
 
+    async def _attest(self, action: str, meta: dict[str, Any], parent: str | None) -> str | None:
+        if self.disabled:
+            return None
+        try:
+            return await self._sign(action, meta, parent)
+        except Exception as err:  # noqa: BLE001 -- a recorder must never break the tool
+            self._warn(action, err)
+            return None
+
     async def intent(self, name: str, tool_input: Mapping[str, Any] | None) -> str | None:
-        """Sign that ``name`` is about to run with these (digested) arguments."""
+        """Sign that ``name`` is about to run with these (digested) arguments.
+
+        When an approval grant is pending, the receipt is signed *with* its
+        nonce, which makes the CLI reserve a use in the Approval Use Journal
+        first. That reservation is the single-use guarantee: a replay of the
+        same approved change is refused here, before the receipt exists.
+
+        Nothing raised in here reaches the tool. A failure to even describe
+        the call (an argument the digest cannot canonicalise, a client that
+        misbehaves before signing) is a dropped receipt, counted and warned
+        about, and the tool runs.
+        """
+        try:
+            return await self._intent(name, tool_input)
+        except Exception as err:  # noqa: BLE001 -- a recorder must never break the tool
+            self._warn(INTENT_ACTION.format(name=name), err)
+            return None
+
+    async def _intent(self, name: str, tool_input: Mapping[str, Any] | None) -> str | None:
         async with self._lock:
             parent = self._head
-        return await self._attest(
-            INTENT_ACTION.format(name=name),
-            {
-                "tool": name,
-                "role": self.role,
-                "args_digest": args_digest(tool_input),
-                "session_tag": self.session_tag,
-            },
-            parent,
-        )
+        action = INTENT_ACTION.format(name=name)
+        meta: dict[str, Any] = {
+            "tool": name,
+            "role": self.role,
+            "args_digest": args_digest(tool_input),
+            "session_tag": self.session_tag,
+        }
+        grant = self.pending_approval
+        if grant is None:
+            return await self._attest(action, meta, parent)
+
+        if self.disabled:
+            return None
+        meta["change_id"] = grant.change_id
+        meta["approval_grant"] = grant.grant_id
+        try:
+            artifact_id = await self._sign(
+                action,
+                {**meta, "approval": "proven"},
+                parent,
+                nonce=grant.nonce,
+                subject=grant.subject,
+            )
+        except Exception as err:  # noqa: BLE001 -- a refused consume is data, not a crash
+            # The grant would not spend: already used, expired, or scoped to
+            # something else. Record the attempt without approval evidence --
+            # silence here would be the one failure that matters.
+            self._approval_outcome = "unproven"
+            logger.warning(
+                "treeship approval not consumed for change %s: %s. The receipt is "
+                "written without approval evidence; the tool is still gated by the "
+                "reference's own approval check.",
+                grant.change_id,
+                err,
+            )
+            return await self._attest(
+                action,
+                {**meta, "approval": "unproven", "approval_note": _refusal_reason(err)},
+                parent,
+            )
+        self._approval_outcome = "proven"
+        return artifact_id
+
+    @property
+    def approval_outcome(self) -> str | None:
+        """The most recent intent's approval verdict, without clearing it."""
+        return self._approval_outcome
+
+    def take_approval_outcome(self) -> str | None:
+        """``"proven"``, ``"unproven"``, or ``None`` when no grant was offered.
+        Reading it clears it, so one apply's outcome cannot be read as the
+        next one's."""
+        outcome, self._approval_outcome = self._approval_outcome, None
+        return outcome
 
     async def result(
         self,
@@ -187,7 +364,22 @@ class TreeshipReceipts:
         intent_id: str | None,
         elapsed_ms: int,
     ) -> str | None:
-        """Sign what ``name`` produced: status, gate, digests, events, timing."""
+        """Sign what ``name`` produced: status, gate, digests, events, timing.
+        Like :meth:`intent`, nothing raised in here reaches the caller."""
+        try:
+            return await self._result(name, outcome, intent_id=intent_id, elapsed_ms=elapsed_ms)
+        except Exception as err:  # noqa: BLE001 -- a recorder must never break the tool
+            self._warn(RESULT_ACTION.format(name=name), err)
+            return None
+
+    async def _result(
+        self,
+        name: str,
+        outcome: Any,
+        *,
+        intent_id: str | None,
+        elapsed_ms: int,
+    ) -> str | None:
         status = outcome_status(outcome)
         meta: dict[str, Any] = {
             "tool": name,
@@ -266,13 +458,25 @@ class TreeshipExecutorMixin:
             self.treeship_receipts = self.treeship_recorder_factory(self)
         return self.treeship_receipts
 
+    def _treeship_hold(self, name: str, tool_input: dict[str, Any] | None) -> Any | None:
+        """A hook for a mixin above this one to hold a call *after* its intent
+        receipt is signed and before the tool runs. Returns the held outcome,
+        or ``None`` to let the call through. Here so an enforced refusal is a
+        signed refusal with the gate's name, never a call that left no trace."""
+        return None
+
     async def execute(self, name: str, tool_input: dict[str, Any] | None) -> Any:
         receipts = self._treeship_recorder()
         if receipts is None:
+            held = self._treeship_hold(name, tool_input)
+            if held is not None:
+                return held
             return await super().execute(name, tool_input)  # type: ignore[misc]
         intent_id = await receipts.intent(name, tool_input)
         started = time.monotonic()
-        outcome = await super().execute(name, tool_input)  # type: ignore[misc]
+        outcome = self._treeship_hold(name, tool_input)
+        if outcome is None:
+            outcome = await super().execute(name, tool_input)  # type: ignore[misc]
         elapsed_ms = int((time.monotonic() - started) * 1000)
         await receipts.result(name, outcome, intent_id=intent_id, elapsed_ms=elapsed_ms)
         return outcome

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -165,6 +165,40 @@ class ArtifactIdHandlingTests(unittest.TestCase):
             self.assertEqual(r.artifact_id, "art_bbb")
 
 
+class ActionSubjectTests(unittest.TestCase):
+    """``subject`` is what an approval's allowed_subjects scope is matched
+    against. Without it a scoped grant refuses every action, so these check
+    the flag reaches the CLI and is validated like every other argument."""
+
+    def _args(self, mock_run) -> list:
+        return mock_run.call_args[0][0]
+
+    def test_subject_is_passed_through_to_the_cli(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json.dumps({"id": "art_1"}))
+            ts.attest_action(
+                actor="agent://merchant",
+                action="commerce.tool.apply_change.intent",
+                subject="change://chg_7f2",
+            )
+            args = self._args(mock_run)
+        self.assertIn("--subject", args)
+        self.assertEqual(args[args.index("--subject") + 1], "change://chg_7f2")
+
+    def test_subject_is_omitted_when_not_given(self) -> None:
+        ts = Treeship()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=json.dumps({"id": "art_1"}))
+            ts.attest_action(actor="agent://t", action="x")
+            self.assertNotIn("--subject", self._args(mock_run))
+
+    def test_subject_rejects_option_like_values(self) -> None:
+        ts = Treeship()
+        with self.assertRaises(TreeshipError):
+            ts.attest_action(actor="agent://t", action="x", subject="--config")
+
+
 class SessionReportTests(unittest.TestCase):
     def test_session_report_uses_json_format(self) -> None:
         ts = Treeship()

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -101,6 +101,7 @@ _MAX_SUMMARY_LEN = 4096     # decision summary (LLM reasoning blurb)
 _MAX_MODEL_LEN = 256        # model identifier
 _MAX_NONCE_LEN = 256        # approval nonce
 _MAX_ARTIFACT_ID_LEN = 256  # art_<hex>
+_MAX_SUBJECT_LEN = 2048     # subject URI an action targets
 _MAX_TOKEN_COUNT = 100_000_000  # 100M tokens — well past any single decision
 
 
@@ -352,8 +353,18 @@ class Treeship:
         parent_id: Optional[str] = None,
         approval_nonce: Optional[str] = None,
         meta: Optional[Dict[str, Any]] = None,
+        subject: Optional[str] = None,
     ) -> ActionResult:
-        """Create a signed action receipt."""
+        """Create a signed action receipt.
+
+        ``subject`` is the URI this action targets. It sets the statement's
+        ``subject.uri``, which is the field an approval's ``allowed_subjects``
+        scope is matched against -- so an approval minted for one target
+        cannot be spent on another. Without it a scoped approval that names
+        subjects refuses every action, because the action carries no subject
+        to match; the CLI has taken ``--subject`` since the scope check
+        existed, and this is the SDK catching up.
+        """
         _reject_option_like("actor", actor)
         _check_length("actor", actor, _MAX_ACTOR_LEN)
         _reject_option_like("action", action)
@@ -364,6 +375,9 @@ class Treeship:
         if approval_nonce is not None:
             _reject_option_like("approval_nonce", approval_nonce)
             _check_length("approval_nonce", approval_nonce, _MAX_NONCE_LEN)
+        if subject is not None:
+            _reject_option_like("subject", subject)
+            _check_length("subject", subject, _MAX_SUBJECT_LEN)
 
         args: List[str] = [
             "attest", "action",
@@ -375,6 +389,8 @@ class Treeship:
             args += ["--parent", parent_id]
         if approval_nonce is not None:
             args += ["--approval-nonce", approval_nonce]
+        if subject is not None:
+            args += ["--subject", subject]
         if meta is not None:
             args += ["--meta", json.dumps(meta)]
         result = self._run_cli_json(args)


### PR DESCRIPTION
## What

The reference's merchant `apply_change` is gated on an in-process set the host fills from its y/N. That set leaves no record and cannot refuse a second apply inside the same window. This makes the operator's yes a **signed, scoped, single-use Approval Grant** and makes the apply's receipt prove it was spent, once.

- `MerchantApprovals.grant(change_id)` mints a grant scoped to one actor, one action, and `change://<change_id>`, `max_uses=1`.
- `approved(receipted(MerchantToolExecutor), approvals)` signs the apply's intent receipt with the grant's nonce, so the CLI reserves a use in the Approval Use Journal **before** it signs. A replay finds the grant spent. A grant for another change is refused by scope: the action's subject comes from the call's own arguments, never from the grant (a test caught the vacuous version of this during development).
- The receipt says `approval: "proven"` or `"unproven"` with the CLI's reason. Recording only by default. `enforce=True` holds an unproven apply *after* its intent receipt, so the hold is itself a signed refusal in the reference's own held-outcome shape.
- `approving(toolset, approvals)` wraps `MerchantToolset.host_approve` / `host_clear` in place, so the reference console's `confirm_staged_changes()` runs unchanged.
- Python SDK: `attest_action(..., subject=)`. The CLI has taken `--subject` since the scope check existed; the SDK could not pass it, so a subject-scoped grant refused every SDK action.

## Also fixed

The reference's MCP server hands the executor parsed pydantic models as arguments. The argument digest called `json.dumps` on them outside the guarded path and the stage call died inside the recorder. The digest is now total (pydantic v1/v2, dataclasses, sets, bytes, datetimes, Decimal, Enum, paths, typed repr fallback), equal to the digest of the same arguments as plain dicts, and nothing raised while describing a call can reach the tool.

## Tested

28 tests on a real ship over the retail and merchant mocks, run in CI against the reviewed commit of the reference: grant binds to its receipt, spendable once, refused for another change, `enforce` holds a missing grant and a spent one (both receipted), the reference's cleared-mark rule, and the merchant side on **all three runtimes** through each one's `executor_class` seam (Agent SDK toolset via `approving()`, Messages API with a scripted model, Managed Agents MCP server). Python SDK: 57.

`python -m treeship_commerce.demo_merchant` (and `--enforce`) from a clean ship: held unapproved, applied once under a signed grant, refused on replay. `treeship package verify` on the sealed session reports `PASS replay-local-journal -- local Approval Use Journal passed, use 1/1`.

## Note for release

Approvals need the SDK's `subject`, which is unreleased; on the published 0.28.0 SDK `grant()` warns once and mints nothing, and the reference's own gate is untouched. Cutting 0.29.0 makes `pip install treeship-sdk treeship-commerce` carry the whole feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K7KU5PGyspTMuLCLmg6Ps