### PR TITLE
Release v0.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.28.0"
+    "version": "0.29.0"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 0.29.0 (2026-09-07)
+
+**Upgrade if you run the merchant side of Anthropic's commerce-agents
+reference.** The operator's approval becomes a signed, scoped, single-use
+grant that the apply's receipt spends exactly once, on all three runtimes,
+with the reference console's loop unchanged. The Python SDK gains
+`attest_action(subject=)`, which scoped approvals need; `treeship-commerce`
+now requires `treeship-sdk>=0.29.0`.
+
 ### Added
 
 - **`treeship-commerce`: signed single-use operator approvals on the merchant

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "base64",
  "clap",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.28.0"
+        "@treeship/core-wasm": "0.29.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.28.0"
+    "@treeship/core-wasm": "0.29.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.28.0",
+        "@treeship/core-wasm": "0.29.0",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.28.0",
+    "@treeship/core-wasm": "0.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -186,7 +186,7 @@ treeship package verify .treeship/sessions/ssn_a52cd0de94f479d3.treeship
 
 `--format json` gives a CI-consumable document: every check by artifact id, `chain_linkage_ok`, and the outcome. A published session renders at `treeship.dev/receipt/<id>` with the timeline and the same verifier running in the browser (`@treeship/verify`, WebAssembly); the hub stores bytes and serves proofs, it never issues a verdict.
 
-The demo's output, from a clean ship with the released 0.28.0 CLI and the SDK from PyPI (the `1 warnings` above is the package's always-on note that the narrative fields are not signature-bound; the artifacts and Merkle root are):
+The demo's output, from a clean ship with the released 0.29.0 CLI and the SDK from PyPI (the `1 warnings` above is the package's always-on note that the narrative fields are not signature-bound; the artifacts and Merkle root are):
 
 ```text
 tool calls        intent-id result-id
@@ -257,7 +257,7 @@ The three runtimes differ in *where* the human's yes enters the process, so they
 
 All three are exercised in the test suite through each runtime's own `executor_class` seam, the way a deployment wires them.
 
-Requires a `treeship-sdk` whose `attest_action` takes `subject` (added after 0.28.0). On an older SDK `grant()` warns once and mints nothing, and the apply stays gated exactly as the unwrapped reference gates it.
+Requires `treeship-sdk` 0.29.0 or later, whose `attest_action` takes `subject`; `treeship-commerce` 0.29.0 declares that floor. On an older SDK `grant()` warns once and mints nothing, and the apply stays gated exactly as the unwrapped reference gates it.
 
 The merchant demo runs all of it with no model and no API key: a staged price change held unapproved, applied once under a signed grant, and refused on replay while the reference's own mark is still set.
 

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/commerce-agents/README.md
+++ b/integrations/commerce-agents/README.md
@@ -101,7 +101,7 @@ MerchantToolExecutor), approvals)` signs the apply's intent receipt with the gra
 so the CLI reserves a use in the Approval Use Journal before signing. A second apply finds
 the grant spent; a grant for another change is refused by scope. The receipt says
 `approval: "proven"` or `"unproven"` with the reason. Recording only, unless
-`enforce=True`. Needs a `treeship-sdk` whose `attest_action` takes `subject`.
+`enforce=True`. Needs `treeship-sdk` 0.29.0 or later (`attest_action` takes `subject`).
 
 On the Agent SDK runtime, `approving(toolset, approvals)` wraps `MerchantToolset.host_approve`
 and `host_clear` in place, so the reference console's y/N loop mints and forgets grants with

--- a/integrations/commerce-agents/pyproject.toml
+++ b/integrations/commerce-agents/pyproject.toml
@@ -9,7 +9,7 @@ description = "Signed, offline-verifiable receipts for every tool call in anthro
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.11"
-dependencies = ["treeship-sdk>=0.27.0"]
+dependencies = ["treeship-sdk>=0.29.0"]
 # The commerce-agents packages (commerce-common, shopping-agent-core, ...) are
 # deliberately unregistered on PyPI; install them from a clone first
 # (`pip install -r requirements.txt` in anthropics/commerce-agents). This

--- a/integrations/commerce-agents/pyproject.toml
+++ b/integrations/commerce-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-commerce"
-version = "0.28.0"
+version = "0.29.0"
 description = "Signed, offline-verifiable receipts for every tool call in anthropics/commerce-agents, on all three of its runtimes."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/integrations/commerce-agents/treeship_commerce/__init__.py
+++ b/integrations/commerce-agents/treeship_commerce/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "receipted",
     "text_digest",
 ]
-__version__ = "0.28.0"
+__version__ = "0.29.0"

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.28.0",
-    "@treeship/cli-linux-arm64": "0.28.0",
-    "@treeship/cli-darwin-arm64": "0.28.0",
-    "@treeship/cli-darwin-x64": "0.28.0"
+    "@treeship/cli-linux-x64": "0.29.0",
+    "@treeship/cli-linux-arm64": "0.29.0",
+    "@treeship/cli-darwin-arm64": "0.29.0",
+    "@treeship/cli-darwin-x64": "0.29.0"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.28.0", path = "../core" }
+treeship-core = { version = "0.29.0", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.28.0", path = "../core" }
+treeship-core = { version = "0.29.0", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.28.0"
+version = "0.29.0"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.28.0"
+        "@treeship/core-wasm": "0.29.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.28.0"
+    "@treeship/core-wasm": "0.29.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.28.0"
+        "@treeship/core-wasm": "0.29.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.28.0"
+    "@treeship/core-wasm": "0.29.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@treeship/verify": "0.28.0"
+        "@treeship/verify": "0.29.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.28.0"
+    "@treeship/verify": "0.29.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@treeship/verify": "0.28.0"
+        "@treeship/verify": "0.29.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.28.0"
+    "@treeship/verify": "0.29.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "dependencies": {
-        "@treeship/verify": "0.28.0"
+        "@treeship/verify": "0.29.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.28.0"
+    "@treeship/verify": "0.29.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
`scripts/release.sh prepare 0.29.0` plus the `treeship-sdk>=0.29.0` floor on `treeship-commerce`, the docs wording, and the CHANGELOG heading.

**Upgrade if you run the merchant side of Anthropic's commerce-agents reference.** The operator's approval becomes a signed, scoped, single-use grant that the apply's receipt spends exactly once, on all three runtimes, with the reference console's loop unchanged (#366). The Python SDK gains `attest_action(subject=)`. Also: the argument digest is total over non-JSON arguments, so the MCP runtime's parsed models no longer break a stage call inside the recorder.

Tag after merge: `scripts/release.sh tag 0.29.0 --sha <merged-main-sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017K7KU5PGyspTMuLCLmg6Ps