### PR TITLE
treeship-commerce: approval verdict on the executor; honest replay row in demo_merchant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **treeship-commerce: the approval verdict next to the tool outcome.** `TreeshipApprovalMixin` now sets `treeship_last_approval` (`proven`, `unproven`, or `None`) on the executor after every apply, so a host can print or log what the intent receipt says about the grant beside what the tool did. `demo_merchant` uses it: the replay row reads `error, approval unproven` in the default run (the journal refused a second use before anything was signed; the mock backend then refused the apply as already applied) instead of a bare `error` that let the backend take credit for the journal's refusal. Under `--enforce` the row is unchanged, `blocked:approval`.
+- **Docs: verify a session package**, a page for the person handed a `.treeship` package (`/commerce/verify-a-package`): what each check proves and does not, the counterparty signature flow (`keys export` → `trust add` → `bundle import` → `verify`), and the limits (`anchoring: UNWITNESSED`, `actor proof: asserted`, `--require-authority` on receipts with no mandate). Shopping demo recording added to the integration page and the announcement post.
+
 ## 0.30.0 (2026-09-07)
 
 **Upgrade if you build on Anthropic's commerce-agents reference.** The

--- a/docs/content/docs/commerce/verify-a-package.mdx
+++ b/docs/content/docs/commerce/verify-a-package.mdx
@@ -60,7 +60,7 @@ What each line establishes:
 | `receipt.json`, `type` | The file is a well-formed session receipt of the expected type. | Anything about its truth. |
 | `determinism` | The receipt re-serializes to the same bytes, so a digest of it is meaningful. | It is explicitly not a signature check. |
 | `receipt_body_binding` (always `WARN` on an unpublished package) | Nothing. It is a reminder: the headline, the narrative, the timeline summaries and the side-effect lists are the producer's prose and are **not** under any signature. | Do not quote the narrative as evidence. Quote artifacts. |
-| `merkle_root` | The root written in the receipt is the root of the tree over exactly the artifact digests listed. | That those digests belong to receipts you have seen. |
+| `merkle_root` | The root written in the receipt is the root of the tree over exactly the artifact ids listed. Ids are content-addressed, so an id names one exact set of signed bytes. | That those bytes are ones you have seen. The `digest` column beside each id is informational and is not itself recomputed by this step; the id is what the tree binds. |
 | `inclusion:<id>` | That artifact's digest was a leaf of the tree when the session was sealed. Nothing was added or removed since. | What the artifact says. |
 | `leaf_count`, `timeline_order` | The count and the ordering are internally consistent. | Wall-clock time. The timestamps are the signer's own clock. |
 

--- a/integrations/commerce-agents/tests/test_approvals.py
+++ b/integrations/commerce-agents/tests/test_approvals.py
@@ -127,10 +127,14 @@ async def test_a_grant_is_spendable_once(ship: Ship, merchant):
 
     first = await executor.execute("apply_change", {"change_id": change_id})
     assert not first.refused, first.result_text
+    assert executor.treeship_last_approval == "proven"
     # The host would normally re-approve; here the same grant is offered twice
     # on purpose, which is exactly the replay the journal has to refuse.
     approvals._grants[change_id] = grant
     await executor.execute("apply_change", {"change_id": change_id})
+    # The verdict a host prints next to the tool's outcome: the backend may
+    # say "already applied", the receipt says the approval was not proven.
+    assert executor.treeship_last_approval == "unproven"
 
     receipts: TreeshipReceipts = executor.treeship_receipts
     intents = [

--- a/integrations/commerce-agents/treeship_commerce/approvals.py
+++ b/integrations/commerce-agents/treeship_commerce/approvals.py
@@ -236,6 +236,12 @@ class TreeshipApprovalMixin:
     treeship_approvals_factory: Callable[[Any], MerchantApprovals] | None = None
     treeship_apply_tool: str = "apply_change"
     treeship_enforce_approval: bool = False
+    #: What the most recent apply's intent receipt says about its grant:
+    #: ``"proven"``, ``"unproven"`` (the grant would not spend: already used,
+    #: expired, or scoped to another change), or ``None`` when no grant was
+    #: offered. Set after every apply so a host can print or log the verdict
+    #: next to the tool's own outcome.
+    treeship_last_approval: str | None = None
     _treeship_apply_lock: asyncio.Lock | None = None
 
     def _treeship_approvals(self) -> MerchantApprovals | None:
@@ -302,6 +308,7 @@ class TreeshipApprovalMixin:
                 if receipts is not None:
                     receipts.pending_approval = None
                     spent = receipts.take_approval_outcome()
+                    self.treeship_last_approval = spent
                     if spent is not None and grant is not None:
                         # A grant is spendable once; drop the handle either
                         # way, so a second apply cannot even offer the nonce.

--- a/integrations/commerce-agents/treeship_commerce/demo_merchant.py
+++ b/integrations/commerce-agents/treeship_commerce/demo_merchant.py
@@ -14,7 +14,10 @@ The third is the one that matters. The reference's approval *gate* lets it
 through, because the host's in-process mark is still set for the rest of the
 turn; the mock backend then happens to refuse it as already applied, which is
 backend state, not evidence. The Approval Use Journal refuses it regardless of
-what the backend knows, before anything is signed, and the receipt says so.
+what the backend knows, before anything is signed, and the receipt says so:
+the row reads ``error, approval unproven`` in the default run (the tool ran
+and the backend refused it; the receipt carries no approval) and
+``blocked:approval`` under ``--enforce`` (the wrapper held the tool itself).
 Every id printed is real; verify them with the commands printed at the end.
 """
 
@@ -93,14 +96,23 @@ async def run(*, enforce: bool) -> int:
             if outcome.blocked
             else ("error" if outcome.is_error else "ok")
         )
+        # What the receipt says about the grant, next to what the tool did.
+        # ``unproven`` is the replay in the default run: the journal refused
+        # a second use before anything was signed, the wrapper recorded the
+        # call without approval evidence, and the mock backend then refused
+        # it as already applied. ``error`` alone would let the backend take
+        # the credit for a refusal the journal made.
+        approval = getattr(executor, "treeship_last_approval", None)
+        if approval:
+            status = f"{status}, approval {approval}"
         new = receipts.recorded[before:]
-        print(f"  {label:<26} {status:<22} {' '.join(new) or '(no receipt written)'}")
+        print(f"  {label:<26} {status:<26} {' '.join(new) or '(no receipt written)'}")
         return outcome
 
     tag = hashlib.sha256(commerce_session.encode()).hexdigest()[:12]
     print(f"session root      {root}")
     print(f"commerce session  sha256:{tag}  (tag; the id itself is never written)")
-    print("steps                      outcome                receipt ids")
+    print("steps                      outcome                    receipt ids")
 
     await call("search_listings", "search_listings", {"query": ""})
     listings = [
@@ -131,7 +143,7 @@ async def run(*, enforce: bool) -> int:
     #    evidence, and the reference's mark, which is what lets the apply run.
     grant = approvals.grant(change_id, summary=f"3% clearance on {listing_id}")
     executor._state.approved_change_ids.add(change_id)
-    print(f"  operator approves          grant signed           {grant.artifact_id}")
+    print(f"  operator approves          grant signed               {grant.artifact_id}")
     await call("apply (approved)", "apply_change", {"change_id": change_id})
 
     # 3. The replay. The reference's mark is still set, so its gate allows this;


### PR DESCRIPTION
In the default run the merchant demo's replay row read `error`, which let the mock backend's "already applied" take credit for a refusal the Approval Use Journal made. The mixin now sets `treeship_last_approval` (`proven` / `unproven` / `None`) on the executor after every apply; the demo prints it beside the tool outcome:

```
  apply (approved)           ok, approval proven        art_…  art_…
  apply again (replay)       error, approval unproven   art_…  art_…
```

`--enforce` unchanged (`blocked:approval`). Test extended to assert both verdicts. Also notes in the verifier guide that `package verify` binds artifact ids; the `digest` column is informational. 35 passed, 1 skipped locally against the released 0.30.0 CLI. Ships to PyPI with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)