### PR TITLE
Release v0.31.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.31.0"
+    "version": "0.31.1"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"
@@ -22,7 +22,7 @@
     {
       "name": "treeship-commerce",
       "description": "Add Treeship receipts to an anthropics/commerce-agents deployment: every tool call signed on all three runtimes, the merchant's approval as a signed single-use grant, and a receipt for exactly the cart that went to checkout.",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+_Nothing yet._
+
+## 0.31.1 (2026-09-08)
+
 - **treeship-commerce: the order receipt no longer forks the chain (QA TS-002, P0).** `order_placed` signed the host's order onto the hand-off receipt. The checkout result, which also follows the hand-off, became a branch off the path the session seals, so it was signed, verifiable on its own, and absent from the package, while `package verify` reported a clean package. The order now chains onto the recorder's head and names the hand-off in `meta.handoff`; `attest_at_handoff` does the same. A test asserts every receipt a recorder writes is on the sealed chain.
 - **`session close` names unsealed branches (QA TS-002).** Signed artifacts whose parent is on the sealed chain but which are not on it themselves are listed in the close output (`unsealed_branches` in JSON, a warning in text) instead of vanishing silently.
 - **The demos run on a clean machine (QA TS-001, TS-004).** `demo` and `demo_merchant` construct the SDK with `bot_mode=True`, so the CLI is resolved (PATH, cache, then the matching release) rather than assumed; a missing workspace or CLI prints a one-line remedy instead of a traceback; a session a previous run left open is closed with a summary that says so, so a second run works.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "base64",
  "clap",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.0"
+        "@treeship/core-wasm": "0.31.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.0"
+    "@treeship/core-wasm": "0.31.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.31.0",
+        "@treeship/core-wasm": "0.31.1",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.31.0",
+    "@treeship/core-wasm": "0.31.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/commerce-agents/plugin/.claude-plugin/plugin.json
+++ b/integrations/commerce-agents/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship-commerce",
   "description": "Add Treeship receipts to an anthropics/commerce-agents deployment: a signed intent and result for every tool call on all three runtimes, the merchant's approval as a signed single-use grant, and a receipt for exactly the cart that went to checkout. One command, one skill; the plugin runs no code of its own.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/commerce-agents/pyproject.toml
+++ b/integrations/commerce-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-commerce"
-version = "0.31.0"
+version = "0.31.1"
 description = "Signed, offline-verifiable receipts for every tool call in anthropics/commerce-agents, on all three of its runtimes."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/integrations/commerce-agents/treeship_commerce/__init__.py
+++ b/integrations/commerce-agents/treeship_commerce/__init__.py
@@ -45,5 +45,5 @@ __all__ = [
     "receipted_backend",
     "text_digest",
 ]
-__version__ = "0.31.0"
+__version__ = "0.31.1"
 from .vi import attest_at_handoff, vi_check, vi_verify  # noqa: E402

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.31.0",
-    "@treeship/cli-linux-arm64": "0.31.0",
-    "@treeship/cli-darwin-arm64": "0.31.0",
-    "@treeship/cli-darwin-x64": "0.31.0"
+    "@treeship/cli-linux-x64": "0.31.1",
+    "@treeship/cli-linux-arm64": "0.31.1",
+    "@treeship/cli-darwin-arm64": "0.31.1",
+    "@treeship/cli-darwin-x64": "0.31.1"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.31.0", path = "../core" }
+treeship-core = { version = "0.31.1", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.31.0", path = "../core" }
+treeship-core = { version = "0.31.1", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.31.0"
+version = "0.31.1"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.0"
+        "@treeship/core-wasm": "0.31.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.0"
+    "@treeship/core-wasm": "0.31.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.0"
+        "@treeship/core-wasm": "0.31.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.0"
+    "@treeship/core-wasm": "0.31.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "dependencies": {
-        "@treeship/verify": "0.31.0"
+        "@treeship/verify": "0.31.1"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.31.0"
+    "@treeship/verify": "0.31.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "dependencies": {
-        "@treeship/verify": "0.31.0"
+        "@treeship/verify": "0.31.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.31.0"
+    "@treeship/verify": "0.31.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "dependencies": {
-        "@treeship/verify": "0.31.0"
+        "@treeship/verify": "0.31.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.31.0"
+    "@treeship/verify": "0.31.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Patch release: the six QA findings on 0.31.0 (#392), headline TS-002 (the order receipt no longer forks the chain; `session close` names unsealed branches). Version bump across the release sites; the lockfile check fails on this PR by design until the tarballs publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)