### PR TITLE
chore: lockfiles for 0.31.2

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -443,18 +443,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.1.tgz",
-      "integrity": "sha512-fd9LxDaYqKnnxZj5FHK0BRbXM7X6w59piu4ffR9d5RsRtBuuTVEQQxqt+AZzhT87KcV7P5iZAZOYrpLlUcMMRg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.2.tgz",
+      "integrity": "sha512-kFytGJHpovoOVnYiouYrsx/IdACIR/k/X0+E7tv52bGhbVvx5tTC8b1aboslGRsHG3WhJP9XvO79BzpRuwJH8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.1"
+        "@treeship/core-wasm": "0.31.2"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -978,18 +978,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.1.tgz",
-      "integrity": "sha512-fd9LxDaYqKnnxZj5FHK0BRbXM7X6w59piu4ffR9d5RsRtBuuTVEQQxqt+AZzhT87KcV7P5iZAZOYrpLlUcMMRg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.2.tgz",
+      "integrity": "sha512-kFytGJHpovoOVnYiouYrsx/IdACIR/k/X0+E7tv52bGhbVvx5tTC8b1aboslGRsHG3WhJP9XvO79BzpRuwJH8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.1"
+        "@treeship/core-wasm": "0.31.2"
       }
     },
     "node_modules/acorn": {

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -316,18 +316,18 @@
       }
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.1.tgz",
-      "integrity": "sha512-SJ4nPvO8B0NPEGAkxZAUxdbawEF0ZVNrTADbWcEjSHgRY6lcy4hzM0CGwjjvWZO+jMMF0mEAI40D1bL7kCqfWg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.2.tgz",
+      "integrity": "sha512-29qPPHA1BiTLyS3ziwNeSMNVPV6AsGVsgbgtJNd3DiyPl/8h6VB69mhJccaJeOEwlDZPzTlQygbj7486NHIbhQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@treeship/verify": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.1.tgz",
-      "integrity": "sha512-fd9LxDaYqKnnxZj5FHK0BRbXM7X6w59piu4ffR9d5RsRtBuuTVEQQxqt+AZzhT87KcV7P5iZAZOYrpLlUcMMRg==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@treeship/verify/-/verify-0.31.2.tgz",
+      "integrity": "sha512-kFytGJHpovoOVnYiouYrsx/IdACIR/k/X0+E7tv52bGhbVvx5tTC8b1aboslGRsHG3WhJP9XvO79BzpRuwJH8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.1"
+        "@treeship/core-wasm": "0.31.2"
       }
     },
     "node_modules/@ts-morph/common": {


### PR DESCRIPTION
`scripts/release.sh refresh-lockfiles 0.31.2` after the npm tarballs published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)