### PR TITLE
fix: QA findings on 0.31.0 (TS-001 to TS-006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-_Nothing yet._
+- **treeship-commerce: the order receipt no longer forks the chain (QA TS-002, P0).** `order_placed` signed the host's order onto the hand-off receipt. The checkout result, which also follows the hand-off, became a branch off the path the session seals, so it was signed, verifiable on its own, and absent from the package, while `package verify` reported a clean package. The order now chains onto the recorder's head and names the hand-off in `meta.handoff`; `attest_at_handoff` does the same. A test asserts every receipt a recorder writes is on the sealed chain.
+- **`session close` names unsealed branches (QA TS-002).** Signed artifacts whose parent is on the sealed chain but which are not on it themselves are listed in the close output (`unsealed_branches` in JSON, a warning in text) instead of vanishing silently.
+- **The demos run on a clean machine (QA TS-001, TS-004).** `demo` and `demo_merchant` construct the SDK with `bot_mode=True`, so the CLI is resolved (PATH, cache, then the matching release) rather than assumed; a missing workspace or CLI prints a one-line remedy instead of a traceback; a session a previous run left open is closed with a summary that says so, so a second run works.
+- **The SDK warns when the CLI is on another release line (QA TS-003).** Once per client, on the first call: `treeship --version` against the SDK's own version, a `RuntimeWarning` naming both and the upgrade command.
+- **Quickstarts use the project-local init (QA TS-006).** `treeship init --config .treeship/config.json` in every commerce quickstart. Bare `treeship init` refuses when a global workspace already exists and the current directory is not it (that guard predates 0.31; it was the first command in the quickstarts that was wrong).
+- **`bootstrap.py` docstring matches `bootstrap_cli` (QA TS-005):** the entry point prints the binary path, or the JSON result with `--json`.
 
 ## 0.31.0 (2026-09-08)
 

--- a/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
+++ b/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
@@ -138,7 +138,8 @@ It does not prove the catalog was truthful, that the tool's answer was right, th
 # in a clone of anthropics/commerce-agents
 pip install -r requirements.txt
 pip install treeship-sdk treeship-commerce
-curl -fsSL https://treeship.dev/install | sh && treeship init
+curl -fsSL https://treeship.dev/install | sh
+treeship init --config .treeship/config.json     # a workspace for this directory
 python -m treeship_commerce.demo               # shopping: the gate, the hand-off, the order
 python -m treeship_commerce.demo_merchant      # merchant: held, approved once, refused on replay
 ```

--- a/docs/content/blog/receipts-for-agentic-commerce.mdx
+++ b/docs/content/blog/receipts-for-agentic-commerce.mdx
@@ -154,7 +154,8 @@ The blueprint's authors drew the line themselves: the gates are theirs, the reco
 # in a clone of anthropics/commerce-agents
 pip install -r requirements.txt
 pip install treeship-sdk treeship-commerce          # 0.30.0
-curl -fsSL https://treeship.dev/install | sh && treeship init
+curl -fsSL https://treeship.dev/install | sh
+treeship init --config .treeship/config.json     # a workspace for this directory
 python -m treeship_commerce.demo                    # shopping: the gate, the hand-off, the order
 python -m treeship_commerce.demo_merchant           # merchant: held, approved once, refused on replay
 

--- a/docs/content/docs/commerce/commerce-agents.mdx
+++ b/docs/content/docs/commerce/commerce-agents.mdx
@@ -82,11 +82,11 @@ What is deliberately **not** in a receipt:
 ## Install
 
 ```bash
-# in a clone of anthropics/commerce-agents, with its venv active
+# in a clone of anthropics/commerce-agents, with its venv active (Python 3.11+)
 pip install -r requirements.txt                  # the reference's packages; unregistered on PyPI by design
 pip install treeship-sdk treeship-commerce
-curl -fsSL https://treeship.dev/install | sh     # the CLI does the signing
-treeship init
+curl -fsSL https://treeship.dev/install | sh     # the CLI does the signing; the demos also fetch it themselves
+treeship init --config .treeship/config.json     # a workspace for this directory
 ```
 
 Or let Claude Code do the wiring. The `treeship-commerce` plugin mirrors the reference's own `commerce-builder`: one command that reads your project, wraps the executor on your runtime, signs the merchant approval surface or the shopping checkout hand-off, and records what it decided in your `CLAUDE.md` decision record.
@@ -240,7 +240,7 @@ backend = receipted_backend(MyStorefront())     # once, where the runtime is bui
 await order_placed(receipts, order_ref=order.order_id, amount=order.total, currency="USD")
 ```
 
-`order_placed` is the host's half of the seam. It chains a signed **order receipt** onto the hand-off: a digest of the order reference (never the reference itself, which is the customer's lookup key), the amount and the currency. A customer, a merchant, or an auditor holding the cart can recompute its digest and check that the order chains from a hand-off for exactly that cart, offline. When the host never wrapped its backend, the order receipt still lands on the session chain and says `handoff_recorded: false` rather than pointing at something invented.
+`order_placed` is the host's half of the seam. It signs an **order receipt** onto the chain after the hand-off, naming the hand-off in `meta.handoff` (never onto the hand-off itself, which would fork the chain and leave the checkout result out of the sealed package): a digest of the order reference (never the reference itself, which is the customer's lookup key), the amount and the currency. A customer, a merchant, or an auditor holding the cart can recompute its digest and check that the order chains from a hand-off for exactly that cart, offline. When the host never wrapped its backend, the order receipt still lands on the session chain and says `handoff_recorded: false` rather than pointing at something invented.
 
 The wrapped backend finds the right recorder by the commerce session: every `TreeshipReceipts` registers itself under its session tag, and the backend looks the session up the same way. That is the default and needs no wiring beyond the `receipted(...)` executor class; pass `recorder=` to override it.
 
@@ -329,7 +329,7 @@ summary["attestation"]["chain_head"] == receipts.last_handoff    # True
 vi_verify(ts, mandate=l2_sdjwt, out="./vi-out")["outcome"]       # "pass"
 ```
 
-The purchase values must describe the cart. The mandate check runs before anything is signed; a purchase outside it raises and writes nothing. The attestation is a receipt (`vi.l3.attested`) chained onto the hand-off, and `order_placed` chains the host's order onto it, so the sealed package holds the whole story: the calls, the refusals, the cart, the credential, the order. What goes to the network (`l3a.sdjwt` with `l2-payment.sdjwt`) and to the merchant (`l3b.sdjwt` with `l2-checkout.sdjwt`) is in `--out`. Needs treeship 0.31.
+The purchase values must describe the cart. The mandate check runs before anything is signed; a purchase outside it raises and writes nothing. The attestation is a receipt (`vi.l3.attested`) on the chain after the hand-off, and `order_placed` chains the host's order onto it, so the sealed package holds the whole story: the calls, the refusals, the cart, the credential, the order. What goes to the network (`l3a.sdjwt` with `l2-payment.sdjwt`) and to the merchant (`l3b.sdjwt` with `l2-checkout.sdjwt`) is in `--out`. Needs treeship 0.31.
 
 ## Operating it
 

--- a/docs/content/docs/integrations/verifiable-intent.mdx
+++ b/docs/content/docs/integrations/verifiable-intent.mdx
@@ -72,9 +72,9 @@ Anthropic's [commerce-agents](/integrations/commerce-agents) reference stops at 
 
 | Verifiable Intent | Treeship commerce receipt | Note |
 |---|---|---|
-| L2 mandate constraints (`amount_range`, `allowed_payees`, `line_items`) | `commerce.checkout.handoff` carries `subtotal`, `currency`, `item_count`, and a per-hand-off `seller` | `treeship vi attest` is run at hand-off with the cart's values; the attestation's `chain_head` is the hand-off receipt, so the claim binds the cart that went to checkout to the credential |
+| L2 mandate constraints (`amount_range`, `allowed_payees`, `line_items`) | `commerce.checkout.handoff` carries `subtotal`, `currency`, `item_count`, and a per-hand-off `seller` | `treeship vi attest` is run at hand-off with the cart's values; the chain the attestation names runs through the hand-off receipt, so the claim binds the cart that went to checkout to the credential |
 | L3b `checkout_hash` (SHA-256 of the merchant's checkout JWT) | `cart_digest` (SHA-256 over the canonical cart) | Different preimages by design: the spec hashes the merchant's token, Treeship hashes the cart the agent built. The claim's `transaction_id` is the former; the chain it names covers the latter |
-| L3a payment leg | `commerce.order.placed`, chained to the hand-off | Treeship records that an order was placed and for how much, digesting the order reference. It does not touch the payment instrument; that stays on the network |
+| L3a payment leg | `commerce.order.placed`, on the chain after the hand-off, naming it | Treeship records that an order was placed and for how much, digesting the order reference. It does not touch the payment instrument; that stays on the network |
 | Provenance-gate refusals | `commerce.tool.*` receipts with status `blocked` | Not part of VI at all, and the part an issuer is most likely to ask about: the planted cart add that the gate refused is in the same chain the credential cites |
 
 Merchant-side approvals (the signed, single-use grants in the merchant vertical) are outside Verifiable Intent, which is the buyer's chain. They stay in the merchant's own session package.

--- a/integrations/commerce-agents/README.md
+++ b/integrations/commerce-agents/README.md
@@ -33,10 +33,11 @@ can correlate and a reader cannot.
 ## Install
 
 ```bash
-# from a clone of anthropics/commerce-agents, with its venv active
+# from a clone of anthropics/commerce-agents, with its venv active (Python 3.11+)
 pip install -r requirements.txt            # their seven packages (unregistered on PyPI)
 pip install treeship-sdk treeship-commerce
-curl -fsSL https://treeship.dev/install | sh && treeship init
+curl -fsSL https://treeship.dev/install | sh   # the CLI does the signing; the demos also fetch it themselves
+treeship init --config .treeship/config.json   # a workspace for this directory
 ```
 
 ## Or let Claude Code wire it
@@ -109,7 +110,7 @@ its one use.
 `receipted_backend(backend)` wraps a storefront backend so `checkout_handoff` also signs a
 hand-off receipt: cart digest, item count, subtotal, currency, and a digest of each hosted
 URL (never the URL). `order_placed(receipts, order_ref=..., amount=..., currency=...)` is
-the host's half: a signed order receipt chained onto the hand-off, the order reference
+the host's half: a signed order receipt on the chain after the hand-off, naming it, the order reference
 digested. A holder of the checkout card can recompute the cart digest from the card alone.
 
 ## Approvals
@@ -148,7 +149,7 @@ summary["attestation"]["chain_head"] == receipts.last_handoff   # True
 vi_verify(ts, mandate=l2_sdjwt, out="./vi-out")["outcome"]      # "pass"
 ```
 
-The purchase values you pass must describe the cart: the check against the mandate happens before anything is signed, and a purchase outside it raises with nothing written. The attestation is itself a receipt (`vi.l3.attested`) chained onto the hand-off, and the host's order chains onto it. Needs treeship 0.31.
+The purchase values you pass must describe the cart: the check against the mandate happens before anything is signed, and a purchase outside it raises with nothing written. The attestation is itself a receipt (`vi.l3.attested`) on the chain after the hand-off, and the host's order chains onto it. Needs treeship 0.31.
 
 ## Keep the preimages
 

--- a/integrations/commerce-agents/plugin/commands/add-treeship-receipts.md
+++ b/integrations/commerce-agents/plugin/commands/add-treeship-receipts.md
@@ -13,7 +13,7 @@ Without a role, read the project and infer it; with both roles present, wire bot
 
 1. The reference (`anthropics/commerce-agents`): the current repo, a local clone, or a fresh clone. Treeship needs it only for the tests and the demos; the deployment imports `treeship_commerce` and its own reference packages.
 2. The user's agent and its runtime. Look for the `executor_class` seam: `ShoppingAgent(...)` / `MerchantAgent(...)` (Messages API), `ShoppingToolset(...)` / `MerchantToolset(...)` (Agent SDK), or `build_server(...)` in a `*-mcp-server` (Managed Agents). A project from `/scaffold-commerce-agent` names its runtime in the `## Commerce agent decision record` of `CLAUDE.md`; read it, and read the approval surface entry for a merchant agent.
-3. A Treeship ship. `treeship --version` must print 0.29.0 or later, and `treeship init` must have run in the deployment's working directory (or `TREESHIP_CONFIG` must point at one). Without a ship, receipts are dropped and counted, never invented; say so and offer to run `treeship init`.
+3. A Treeship ship. `treeship --version` must print 0.29.0 or later, and `treeship init --config .treeship/config.json` must have run in the deployment's working directory (or `TREESHIP_CONFIG` must point at one). Without a ship, receipts are dropped and counted, never invented; say so and offer to run `treeship init --config .treeship/config.json`.
 
 ## Step 2: Install
 

--- a/integrations/commerce-agents/tests/test_checkout.py
+++ b/integrations/commerce-agents/tests/test_checkout.py
@@ -142,12 +142,20 @@ async def test_the_hosts_order_chains_from_the_handoff(ship: Ship):
     await executor.execute("checkout", {})
     receipts: TreeshipReceipts = executor.treeship_receipts
 
+    head_before = receipts.head  # the checkout result, which follows the hand-off
     order_id = await order_placed(receipts, order_ref="ord_77accf", amount=199.0, currency="USD")
     assert order_id is not None
     order = ship.artifacts()[order_id]
     assert order["statement"]["action"] == ORDER_ACTION
-    assert order["statement"]["parentId"] == backend.handoffs[0]
+    # Onto the head, never onto the hand-off: signing onto the hand-off
+    # forks the chain and the checkout result drops out of the package
+    # (QA TS-002 on 0.31.0). The hand-off is named in meta instead.
+    assert order["statement"]["parentId"] == head_before
     meta = order["statement"]["meta"]
+    assert meta["handoff"] == backend.handoffs[0]
+    # Every receipt this recorder wrote is on the one chain the session seals.
+    on_chain = {c["record"]["artifact_id"] for c in ship.chain(receipts.head)}
+    assert set(receipts.recorded) <= on_chain, set(receipts.recorded) - on_chain
     assert meta["order_ref_digest"] == text_digest("ord_77accf")
     assert "ord_77accf" not in order["raw"]
     assert meta["amount"] == 199.0 and meta["currency"] == "USD"

--- a/integrations/commerce-agents/tests/test_vi.py
+++ b/integrations/commerce-agents/tests/test_vi.py
@@ -49,13 +49,16 @@ async def test_the_credential_names_the_handoff_and_the_order_chains_onto_it(shi
     _import_agent_key(ship)
     _, receipts = await _handed_off(ship)
     handoff = receipts.last_handoff
+    head_before = receipts.head  # the checkout result, after the hand-off
 
     summary = attest_at_handoff(
         ship.client, receipts, mandate=FIXTURE["l2"], checkout_jwt=FIXTURE["checkout_jwt"],
         **PURCHASE, **AUD, iss="https://agent.example.com", out=ship.root / "vi-out", workdir=ship.root, env=ship.env,
     )
     att = summary["attestation"]
-    assert att["chain_head"] == handoff, "the credential names the hand-off receipt"
+    assert att["chain_head"] == head_before, "onto the head, never a fork off the hand-off"
+    assert summary["handoff"] == handoff
+    assert handoff in {c["record"]["artifact_id"] for c in ship.chain(att["chain_head"])}, "the chain it names runs through the hand-off"
     assert att["recorded"] is True
     assert att["reaches_session_root"] is True
     assert att["checkpoint"].startswith("mroot_")
@@ -67,7 +70,7 @@ async def test_the_credential_names_the_handoff_and_the_order_chains_onto_it(shi
     assert receipts.head == att["artifact_id"]
     statement = ship.artifacts()[att["artifact_id"]]["statement"]
     assert statement["action"] == "vi.l3.attested"
-    assert statement["parentId"] == handoff
+    assert statement["parentId"] == head_before
     assert statement["meta"]["transaction_id"] == summary["checkout_hash"]
 
     # The host's order chains onto the attestation, so the sealed session
@@ -75,10 +78,12 @@ async def test_the_credential_names_the_handoff_and_the_order_chains_onto_it(shi
     order = await order_placed(receipts, order_ref="ord_1", amount=279.99, currency="USD", handoff_id=att["artifact_id"])
     assert ship.artifacts()[order]["statement"]["parentId"] == att["artifact_id"]
     assert ship.cli_json("verify", order)["outcome"] == "pass"
+    on_chain = {c["record"]["artifact_id"] for c in ship.chain(order)}
+    assert set(receipts.recorded) <= on_chain, "nothing this recorder wrote is left off the sealed chain"
 
     report = vi_verify(ship.client, mandate=FIXTURE["l2"], out=ship.root / "vi-out", l1=FIXTURE["l1"], issuer_jwk=FIXTURE["issuer_public_jwk"], workdir=ship.root, env=ship.env)
     assert report["outcome"] == "pass", [c for c in report["checks"] if not c["pass"]]
-    assert report["attestation"]["chain_head"] == handoff
+    assert report["attestation"]["chain_head"] == head_before
 
 
 async def test_a_cart_outside_the_mandate_is_refused_with_nothing_written(ship: Ship):

--- a/integrations/commerce-agents/treeship_commerce/checkout.py
+++ b/integrations/commerce-agents/treeship_commerce/checkout.py
@@ -18,7 +18,7 @@ receipts, so it sits after the ``checkout`` intent that caused it.
 
 Then the host places the order, on its own checkout page, out of the agent's
 sight. :func:`order_placed` lets the host chain a signed **order receipt**
-onto the hand-off: a digest of the order reference, the amount and currency.
+after the hand-off, naming it: a digest of the order reference, the amount and currency.
 A customer, a merchant, or an auditor holding the cart can recompute the cart
 digest and check that the order chains from a hand-off for exactly that cart.
 
@@ -188,27 +188,42 @@ async def order_placed(
     currency: str | None,
     handoff_id: str | None = None,
 ) -> str | None:
-    """The host's side of the seam: chain the placed order onto the hand-off.
+    """The host's side of the seam: the placed order, chained onto the chain
+    after the hand-off and naming it.
 
-    ``handoff_id`` defaults to the most recent hand-off receipt this recorder
-    wrote; pass it explicitly when the host places orders asynchronously. The
-    order reference is digested, never written: it is the customer's lookup
-    key on the host, and the receipt only needs to let a holder of it check.
+    The order is signed onto the recorder's current head, which sits after
+    the hand-off receipt (the checkout result follows the hand-off on the
+    same chain). It is *not* signed onto the hand-off itself: that would
+    fork the chain, and the checkout result would branch off the path the
+    session seals, so it would be missing from the package (QA finding
+    TS-002 on 0.31.0). ``meta.handoff`` names the hand-off receipt
+    explicitly, so a holder of the cart still finds the order that followed
+    it in one step. ``handoff_id`` defaults to the most recent hand-off
+    this recorder wrote; pass it when the host places orders asynchronously.
+    The order reference is digested, never written: it is the customer's
+    lookup key on the host, and the receipt only needs to let a holder of
+    it check.
     """
-    parent = handoff_id or receipts.last_handoff
-    if parent is None:
+    handoff = handoff_id or receipts.last_handoff
+    if handoff is None:
         logger.warning(
-            "treeship order receipt has no hand-off to chain from; writing it on the "
-            "session chain instead. Wrap the backend with receipted_backend() so the "
+            "treeship order receipt has no hand-off to name; writing it on the "
+            "session chain without one. Wrap the backend with receipted_backend() so the "
             "cart that went to checkout is signed first."
         )
     meta: dict[str, Any] = {
         "order_ref_digest": text_digest(str(order_ref)),
         "amount": amount,
         "currency": currency,
-        "handoff_recorded": parent is not None,
+        "handoff_recorded": handoff is not None,
         "session_tag": receipts.session_tag,
     }
+    if handoff is not None:
+        meta["handoff"] = handoff
+    # Chain onto the head (never fork), unless the caller names a hand-off
+    # that is not on this recorder's chain at all (an asynchronous host
+    # with its own recorder), in which case it is the only link we have.
+    parent = receipts.head if receipts.head is not None else handoff
     return await receipts.attest(ORDER_ACTION, meta, parent=parent)
 
 

--- a/integrations/commerce-agents/treeship_commerce/demo.py
+++ b/integrations/commerce-agents/treeship_commerce/demo.py
@@ -19,10 +19,10 @@ import os
 import sys
 import uuid
 
-from treeship_sdk import Treeship
+from treeship_sdk import Treeship, TreeshipError
 
 from . import TreeshipReceipts, attach, order_placed, receipted, receipted_backend
-from .lifecycle import close_session, session_status, start_session
+from .lifecycle import close_session, open_demo_session, session_status
 
 ACTOR = "agent://shopping"
 
@@ -65,9 +65,11 @@ def _build_executor(session_id: str):
 
 
 async def run(report: bool) -> int:
-    ts = Treeship()
+    # bot_mode resolves the CLI (PATH, then the per-user cache, then the
+    # matching GitHub release) instead of assuming it is on PATH.
+    ts = Treeship(bot_mode=True)
     commerce_session = f"demo-{uuid.uuid4().hex}"  # the reference treats this as a credential
-    root = start_session(ts, name="commerce:retail-demo", actor=ACTOR)
+    root = open_demo_session(ts, name="commerce:retail-demo", actor=ACTOR)
     executor = attach(
         _build_executor(commerce_session),
         TreeshipReceipts(ts, actor=ACTOR, session_id=commerce_session, parent_id=root),
@@ -131,6 +133,24 @@ async def run(report: bool) -> int:
     return 0 if receipts.dropped == 0 else 2
 
 
+def _explain(err: Exception) -> str | None:
+    """A one-line remedy for the two setup failures a fresh machine hits,
+    or ``None`` when the error is not one of them."""
+    text = str(err)
+    if "not initialized" in text or "no .treeship directory" in text or "treeship init" in text:
+        return (
+            "no Treeship workspace in this directory. Create one:\n"
+            "  treeship init --config .treeship/config.json"
+        )
+    if "CLI not found" in text or "bootstrap failed" in text or isinstance(err, FileNotFoundError):
+        return (
+            "the treeship CLI is not installed. Install it:\n"
+            "  curl -fsSL https://treeship.dev/install | sh\n"
+            "  (or: python -m treeship_sdk.bootstrap_cli)"
+        )
+    return None
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -139,7 +159,14 @@ def main() -> None:
     args = parser.parse_args()
     if os.environ.get("TREESHIP_DISABLE") == "1":
         sys.exit("TREESHIP_DISABLE=1 is set; this demo exists to write receipts")
-    sys.exit(asyncio.run(run(report=args.report)))
+    try:
+        code = asyncio.run(run(report=args.report))
+    except (TreeshipError, FileNotFoundError) as err:
+        remedy = _explain(err)
+        if remedy is None:
+            raise
+        sys.exit(f"{remedy}\n\n  (treeship said: {err})")
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/integrations/commerce-agents/treeship_commerce/demo_merchant.py
+++ b/integrations/commerce-agents/treeship_commerce/demo_merchant.py
@@ -30,10 +30,10 @@ import os
 import sys
 import uuid
 
-from treeship_sdk import Treeship
+from treeship_sdk import Treeship, TreeshipError
 
 from . import MerchantApprovals, TreeshipReceipts, approved, attach, receipted
-from .lifecycle import _run_json, close_session, session_status, start_session
+from .lifecycle import _run_json, close_session, open_demo_session, session_status
 from .receipts import sdk_supports_subject
 
 ACTOR = "agent://merchant"
@@ -76,9 +76,11 @@ async def run(*, enforce: bool) -> int:
             "the installed treeship-sdk cannot name an action's subject, so a "
             "single-use grant would be refused by its own scope. Upgrade treeship-sdk."
         )
-    ts = Treeship()
+    # bot_mode resolves the CLI (PATH, then the per-user cache, then the
+    # matching GitHub release) instead of assuming it is on PATH.
+    ts = Treeship(bot_mode=True)
     commerce_session = f"demo-{uuid.uuid4().hex}"  # the reference treats this as a credential
-    root = start_session(ts, name="commerce:merchant-demo", actor=ACTOR)
+    root = open_demo_session(ts, name="commerce:merchant-demo", actor=ACTOR)
     approvals = MerchantApprovals(ts, approver=APPROVER, actor=ACTOR)
     executor = attach(
         _build_executor(commerce_session, approvals, enforce=enforce),
@@ -178,6 +180,24 @@ async def run(*, enforce: bool) -> int:
     return 0 if receipts.dropped == 0 else 2
 
 
+def _explain(err: Exception) -> str | None:
+    """A one-line remedy for the two setup failures a fresh machine hits,
+    or ``None`` when the error is not one of them."""
+    text = str(err)
+    if "not initialized" in text or "no .treeship directory" in text or "treeship init" in text:
+        return (
+            "no Treeship workspace in this directory. Create one:\n"
+            "  treeship init --config .treeship/config.json"
+        )
+    if "CLI not found" in text or "bootstrap failed" in text or isinstance(err, FileNotFoundError):
+        return (
+            "the treeship CLI is not installed. Install it:\n"
+            "  curl -fsSL https://treeship.dev/install | sh\n"
+            "  (or: python -m treeship_sdk.bootstrap_cli)"
+        )
+    return None
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -188,7 +208,14 @@ def main() -> None:
     args = parser.parse_args()
     if os.environ.get("TREESHIP_DISABLE") == "1":
         sys.exit("TREESHIP_DISABLE=1 is set; this demo exists to write receipts")
-    sys.exit(asyncio.run(run(enforce=args.enforce)))
+    try:
+        code = asyncio.run(run(enforce=args.enforce))
+    except (TreeshipError, FileNotFoundError) as err:
+        remedy = _explain(err)
+        if remedy is None:
+            raise
+        sys.exit(f"{remedy}\n\n  (treeship said: {err})")
+    sys.exit(code)
 
 
 if __name__ == "__main__":

--- a/integrations/commerce-agents/treeship_commerce/lifecycle.py
+++ b/integrations/commerce-agents/treeship_commerce/lifecycle.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import subprocess
 from typing import Any, Mapping, Sequence
 
@@ -56,6 +57,31 @@ def _run_json(
     if not docs:
         raise TreeshipError(f"treeship {' '.join(args[:2])} printed no JSON", list(args))
     return docs[-1]
+
+
+def open_demo_session(
+    client: Treeship,
+    *,
+    name: str,
+    actor: str,
+    env: Mapping[str, str] | None = None,
+    cwd: str | os.PathLike[str] | None = None,
+) -> str:
+    """``start_session`` for a demo that must run twice in a row: a session a
+    previous run left open (a crash, a Ctrl-C) is closed first, with a
+    summary that says so, instead of failing the run with a traceback.
+    Returns the new session's root artifact id."""
+    status = session_status(client, env=env, cwd=cwd)
+    if status.get("active"):
+        stale = status.get("session_id", "?")
+        print(f"closing session {stale} that a previous run left open", file=sys.stderr)
+        _run_json(
+            client,
+            ["session", "close", "--summary", f"Closed by a later demo run; this run did not finish."],
+            env=env,
+            cwd=cwd,
+        )
+    return start_session(client, name=name, actor=actor, env=env, cwd=cwd)
 
 
 def start_session(

--- a/integrations/commerce-agents/treeship_commerce/vi.py
+++ b/integrations/commerce-agents/treeship_commerce/vi.py
@@ -5,8 +5,8 @@ signed (see :mod:`treeship_commerce.checkout`) and a hosted checkout takes
 over. Verifiable Intent (the Mastercard-maintained v0.1 draft) wants a chain
 from the user's mandate to the transaction. ``treeship vi attest`` signs that
 chain's Layer 3 pair with the spec's ``agent_attestation`` claim pointing at
-the receipt chain; run at hand-off, the chain head it names is the hand-off
-receipt, so the credential binds the cart that went to checkout.
+the receipt chain; run at hand-off, the chain it names runs through the
+hand-off receipt, so the credential binds the cart that went to checkout.
 
     from treeship_commerce.vi import attest_at_handoff
 
@@ -18,7 +18,7 @@ receipt, so the credential binds the cart that went to checkout.
         aud_network="https://www.mastercard.com", aud_merchant="https://tennis-warehouse.com",
         out="./vi-out",
     )
-    summary["attestation"]["chain_head"] == receipts.last_handoff   # True
+    summary["handoff"] == receipts.last_handoff                    # True
 
 Nothing here changes what the reference does. The mandate check happens
 before anything is signed; a cart outside the mandate raises and writes
@@ -93,14 +93,17 @@ def attest_at_handoff(
 ) -> dict[str, Any]:
     """Sign the Layer 3 pair for the cart that just went to checkout.
 
-    ``head`` defaults to the recorder's most recent hand-off receipt, so the
-    attestation names it as the chain head. Returns ``summary.json`` as a
+    ``head`` defaults to the recorder's current head, which sits after the
+    hand-off receipt on the same chain (never the hand-off itself: signing
+    onto it would fork the chain and leave the checkout result unsealed).
+    The returned summary carries ``handoff`` so the credential's chain and
+    the hand-off it followed are both named. Returns ``summary.json`` as a
     dict. Raises :class:`treeship_sdk.TreeshipError` when the purchase is
     outside the mandate (nothing is signed) or the CLI fails.
     """
-    chain_head = head or receipts.last_handoff or receipts.head
+    chain_head = head or receipts.head
     if chain_head is None:
-        raise ValueError("no chain head: sign the hand-off first (receipted_backend) or pass head=")
+        raise ValueError("no chain head: record something first (receipted_backend signs the hand-off) or pass head=")
     work = Path(workdir or ".")
     mandate_path = _write(work / ".vi", "l2.sdjwt", mandate)
     jwt_path = _write(work / ".vi", "checkout.jwt", checkout_jwt)
@@ -120,7 +123,8 @@ def attest_at_handoff(
     if key:
         args += ["--key", key]
     summary = _run_json(client, args, env=env, cwd=workdir)
-    # The attestation is a receipt chained onto the hand-off; keep the
+    summary["handoff"] = receipts.last_handoff
+    # The attestation is a receipt chained onto the head; keep the
     # recorder's head current so the host's order chains onto it too.
     art = summary.get("attestation", {}).get("artifact_id")
     if art and summary.get("attestation", {}).get("recorded"):

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1538,6 +1538,24 @@ pub fn close(
     let artifact_entries: Vec<session::receipt::ArtifactEntry> =
         collect_artifact_entries(&ctx, &manifest);
 
+    // Artifacts that branch off this chain (their parent is on it, they are
+    // not) are signed but will not be sealed: the package walks one path
+    // from the head. Silence here let a checkout result go missing from an
+    // otherwise clean package (QA finding TS-002 on 0.31.0). Name them.
+    let unsealed_branches = find_unsealed_branches(&ctx, &artifact_entries);
+    if !unsealed_branches.is_empty() {
+        printer.warn(
+            &format!(
+                "{} signed artifact(s) branch off this chain and will not be in the package",
+                unsealed_branches.len()
+            ),
+            &[("unsealed", &unsealed_branches.join(", "))],
+        );
+        printer.hint(
+            "a receipt signed with a stale --parent forks the chain; sign onto the current head",
+        );
+    }
+
     // Update manifest for receipt composition
     let mut receipt_manifest = manifest.clone();
     receipt_manifest.status = session::SessionStatus::Completed;
@@ -1715,6 +1733,7 @@ pub fn close(
             "receipts": artifact_count,
             "events": event_log.event_count(),
             "package": sealed_pkg_path.as_ref().map(|path| path.display().to_string()),
+            "unsealed_branches": unsealed_branches,
         }));
     } else {
         printer.blank();
@@ -2049,6 +2068,35 @@ fn has_zk_proofs(ts_dir: &Path, session_id: &str) -> bool {
 // ---------------------------------------------------------------------------
 // Collect artifact entries from the chain for receipt composition
 // ---------------------------------------------------------------------------
+
+/// Signed artifacts whose parent is on the sealed chain but which are not on
+/// it themselves: forks the package will not carry. Only the index is read,
+/// so this is one directory listing, not a walk.
+fn find_unsealed_branches(
+    ctx: &ctx::Ctx,
+    chain: &[session::receipt::ArtifactEntry],
+) -> Vec<String> {
+    let on_chain: std::collections::HashSet<&str> =
+        chain.iter().map(|e| e.artifact_id.as_str()).collect();
+    if on_chain.is_empty() {
+        return Vec::new();
+    }
+    let mut out: Vec<String> = ctx
+        .storage
+        .list()
+        .into_iter()
+        .filter(|e| !on_chain.contains(e.id.as_str()))
+        .filter(|e| {
+            e.parent_id
+                .as_deref()
+                .map(|p| on_chain.contains(p))
+                .unwrap_or(false)
+        })
+        .map(|e| e.id.clone())
+        .collect();
+    out.sort();
+    out
+}
 
 fn collect_artifact_entries(
     ctx: &ctx::Ctx,

--- a/packages/cli/tests/session_unsealed_branch_cli.rs
+++ b/packages/cli/tests/session_unsealed_branch_cli.rs
@@ -1,0 +1,137 @@
+//! A receipt signed onto a stale parent forks the chain. The package seals
+//! one path from the head, so the fork is signed but unsealed. `session
+//! close` must say so instead of reporting a clean package (QA TS-002).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Ws {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Ws {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = Self { _tmp: tmp, root };
+        assert!(ws
+            .cmd()
+            .args(["init", "--name", "fork-test", "--config"])
+            .arg(ws.config())
+            .status()
+            .unwrap()
+            .success());
+        ws
+    }
+    fn config(&self) -> PathBuf {
+        self.root.join(".treeship/config.json")
+    }
+    fn cmd(&self) -> Command {
+        let mut c = Command::new(cli_path());
+        c.env("HOME", &self.root)
+            .env("TREESHIP_ALLOW_INSECURE_KEY_PERMS", "1")
+            .current_dir(&self.root);
+        c
+    }
+    fn json(&self, args: &[&str]) -> Value {
+        let out = self
+            .cmd()
+            .args(args)
+            .args(["--format", "json", "--config"])
+            .arg(self.config())
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "{args:?}: {stdout}\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let last = stdout
+            .trim()
+            .rsplit("\n{")
+            .next()
+            .map(|s| {
+                if s.starts_with('{') {
+                    s.to_string()
+                } else {
+                    format!("{{{s}")
+                }
+            })
+            .unwrap();
+        serde_json::from_str(&last).unwrap_or_else(|e| panic!("{e}: {stdout}"))
+    }
+    fn attest(&self, action: &str, parent: &str) -> String {
+        let v = self.json(&[
+            "attest",
+            "action",
+            "--actor",
+            "agent://t",
+            "--action",
+            action,
+            "--parent",
+            parent,
+        ]);
+        v["id"]
+            .as_str()
+            .or_else(|| v["artifact_id"].as_str())
+            .unwrap()
+            .to_string()
+    }
+}
+
+#[test]
+fn close_names_artifacts_that_branch_off_the_sealed_chain() {
+    let ws = Ws::new();
+    ws.json(&["session", "start", "--name", "fork", "--actor", "agent://t"]);
+    let root = ws.json(&["session", "status"])["root_artifact_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let a = ws.attest("step.one", &root);
+    let b = ws.attest("step.two", &a);
+    // A receipt signed onto `a` after `b` exists: `.last` is now this fork,
+    // so re-point it at `b` the way a host that kept the real head would.
+    let fork = ws.attest("step.fork", &a);
+    std::fs::write(ws.root.join(".treeship/artifacts/.last"), &b).unwrap();
+
+    let closed = ws.json(&["session", "close", "--summary", "forked"]);
+    let unsealed: Vec<&str> = closed["unsealed_branches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(unsealed, vec![fork.as_str()], "{closed}");
+    assert_eq!(
+        closed["receipts"], 2,
+        "root + a + b are the chain; the fork is not counted"
+    );
+
+    // A clean chain reports none.
+    let ws2 = Ws::new();
+    ws2.json(&[
+        "session",
+        "start",
+        "--name",
+        "clean",
+        "--actor",
+        "agent://t",
+    ]);
+    let root2 = ws2.json(&["session", "status"])["root_artifact_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let a2 = ws2.attest("step.one", &root2);
+    ws2.attest("step.two", &a2);
+    let closed2 = ws2.json(&["session", "close", "--summary", "clean"]);
+    assert_eq!(closed2["unsealed_branches"].as_array().unwrap().len(), 0);
+}

--- a/packages/sdk-python/tests/test_client.py
+++ b/packages/sdk-python/tests/test_client.py
@@ -443,3 +443,31 @@ class SessionEventTests(unittest.TestCase):
             mock_run.return_value = _completed(stdout='{"status":"ok"}')
             with self.assertRaises(TreeshipError):
                 ts.session_event("agent.called_tool", tool="x")
+
+
+def test_warns_once_when_the_cli_is_on_another_release_line(tmp_path, monkeypatch):
+    """A warm CLI cache after a pip upgrade pairs a new SDK with an old CLI
+    silently otherwise (QA TS-003 on 0.31.0)."""
+    import warnings
+
+    from treeship_sdk import Treeship, __version__
+
+    fake = tmp_path / "treeship"
+    fake.write_text("#!/bin/sh\nif [ \"$1\" = --version ]; then echo treeship 0.1.0; exit 0; fi\necho '{\"status\":\"ok\"}'\n")
+    fake.chmod(0o755)
+    ts = Treeship(cli_path=fake)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ts._run_cli_raw(["status"])
+        ts._run_cli_raw(["status"])
+    hits = [w for w in caught if issubclass(w.category, RuntimeWarning) and "different release lines" in str(w.message)]
+    assert len(hits) == 1, [str(w.message) for w in caught]
+    assert __version__ in str(hits[0].message)
+
+    same = tmp_path / "treeship-same"
+    same.write_text(f"#!/bin/sh\nif [ \"$1\" = --version ]; then echo treeship {__version__}; exit 0; fi\necho ok\n")
+    same.chmod(0o755)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Treeship(cli_path=same)._run_cli_raw(["status"])
+    assert not [w for w in caught if "different release lines" in str(w.message)]

--- a/packages/sdk-python/treeship_sdk/bootstrap.py
+++ b/packages/sdk-python/treeship_sdk/bootstrap.py
@@ -33,8 +33,9 @@ calls this internally so an agent can do:
     # Treeship now has a working CLI even on a fresh machine; no prompt.
 
 There is also a ``python -m treeship_sdk.bootstrap_cli`` entry point
-that prints the JSON result and exits — useful for shell scripts and
-agents that want to bootstrap without instantiating the SDK first.
+that prints the resolved binary path and exits, or the full JSON result
+with ``--json`` — useful for shell scripts and agents that want to
+bootstrap without instantiating the SDK first.
 """
 
 from __future__ import annotations

--- a/packages/sdk-python/treeship_sdk/client.py
+++ b/packages/sdk-python/treeship_sdk/client.py
@@ -7,6 +7,7 @@ import os
 import re
 import shlex
 import subprocess
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
@@ -217,6 +218,7 @@ class Treeship:
         # back to PATH. The fix: store the resolved path and require
         # every subprocess invocation to go through `_run_cli`.
         self._bootstrap: Optional[BootstrapResult] = None
+        self._version_checked = False
 
         if cli_path is not None:
             self._binary: str = str(cli_path)
@@ -253,6 +255,45 @@ class Treeship:
 
     # ---- subprocess helpers --------------------------------------------------
 
+    def _check_cli_version(self) -> None:
+        """Once per client: warn when the CLI and this SDK are on different
+        release lines. A warm ``~/.cache/treeship/bin`` after a ``pip``
+        upgrade pairs a new SDK with an old CLI silently otherwise (QA
+        finding TS-003 on 0.31.0). Never raises; a CLI that cannot report
+        its version is left to fail on the real call with a real error."""
+        if self._version_checked:
+            return
+        self._version_checked = True
+        # Only a binary that resolves on disk is probed; a bare name that
+        # does not resolve is left for the real call to report. Popen rather
+        # than subprocess.run so the probe is invisible to callers (and
+        # tests) that wrap `subprocess.run` around the real command.
+        import shutil
+
+        resolved = self._binary if os.path.isfile(self._binary) else shutil.which(self._binary)
+        if not resolved:
+            return
+        try:
+            proc = subprocess.Popen(
+                [resolved, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            )
+            stdout, _ = proc.communicate(timeout=10)
+        except (OSError, subprocess.SubprocessError):
+            return
+        cli = stdout.strip().split()[-1] if stdout and stdout.strip() else ""
+        from treeship_sdk import __version__ as sdk  # the package resolves its own version
+        if not cli or cli == sdk:
+            return
+        line = lambda v: ".".join(v.split(".")[:2])  # noqa: E731
+        if line(cli) != line(sdk):
+            warnings.warn(
+                f"treeship CLI {cli} at {self._binary!r} and treeship-sdk {sdk} are on different release lines; "
+                f"upgrade the CLI (curl -fsSL treeship.dev/install | sh, or python -m treeship_sdk.bootstrap_cli) "
+                f"or pin the SDK to match.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
     def _run_cli_raw(
         self,
         args: Sequence[str],
@@ -272,6 +313,7 @@ class Treeship:
         if self._env is not None:
             env = {**os.environ, **self._env} if self._env_is_extension() else dict(self._env)
 
+        self._check_cli_version()
         try:
             return subprocess.run(
                 [self._binary, *args],


### PR DESCRIPTION
Piyush's `ac-findings-v0.31.md`, all six, each reproduced first.

**TS-002 (P0, confirmed).** `order_placed` signed the host's order with the hand-off receipt as parent. The checkout result also follows the hand-off, so it became a branch off the path `session close` walks from `.last`: signed, verifiable on its own, absent from the package's artifact list and proofs, while `package verify` reported 19 passed. Fix: the order chains onto the recorder's current head and names the hand-off in `meta.handoff`; `attest_at_handoff` chains onto the head too and reports `handoff` in its summary; tests assert every receipt a recorder writes is on the sealed chain. And `session close` now lists signed artifacts whose parent is on the chain but which are not (`unsealed_branches` in JSON, a warning in text), so the shape can never be silent again. Same-line story in the docs, README, and the VI page.

**TS-001 (P0) and TS-004 (P1).** Demos construct `Treeship(bot_mode=True)` so the CLI resolves (PATH, cache, then the matching release; verified from an empty cache with the published wheel). A missing workspace or CLI prints a one-line remedy. A session a previous run left open is closed with a summary that says so, then the run proceeds (verified twice in a row).

**TS-003 (P1).** `Treeship` warns once, on the first call, when `treeship --version` is on a different release line from the SDK (`RuntimeWarning` naming both and the upgrade command). Probed through `Popen` on a resolved path so the 21 tests that wrap `subprocess.run` are untouched. Verified: 0.30 CLI with this SDK warns; matching versions do not.

**TS-006 (P1).** Not a 0.31 regression: bare `treeship init` refuses on 0.30 too when a global workspace exists and the directory is not it (reproduced with both binaries). Every commerce quickstart (README, docs, both blog posts, the plugin command, the site) now uses `treeship init --config .treeship/config.json` and names Python 3.11+.

**TS-005 (P2).** Docstring corrected: the entry point prints the path, or JSON with `--json`.

Local: sdk-python 58 passed; commerce 37 passed 1 skipped (released 0.31.0 binary); new CLI test for unsealed branches; clippy and fmt clean. Piyush's crates.io note: 0.31.0 resolves on the public API from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)