### PR TITLE
chore: lock the JS workspaces to the published 0.30.0 tarballs

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.29.0.tgz",
-      "integrity": "sha512-j59IrC6TEV0Yw4egTayhY65QTUoKeNoHa8P/TWHBgZ8WERPqwm/uyJT7Pf0I2Sx6RnR3if1y5kMXO8noOT0NSA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.30.0.tgz",
+      "integrity": "sha512-NYbVVoXpV8/u77Qfi42VtSEhxuBZtbf+booHvzSOXs2FTm0fD62R5REbXfFumv1ewuX5URP2qiZxyaQF+iV5LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.29.0"
+        "@treeship/core-wasm": "0.30.0"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.29.0.tgz",
-      "integrity": "sha512-j59IrC6TEV0Yw4egTayhY65QTUoKeNoHa8P/TWHBgZ8WERPqwm/uyJT7Pf0I2Sx6RnR3if1y5kMXO8noOT0NSA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.30.0.tgz",
+      "integrity": "sha512-NYbVVoXpV8/u77Qfi42VtSEhxuBZtbf+booHvzSOXs2FTm0fD62R5REbXfFumv1ewuX5URP2qiZxyaQF+iV5LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.29.0"
+        "@treeship/core-wasm": "0.30.0"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.29.0.tgz",
-      "integrity": "sha512-f60fPudX+I0ZiZI5LveuBl4RGrJ0Qm9kgry6mYeZ19lGXRqKd0YAtmOet7lHhA9+LQEb34A2zTPUObkkfJxZig==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.30.0.tgz",
+      "integrity": "sha512-meKWNwBxbv40EOcYX+Pi5UbCje76jNDjnhyISC/pcm2H45qHOVc7Eez6sA0hzdUV/JJePy8s6r4wtxZRdwe7jw==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.29.0.tgz",
-      "integrity": "sha512-j59IrC6TEV0Yw4egTayhY65QTUoKeNoHa8P/TWHBgZ8WERPqwm/uyJT7Pf0I2Sx6RnR3if1y5kMXO8noOT0NSA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.30.0.tgz",
+      "integrity": "sha512-NYbVVoXpV8/u77Qfi42VtSEhxuBZtbf+booHvzSOXs2FTm0fD62R5REbXfFumv1ewuX5URP2qiZxyaQF+iV5LA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.29.0"
+        "@treeship/core-wasm": "0.30.0"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
The other half of the release-time lockfile fallback: `scripts/release.sh refresh-lockfiles` now that v0.30.0 is on npm. Merge first; every other PR fails `npm ci` until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)