### PR TITLE
docs: default social image, canonicals, robots and structured data

### DIFF
--- a/docs/app/[[...slug]]/page.tsx
+++ b/docs/app/[[...slug]]/page.tsx
@@ -86,6 +86,7 @@ export async function generateMetadata(props: {
   return {
     title: data.title,
     description: data.description,
+    alternates: { canonical: url },
     openGraph: {
       type: 'article',
       title: fullTitle,

--- a/docs/app/blog/[...slug]/page.tsx
+++ b/docs/app/blog/[...slug]/page.tsx
@@ -14,9 +14,35 @@ export default async function BlogPost(props: {
   const MDX = post.data.body;
   const tags: string[] = post.data.tags ?? [];
   const kicker = [post.data.date, ...tags].filter(Boolean).join(' · ');
+  const image = `https://docs.treeship.dev/og?${new URLSearchParams({
+    title: post.data.title,
+    description: post.data.description ?? '',
+    section: 'blog',
+  }).toString()}`;
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.data.title,
+    description: post.data.description ?? '',
+    datePublished: post.data.date ? `${post.data.date}T00:00:00Z` : undefined,
+    image,
+    keywords: tags.join(', ') || undefined,
+    mainEntityOfPage: `https://docs.treeship.dev${post.url}`,
+    author: { '@type': 'Organization', name: 'Zerker Labs', url: 'https://zerkerlabs.com' },
+    publisher: {
+      '@type': 'Organization',
+      name: 'Zerker Labs',
+      url: 'https://zerkerlabs.com',
+      logo: { '@type': 'ImageObject', url: 'https://www.treeship.dev/icon-512.png' },
+    },
+  };
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <BlogChrome crumb={post.data.title} />
       <main className="mx-auto w-full max-w-[860px] px-7 pb-20 pt-14">
         <p className="doc-kicker mb-3">{kicker}</p>
@@ -61,10 +87,16 @@ export async function generateMetadata(props: {
   return {
     title: post.data.title,
     description: post.data.description,
+    alternates: { canonical: post.url },
     openGraph: {
       type: 'article',
       title: post.data.title,
       description: post.data.description,
+      url: post.url,
+      siteName: 'Treeship',
+      publishedTime: post.data.date ? `${post.data.date}T00:00:00Z` : undefined,
+      authors: ['Zerker Labs'],
+      tags: post.data.tags ?? [],
       images: [{ url: image, width: 1200, height: 630, alt: post.data.title }],
     },
     twitter: {

--- a/docs/app/blog/page.tsx
+++ b/docs/app/blog/page.tsx
@@ -2,6 +2,25 @@ import Link from 'next/link';
 import { blogSource } from '@/lib/blog';
 import { BlogChrome } from './chrome';
 
+const indexImage = `/og?${new URLSearchParams({
+  title: 'Treeship blog',
+  description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+  section: 'blog',
+}).toString()}`;
+
+export const metadata = {
+  title: 'Blog',
+  description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: 'Treeship blog',
+    description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+    url: '/blog',
+    images: [{ url: indexImage, width: 1200, height: 630, alt: 'Treeship blog' }],
+  },
+  twitter: { card: 'summary_large_image', title: 'Treeship blog', images: [indexImage] },
+};
+
 export default function BlogIndex() {
   const posts = blogSource.getPages().sort((a, b) => {
     const da = a.data.date ?? '0';

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -9,6 +9,12 @@ const siteName = 'Treeship';
 const siteDescription =
   'Cryptographic receipts for AI agent actions. Verifiable proofs of what an agent did, when, and to which inputs.';
 
+const defaultImage = `/og?${new URLSearchParams({
+  title: 'Treeship Docs',
+  description: siteDescription,
+  section: 'docs',
+}).toString()}`;
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://docs.treeship.dev'),
   title: {
@@ -17,18 +23,52 @@ export const metadata: Metadata = {
   },
   description: siteDescription,
   applicationName: siteName,
+  alternates: { canonical: siteUrl },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true, 'max-image-preview': 'large', 'max-snippet': -1 },
+  },
   openGraph: {
     type: 'website',
     siteName,
+    locale: 'en_US',
     title: 'Treeship Docs',
     description: siteDescription,
     url: siteUrl,
+    // Every page without its own image (the blog index, the root) still
+    // shares with the Treeship card rather than whatever a crawler picks.
+    images: [{ url: defaultImage, width: 1200, height: 630, alt: 'Treeship Docs' }],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Treeship Docs',
     description: siteDescription,
+    images: [defaultImage],
   },
+};
+
+// Structured data for search: who publishes this, what it documents.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': 'https://zerkerlabs.com/#org',
+      name: 'Zerker Labs',
+      url: 'https://zerkerlabs.com',
+      logo: 'https://www.treeship.dev/icon-512.png',
+      sameAs: ['https://github.com/zerkerlabs', 'https://moltbook.com/u/treeshipzk'],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${siteUrl}/#website`,
+      url: siteUrl,
+      name: 'Treeship Docs',
+      publisher: { '@id': 'https://zerkerlabs.com/#org' },
+      about: { '@id': 'https://www.treeship.dev/#software' },
+    },
+  ],
 };
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -42,6 +82,10 @@ export default function Layout({ children }: { children: ReactNode }) {
         />
       </head>
       <body>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         <RootProvider theme={{ defaultTheme: 'light' }}>{children}</RootProvider>
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-SHQD226S2V"


### PR DESCRIPTION
The docs root and the blog index shipped no `og:image`, and no docs page had a canonical. Now: a default Treeship card on the layout (so every page shares with the mark), `alternates.canonical` on docs pages, blog posts and the blog index, `robots` with `max-image-preview:large`, Organization + WebSite JSON-LD in the layout, BlogPosting JSON-LD per post (headline, date, image, author Zerker Labs, publisher logo). The OG route itself already draws the Treeship node mark, not the Zerker Z; previews that show otherwise are scraper caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)