### PR TITLE
docs: the Treeship mark and wordmark in the docs nav and blog chrome

### DIFF
--- a/docs/app/[[...slug]]/layout.tsx
+++ b/docs/app/[[...slug]]/layout.tsx
@@ -2,6 +2,7 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { source } from '@/lib/source';
 import { CopyInstall } from '@/components/copy-install';
+import { TreeshipMark } from '@/components/treeship-mark';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -9,7 +10,8 @@ export default function Layout({ children }: { children: ReactNode }) {
       tree={source.pageTree}
       nav={{
         title: (
-          <span className="text-base font-semibold tracking-tight text-fd-foreground">
+          <span className="inline-flex items-center gap-2 text-base font-semibold tracking-tight text-fd-foreground">
+            <TreeshipMark size={22} />
             Treeship
           </span>
         ),

--- a/docs/app/blog/chrome.tsx
+++ b/docs/app/blog/chrome.tsx
@@ -1,15 +1,13 @@
 import Link from 'next/link';
+import { TreeshipWordmark } from '@/components/treeship-mark';
 
 // The sticky document chrome from the design system: wordmark, a crumb, and
 // the two places a reader of a post goes next. Server component; no state.
 export function BlogChrome({ crumb }: { crumb: string }) {
   return (
     <div className="sticky top-0 z-10 flex items-center gap-4 border-b border-zk-hairline bg-zk-bg/90 px-7 py-3.5 font-mono text-[11px] uppercase tracking-[0.12em] text-zk-text-secondary backdrop-blur">
-      <Link
-        href="https://treeship.dev"
-        className="inline-flex items-center gap-2 font-bold tracking-[0.3em] text-zk-ink no-underline"
-      >
-        Treeship
+      <Link href="https://treeship.dev" className="no-underline" aria-label="Treeship home">
+        <TreeshipWordmark />
       </Link>
       <span className="flex-1 truncate">{crumb}</span>
       <Link href="/blog" className="text-zk-ink no-underline hover:text-zk-accent">

--- a/docs/components/treeship-mark.tsx
+++ b/docs/components/treeship-mark.tsx
@@ -1,0 +1,26 @@
+// The Treeship mark: the node glyph from the homepage nav and the favicon.
+// Zerker's wordmark is a slashed Z in tracked capitals; this is not that.
+// currentColor, so it takes the ink of whatever chrome it sits in.
+export function TreeshipMark({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 26 26" fill="none" aria-hidden="true">
+      <circle cx="13" cy="5" r="3" fill="currentColor" />
+      <circle cx="5" cy="20" r="3" fill="currentColor" opacity="0.55" />
+      <circle cx="21" cy="20" r="3" fill="currentColor" opacity="0.55" />
+      <line x1="13" y1="8" x2="5" y2="17" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.45" />
+      <line x1="13" y1="8" x2="21" y2="17" stroke="currentColor" strokeWidth="1.5" strokeOpacity="0.45" />
+      <line x1="5" y1="20" x2="21" y2="20" stroke="currentColor" strokeWidth="1" strokeOpacity="0.2" strokeDasharray="2 3" />
+    </svg>
+  );
+}
+
+// Mark + wordmark, set the way the homepage nav sets it: Geist, semibold,
+// sentence case, tight tracking. Never uppercase, never letter-spaced.
+export function TreeshipWordmark({ size = 22 }: { size?: number }) {
+  return (
+    <span className="inline-flex items-center gap-2 font-sans text-[15px] font-semibold normal-case tracking-[-0.02em] text-zk-ink">
+      <TreeshipMark size={size} />
+      Treeship
+    </span>
+  );
+}


### PR DESCRIPTION
The blog chrome rendered TREESHIP as spaced mono capitals (Zerker's wordmark treatment) and the docs sidebar title was plain text. Both now carry the Treeship node mark with the homepage's sentence-case wordmark, from one shared component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)