### PR TITLE
docs blog: categories, systems, tags, and 22 retrospective release entries

### DIFF
--- a/docs/app/blog/[...slug]/page.tsx
+++ b/docs/app/blog/[...slug]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import Link from 'next/link';
 import { BlogChrome } from '../chrome';
+import { CategoryChip, SystemChip } from '@/components/blog-list';
+import { CATEGORIES, tagSlug, type Category } from '@/lib/taxonomy';
 
 export default async function BlogPost(props: {
   params: Promise<{ slug: string[] }>;
@@ -13,7 +15,15 @@ export default async function BlogPost(props: {
 
   const MDX = post.data.body;
   const tags: string[] = post.data.tags ?? [];
-  const kicker = [post.data.date, ...tags].filter(Boolean).join(' · ');
+  const systems: string[] = post.data.systems ?? [];
+  const category = post.data.category as Category;
+  const kicker = [
+    CATEGORIES[category].singular,
+    post.data.release ? `v${post.data.release}` : undefined,
+    post.data.date,
+  ]
+    .filter(Boolean)
+    .join(' · ');
   const image = `https://docs.treeship.dev/og?${new URLSearchParams({
     title: post.data.title,
     description: post.data.description ?? '',
@@ -26,7 +36,8 @@ export default async function BlogPost(props: {
     description: post.data.description ?? '',
     datePublished: post.data.date ? `${post.data.date}T00:00:00Z` : undefined,
     image,
-    keywords: tags.join(', ') || undefined,
+    keywords: [...tags, ...systems].join(', ') || undefined,
+    articleSection: CATEGORIES[category].label,
     mainEntityOfPage: `https://docs.treeship.dev${post.url}`,
     author: { '@type': 'Organization', name: 'Zerker Labs', url: 'https://zerkerlabs.com' },
     publisher: {
@@ -52,9 +63,27 @@ export default async function BlogPost(props: {
         {post.data.description && (
           <p className="doc-lede mb-2 max-w-[780px]">{post.data.description}</p>
         )}
-        <div className="doc-meta mb-10 flex flex-wrap gap-x-6 gap-y-2 border-b border-zk-hairline pb-4 pt-4">
-          {post.data.readTime && <span>{post.data.readTime}</span>}
-          <Link href="/blog" className="text-zk-text-secondary no-underline hover:text-zk-accent">
+        <div className="mb-10 flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-zk-hairline pb-4 pt-4">
+          <CategoryChip category={category} />
+          {systems.map((id) => (
+            <SystemChip key={id} id={id} />
+          ))}
+          {tags.map((t) => (
+            <Link
+              key={t}
+              href={`/blog/tag/${tagSlug(t)}`}
+              className="doc-meta no-underline hover:text-zk-accent"
+            >
+              #{tagSlug(t)}
+            </Link>
+          ))}
+          {post.data.readTime && <span className="doc-meta">{post.data.readTime}</span>}
+          {post.data.written && (
+            <span className="doc-meta" title="A retrospective entry, filed under the date of the release it documents.">
+              written {post.data.written}
+            </span>
+          )}
+          <Link href="/blog" className="doc-meta ml-auto text-zk-text-secondary no-underline hover:text-zk-accent">
             All posts
           </Link>
         </div>

--- a/docs/app/blog/category/[category]/page.tsx
+++ b/docs/app/blog/category/[category]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from 'next/navigation';
+import { BlogChrome } from '../../chrome';
+import { BlogList, presentValues } from '@/components/blog-list';
+import { CATEGORIES, isCategory } from '@/lib/taxonomy';
+
+export default async function CategoryPage(props: { params: Promise<{ category: string }> }) {
+  const { category } = await props.params;
+  if (!isCategory(category)) notFound();
+  const info = CATEGORIES[category];
+  return (
+    <>
+      <BlogChrome crumb={info.label} />
+      <BlogList filter={{ category }} heading={info.label} lede={info.blurb} />
+    </>
+  );
+}
+
+export function generateStaticParams() {
+  return presentValues().categories.map((category) => ({ category }));
+}
+
+export async function generateMetadata(props: { params: Promise<{ category: string }> }) {
+  const { category } = await props.params;
+  if (!isCategory(category)) return {};
+  const info = CATEGORIES[category];
+  const image = `/og?${new URLSearchParams({ title: `${info.label} · Treeship blog`, description: info.blurb, section: 'blog' }).toString()}`;
+  return {
+    title: `${info.label} · Blog`,
+    description: info.blurb,
+    alternates: { canonical: `/blog/category/${category}` },
+    openGraph: { title: `${info.label} · Treeship blog`, description: info.blurb, url: `/blog/category/${category}`, images: [{ url: image, width: 1200, height: 630 }] },
+    twitter: { card: 'summary_large_image', title: `${info.label} · Treeship blog`, images: [image] },
+  };
+}

--- a/docs/app/blog/page.tsx
+++ b/docs/app/blog/page.tsx
@@ -1,20 +1,22 @@
-import Link from 'next/link';
-import { blogSource } from '@/lib/blog';
 import { BlogChrome } from './chrome';
+import { BlogList } from '@/components/blog-list';
+
+const description =
+  'Releases, integrations, guides and engineering notes: what Treeship signs, for which systems, and how to check it.';
 
 const indexImage = `/og?${new URLSearchParams({
   title: 'Treeship blog',
-  description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+  description,
   section: 'blog',
 }).toString()}`;
 
 export const metadata = {
   title: 'Blog',
-  description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+  description,
   alternates: { canonical: '/blog' },
   openGraph: {
     title: 'Treeship blog',
-    description: 'Agent trust, portable verification, and cryptographic accountability in AI workflows.',
+    description,
     url: '/blog',
     images: [{ url: indexImage, width: 1200, height: 630, alt: 'Treeship blog' }],
   },
@@ -22,67 +24,10 @@ export const metadata = {
 };
 
 export default function BlogIndex() {
-  const posts = blogSource.getPages().sort((a, b) => {
-    const da = a.data.date ?? '0';
-    const db = b.data.date ?? '0';
-    return db.localeCompare(da);
-  });
-
-  const featured = posts[0];
-  const rest = posts.slice(1);
-
   return (
     <>
       <BlogChrome crumb="Writing" />
-      <main className="mx-auto w-full max-w-[860px] px-7 pb-20 pt-14">
-        <p className="doc-kicker mb-3">Writing</p>
-        <h1 className="mb-4 text-[clamp(30px,4vw,42px)] font-[750] leading-[1.08] tracking-[-0.03em] text-zk-ink">
-          Blog
-        </h1>
-        <p className="doc-lede mb-10 max-w-[780px]">
-          Agent trust, portable verification, and cryptographic accountability in AI workflows.
-        </p>
-
-        {featured && (
-          <Link
-            href={featured.url}
-            className="group mb-8 block rounded-[14px] border border-zk-hairline bg-zk-surface p-6 no-underline transition-colors hover:border-zk-hairline-strong sm:p-8"
-          >
-            <span className="doc-meta text-zk-accent">Latest · {featured.data.date}</span>
-            <h2 className="mt-3 text-2xl font-bold leading-tight tracking-[-0.02em] text-zk-ink">
-              {featured.data.title}
-            </h2>
-            <p className="mt-3 max-w-[780px] text-[15px] leading-relaxed text-zk-text-secondary">
-              {featured.data.description}
-            </p>
-            {featured.data.readTime && (
-              <span className="doc-meta mt-4 block">{featured.data.readTime}</span>
-            )}
-          </Link>
-        )}
-
-        <div className="flex flex-col divide-y divide-zk-hairline rounded-[14px] border border-zk-hairline bg-zk-surface">
-          {rest.map((post) => (
-            <Link
-              key={post.url}
-              href={post.url}
-              className="group block p-5 no-underline transition-colors hover:bg-zk-accent-soft first:rounded-t-[14px] last:rounded-b-[14px]"
-            >
-              <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
-                <div className="flex-1">
-                  <h2 className="text-[17px] font-semibold leading-snug tracking-[-0.01em] text-zk-ink">
-                    {post.data.title}
-                  </h2>
-                  <p className="mt-1.5 line-clamp-2 text-[14px] leading-relaxed text-zk-text-secondary">
-                    {post.data.description}
-                  </p>
-                </div>
-                <time className="doc-meta shrink-0 sm:mt-1">{post.data.date}</time>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </main>
+      <BlogList filter={{}} heading="Blog" lede={description} />
     </>
   );
 }

--- a/docs/app/blog/system/[system]/page.tsx
+++ b/docs/app/blog/system/[system]/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { BlogChrome } from '../../chrome';
+import { BlogList, presentValues } from '@/components/blog-list';
+import { SYSTEMS } from '@/lib/taxonomy';
+
+export default async function SystemPage(props: { params: Promise<{ system: string }> }) {
+  const { system } = await props.params;
+  const info = SYSTEMS[system];
+  if (!info) notFound();
+  const lede = info.vendor ? `Treeship and ${info.label}, by ${info.vendor}.` : `Treeship and ${info.label}.`;
+  return (
+    <>
+      <BlogChrome crumb={info.label} />
+      <BlogList filter={{ system }} heading={info.label} lede={lede} />
+      {info.docs && (
+        <p className="mx-auto -mt-12 mb-20 w-full max-w-[860px] px-7">
+          <Link href={info.docs} className="doc-meta text-zk-ink no-underline hover:text-zk-accent">
+            Integration guide →
+          </Link>
+        </p>
+      )}
+    </>
+  );
+}
+
+export function generateStaticParams() {
+  return presentValues().systems.map((system) => ({ system }));
+}
+
+export async function generateMetadata(props: { params: Promise<{ system: string }> }) {
+  const { system } = await props.params;
+  const info = SYSTEMS[system];
+  if (!info) return {};
+  const description = `Posts about Treeship and ${info.label}.`;
+  const image = `/og?${new URLSearchParams({ title: `${info.label} · Treeship blog`, description, section: 'blog' }).toString()}`;
+  return {
+    title: `${info.label} · Blog`,
+    description,
+    alternates: { canonical: `/blog/system/${system}` },
+    openGraph: { title: `${info.label} · Treeship blog`, description, url: `/blog/system/${system}`, images: [{ url: image, width: 1200, height: 630 }] },
+    twitter: { card: 'summary_large_image', title: `${info.label} · Treeship blog`, images: [image] },
+  };
+}

--- a/docs/app/blog/tag/[tag]/page.tsx
+++ b/docs/app/blog/tag/[tag]/page.tsx
@@ -1,0 +1,28 @@
+import { notFound } from 'next/navigation';
+import { BlogChrome } from '../../chrome';
+import { BlogList, presentValues } from '@/components/blog-list';
+
+export default async function TagPage(props: { params: Promise<{ tag: string }> }) {
+  const { tag } = await props.params;
+  if (!presentValues().tags.includes(tag)) notFound();
+  return (
+    <>
+      <BlogChrome crumb={`#${tag}`} />
+      <BlogList filter={{ tag }} heading={`#${tag}`} lede={`Every post tagged ${tag}.`} />
+    </>
+  );
+}
+
+export function generateStaticParams() {
+  return presentValues().tags.map((tag) => ({ tag }));
+}
+
+export async function generateMetadata(props: { params: Promise<{ tag: string }> }) {
+  const { tag } = await props.params;
+  return {
+    title: `#${tag} · Blog`,
+    description: `Every Treeship post tagged ${tag}.`,
+    alternates: { canonical: `/blog/tag/${tag}` },
+    robots: { index: false, follow: true },
+  };
+}

--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { source } from '@/lib/source';
 import { blogSource } from '@/lib/blog';
+import { presentValues } from '@/components/blog-list';
 
 const baseUrl = 'https://docs.treeship.dev';
 
@@ -17,9 +18,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.5,
   }));
 
+  const present = presentValues();
+  const listings = [
+    ...present.categories.map((c) => ({ url: `${baseUrl}/blog/category/${c}`, changeFrequency: 'weekly' as const, priority: 0.6 })),
+    ...present.systems.map((s) => ({ url: `${baseUrl}/blog/system/${s}`, changeFrequency: 'weekly' as const, priority: 0.6 })),
+  ];
+
   return [
     { url: baseUrl, changeFrequency: 'weekly', priority: 1 },
     { url: `${baseUrl}/blog`, changeFrequency: 'weekly', priority: 0.8 },
+    ...listings,
     ...docs,
     ...posts,
   ];

--- a/docs/components/blog-list.tsx
+++ b/docs/components/blog-list.tsx
@@ -1,0 +1,228 @@
+import Link from 'next/link';
+import { blogSource } from '@/lib/blog';
+import {
+  CATEGORIES,
+  CATEGORY_ORDER,
+  SYSTEMS,
+  SYSTEM_GROUPS,
+  systemInfo,
+  tagSlug,
+  type Category,
+  type SystemGroup,
+} from '@/lib/taxonomy';
+
+// One listing for the whole blog: the index and every category, system and
+// tag route render this with a different filter. Server component; the
+// filters are links, so every view is a static page with its own URL.
+
+export type Post = ReturnType<typeof blogSource.getPages>[number];
+
+export interface Filter {
+  category?: Category;
+  system?: string;
+  tag?: string;
+}
+
+export function allPosts(): Post[] {
+  return blogSource.getPages().sort((a, b) => {
+    const da = a.data.date ?? '0';
+    const db = b.data.date ?? '0';
+    return db.localeCompare(da);
+  });
+}
+
+export function filterPosts(posts: Post[], filter: Filter): Post[] {
+  return posts.filter((p) => {
+    if (filter.category && p.data.category !== filter.category) return false;
+    if (filter.system && !(p.data.systems ?? []).includes(filter.system)) return false;
+    if (filter.tag && !(p.data.tags ?? []).some((t) => tagSlug(t) === filter.tag)) return false;
+    return true;
+  });
+}
+
+function count<K extends string>(posts: Post[], pick: (p: Post) => K[]): Map<K, number> {
+  const m = new Map<K, number>();
+  for (const p of posts) for (const k of pick(p)) m.set(k, (m.get(k) ?? 0) + 1);
+  return m;
+}
+
+export function CategoryChip({ category, active }: { category: Category; active?: boolean }) {
+  return (
+    <Link
+      href={`/blog/category/${category}`}
+      className={
+        active
+          ? 'inline-flex items-center rounded-md bg-zk-ink px-2 py-0.5 font-mono text-[11px] text-white no-underline'
+          : 'inline-flex items-center rounded-md bg-zk-accent-soft px-2 py-0.5 font-mono text-[11px] text-zk-accent no-underline hover:bg-zk-accent hover:text-white'
+      }
+    >
+      {CATEGORIES[category].singular.toLowerCase()}
+    </Link>
+  );
+}
+
+export function SystemChip({ id, active }: { id: string; active?: boolean }) {
+  const info = systemInfo(id);
+  return (
+    <Link
+      href={`/blog/system/${id}`}
+      className={
+        active
+          ? 'inline-flex items-center rounded-full border border-zk-ink bg-zk-ink px-2.5 py-0.5 text-[12px] font-medium text-white no-underline'
+          : 'inline-flex items-center rounded-full border border-zk-hairline bg-zk-surface px-2.5 py-0.5 text-[12px] font-medium text-zk-text no-underline hover:border-zk-hairline-strong'
+      }
+    >
+      {info.label}
+    </Link>
+  );
+}
+
+function FilterBar({ posts, filter }: { posts: Post[]; filter: Filter }) {
+  const byCategory = count(posts, (p) => [p.data.category as Category]);
+  const bySystem = count(posts, (p) => (p.data.systems ?? []) as string[]);
+  const groups = new Map<SystemGroup, string[]>();
+  for (const id of Object.keys(SYSTEMS)) {
+    if (!bySystem.has(id)) continue;
+    const g = SYSTEMS[id].group;
+    groups.set(g, [...(groups.get(g) ?? []), id]);
+  }
+  const noFilter = !filter.category && !filter.system && !filter.tag;
+
+  return (
+    <nav aria-label="Filter posts" className="mb-10 flex flex-col gap-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Link
+          href="/blog"
+          className={
+            noFilter
+              ? 'rounded-full bg-zk-ink px-3.5 py-1.5 text-[13px] font-semibold text-white no-underline'
+              : 'rounded-full border border-zk-hairline bg-zk-surface px-3.5 py-1.5 text-[13px] font-medium text-zk-text no-underline hover:border-zk-hairline-strong'
+          }
+        >
+          All <span className="ml-1 font-mono text-[11px] opacity-60">{posts.length}</span>
+        </Link>
+        {CATEGORY_ORDER.filter((c) => byCategory.has(c)).map((c) => (
+          <Link
+            key={c}
+            href={`/blog/category/${c}`}
+            className={
+              filter.category === c
+                ? 'rounded-full bg-zk-ink px-3.5 py-1.5 text-[13px] font-semibold text-white no-underline'
+                : 'rounded-full border border-zk-hairline bg-zk-surface px-3.5 py-1.5 text-[13px] font-medium text-zk-text no-underline hover:border-zk-hairline-strong'
+            }
+          >
+            {CATEGORIES[c].label}{' '}
+            <span className="ml-1 font-mono text-[11px] opacity-60">{byCategory.get(c)}</span>
+          </Link>
+        ))}
+      </div>
+      <div className="flex flex-col gap-3 border-t border-zk-hairline pt-5">
+        {[...groups.entries()].map(([g, ids]) => (
+          <div key={g} className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            <span className="doc-meta w-full sm:w-[150px] sm:shrink-0">{SYSTEM_GROUPS[g]}</span>
+            <div className="flex flex-wrap gap-1.5">
+              {ids.map((id) => (
+                <SystemChip key={id} id={id} active={filter.system === id} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}
+
+function PostMeta({ post }: { post: Post }) {
+  const systems = (post.data.systems ?? []) as string[];
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+      <time className="doc-meta">{post.data.date}</time>
+      <CategoryChip category={post.data.category as Category} />
+      {post.data.release && (
+        <span className="doc-meta text-zk-ink">v{post.data.release}</span>
+      )}
+      {systems.map((id) => (
+        <SystemChip key={id} id={id} />
+      ))}
+      {post.data.readTime && <span className="doc-meta">{post.data.readTime}</span>}
+    </div>
+  );
+}
+
+export function BlogList({
+  filter,
+  heading,
+  lede,
+}: {
+  filter: Filter;
+  heading: string;
+  lede: string;
+}) {
+  const all = allPosts();
+  const posts = filterPosts(all, filter);
+  const [featured, ...rest] = filter.category || filter.system || filter.tag ? [undefined, ...posts] : posts;
+
+  return (
+    <main className="mx-auto w-full max-w-[860px] px-7 pb-20 pt-14">
+      <p className="doc-kicker mb-3">Writing</p>
+      <h1 className="mb-4 text-[clamp(30px,4vw,42px)] font-[750] leading-[1.08] tracking-[-0.03em] text-zk-ink [text-wrap:balance]">
+        {heading}
+      </h1>
+      <p className="doc-lede mb-8 max-w-[780px]">{lede}</p>
+
+      <FilterBar posts={all} filter={filter} />
+
+      {featured && (
+        <Link
+          href={featured.url}
+          className="group mb-8 block rounded-[14px] border border-zk-hairline bg-zk-surface p-6 no-underline transition-colors hover:border-zk-hairline-strong sm:p-8"
+        >
+          <span className="doc-meta text-zk-accent">Latest</span>
+          <h2 className="mt-3 text-2xl font-bold leading-tight tracking-[-0.02em] text-zk-ink">
+            {featured.data.title}
+          </h2>
+          <p className="mt-3 max-w-[780px] text-[15px] leading-relaxed text-zk-text-secondary">
+            {featured.data.description}
+          </p>
+          <PostMeta post={featured} />
+        </Link>
+      )}
+
+      {rest.length === 0 && !featured ? (
+        <p className="doc-meta">Nothing here yet.</p>
+      ) : (
+        <div className="flex flex-col divide-y divide-zk-hairline rounded-[14px] border border-zk-hairline bg-zk-surface">
+          {rest.filter(Boolean).map((post) => (
+            <Link
+              key={post!.url}
+              href={post!.url}
+              className="group block p-5 no-underline transition-colors hover:bg-zk-accent-soft first:rounded-t-[14px] last:rounded-b-[14px]"
+            >
+              <h2 className="text-[17px] font-semibold leading-snug tracking-[-0.01em] text-zk-ink">
+                {post!.data.title}
+              </h2>
+              <p className="mt-1.5 line-clamp-2 text-[14px] leading-relaxed text-zk-text-secondary">
+                {post!.data.description}
+              </p>
+              <PostMeta post={post!} />
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+/** Every value present on at least one post, for generateStaticParams. */
+export function presentValues() {
+  const posts = allPosts();
+  const categories = new Set<string>();
+  const systems = new Set<string>();
+  const tags = new Set<string>();
+  for (const p of posts) {
+    categories.add(p.data.category as string);
+    for (const s of (p.data.systems ?? []) as string[]) systems.add(s);
+    for (const t of (p.data.tags ?? []) as string[]) tags.add(tagSlug(t));
+  }
+  return { categories: [...categories], systems: [...systems], tags: [...tags] };
+}

--- a/docs/content/blog/a2a-treeship-the-trust-layer-for-agent-to-agent.mdx
+++ b/docs/content/blog/a2a-treeship-the-trust-layer-for-agent-to-agent.mdx
@@ -4,6 +4,8 @@ description: "Google's Agent2Agent protocol gives every agent a way to talk to e
 date: 2026-04-07
 tags: ["a2a", "agent2agent", "agents", "attestation", "trust", "interoperability"]
 readTime: "16 min read"
+category: integration
+systems: ["a2a"]
 ---
 
 In April 2025 Google launched Agent2Agent, A2A, as an open protocol for letting AI agents talk to each other across vendors and frameworks. It is now under the Linux Foundation with 150+ organizations behind it, including Anthropic, Salesforce, PayPal, SAP, Workday, and every major systems integrator. Version 1.0 is current. The framing the maintainers settled on is the cleanest one-liner in the agent space:

--- a/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
+++ b/docs/content/blog/agentic-commerce-tamper-proof-receipts.mdx
@@ -4,6 +4,9 @@ description: "Anthropic's commerce-agents reference enforces its gates in code a
 date: 2026-09-06
 tags: ["commerce", "integrations", "release"]
 readTime: "8 min read"
+category: integration
+systems: ["commerce-agents", "python-sdk", "claude-code-plugin"]
+release: "0.28.0"
 ---
 
 # You can't have agentic commerce without tamper-proof receipts

--- a/docs/content/blog/agentic-commerce-with-treeship.mdx
+++ b/docs/content/blog/agentic-commerce-with-treeship.mdx
@@ -4,6 +4,8 @@ description: "How agents can prove they had approval before spending money."
 date: 2026-03-28
 tags: ["commerce", "approvals"]
 readTime: "6 min read"
+category: guide
+systems: []
 ---
 
 > **Update (2026-08-18, v0.24).** This post's replay section describes the

--- a/docs/content/blog/approval-nonces-and-why-a-single-field-prevents-an-entire-attack-class.mdx
+++ b/docs/content/blog/approval-nonces-and-why-a-single-field-prevents-an-entire-attack-class.mdx
@@ -4,6 +4,8 @@ description: "The approvalNonce field in Treeship's ActionStatement is doing a l
 date: 2025-10-07
 tags: ["security", "cryptography"]
 readTime: "7 min read"
+category: security
+systems: []
 ---
 
 Approval reuse is subtle. An agent gets permission to perform one action, and -- without cryptographic binding -- nothing stops that approval from being used again. The nonce is the fix, and it's six characters of schema design.

--- a/docs/content/blog/chain-of-custody-for-ai-agents-what-software-can-learn-from-physical-evidence-handling.mdx
+++ b/docs/content/blog/chain-of-custody-for-ai-agents-what-software-can-learn-from-physical-evidence-handling.mdx
@@ -4,6 +4,8 @@ description: "Physical evidence handling has solved chain of custody over centur
 date: 2026-02-12
 tags: ["chain-of-custody", "agents", "compliance"]
 readTime: "12 min read"
+category: perspective
+systems: []
 ---
 
 Physical evidence handling has solved chain of custody over centuries. Every handoff is documented, every handler signs for what they received, and the integrity of the chain is what makes evidence admissible. AI agent workflows need exactly this.

--- a/docs/content/blog/dsse-dead-simple-signing-explained.mdx
+++ b/docs/content/blog/dsse-dead-simple-signing-explained.mdx
@@ -4,6 +4,8 @@ description: "DSSE is the signing envelope Treeship uses for every artifact. Her
 date: 2025-11-03
 tags: ["cryptography", "dsse"]
 readTime: "9 min read"
+category: engineering
+systems: []
 ---
 
 DSSE is what happens when you strip JWT down to the signing part and stop trying to build auth on top of it. It's 40 lines of spec. Here's why it's exactly the right primitive for agent attestation.

--- a/docs/content/blog/four-layers-of-proof-how-treeship-uses-zero-knowledge.mdx
+++ b/docs/content/blog/four-layers-of-proof-how-treeship-uses-zero-knowledge.mdx
@@ -4,6 +4,8 @@ description: "Signatures prove authenticity. Merkle proofs prove timing. Circom 
 date: 2026-04-02
 tags: ["zero-knowledge", "merkle", "cryptography"]
 readTime: "8 min read"
+category: engineering
+systems: []
 ---
 
 > **Update (2026-07):** This post describes the intended four-layer design. The two layers that ship in every release binary — Ed25519 signatures and the Merkle audit log — work as described. The two ZK layers (Circom/Groth16 and RISC Zero) are experimental, excluded from release binaries, and being rebuilt statement-first after an internal audit found the Groth16 path forgeable as implemented (no real trusted setup). Current status and the rebuild are in the [ZK verification spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md).

--- a/docs/content/blog/from-subprocess-to-wasm-eliminating-the-subprocess-attack-surface.mdx
+++ b/docs/content/blog/from-subprocess-to-wasm-eliminating-the-subprocess-attack-surface.mdx
@@ -4,6 +4,8 @@ description: "When your TypeScript SDK spawns a Rust binary, you've introduced a
 date: 2026-01-08
 tags: ["wasm", "security", "engineering"]
 readTime: "8 min read"
+category: engineering
+systems: ["typescript-sdk", "wasm-verifier"]
 ---
 
 When your TypeScript SDK spawns a Rust binary, you've introduced a $PATH dependency, a binary substitution attack surface, and an IPC channel. All three go away when you compile to WASM.

--- a/docs/content/blog/introducing-trust-templates.mdx
+++ b/docs/content/blog/introducing-trust-templates.mdx
@@ -4,6 +4,8 @@ description: "Trust templates give any workflow — a Solidity audit, a clinical
 date: 2026-03-27
 tags: ["templates", "attestation", "workflows", "release"]
 readTime: "8 min read"
+category: release
+systems: ["cli"]
 ---
 
 > **Editorial note (2026-08-18).** This post is kept as published. Two commands

--- a/docs/content/blog/introducing-zerker-labs.mdx
+++ b/docs/content/blog/introducing-zerker-labs.mdx
@@ -4,6 +4,8 @@ description: "Treeship is the first product from Zerker Labs, an applied AI lab 
 date: 2026-06-04
 tags: ["announcement", "zerker-labs", "trust", "provenance"]
 readTime: "3 min read"
+category: announcement
+systems: []
 ---
 
 Today we're introducing Zerker Labs, the lab behind Treeship.

--- a/docs/content/blog/lobster-cash-treeship-agent-payments.mdx
+++ b/docs/content/blog/lobster-cash-treeship-agent-payments.mdx
@@ -4,6 +4,8 @@ description: "Lobster.cash handles wallet and settlement. Treeship proves what h
 date: 2026-03-26
 tags: ["integrations", "commerce"]
 readTime: "5 min read"
+category: integration
+systems: ["lobster-cash"]
 ---
 
 > **Update (2026-07):** The signed-receipt verification described here ships and works today. Any mention of an automatic zero-knowledge spend-limit proof refers to the experimental ZK layer, which is excluded from release binaries and being rebuilt statement-first; see the [ZK verification spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md). Spend-limit conformance is currently proven by the signed approval, not by a ZK proof.

--- a/docs/content/blog/mastercard-verifiable-intent-treeship.mdx
+++ b/docs/content/blog/mastercard-verifiable-intent-treeship.mdx
@@ -4,6 +4,8 @@ description: "How Treeship's approval receipts align with Mastercard's open stan
 date: 2026-03-24
 tags: ["standards", "commerce"]
 readTime: "5 min read"
+category: integration
+systems: ["verifiable-intent"]
 ---
 
 Mastercard's [Verifiable Intent](https://verifiableintent.dev/) is an open standard for proving an agent was authorized to make a purchase. It addresses the same problem Treeship solves: how do you prove intent and authorization in agent commerce?

--- a/docs/content/blog/mcp-bridge-agent-attestation.mdx
+++ b/docs/content/blog/mcp-bridge-agent-attestation.mdx
@@ -4,6 +4,8 @@ description: "The Model Context Protocol specification is explicit: tool calls a
 date: 2026-03-27
 tags: ["mcp", "agents", "security", "attestation"]
 readTime: "10 min read"
+category: integration
+systems: ["mcp"]
 ---
 
 The Model Context Protocol specification contains a sentence that most teams skip past:

--- a/docs/content/blog/merchant-approvals-signed-once.mdx
+++ b/docs/content/blog/merchant-approvals-signed-once.mdx
@@ -4,6 +4,9 @@ description: "In Anthropic's commerce-agents reference, a merchant change applie
 date: 2026-09-07
 tags: ["commerce", "integrations", "release"]
 readTime: "5 min read"
+category: integration
+systems: ["commerce-agents", "python-sdk"]
+release: "0.29.0"
 ---
 
 # The operator's yes, signed once

--- a/docs/content/blog/multi-agent-skills.mdx
+++ b/docs/content/blog/multi-agent-skills.mdx
@@ -4,6 +4,8 @@ description: "Install Treeship on Kimi Code CLI, Claude Code, Codex, Cursor, Ope
 date: 2026-05-01
 tags: ["skills", "integrations", "multi-agent", "release"]
 readTime: "5 min read"
+category: integration
+systems: ["kimi", "claude-code", "codex", "cursor", "openclaw", "hermes"]
 ---
 
 # Treeship Agent Skills: One Skill, Every Agent

--- a/docs/content/blog/one-treeship-many-agents.mdx
+++ b/docs/content/blog/one-treeship-many-agents.mdx
@@ -4,6 +4,8 @@ description: "Teams adopting cryptographic attestation for agents keep hitting t
 date: 2026-03-27
 tags: ["architecture", "trust", "agents", "key-management"]
 readTime: "9 min read"
+category: engineering
+systems: []
 ---
 
 A team at a mid-sized fintech was six months into their agent attestation rollout when the audit came. They had done everything right, technically. Every agent action was signed. Every tool call had a receipt. The cryptography was solid.

--- a/docs/content/blog/privacy-in-agent-workflows-attestation-without-exposure.mdx
+++ b/docs/content/blog/privacy-in-agent-workflows-attestation-without-exposure.mdx
@@ -4,6 +4,8 @@ description: "Attestation and privacy aren't opposites. You can prove an agent a
 date: 2025-11-18
 tags: ["privacy", "enterprise"]
 readTime: "8 min read"
+category: perspective
+systems: []
 ---
 
 > **Update (2026-07):** The digest-based attestation described here (proving over hashes, never raw data) ships today. Cryptographic selective disclosure — proving a property of a credential without revealing it — is the designed ZK presentation surface, not yet shipped; the experimental ZK layer is being rebuilt statement-first. See the [ZK verification spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md).

--- a/docs/content/blog/proving-what-an-agent-can-do.mdx
+++ b/docs/content/blog/proving-what-an-agent-can-do.mdx
@@ -4,6 +4,8 @@ description: "Descriptor formats like A2A's AgentCard tell you what an agent cla
 date: 2026-06-24
 tags: ["agents", "attestation", "capability", "identity", "trust", "verification"]
 readTime: "12 min read"
+category: engineering
+systems: ["a2a"]
 ---
 
 Every agent framework now has a way for an agent to describe itself. A2A has the `AgentCard`. NANDA has its registry entries. Model cards, tool manifests, skill descriptors, the list keeps growing. They all answer the same question: *what does this agent say it can do?*

--- a/docs/content/blog/receipts-for-agentic-commerce.mdx
+++ b/docs/content/blog/receipts-for-agentic-commerce.mdx
@@ -4,6 +4,9 @@ description: "Anthropic's Claude Commerce Agents blueprint tells an agent what i
 date: 2026-09-07
 tags: ["commerce", "integrations", "trust-model"]
 readTime: "10 min read"
+category: integration
+systems: ["commerce-agents", "claude-code-plugin", "python-sdk"]
+release: "0.30.0"
 ---
 
 # Receipts for agentic commerce

--- a/docs/content/blog/robinhood-agentic-trading-treeship.mdx
+++ b/docs/content/blog/robinhood-agentic-trading-treeship.mdx
@@ -4,6 +4,8 @@ description: "How Treeship can provide local proofs, approvals, and audit trails
 date: 2026-05-27
 tags: ["mcp", "finance", "approvals", "receipts"]
 readTime: "7 min read"
+category: integration
+systems: ["robinhood", "mcp"]
 ---
 
 Robinhood Agentic Trading makes the boundary very real: an AI agent can connect to a dedicated brokerage account through MCP, inspect account data, reason about a strategy, and place trades.

--- a/docs/content/blog/the-ack-is-not-the-act.mdx
+++ b/docs/content/blog/the-ack-is-not-the-act.mdx
@@ -4,6 +4,9 @@ description: "A valid signature proves a receipt is authentic. It does not prove
 date: 2026-07-21
 tags: ["release", "v0.21", "effect", "verification", "honesty"]
 readTime: "5 min read"
+category: release
+systems: ["cli"]
+release: "0.21.0"
 ---
 
 An agent tells you it shipped the deploy. Exit code 0. Valid JSON came back. CI turned green. The tool call returned "ok."

--- a/docs/content/blog/the-case-for-portable-trust.mdx
+++ b/docs/content/blog/the-case-for-portable-trust.mdx
@@ -4,6 +4,8 @@ description: "Why trust artifacts need to travel with the work, not stay locked 
 date: 2025-09-15
 tags: ["trust", "architecture"]
 readTime: "7 min read"
+category: perspective
+systems: []
 ---
 
 Trust that only works inside one platform isn't trust -- it's permission. What agent workflows actually need is cryptographic proof that travels with the artifact, not with the infrastructure.

--- a/docs/content/blog/treeship-0-1-signed-content-addressed-offline.mdx
+++ b/docs/content/blog/treeship-0-1-signed-content-addressed-offline.mdx
@@ -1,0 +1,67 @@
+---
+title: "Treeship 0.1: signed, content-addressed, verifiable offline"
+description: "The first release put a DSSE signature on every agent action, named each artifact by its bytes, and let anyone check the result without a server."
+date: 2026-03-31
+written: 2026-09-11
+category: release
+release: "0.1.0"
+systems: [cli, hub, mcp, typescript-sdk, python-sdk]
+tags: [receipts, keystore, merkle, hub, dpop, release]
+readTime: "4 min read"
+---
+
+# Treeship 0.1: signed, content-addressed, verifiable offline
+
+## What shipped
+
+Treeship 0.1.0 is the founding release. It records what an agent did as a signed artifact, names that artifact by its own bytes, and lets a third party verify it with no network. Everything shipped since builds on those three decisions.
+
+The core is a Rust library. It signs DSSE envelopes with Ed25519 using `ed25519-dalek`, the NCC-audited implementation. It supports six statement types: `action`, `approval`, `handoff`, `endorsement`, `receipt`, and `decision`. Keys live in an encrypted keystore, AES-256-CTR with an HMAC, bound to the machine that created them. A rules engine reads YAML config and matches command patterns. A Merkle tree provides checkpoints, inclusion proofs, and offline verification. The core shipped with more than 120 tests.
+
+Around the core, the release added:
+
+- A CLI with more than 30 commands, including `init`, `wrap`, `attest`, `verify`, `session`, `approve`, `hub`, `merkle`, `ui`, and `otel`.
+- Rich `wrap` receipts that record the output digest, file changes, git state, and chain to the previous artifact automatically.
+- Shell hooks for automatic attestation, and seven official trust templates: `github-contributor`, `ci-cd`, `mcp-agent`, `claude-code`, `openclaw`, `hermes`, and `research`.
+- An interactive Ratatui TUI dashboard, a background daemon for file watching, and a `doctor` diagnostic with nine checks.
+- A Go hub with 12 API endpoints, device-flow authentication with DPoP, artifact push and pull with Rekor anchoring, and Merkle checkpoint storage.
+- SDKs on every registry: `@treeship/sdk` and `@treeship/mcp` on npm, `treeship-sdk` on PyPI, `treeship-core` and `treeship-cli` on crates.io, plus an npm binary wrapper.
+- treeship.dev with `/verify`, `/merkle`, `/connect`, `/hub/activate`, and `/open`, and a 67-page docs site.
+
+## Why it matters
+
+Before 0.1.0, the record of an agent's work was a log. A log can be edited after the fact, and nothing in it tells a reader who wrote it. A signed artifact changes both properties. The signature binds the statement to a key. The content-addressed id means the id changes if any byte changes.
+
+The third decision is the one that shaped the product. Verification runs offline. A Merkle inclusion proof and a public key are enough to check an artifact. The hub stores and serves proofs, but a reader does not need to trust the hub, or reach it, to check what they were handed.
+
+## How it works
+
+```bash
+treeship init
+treeship wrap -- <command>
+treeship attest
+treeship verify
+treeship merkle
+```
+
+`init` creates the ship identity and the encrypted keystore. The keystore is machine-bound, so a copied key file does not decrypt elsewhere. `wrap` runs a command and signs a receipt for it: the output digest, the files that changed, the git state at the time. Each receipt chains to the previous one without the user naming it.
+
+`attest` signs one of the six statement types directly. The signed bytes go through DSSE pre-authentication encoding, and the artifact id is derived from those PAE bytes. That is what content-addressed means here: the id is a function of exactly what was signed.
+
+`verify` checks the envelope signature against the key, recomputes the id from the bytes, and checks the Merkle inclusion proof against a checkpoint. `merkle` manages those checkpoints. A verifier needs the artifact, the proof, and the public key. It does not need the hub.
+
+The hub authenticates with a device flow and DPoP, so no session token is stored on disk. Pushed artifacts are anchored in Rekor. Security baseline in the same release: PID file locking, `0600` and `0700` file permissions, command sanitization that redacts secrets, untrusted config detection, and shell hooks pinned to absolute paths so PATH cannot be hijacked.
+
+## What it does not do
+
+0.1.0 has no session receipt and no `.treeship` package. A session in this release is a sequence of chained artifacts, not a sealed document with its own Merkle root; that arrived in 0.7.0. OpenTelemetry export is feature-flagged and off by default. Trust templates describe policy for the rules engine; they do not verify anything on their own. Verification proves that a signed statement is authentic and unmodified. It does not prove the statement is true, which is a limit every later release has had to state carefully.
+
+## Where to go next
+
+- [Artifacts](/docs/concepts/artifacts): what a signed artifact contains and how its id is derived.
+- [Merkle proofs](/docs/guides/merkle-proofs): checkpoints, inclusion proofs, and offline verification.
+- [`treeship attest`](/docs/cli/attest) and [`treeship verify`](/docs/cli/verify): CLI reference for the two core commands.
+- [Trust model](/docs/concepts/trust-model): what a signature proves and what it does not.
+- [DSSE, dead simple signing, explained](/blog/dsse-dead-simple-signing-explained): the envelope format under every artifact.
+
+*This entry was written on 11 September 2026 from the 0.1.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-1-signed-content-addressed-offline.mdx
+++ b/docs/content/blog/treeship-0-1-signed-content-addressed-offline.mdx
@@ -40,7 +40,7 @@ The third decision is the one that shaped the product. Verification runs offline
 treeship init
 treeship wrap -- <command>
 treeship attest
-treeship verify
+treeship verify last
 treeship merkle
 ```
 

--- a/docs/content/blog/treeship-0-10-4-the-audit-hardening-release.mdx
+++ b/docs/content/blog/treeship-0-10-4-the-audit-hardening-release.mdx
@@ -1,0 +1,74 @@
+---
+title: "Treeship 0.10.4: the audit hardening release"
+description: "A keystore that claimed AES-GCM but was not, verifiers that trusted embedded keys, and a Merkle downgrade path. 0.10.3 and 0.10.4 close the audit findings and publish TS-2026-001."
+date: 2026-05-17
+written: 2026-09-11
+category: security
+release: "0.10.4"
+systems: [python-sdk, wasm-verifier, typescript-sdk, hub, openclaw, codex]
+tags: [keystore, security-advisory, trust-roots, merkle, verifier, security]
+readTime: "5 min read"
+---
+
+# Treeship 0.10.4: the audit hardening release
+
+## What shipped
+
+A post-launch security audit of 0.10.2 found eleven P0 issues across the crypto, trust, and supply-chain surfaces. 0.10.3 closes every one. 0.10.4 closes the P1 follow-ups that surfaced while landing them. The pair makes the crypto and trust paths live up to what the protocol already claimed.
+
+The headline is the keystore. The code and docs said private keys were encrypted with AES-256-GCM. The implementation was a homemade SHA-256-CTR keystream with an HMAC-SHA-256 tag, and the keystream was degenerate: one SHA-256 output byte was reused for every plaintext byte via `block[i % 32]`. Advisory TS-2026-001 rates it High, CVSS 7.1, local only. An attacker with read and write access to `~/.treeship/keys/` could recover an Ed25519 private key with known plaintext, forge a key file, or swap in a controlled key. No field exploitation was observed. 0.10.3 replaces the construction with the RustCrypto `aes-gcm` crate.
+
+Other changes across the two versions:
+
+- `treeship trust` with `list`, `add`, and `remove` over `~/.treeship/trust_roots.json`; checkpoint, hub-org checkpoint, and agent-certificate verification now require a pinned root.
+- Merkle hashing uses RFC 9162 domain separation, and receipts carry `merkle_version: 2`.
+- Checkpoint canonical signing binds `merkle_version` in 0.10.3, then `canonical_version`, `algorithm`, and `zk_proof_digest` in 0.10.4's v3 format.
+- The verifier refuses zero-signature envelopes and `bundle::import` refuses unverified envelopes; the fake `chain_linkage = pass` row is gone.
+- The Python SDK verifies the CLI binary's SHA-256 before exec, matching the npm side from 0.10.1.
+- `Ed25519Signer` zeroizes its secret key on drop, and security-sensitive randomness uses `OsRng`.
+- TOCTOU windows in `Store::signer()` and `TrustRootStore::open()` are closed by opening once and fstat-checking the descriptor.
+- The OpenClaw plugin captures tool calls again under OpenClaw's `beforeToolCall` and `afterToolCall` hook API.
+- GitHub Actions are pinned to commit SHAs, and `contents: write` is scoped to the release job.
+
+## Why it matters
+
+Before 0.10.3, a checkpoint or agent certificate verified against whatever public key it embedded, so a self-signed forgery always passed. `replay-hub-org` warned on an untrusted signature and exited 0 unless you passed `--strict`. A 64-byte artifact id whose SHA-256 matched an internal node hash could forge an inclusion proof, and `verify_proof` dispatched on the attacker-controllable `proof.merkle_version`, which was the downgrade primitive. Under all of that sat a keystore whose "AEAD" guarantee never existed.
+
+After these releases, the verifier fails closed on an unpinned issuer, the version selector is bound into the signature, and the keys that sign receipts are protected by a real AEAD. Every wire-controllable field that participates in dispatch or display is bound into the canonical, which is the fix shape 0.10.4 applies to the long tail.
+
+## How it works
+
+```bash
+treeship trust add <key_id> <pubkey> --kind hub_checkpoint --yes
+treeship trust list
+treeship verify <path>
+treeship merkle verify
+```
+
+`treeship trust add` pins an issuer key under one of `hub_checkpoint`, `ship`, or `agent_cert`. It prints the key's 16-hex-character SHA-256 fingerprint and requires a y/N confirmation or `--yes`; a replacement shows both fingerprints so a swap is visible. The file is mode `0o600`. `verify_package` loads it automatically and emits a `trust-root` fail row if the file is malformed or too open, rather than falling back to an empty store. `TREESHIP_TRUST_ROOTS` overrides the path with a one-time stderr warning, because that variable is exactly the lever a CI attacker would pull.
+
+The new keystore entry is `[magic=0x54, version=0x02, nonce(12), ciphertext || tag(16)]`: a 96-bit random nonce per write and a 128-bit GCM tag. The AAD binds the framing prefix, the entry id, and the public key, so copying entry A's ciphertext into entry B's envelope fails the MAC. Migration is automatic on first decrypt, written atomically with an advisory lock, and retried if the write fails.
+
+For Merkle trees, leaves are prefixed `0x00` and internal nodes `0x01`. `MerkleTree::verify_proof` now takes `expected_version` from a signature-verified checkpoint or parent receipt section and rejects a proof that disagrees. Receipts without the field deserialize as version 1 and still verify. A v3 checkpoint signs `"v3|{canonical_version}|{merkle_version}|{algorithm_or_empty}|{zk_proof_digest_or_empty}|{index}|{root}|{tree_size}|{height}|{signer}|{signed_at}"`, and flipping `canonical_version` on the wire fails because the bytes re-canonicalize differently.
+
+The WASM exports `verify_certificate`, `cross_verify`, and `verify_merkle_proof` take a `trust_roots_json` argument, where an empty string fails closed. `@treeship/verify` exposes it as `trustRoots`.
+
+## What it does not do
+
+- No backport to 0.9.x. Users there upgrade to receive the keystore fix.
+- The `treeship-vi` sibling keystore is not migrated and stays on the prior construction until vi's own release. Plan to rotate vi-issued keys after that.
+- `treeship trust extract` is tracked separately and not shipped. Operators with existing hub artifacts extract the embedded key by hand from `hub_public_key`, `public_key`, or `signature.public_key`.
+- Third-party verifiers that reproduce the canonical string outside the Rust core must update for both v2 and v3.
+- v1 Merkle verification is scheduled for removal in 0.13.0.
+- The daemon's `update_checkpoint_with_proof` is broken by design under v3 and tracked as a 0.10.5 follow-up; it affects only operators with the opt-in `zk` feature.
+- `TREESHIP_ALLOW_INSECURE_KEY_PERMS=1` still bypasses permission checks, with a warning.
+
+## Where to go next
+
+- [CLI: trust](/docs/cli/trust)
+- [Trust model](/docs/concepts/trust-model)
+- [Security](/docs/concepts/security)
+- [Merkle proofs](/docs/guides/merkle-proofs)
+- [OpenClaw integration](/docs/integrations/openclaw)
+
+*This entry was written on 11 September 2026 from the 0.10.3 and 0.10.4 changelogs and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-10-agent-native-sharing.mdx
+++ b/docs/content/blog/treeship-0-10-agent-native-sharing.mdx
@@ -1,0 +1,75 @@
+---
+title: "Treeship 0.10.1: agent-native sharing and a supply-chain floor"
+description: "An agent in a fresh sandbox can install Treeship, run a session, and return three working URLs. 0.10.1 hardens the binary, keystore, SDK, and MCP server underneath."
+date: 2026-05-01
+written: 2026-09-11
+category: release
+release: "0.10.1"
+systems: [hub, python-sdk, kimi, mcp, claude-code, codex, cursor]
+tags: [receipts, sessions, hub, keystore, release-engineering, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.10.1: agent-native sharing and a supply-chain floor
+
+## What shipped
+
+Treeship 0.10.0 makes the receipt readable by things that are not browsers. A human can say "agent, set up Treeship and send me the receipt," and the agent comes back with `receipt_url`, `raw_json_url`, `package_download_url`, `receipt_digest`, `package_digest`, `verification_status`, and `warnings`. No clarifying question, no browser auth, no `sudo`, no `PATH` edits. Before this release, `curl /receipt/<id>` returned the literal text `Loading receipt...`, so AI agents, link unfurlers, and offline reviewers got nothing.
+
+0.10.1 hardens the floor under that loop: the binary that gets installed, the keystore that signs, the SDK that drives the CLI, and the MCP integration. The connective idea is that trust starts before the receipt is signed.
+
+Other additions across the two versions:
+
+- `treeship session report --share --format json` returns the `treeship/share-result/v1` shape, and `--no-upload` computes digests and runs local verify without hub auth.
+- `/receipt/<sessionId>` on treeship.dev is server-rendered with OpenGraph and Twitter metadata; `/api/receipt/<id>/agent` returns the stable `treeship/receipt-agent/v1` contract; `/receipt/<id>/package` serves a `.tar.gz` in the `.treeship` layout.
+- `treeship setup --format json` returns a real `treeship/setup-result/v1` shape instead of `{}`.
+- Python `Treeship(bot_mode=True)` and `python -m treeship_sdk.bootstrap_cli --json` resolve a working CLI via env, PATH, cache, npm, then GitHub Release.
+- `@treeship/mcp` ships a real stdio server, `bin: treeship-mcp`, exposing `treeship_session_status`, `treeship_session_event`, `treeship_attest_action`, `treeship_verify`, and `treeship_session_report`.
+- Signing refuses a private key file with group or world bits, and `treeship doctor --fix` repairs the keystore in place.
+- The npm `postinstall.js` verifies the binary's SHA-256 against `expected-checksum.txt` and fails closed.
+- The Linux x86_64 binary is a static musl build, gated by a distro smoke job before any publish step.
+- `treeship init --force` refuses to clobber the global keystore, and `attest action --format json` returns `{"status": "error", "error": ...}` envelopes instead of `{}`.
+
+## Why it matters
+
+The Kimi dogfood failure that motivated 0.10.0 read: CLI missing from PATH, install script timed out, agent had to ask a human. 0.10.0 is the first release where an agent with no PATH, no installed CLI, and no global state can bootstrap, set up, run a session, share the result, and hand back three URLs that all work.
+
+0.10.1 fixes what the review and multi-agent dogfooding found underneath. The 0.10.0 `@treeship/mcp` package was a client wrapper only and silently failed to boot when configured as a server. Every Python SDK user with `bot_mode=True` was still depending on PATH, because a free function hardcoded `"treeship"`. The Linux GNU build needed GLIBC 2.39 and failed on Debian 12, Ubuntu 22.04, RHEL 9, Amazon Linux 2023, and every Alpine. A receipt is only as trustworthy as the install path that delivered the binary.
+
+## How it works
+
+```bash
+python -m treeship_sdk.bootstrap_cli --json
+treeship setup --yes --format json
+treeship session report --share --format json
+curl -L https://www.treeship.dev/receipt/<id>/package | tar xz
+treeship package verify ./<id>.treeship/
+treeship doctor --fix
+```
+
+The bootstrap returns `treeship/bootstrap-result/v1` with `ok`, `binary`, `version`, and `source`. Setup returns detected agents and draft cards. The share command uploads, then derives `raw_json_url` and `package_download_url` from the hub-issued `receipt_url` origin, so all three point at one site. `package_digest` is a content-addressed manifest digest: SHA-256 over sorted `<relpath>:<sha256_hex>` lines, stable across tar and gzip nondeterminism. When hub auth is missing in JSON mode, the response carries `error` plus the local digests and verify result, with URL fields null, rather than a fabricated URL.
+
+The package endpoint returns `receipt.json`, `merkle.json`, `render.json`, per-artifact proofs, and the `approvals/` tree, with an `X-Package-Digest` header. A recipient extracts it and runs `treeship package verify` for the full offline path.
+
+On the supply-chain side, the expected hash ships inside the npm package and the binary ships on GitHub Releases, two independent trust roots. `postinstall.js` downloads to a `.partial` file, checks the hash, and renames atomically. A tampered binary fails the embedded hash; a tampered hash fails because the GitHub binary does not match. Missing checksum, malformed checksum, non-200 response, redirect chain over 5, and timeout all fail. In CI, a `smoke` job mounts the linux artifact into `debian:12`, `ubuntu:22.04`, `ubuntu:24.04`, and `alpine:3.20` and exercises install, `--version`, `init`, `attest action`, and `verify`; `release` and every publish job need it to pass.
+
+For keys, `Store::signer` checks the file mode before decrypting and returns `InsecureKeyPerms` on loose bits. `doctor --fix` sets the directory to 0700 and key files to 0600 and reports each change. `TREESHIP_ALLOW_INSECURE_KEY_PERMS=1` bypasses for sandboxed CI.
+
+## What it does not do
+
+- No new trust subsystem: no Hub server changes, no runtime enforcement, no issuer or registry identity.
+- The transparent MCP forwarder is roadmap. `@treeship/mcp` serves Treeship tools; it does not forward other tools.
+- `agent_cards`, `harnesses`, and `package_digest` in the `/agent` contract stay `null` until the hub serves them.
+- No Linux ARM64 binary and no native Windows binary. Windows users go through WSL.
+- No Sigstore or cosign signatures. Two-trust-root SHA-256 is the 0.10.x answer.
+- No `treeship-cli` on crates.io; distribution is npm plus GitHub Releases.
+
+## Where to go next
+
+- [CLI: session](/docs/cli/session)
+- [Python SDK](/docs/sdk/python)
+- [MCP integration](/docs/integrations/mcp)
+- [Install guide](/docs/guides/install)
+- [CLI: doctor](/docs/cli/doctor)
+
+*This entry was written on 11 September 2026 from the 0.10.0 and 0.10.1 changelogs and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-10-agent-native-sharing.mdx
+++ b/docs/content/blog/treeship-0-10-agent-native-sharing.mdx
@@ -20,7 +20,7 @@ Treeship 0.10.0 makes the receipt readable by things that are not browsers. A hu
 
 Other additions across the two versions:
 
-- `treeship session report --share --format json` returns the `treeship/share-result/v1` shape, and `--no-upload` computes digests and runs local verify without hub auth.
+- `treeship session report --share --format json` returns the `treeship/share-result/v1` shape (sharing is now the default, so the flag has since been folded away), and `--no-upload` computes digests and runs local verify without hub auth.
 - `/receipt/<sessionId>` on treeship.dev is server-rendered with OpenGraph and Twitter metadata; `/api/receipt/<id>/agent` returns the stable `treeship/receipt-agent/v1` contract; `/receipt/<id>/package` serves a `.tar.gz` in the `.treeship` layout.
 - `treeship setup --format json` returns a real `treeship/setup-result/v1` shape instead of `{}`.
 - Python `Treeship(bot_mode=True)` and `python -m treeship_sdk.bootstrap_cli --json` resolve a working CLI via env, PATH, cache, npm, then GitHub Release.
@@ -41,7 +41,7 @@ The Kimi dogfood failure that motivated 0.10.0 read: CLI missing from PATH, inst
 ```bash
 python -m treeship_sdk.bootstrap_cli --json
 treeship setup --yes --format json
-treeship session report --share --format json
+treeship session report --format json
 curl -L https://www.treeship.dev/receipt/<id>/package | tar xz
 treeship package verify ./<id>.treeship/
 treeship doctor --fix

--- a/docs/content/blog/treeship-0-11-agent-invitations.mdx
+++ b/docs/content/blog/treeship-0-11-agent-invitations.mdx
@@ -1,0 +1,75 @@
+---
+title: "Treeship 0.11: agent invitations"
+description: "A second agent can join a session through a signed, single-use, expiring invitation that the host countersigns. Plus a local dashboard, a feature inventory, and new skills."
+date: 2026-05-28
+written: 2026-09-11
+category: release
+release: "0.11.0"
+systems: [robinhood, perplexity, kimi, claude-code-plugin, cli]
+tags: [rooms, sessions, trust-roots, templates, docs, release]
+readTime: "4 min read"
+---
+
+# Treeship 0.11: agent invitations
+
+## What shipped
+
+Treeship 0.11.0 ships phase 1 of agent invitations. A session host mints a signed, single-use, expiring grant. A second agent presents it, joins the session, and the host countersigns the join. The result is a participant record that both parties signed and that a verifier can check against a pinned host key.
+
+Two new canonical statement types carry this: `treeship/invitation/v1` and `treeship/session-participant/v1`. An invitation holds `session_ref`, the host's `issuer` pubkey, an `invitee_restriction`, `granted_capabilities.action_types`, `expires_at`, `max_uses`, and a random `nonce`. A participant envelope requires exactly two DSSE signatures, and either one alone is invalid.
+
+Other additions:
+
+- `treeship session invite <session_id>` mints the invitation and prints an armored bootstrap blob, or raw JSON with `--no-armor`.
+- `treeship session join --invite <blob>` or `--invite-file <path>`, with `--actor`, decodes and verifies the blob and emits a pending participant envelope.
+- `treeship session countersign <participant_artifact_id>` attaches the host signature and finalizes the record.
+- A `session_host` trust-root kind, registered with `treeship trust add ... --kind session_host`.
+- `treeship dashboard`, a localhost-only, read-only browser control plane over sealed `.treeship` packages with JSON endpoints.
+- A Robinhood Agentic Trading receipt template and integration docs.
+- `docs/feature-inventory.yml`, 29 entries with a status each, rendered as the Feature matrix docs page and linted by `scripts/check-feature-inventory.py`.
+- A Perplexity skill, a Kimi skill bundle, a `skills/README.md` index, and `integrations/agents.json` mirrored to `/.well-known/treeship-agents.json`.
+
+## Why it matters
+
+Since 0.9.8 the changelog had carried `treeship agent invite` and `join --invite` as a deferred item for remote attach. Until now a multi-agent session had no way to admit a second agent that the host had not started itself, and no signed record that the host had observed the join. A receipt could name multiple agents, but nothing bound the second agent's presence to a grant the host issued.
+
+Now the grant is a signed statement with an expiry and a nonce, the join consumes that nonce through the same Approval Use Journal that guards approvals, and the host's countersignature turns "I am joining" into "I observed this join." The `session_host` kind is separate from `ship` on purpose: a machine can trust a hub's checkpoints without trusting that hub to host rooms.
+
+## How it works
+
+```bash
+treeship trust add <key_id> ed25519:<pubkey> --kind session_host --yes
+treeship session invite <session_id> --invitee-pubkey <fingerprint>
+treeship session join --invite-file <path> --actor agent://guest
+treeship session countersign <participant_artifact_id>
+treeship dashboard
+```
+
+The host's key must be pinned under `session_host` first. Without the pin a self-signed forgery verifies cryptographically but is quarantined by trust-root enforcement.
+
+`session invite` signs against the keystore's default key, persists the invitation in the artifact store, and prints a `-----BEGIN TREESHIP INVITATION-----` blob. Restriction selection is explicit: exactly one of `--invitee-cert`, `--invitee-pubkey`, or `--open`. Open accepts any holder of the blob and is opt-in for that reason. The canonical signing string is a pipe-delimited line in the 0.10.4 shape, `"v1|invitation|{session_ref}|{issuer}|{restriction_digest}|{capabilities_digest}|{expires_at}|{max_uses}|{nonce_digest}"`, with variable-length fields folded into `sha256:<hex>` digests so the canonical stays single-line.
+
+`session join` decodes the blob, pins the issuer against `SessionHost` roots, verifies the envelope signature, checks expiry and restriction, then writes the nonce into the Approval Use Journal with `max_uses=1`. A second join with the same blob fails through the journal's existing `MaxUsesExceeded` path. The output is a single-signature envelope awaiting countersign.
+
+`session countersign` reads the pending envelope, confirms the running default key matches the invitation's issuer, signs the same canonical bytes, self-verifies, and overwrites the record with the two-signature envelope. `verify_participant_envelope` rejects `MissingHostCountersign`, `TooManySignatures`, any signature that fails, and any countersign whose key is not the invitation's issuer.
+
+`treeship dashboard` reads sealed packages on the local machine and shows trust status, instances, agent membership, receipt and report evidence, and review items, with JSON endpoints for status, treeships, sessions, agents, collaboration, and capabilities so scripts can use it too.
+
+## What it does not do
+
+- Phase 1 only. `max_uses` is always 1. Lifetime defaults to one hour and cannot exceed the 7-day protocol ceiling.
+- `TrustRootKind` gained a variant, which is breaking: third-party code with exhaustive matches must add the `SessionHost` arm. No existing roots are migrated; operators add session-host pins explicitly.
+- The dashboard is localhost-only and read-only. It does not require Hub and does not replace it.
+- The Robinhood template is receipt support only. Brokerage execution and policy-gateway enforcement stay outside this repo.
+- The feature inventory linter warns only; build-failing enforcement is a deliberate later step.
+
+## Where to go next
+
+- [Multi-agent sessions](/docs/concepts/multi-agent-sessions)
+- [Room sessions](/docs/concepts/room-sessions)
+- [CLI: session](/docs/cli/session)
+- [CLI: dashboard](/docs/cli/dashboard)
+- [Feature matrix](/docs/reference/feature-matrix)
+- [Robinhood Agentic Trading needs receipts](/blog/robinhood-agentic-trading-treeship)
+
+*This entry was written on 11 September 2026 from the 0.11.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-14-capability-cards-and-the-resolver.mdx
+++ b/docs/content/blog/treeship-0-14-capability-cards-and-the-resolver.mdx
@@ -1,0 +1,80 @@
+---
+title: "Treeship 0.14: capability cards and the agent resolver"
+description: "Agents get per-agent keys, signed capability cards, and a hub-backed resolver with a transparency log that your own machine re-verifies."
+date: 2026-06-25
+written: 2026-09-11
+category: release
+release: "0.14.0"
+systems: [wasm-verifier, hub, claude-code]
+tags: [capability-cards, identity, merkle, hub, revocation, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.14: capability cards and the agent resolver
+
+## What shipped
+
+Two releases landed a day apart. 0.13.0 gave an agent a provable identity: a key of its own, a typed capability card, and a `verify` line that says whether the `actor` on a receipt is proven or merely asserted. 0.14.0 put that identity on the network. You publish the card to a hub, resolve it from anywhere, and audit the hub's log for omission. Every check runs again on your own machine.
+
+The rest of 0.13.0:
+
+- A predicate registry binds the registered kinds `memory.write.v1`, `memory.read.v1`, `boundary.v1`, `agent_card.v1`, and `agent_card_revocation.v1` to a JSON Schema checked before signing.
+- `treeship attest card` mints an `agent_card.v1` card, and `treeship verify-capability <card>` cross-checks it against the agent's captured action receipts.
+- `treeship revoke-capability <card> --reason …` mints an `agent_card_revocation.v1` that verifiers honor only from an authorized signer.
+- A WASM `verify_capability(card, actions, trust_roots)` export and `verifyCapability()` in `@treeship/verify` return the same verdict as the CLI.
+- `treeship resolve <agent>` builds the agent's bundle from local artifacts with a `captured`, `checked`, or `asserted` grade on every fact.
+
+The rest of 0.14.0:
+
+- `MerkleTree::consistency_proof(old_size)` and `verify_consistency(...)` in core prove that a later tree only appended to an earlier one.
+- Hub endpoints `GET /v1/agents?agent=<uri>` and `GET /v1/agents/log?agent=<uri>` serve raw signed envelopes, and metadata plus anchors, respectively.
+- `treeship audit --watch` re-audits on an `--interval`, default 30s, and keeps alerting on omission.
+- `treeship attest card --from-harness <path>` reads a Claude Code `settings.json` and stamps each capability `captured` with its `source`.
+- `verify-capability` and `resolve` grade each capability `captured`, `exercised`, or `declared-only` from a new optional `capability_provenance` field.
+
+## Why it matters
+
+Before 0.13.0 the `actor` on a receipt was a label. Anyone holding the ship key could write any name into it. Now `treeship agent register --own-key` mints a per-agent key, the ship certifies it as issuer, and the key is pinned under `AgentCert`. `attest action`, `attest card`, `attest decision`, and `attest handoff` sign with that key when the actor has one. `treeship verify` reports `actor proof: proven (key-bound) | asserted`.
+
+Before 0.14.0 a card only resolved on the machine that minted it. Now a counterparty fetches it from a hub, confirms it sits in a signed log, and detects when the hub leaves entries out. The hub performs no verification or authorization on these paths. It serves bytes, and the CLI or the WASM verifier decides.
+
+## How it works
+
+```bash
+treeship agent register --own-key
+treeship attest card --from-harness <path>
+treeship verify-capability <card>
+treeship publish <agent>
+treeship resolve <agent> --hub <url>
+treeship audit <agent> --hub <url>
+treeship revoke-capability <card> --reason <reason>
+```
+
+`register --own-key` creates the key and the `AgentCert` pin. `attest card --from-harness` builds the capability set from the `permissions.allow` list in a Claude Code `settings.json`, so the set comes from observed config rather than a hand-typed `--tools` string. Any `--tools` entries given alongside are merged as `declared`.
+
+`verify-capability` treats a card as key-bound only when its `keyid` is the envelope signer pinned under `AgentCert`. Otherwise it reports `self-asserted`. It then lists in-scope and out-of-scope actions, matched exactly or by `family.*` glob, checks an optional `evidence_anchor`, and reports the provenance breakdown.
+
+`publish` pushes the agent's current card and any revocations through the authenticated `hub push` path. `resolve --hub` fetches that bundle and re-verifies it against your own trust roots with an Ed25519 check. It reports `signature: verified | UNVERIFIED`, `key-bound`, the revocation status, and the captured-capability mix. When the card has been anchored, the hub includes its Merkle inclusion proof, and `resolve` reports `transparency: anchored & verified (checkpoint #N)` or `not anchored`.
+
+`audit --hub` pulls the agent's history, re-verifies each anchored entry's inclusion offline, and compares the observed entries against the card's committed `evidence_anchor`. A shortfall reports `OMISSION` with the committed and observed counts.
+
+A revocation is honored only when its signer is the card's own key or a `Ship` trust root, and then `verify-capability` reports `status: REVOKED`. An unauthorized revocation is ignored.
+
+## What it does not do
+
+- The cross-check proves consistency over captured evidence. It is never a completeness guarantee.
+- Over the network the `exercised` grade is local-only, because the resolved bundle carries no action receipts.
+- Cards without a `capability_provenance` block are treated as fully declared.
+- The consistency proof lives in core only at this point. `audit` does not yet use it to prove the log was append-only.
+- Agents without a per-agent key still sign with the ship key, so their receipts stay `asserted`.
+
+## Where to go next
+
+- [Capability cards](/docs/concepts/capability-cards)
+- [Agent resolution](/docs/concepts/agent-resolution)
+- [CLI: resolve](/docs/cli/resolve)
+- [CLI: audit](/docs/cli/audit)
+- [Predicate registry](/docs/reference/predicates)
+- [Proving what an agent can do](/blog/proving-what-an-agent-can-do)
+
+*This entry was written on 11 September 2026 from the 0.13.0 and 0.14.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-15-bridges-sign-with-their-own-keys.mdx
+++ b/docs/content/blog/treeship-0-15-bridges-sign-with-their-own-keys.mdx
@@ -1,0 +1,70 @@
+---
+title: "Treeship 0.15: bridges sign with their own keys"
+description: "The MCP and A2A bridges provision per-agent keys by default, A2A skills become cards, and audit proves a hub log was only appended to."
+date: 2026-06-26
+written: 2026-09-11
+category: release
+release: "0.15.0"
+systems: [mcp, a2a, hub]
+tags: [identity, capability-cards, merkle, keystore, hub, release]
+readTime: "4 min read"
+---
+
+# Treeship 0.15: bridges sign with their own keys
+
+## What shipped
+
+Receipts from the `@treeship/mcp` bridge now verify as `actor proof: proven (key-bound)` instead of `asserted`. On startup the bridge runs `agent register --own-key --quiet`, so the `attest action --actor <agent>` calls it already makes sign with the agent's own key. The `@treeship/a2a` middleware does the same on construction through `provisionAgentKey`, so its task and handoff receipts verify as `proven (key-bound)` too.
+
+The second headline is on the hub side. `treeship audit` now proves a hub's log was only appended to since you last looked, with a Merkle consistency proof you re-verify offline.
+
+Also in this release:
+
+- `treeship agent register --own-key` is idempotent, and `--quiet` skips the on-disk `.agent` package.
+- `treeship attest card --tools-json <path>` records an operator's declared tool list, each entry stamped `declared` with the file as its `source`.
+- `treeship attest card --from-a2a <AgentCard.json>` maps an A2A agent's published `AgentCard.skills` to `agent_card.v1` capabilities with a new `discovered` provenance grade.
+- `treeship audit` persists the highest verified checkpoint per `(hub, signer)` under `~/.treeship/merkle/witnessed/` and warns on a forking or regressing hub.
+- `treeship merkle publish` computes a consistency proof from the previous checkpoint to the current one, and the hub serves it at `GET /v1/merkle/consistency`.
+- The keystore canonicalizes its store path before deriving the machine key, so symlinked paths no longer fail with `MAC verification failed`.
+
+## Why it matters
+
+The identity stack from 0.13.0 required someone to run `agent register --own-key` by hand. Agents speaking MCP or A2A never did, so their receipts stayed `asserted`. This release wires the key provisioning into the protocol bridges, so the receipts real agents already produce become provable with no change to the attestation path.
+
+The audit side closes a different gap. Witnessing across runs catches a hub that contradicts itself, but it does not prove the later tree extends the earlier one. The consistency proof does. Without it, a hub could rewrite history between two audits that each looked clean on their own.
+
+The keystore fix matters to anyone on macOS. The machine key hashed the keystore path, so `/var` and `/private/var` derived two different keys for the same directory, and a valid keystore refused to open.
+
+## How it works
+
+```bash
+treeship agent register --own-key --quiet
+treeship attest card --tools-json <path>
+treeship attest card --from-a2a <AgentCard.json>
+treeship merkle publish
+treeship audit <agent> --hub <url>
+```
+
+Re-registering an agent that already has a per-agent key reuses that key. There is no key pile-up and no duplicate `AgentCert` pin, which is what makes the bridges safe to run the command on every startup. The bridges are best-effort: if `treeship` is missing or uninitialized, the bridge still runs, and receipts fall back to the shared key with a one-line note.
+
+`--tools-json` accepts a `["tool", ...]` array or `{ "tools": [...] }`. A capability already captured from a harness keeps the stronger `captured` grade. `--from-a2a` reads the agent's own descriptor and stamps each skill `discovered`, with the AgentCard `url` as `source`. Protocol-level `capabilities` such as streaming and push are excluded, since they describe transport rather than domain capability. `verify-capability` and `resolve` count `discovered` in its own bucket, so A2A skills are never mislabeled as operator-declared.
+
+The hub holds no Merkle tree of its own, so the append-only proof is generated on the publishing side. `merkle publish` builds the tree truncated to exactly the checkpoint size, cross-checks that root against the checkpoint's own root, computes the consistency proof, and POSTs it. `audit` fetches the chain and re-verifies every link with the shipped `verify_consistency` primitive. Four properties must hold: the chain starts at the witnessed checkpoint, every link's proof verifies, links are contiguous, and the chain ends at the current checkpoint. A passing audit reports `append-only VERIFIED`. A failing served chain warns of a possible history rewrite. The `consistency:` line separately reports monotonic growth, and two roots at the same `tree_size`, or a `tree_size` that went backwards, raise a warning.
+
+## What it does not do
+
+- Witnessing alone does not prove append-only. Only a verified consistency chain does.
+- The MCP bridge exposes Treeship's own meta-tools, not the agent's domain tools, so the bridge does not auto-capture capabilities. Operators declare them with `--tools-json`, and the grade says so.
+- `discovered` is weaker than receipt-backed `exercised`. It records what the agent says about itself.
+- The raw-path machine key is kept as a decrypt-only fallback, so older keystores still open, but this is a fallback, not a second identity.
+
+## Where to go next
+
+- [@treeship/mcp](/docs/integrations/mcp)
+- [@treeship/a2a](/docs/integrations/a2a)
+- [CLI: audit](/docs/cli/audit)
+- [CLI: attest](/docs/cli/attest)
+- [Merkle proofs](/docs/guides/merkle-proofs)
+- [The MCP bridge and agent attestation](/blog/mcp-bridge-agent-attestation)
+
+*This entry was written on 11 September 2026 from the 0.15.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-18-onboard-once-present-anywhere.mdx
+++ b/docs/content/blog/treeship-0-18-onboard-once-present-anywhere.mdx
@@ -1,0 +1,83 @@
+---
+title: "Treeship 0.18: onboard once, present anywhere"
+description: "Signed work history, certificate chains to the ship, offline presentations with a challenge handshake, and a checkpoint-pinned track record."
+date: 2026-07-07
+written: 2026-09-11
+category: release
+release: "0.18.0"
+systems: [hub, mcp, a2a, claude-code-plugin]
+tags: [identity, sessions, capability-cards, merkle, trust-roots, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.18: onboard once, present anywhere
+
+## What shipped
+
+Four releases in two days completed the identity stack. An agent now goes from nothing to verifiable with `treeship onboard`, carries its own certificate chain to its ship, hands a counterparty a presentation that verifies fully offline, and answers a live challenge to prove it holds the key right now. Its closed sessions become signed work-history records, and its track record is pinned to a Merkle checkpoint so a mismatch is a provable lie.
+
+From 0.16.0:
+
+- `treeship session close` mints a `session.v1` receipt with headline, outcome, duration, `tools_exercised`, counts, a `receipt_digest`, and an attestation class of `self`, `runtime`, or `countersigned`.
+- `treeship keys export` prints a key's public half as `ed25519:<base64url>` together with the exact `treeship trust add` commands a counterparty runs.
+- Capability matching now handles mid-pattern globs like `Bash(git:*)` captured from a Claude Code `settings.json`.
+
+From 0.17.0:
+
+- `agent register --own-key` also mints a typed `agent_cert.v1` receipt, signed by the ship key, binding `agent://<name>` to its per-agent public key.
+- `treeship present` and `verify-presentation` carry the card, the cert chain, known revocations, and a Merkle staple, with `--max-staple-age` turning freshness into a `STALE` verdict.
+- `present --challenge <nonce>` and `verify-presentation --challenge` prove the bearer controls the key now.
+- `treeship onboard` composes register, `attest card`, and `--publish` in one idempotent pass.
+
+From 0.17.1 and 0.18.0:
+
+- `merkle publish` and `merkle proof` build the tree truncated to the checkpoint's `tree_size`, and `merkle proof` refuses an artifact newer than the checkpoint.
+- `resolve`, `audit`, `verify-capability`, and `verify-presentation` exit nonzero on a hostile verdict and emit one JSON verdict object under `--format json`.
+- `treeship profile` and `verify-profile` compute a checkpoint-pinned track record, with `--attest` signing it as a `profile.v1` claim.
+- `treeship history <agent>` projects the log to signed `session.v1` records, filterable with `--class self|runtime|countersigned`, `--since`, and `--limit`.
+
+## Why it matters
+
+Before 0.17.0 a counterparty had to pin every agent's leaf key by hand, and verification needed a registry in the loop. Now a counterparty pins one ship key and verifies every agent under it, the same shape as a TLS chain. A static presentation proves the record, and the challenge proves the bearer.
+
+Two bugs found by dogfooding made the fixes urgent. Registering a second agent in the same workspace silently overwrote the first agent's card, because the agent's name was not part of `derive_agent_id`. And every Merkle proof emitted after a checkpoint reconstructed the wrong root, so legitimate artifacts read `inclusion INVALID` to every auditor. Both are fixed and regression-tested.
+
+## How it works
+
+```bash
+treeship onboard <agent> --publish
+treeship keys export
+treeship present <agent>
+treeship verify-presentation <path> --max-staple-age 15m
+treeship present <agent> --challenge <nonce>
+treeship verify-presentation <path> --challenge <nonce>
+treeship profile <agent> --attest
+treeship verify-profile <path>
+treeship history <agent> --class countersigned
+```
+
+`onboard` runs `agent register --own-key`, `attest card` from `--from-harness`, `--tools-json`, `--from-a2a`, or `--tools`, and with `--publish` the full `publish`, `merkle checkpoint`, and `merkle publish` anchor. It ends by printing the trust bundle: the `trust add` commands for `agent_cert` and `hub_checkpoint`, plus the `resolve` and `audit` commands that verify the agent.
+
+`verify-presentation` walks the `agent_cert.v1` chain to a pinned ship root, with the pubkey always taken from your trust store and never from the wire. It enforces the validity window fail-closed, honors authorized revocations, re-checks the staple's checkpoint signature and inclusion proof, and reports the staple age as an explicit bound. In challenge mode the response is checked only against the subject key the card verification itself established. A replayed response, a response signed by a non-card key, or a tampered timestamp each reject with a specific reason.
+
+`verify-profile` rebuilds the log's first `tree_size` leaves at the pinned checkpoint, cross-checks the root against the pin, recomputes every field through the same aggregation path as `profile`, and compares. A match grades the profile `checked`. A mismatch names the differing field and exits nonzero. `history` re-verifies every `session.v1` envelope on your machine and re-proves each anchored entry's inclusion offline.
+
+## What it does not do
+
+- A static presentation is replayable. It proves the record, not the bearer. Only challenge mode proves live key control.
+- The `session.v1` record is best-effort. A record failure warns and never wedges `session close`, and the sealed package stays the source of truth.
+- `anchored` is not an attestation class the record carries. It is a later, derivable state.
+- History proves what was recorded, never everything that happened.
+- Keystore entries rewrapped under the hardware machine key in 0.16.0 are not decryptable by older binaries. Keep one CLI version per machine.
+- `keys export` in this range emits `--kind ship`. The kind was split three ways in 0.19.0.
+
+## Where to go next
+
+- [The agent handshake](/docs/concepts/agent-handshake)
+- [Agent identity](/docs/concepts/agent-identity)
+- [CLI: present / verify-presentation](/docs/cli/present)
+- [CLI: onboard](/docs/cli/onboard)
+- [CLI: profile / verify-profile](/docs/cli/profile)
+- [Treeship 0.19: the security-hardening release](/blog/treeship-0-19-the-security-hardening-release)
+
+*This entry was written on 11 September 2026 from the 0.16.0, 0.17.0, 0.17.1, and 0.18.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-19-the-security-hardening-release.mdx
+++ b/docs/content/blog/treeship-0-19-the-security-hardening-release.mdx
@@ -1,0 +1,75 @@
+---
+title: "Treeship 0.19: the security-hardening release"
+description: "Two adversarial audits, every confirmed finding in the default binary fixed with a regression test, and a receipt export any Ed25519 library can verify."
+date: 2026-07-11
+written: 2026-09-11
+category: security
+release: "0.19.1"
+systems: [wasm-verifier, hub, a2a, claude-code-plugin, kimi, lobster-cash]
+tags: [security-advisory, trust-roots, keystore, verifier, redaction, security]
+readTime: "5 min read"
+---
+
+# Treeship 0.19: the security-hardening release
+
+## What shipped
+
+Two independent AI-assisted adversarial audits ran against the codebase. Every confirmed finding that ships in the default binary is fixed in 0.19.0, each with a regression test that fails before the fix. The pattern both audits named was the same: a higher-level surface reported `verified`, `authentic`, or `pass` from attacker-controlled input without anchoring to a verified signature. That class is closed across the CLI, the WASM verifier, the hub, the SDKs, and the bridges.
+
+The one breaking change: the `ship` trust-root kind is split into `hub_org`, `cert_issuer`, and `revoker`. A single `--kind ship` pin used to grant three unrelated powers at once. No verifier honors `ship` any more, and `treeship trust add --kind ship` is rejected with guidance to the new kinds.
+
+The security fixes:
+
+- `treeship verify` on a fetched receipt, URL, or package reports `Structurally consistent` with `outcome: "structural-pass"` and `signatures_verified: false`, never `authentic`.
+- The hub DPoP signing key is sealed under the machine key with AES-256-GCM instead of sitting in `config.json` as plaintext hex.
+- WASM `verify_capability` builds a real verifier from pinned trust roots instead of trusting the unverified `signatures[0].keyid` label.
+- Keystore keys derive from a 32-byte OS-CSPRNG `machine_seed`, not from a guessable machine id, serial, or hostname.
+- Every core verifier uses `verify_strict`, and the chain walk cross-checks each child's signed `parentId`, exiting nonzero with `SIGNED LINKAGE BROKEN`.
+- A self-declared `attestation_class` can no longer launder a hand-signed `session.v1` into the `countersigned` bucket.
+- Hub proof and consistency publishes require the caller to own the artifact, checkpoint, or signer, and the hub gained request timeouts and a Rekor timeout.
+- The Claude Code and Kimi plugins redact env-assignment secrets, secret flags, and bearer tokens from captured commands before they reach a shareable receipt.
+
+Also added: `treeship match --exercised <glob>` and `GET /v1/agents/match`, `GET /v1/stats`, and a `treeship --help` that surfaces the core loop first, with `treeship help --all` listing the hidden extension commands.
+
+0.19.1 followed two days later with `treeship receipt export <id>`, a reference verifier at `scripts/verify-receipt.py`, and a receipt-format reference page.
+
+## Why it matters
+
+Pinning a hub for dedup used to also let that hub mint agent certificates and revoke your capabilities. Each verifier is now scoped to the one power it needs. Nothing published breaks, because the trust kind is a local verifier-side setting. A legacy `ship` pin stays parseable but inert until re-pinned.
+
+The `structural-pass` change is a matter of honesty. The fetched-receipt path ran only keyless, self-referential checks and then printed "Verified. This receipt is authentic." Any internally consistent forgery passed, and so did an empty receipt. It now says what it checked and what it did not. An empty receipt is a `fail`.
+
+0.19.1 closed a smaller gap with a long tail. A Treeship signature covers the DSSE PAE, not the payload JSON, and nothing exported those exact bytes. A counterparty verifying with a third-party Ed25519 library had to guess the construction and failed.
+
+## How it works
+
+```bash
+treeship trust add <key_id> <pubkey> --kind cert_issuer
+treeship match --hub <url> --exercised <glob>
+treeship receipt export <id> --format json | python3 scripts/verify-receipt.py
+```
+
+The migration is one `trust add` per power you intend to grant: `cert_issuer` for issuing agent certificates, `revoker` for revocations, `hub_org` for hub-org checkpoints. `keys export` now emits the new kinds.
+
+`match` asks the hub for candidates by `tools_exercised` in the signed `session.v1` records it holds. The client re-verifies every candidate on this machine and re-ranks by verified sessions. A record that does not verify shows as `unverified` rather than trusting the hub's own match.
+
+`receipt export` emits the exact `{message (the PAE), signature, public_key, algorithm}` triple in base64. The message is rebuilt from the same `payload_type` and `payload` the verifier sees, so what is exported is provably what the signature covers. The reference script performs an independent Ed25519 check offline and prints `VALID`. 0.19.1 also restored `verification_status: "pass"` for a clean session, since the always-on `receipt_body_binding` caveat had made `pass` unreachable, and pinned npm to 11.5.1 after the 0.19.0 publish failed on Node 24.
+
+## What it does not do
+
+- `receipt export` is for a receipt you produced, since the public key comes from the local keystore. A received receipt is still checked with `treeship verify`.
+- `structural-pass` is not a pass. It means the bytes are consistent with themselves, and signatures and issuer were not verified.
+- Provenance grades on a card that is not key-bound are marked `SELF-ASSERTED (not machine-verified)`.
+- `GET /v1/stats` reports counts only, never identifiers, and returns 500 on any query failure rather than partial zeros.
+- The `zk` feature received soundness fixes but remains pre-release and non-authoritative.
+
+## Where to go next
+
+- [Security](/docs/concepts/security)
+- [Trust model](/docs/concepts/trust-model)
+- [CLI: trust](/docs/cli/trust)
+- [CLI: receipt export](/docs/cli/receipt)
+- [Receipt format](/docs/reference/receipt-format)
+- [DSSE: dead simple signing explained](/blog/dsse-dead-simple-signing-explained)
+
+*This entry was written on 11 September 2026 from the 0.19.0 and 0.19.1 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-20-selective-disclosure.mdx
+++ b/docs/content/blog/treeship-0-20-selective-disclosure.mdx
@@ -1,0 +1,64 @@
+---
+title: "Treeship 0.20: selective disclosure"
+description: "An agent can present only the capabilities a verifier needs, and the unsound Groth16 path is quarantined in favor of a statement-first design."
+date: 2026-07-12
+written: 2026-09-11
+category: release
+release: "0.20.0"
+systems: []
+tags: [capability-cards, zk, identity, docs, release]
+readTime: "4 min read"
+---
+
+# Treeship 0.20: selective disclosure
+
+## What shipped
+
+An agent can now prove a subset of what it is authorized to do without revealing the rest. `treeship present --disclose <caps>` layers an SD-JWT-style disclosure over the existing DSSE signature. The verifier reconstructs the disclosed subset, checks it against the signed commitment, and learns nothing about the withheld entries. The card's signature still verifies.
+
+The second change is a correction. The experimental Groth16 zero-knowledge path was not sound to ship. It had no trusted-setup ceremony, and its proofs were not bound to the statement being proven, so a proof could be replayed or forged. That path is quarantined, the dead ZK code is deleted, and the docs no longer imply it was authoritative.
+
+Also in this release:
+
+- Core gains `disclose_capabilities` and `reconstruct_capabilities`, round-trip tested end to end.
+- The design formerly called `zk-verification` is renamed private verification, is statement-first, and names its two tiers concretely.
+- `treeship zk-setup` and `zk-tls-setup` scaffold the SRI-identified building blocks for that design.
+- A private-verification spec with the first-principles argument and citations, and a first-draft "cyberlogic" theory of Treeship's trust model.
+
+## Why it matters
+
+A capability card commits to an agent's full capability set. Until now, presenting the card meant presenting all of it. A payments counterparty had to see every unrelated tool an agent could call, and an agent working for several parties leaked its whole tool inventory to each of them. Now the holder chooses what each verifier sees, and the verifier still gets a signature it can check against its own trust roots.
+
+The ZK correction matters because a proof that is not bound to its statement is worse than no proof. It reads as verified while proving nothing about the claim in front of you. Shipping that under the Treeship name would have put an unsound check in the same trust ladder as the checks that hold. Quarantining it keeps the default trust path honest.
+
+## How it works
+
+```bash
+treeship present <agent> --disclose <caps>
+treeship verify-presentation <path>
+treeship zk-setup
+```
+
+`--disclose` takes the capability names to reveal. The presentation carries the disclosed entries in the open and the rest as commitments. On the verifying side, `reconstruct_capabilities` rebuilds the disclosed subset and checks it against the signed commitment. Three properties hold: the withheld set cannot be forged, it cannot be silently extended, and an omitted capability cannot be presented as disclosed. The verifier learns which capabilities were disclosed and that the card's signature covers the full commitment. It does not learn what was withheld.
+
+The private-verification design is statement-first. It starts from the statement a verifier needs proven and works back to the mechanism, rather than starting from a proof system and searching for a use. `zk-setup` and `zk-tls-setup` lay down the building blocks that design identifies, with subresource-integrity identification so what is fetched is what was reviewed.
+
+## What it does not do
+
+This is the release where the ZK story is stated plainly, so here is the plain version.
+
+- The `zk` feature remains pre-release and non-authoritative. Nothing in the default trust path depends on it.
+- `zk-setup` and `zk-tls-setup` are scaffolding. They do not produce a proof that a Treeship verifier treats as authoritative.
+- The quarantined Groth16 path is gone from the shipping surface, not repaired. There is no trusted-setup ceremony and no statement binding in any shipped ZK proof.
+- Selective disclosure is not zero-knowledge. It hides withheld entries behind commitments in a signed card. It is the SD-JWT shape, not a ZK proof.
+- Per the CLI's own help text, a disclosed presentation is an ephemeral re-sign and is not transparency-anchored, so it omits the Merkle staple.
+
+## Where to go next
+
+- [Capability cards](/docs/concepts/capability-cards)
+- [Zero-knowledge proofs](/docs/concepts/zero-knowledge)
+- [CLI: present / verify-presentation](/docs/cli/present)
+- [Treeship 0.18: onboard once, present anywhere](/blog/treeship-0-18-onboard-once-present-anywhere)
+- [Privacy in agent workflows: attestation without exposure](/blog/privacy-in-agent-workflows-attestation-without-exposure)
+
+*This entry was written on 11 September 2026 from the 0.20.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-23-grants-you-can-issue.mdx
+++ b/docs/content/blog/treeship-0-23-grants-you-can-issue.mdx
@@ -1,0 +1,67 @@
+---
+title: "Treeship 0.23: grants you can issue"
+description: "0.22 taught the verifier to judge delegation chains and effect finality. 0.23 gives the CLI the commands to mint grants and emit the action/v2 receipts those checks apply to."
+date: 2026-08-05
+written: 2026-09-11
+category: release
+release: "0.23.0"
+systems: [cli]
+tags: [approvals, effects, receipts, verifier, release-engineering, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.23: grants you can issue
+
+## What shipped
+
+Treeship 0.22 and 0.23 shipped on the same day, and together they close one loop. 0.22 taught `treeship verify` to judge whether authority was legitimately delegated and whether an effect actually landed. 0.23 gave the CLI the commands to mint that authority and emit the receipts that carry it. Before 0.23, nothing on the command line could produce a receipt the new checks applied to.
+
+The headline is `treeship grant issue`, `grant list`, and `grant show`. They mint signed capability grants with content-derived ids, delegate a narrower grant with `--parent`, and re-check a grant off disk. Next to them, `treeship attest action --v2` emits a real action/v2 receipt that names the grant it ran under.
+
+The rest of the two releases:
+
+- 0.22: grant chain resolution derives chain order from the signed `parent_grant_id` links, so reordering is a no-op, truncation surfaces as a missing ancestor, and splicing as an unreachable extra.
+- 0.22: `treeship verify` gains an authority line (in scope, in window, not revoked) and a chain line reporting `holds`, `widened`, `unresolvable`, or `not_claimed`; `--format json` adds per-check `authority` and `delegation_chain` objects and a top-level `authority_ok`.
+- 0.22: `EffectFinality` (`NotAttempted`, `Initiated`, `Finalized`, `Failed`, `Indeterminate`) is a lifecycle axis kept separate from `EffectConfidence`.
+- 0.22: `Resolution { deadline, on_deadline }` and `check_resolution` bound an unresolved effect, and `Indefinite` is reported as its own outcome.
+- 0.23: `attest action --v2` takes `--grant` or `--grant-file`, the effect flags `--effect-confidence`, `--finality`, `--readback`, `--context-snapshot`, `--resolution-deadline` and `--on-deadline`, and runtime identity through `--provider` and `--model`.
+- 0.23: `treeship-core` publishes to crates.io again after a webfont embedded from outside the crate root broke `cargo publish` in 0.22.0; a script and a CI `cargo package` step now guard it.
+
+## Why it matters
+
+Treeship 0.21 made "the ack is not the act" something you can check: a receipt grades the evidence that an effect happened. Two questions sat behind that one. Was the authority the action ran under legitimately delegated? And did the change land, or only start?
+
+Before 0.22, a chain of grants was whatever order the carrier supplied, and a verifier had no way to notice a reordered, truncated, or spliced chain. A receipt could also be accurate in every field and false as a whole: a write accepted, acknowledged, assigned an id, served back on read, and never committed. Now a delegated action carries its ancestors inline and verifies offline, and the chain's shape is derived from signed links before attenuation is judged. An invalid chain that exists is one somebody will eventually be asked to trust, so refusing to create it is the fix.
+
+## How it works
+
+```bash
+treeship grant issue --scope 'payments.*' --audience acme --expiry 2027-12-31T23:59:59Z
+treeship grant issue --parent grn_… --scope payments.charge --audience acme --expiry 2027-06-30T00:00:00Z
+treeship attest action --v2 --actor agent://worker --action payments.charge --grant grn_… \
+  --effect-confidence not_verified --finality initiated
+treeship verify last --format json
+```
+
+The first line mints a root grant. Its id is `grn_` plus the first sixteen hex characters of `sha256(canonical)`, so a parent pointer is a hash commitment to one specific grant, not a name anyone could claim. The second line delegates a child. Issuing refuses a child that widens scope, outlives its parent, changes audience, exceeds `max_delegation`, or carries an expiry already in the past. `delegation_depth` is derived from the parent rather than accepted from the caller.
+
+The third line emits the action/v2 receipt. Ancestors are walked from `parent_grant_id` and carried inline in `mandate.chain`, so the delegated action still verifies with no fetch. The verifier then reports four objects: `authority`, `delegation_chain` with its `hops` and `outcome`, `resolution`, and `effect` with an `effective_finality`. A root grant leaves `mandate.chain` empty and the chain line reads `not_claimed`. A one-element chain has no adjacent pair to check, and reporting "attenuation holds" would name a check that never ran.
+
+On the effect axis, `verify_effect` caps an unbacked `Finalized` exactly as it already caps an unbacked `Verified`; those are the only two claims that assert something definite. `check_resolution` takes `now_unix` explicitly, so a replay gives the same answer as the first run. `grant show` re-derives the id and re-checks the signature off disk.
+
+## What it does not do
+
+- Revocation is still unchecked. The authority verdict is `unverified`, never `pass`, and names the layer it could not check. The hub endpoint is an unsigned, hardcoded-empty stub, and reading it would turn an honest "I don't know" into a false "not revoked" for every grant ever issued.
+- Capability grants ship as beta, not stable, for that reason.
+- A known wart is left on purpose: `EffectConfidence` serializes as `snake_case`, so a receipt carries `not_verified` while `--format json` reports `not-verified`.
+- Both new `Effect` fields are optional and skipped when absent, so existing v2 receipts keep byte-identical canonical bytes.
+
+## Where to go next
+
+- [grant command reference](/docs/cli/grant)
+- [attest command reference](/docs/cli/attest)
+- [verify command reference](/docs/cli/verify)
+- [Effect receipts](/docs/concepts/effect-receipts)
+- [The ack is not the act](/blog/the-ack-is-not-the-act), the 0.21 post this builds on
+
+*This entry was written on 11 September 2026 from the 0.22.0 and 0.23.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-24-trusted-rooms.mdx
+++ b/docs/content/blog/treeship-0-24-trusted-rooms.mdx
@@ -1,0 +1,68 @@
+---
+title: "Treeship 0.24: trusted rooms end to end"
+description: "A room is a session whose participant set grows by signed invitation. 0.24 signs the room into the receipt, derives the roster from evidence, and adds a liveness challenge on join."
+date: 2026-08-10
+written: 2026-09-11
+category: release
+release: "0.24.0"
+systems: [cli, hub, go-client, claude-code-plugin]
+tags: [rooms, sessions, identity, wrap, redaction, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.24: trusted rooms end to end
+
+## What shipped
+
+Treeship 0.24 ships Trusted Rooms end to end. A room is a session whose participant set evolves through signed invitations. `treeship room create`, `room status`, and `room participants` are sugar over `treeship session`, and the room's `RoomInfo` is mirrored into the DSSE-signed `session.v1`. That means `invitation_authority` is attested inside the receipt rather than living only in an editable local file.
+
+Around the rooms work, the release adds a liveness check for joining agents, a custody field on the receipt, a stronger identity for wrapped commands, and a Go client for the hub:
+
+- `room participants` derives the roster from two-signature participant artifacts instead of reading a list from `session.json`.
+- Opt-in `--challenge` and `--challenge-response` on countersign prove the joining agent controls its key now, not whenever `join` ran.
+- `treeship session mint-challenge` mints 128 bits from `OsRng`, and weak nonces are refused at both ends.
+- `Custody` on the session receipt records when a service signed on an actor's behalf rather than the actor signing for itself.
+- `execution_identity` on wrapped commands records the resolved executable path, sha256, argv, cwd, uid/gid, and environment variable names only.
+- A public Go client for the hub ships as `pkg/dpop` and `pkg/hubclient`, tested against the real server verifier.
+- A generated `capability-map.json` records every reachable surface: 34 CLI commands, 22 routes, 109 wire types.
+- New concept pages cover what a receipt proves, logs versus receipts, effect receipts, secrets and redaction, authority delta, and wrapping real commands.
+
+Three fixes are worth the upgrade on their own. Every `receipt.v1` landing mid-chain reported `chain SIGNED LINKAGE BROKEN` against correctly-signed evidence. Keystores were not portable, because `storage_dir` and `keys_dir` were always absolute. And the Claude Code plugin monitor emitted a line on every counter change, well over a hundred per working session.
+
+## Why it matters
+
+Before 0.24, a multi-agent session had a roster, but the roster was a list in a local file. Anyone with write access could edit it, and it was silently incomplete whenever the best-effort append was skipped. A verifier reading it learned what the file said, not who had actually joined. Now the roster is derived from the signed evidence, and the room's invitation policy travels inside the signed receipt.
+
+The false tampering alarm mattered more than it looks. `mint_session_record` writes the parent as `subject.artifactId`, and the linkage check looked only for a top-level `parentId`. Measured on a real store, 4 of 4 receipts were affected. A false alarm on the one signal the product exists to give teaches operators to ignore it, so the check now reads the field the record actually carries.
+
+## How it works
+
+```bash
+treeship room create --invitation-authority host-only
+treeship room status
+treeship room participants
+treeship session mint-challenge
+treeship session countersign art_part_… --challenge <nonce> --challenge-response ./art_part_….challenge-response.json
+```
+
+`room create` starts a session and populates `SessionManifest.room`. `room status` prints session status plus the room fields, and errors if the active session is not a room. `room participants` walks the participant artifacts and lists only finalized, two-signature joins, in join order.
+
+The liveness challenge is opt-in. The host mints a nonce with `session mint-challenge`, the joining agent signs it with `session answer-challenge`, and the host passes both to `countersign`. Countersign refuses to finalize unless the answer verifies against the same nonce and the pending event's joining-agent key. Omitting both flags countersigns exactly as before. A guessable nonce can be pre-signed, so both ends refuse short or low-entropy values.
+
+`Custody` is deliberately a separate axis from `attestation_class`. One grades how evidence was captured; the other grades who held the key. Absent means self-custody, so existing receipts stay byte-identical. `execution_identity` exists because `git` is `git` only until `PATH` says otherwise; two receipts with identical argv and different digests are two different events.
+
+For keystores, relative `storage_dir` and `keys_dir` values now resolve against the config's own directory, and absolute paths are untouched. Moving `~/.treeship` aside produces a backup whose config points at itself.
+
+## What it does not do
+
+`invitation_authority` is carried and signed but not yet enforced. `verify` does not read it, so a receipt naming `host-only` and an invite minted by a non-host both verify clean. The changelog calls conformance checking the follow-up, and the 0.25.0 notes repeat the limit: fail-safe today because nothing trusts the field, but not access control. `room create` also accepts `--workflow-ref` and `--checkpoint-every`, and the CLI help marks both as carried on the manifest and not enforced yet. The redaction page documents, with a measured table, which secret shapes the scrubber catches and which it misses.
+
+## Where to go next
+
+- [Room sessions](/docs/concepts/room-sessions)
+- [session command reference](/docs/cli/session)
+- [Multi-agent sessions](/docs/concepts/multi-agent-sessions)
+- [Secrets and redaction](/docs/concepts/secrets-and-redaction)
+- [Wrapping commands](/docs/guides/wrapping-commands)
+
+*This entry was written on 11 September 2026 from the 0.24.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-25-revocation-and-the-wasm-saga.mdx
+++ b/docs/content/blog/treeship-0-25-revocation-and-the-wasm-saga.mdx
@@ -1,0 +1,70 @@
+---
+title: "Treeship 0.25: revocation, and the wasm saga"
+description: "Grant revocation works end to end and Linux arm64 binaries ship. It took four point releases to get a working verifier back onto npm, and the lesson is worth the telling."
+date: 2026-08-31
+written: 2026-09-11
+category: release
+release: "0.25.3"
+systems: [cli, hub, wasm-verifier, typescript-sdk, python-sdk, mcp]
+tags: [revocation, verifier, hub, keystore, release-engineering, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.25: revocation, and the wasm saga
+
+## What shipped
+
+Treeship 0.25.0 makes grant revocation work end to end. `treeship grant revoke` mints a signed `grant_revocation.v1`. `verify` honors it locally and from a hub's published list. The hub publishes real revocations over an indexed lookup, and each entry carries `dock_id` and `rekor_index` so a client can check inclusion itself. `grant show --check-log` walks the dock's consistency chain and re-verifies every link with RFC 6962. Unknown stays a third state throughout, never a quiet pass.
+
+The same release closes the gap 0.23 left open: `verify` now gates on authority and reports what was granted but never used, so `authority_ok: true` can no longer mean "checked nothing". Alongside:
+
+- Linux arm64 binaries are built and executed on a native `ubuntu-24.04-arm` runner, so a broken target blocks merge.
+- `grant show` and `grant list` no longer put a clean checkmark on a revoked grant.
+- The MCP bridge digests error text before signing it into a receipt, with raw text behind an explicit opt-in.
+- `ship.session.event()` lands in the TypeScript SDK, and `treeship session event --format json` prints a document instead of nothing.
+- Hub `/v1/stats` labels agent counts as `claimed_total`, and the hub indexes on fields derived from the envelope.
+
+0.25.1 fixes two SDK entry points that were structurally unable to succeed: the Python SDK's `attest_approval` passed `expires_in` where the CLI takes `expires_at` and forwarded no scoping arguments, and `treeship wrap --format json` printed nothing parseable. It also adds eight docs-versus-CLI drift gates. 0.25.2 and 0.25.3 are the wasm story below.
+
+## Why it matters
+
+A signature stays valid forever. Revocation is what makes a grant stop counting, and until 0.25.0 nothing could withdraw one. Now a grantor can, and only a grantor can: a revocation anyone could mint would be a denial of service against every grant whose id appears in a published receipt. Actions signed before the revocation instant remain authorized; revoking withdraws authority without unmaking what was done under it.
+
+The hub's response states that absence is not evidence. A list can prove a grant was revoked, not that one was not, so `verify` reports unknown as its own state rather than passing when nobody looked.
+
+## How it works
+
+```bash
+treeship grant revoke grn_… --reason task-complete
+treeship grant show grn_… --check-log
+treeship verify last --require-authority
+```
+
+`grant revoke` writes the signed revocation receipt. `grant show --check-log` is opt-in because it costs two network round trips. `verify --require-authority` turns a failed mandate, an unverifiable one, or no mandate at all into a nonzero exit. The last case matters: requiring authority and finding none is not a pass.
+
+Now the saga. 0.25.0 was forced because `@treeship/core-wasm@0.24.0` could not be loaded in Node and npm does not allow republishing a version. The cause was a bundler-only build: `build-npm.sh` ran only `wasm-pack --target bundler`, which emits an import that needs a bundler to resolve. It survived because the one consumer anyone exercised was the website, which bundles the wasm. The fix was a dual-target build with an `exports` map routing Node to a nodejs build.
+
+That fixed the structural half. 0.25.0 and 0.25.1 still threw `WebAssembly.Table.grow(): failed to grow table by 4` on first use. The binary was miscompiled: the export `__wbindgen_externrefs` was bound to a table emitted with `min == max`, which cannot grow. Same rustc, wasm-bindgen and wasm-pack as a working local build; the difference was the host platform, invisible on a Mac and fatal from Linux CI.
+
+0.25.2 added the gate that should have existed all along. `build-npm.sh` now loads its own nodejs output and calls into it before packaging, and the release installs `@treeship/verify` from the registry after publishing and calls a verify function, because the wasm loads lazily and an import proves nothing. Every earlier check had run against an artifact CI had just built, and the post-publish smoke installed only the Rust CLI. The gate caught that the artifact still did not load, so 0.25.2 never reached npm.
+
+0.25.3 found the cause. `wasm-pack` runs `wasm-opt` on the package it just built whenever binaryen is on `PATH`. The release workflow installed binaryen from apt, which on Ubuntu noble is `108-1`, a 2022 build predating the `bulk-memory-opt` and `call-indirect-overlong` features the module declares. It lowered the externref table to a non-growable one. The `wasm-opt` pass is now disabled for `core-wasm`, so the published artifact is `wasm-bindgen`'s output and nothing else. CI and release install a checksummed binaryen 132 tarball, and `rust-toolchain.toml` pins `wasm32-unknown-unknown`.
+
+The lesson, stated plainly: pin every tool that rewrites the artifact, build in CI the way release builds, and test what the registry serves.
+
+## What it does not do
+
+- `invitation_authority` on a room is recorded and not enforced; `verify` does not read it.
+- A receipt fetched by URL is verified structurally only. Signatures and issuer are not checked from that source.
+- `grant show --check-log` proves the log was not rewritten, not that the revocation list is complete.
+- Keystore recovery advice was corrected in 0.25.2: receipts report `unknown key` until the old keystore is restored.
+
+## Where to go next
+
+- [grant command reference](/docs/cli/grant)
+- [Revocation feed](/docs/api/revoked)
+- [verify command reference](/docs/cli/verify)
+- [@treeship/verify](/docs/sdk/verify)
+- [Treeship 0.23: grants you can issue](/blog/treeship-0-23-grants-you-can-issue)
+
+*This entry was written on 11 September 2026 from the 0.25.0, 0.25.1, 0.25.2 and 0.25.3 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-26-workflow-conformance.mdx
+++ b/docs/content/blog/treeship-0-26-workflow-conformance.mdx
@@ -1,0 +1,69 @@
+---
+title: "Treeship 0.26: workflow conformance"
+description: "A signed workflow.v1 declaration can now be verified against what a session actually did. One fail-closed path runs from the declaration to a conformance report."
+date: 2026-09-01
+written: 2026-09-11
+category: release
+release: "0.26.0"
+systems: [cli]
+tags: [workflows, merkle, verifier, sessions, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.26: workflow conformance
+
+## What shipped
+
+Treeship 0.26 lands workflow conformance. You declare a workflow as a signed `workflow.v1` artifact, bind it into a session at start, and afterwards ask whether the session did what the declaration said. `treeship workflow verify` is the one fail-closed path from the signed declaration to a conformance report, and it is the only place the pre-existence grade is decided.
+
+The pieces underneath it:
+
+- A pure conformance reducer in `treeship-core` reports path deviations, missing terminals, actor and tool authority deviations, bounded-loop breaches, and `checked | captured | asserted` provenance on separate axes.
+- `workflow.v1` is a registered predicate whose nested graph runs the full validator before the generic `attest receipt` path signs it.
+- `treeship session start --workflow-ref art_...` validates a locally signed declaration before writing any run state and binds its id inside the signed `session.start` root action.
+- `verify_workflow_pre_existence` checks real checkpoint ordering: trusted signatures, both inclusion proofs, leaf position, and consistency must all pass.
+- `verify_first_run_workflow_binding` independently checks the trusted root signature, the content-derived run id, the action type, and the exact declaration reference.
+- `derive_observed_run` builds the observation set from verified actions, so the attribution rule is code with tests against it.
+- `--strict` exits non-zero on any deviation, gap, or exceeded limit.
+- Seven golden reports pin the contract.
+
+One more item is a recovery rather than a feature. `workflow_conformance.rs`, its golden fixtures, and the `workflow.v1` schema had existed only in a local stash since 2026-08-18. They are on main.
+
+## Why it matters
+
+Before 0.26 the three verification pieces existed separately, and nothing composed them: the declaration's signature, the signed `session.start` that binds a run to it, and the Merkle evidence that the declaration pre-existed the run. Worse, `evaluate_workflow_conformance` read `pre_existence.grade` off its input, and its doc comment made not-lying an obligation on callers. An observation set that claimed `checked` with placeholder checkpoint ids got a `checked` report.
+
+The composed path discards whatever the input claims and replaces it with what the supplied evidence proves. A run with no `--proof` reports `asserted` no matter what its file says. Omitting the proof is allowed and costs the run its `checked` grade; it is not an error, because an unproven ordering claim is a weaker report rather than a malformed one.
+
+The other hole was attribution. `workflow verify --run` read a file somebody wrote, which meant the rule deciding which declared node an action belongs to lived outside the trust boundary entirely. That rule is now derived from verified actions.
+
+## How it works
+
+```bash
+treeship session start --workflow-ref art_…
+treeship workflow verify --workflow art_… --first-run art_… --run ./run.json --proof ./proof.json --strict
+```
+
+`session start --workflow-ref` refuses a declaration that does not validate, and the reference lands inside the signed root action. The manifest and the composed session receipt mirror it, but the verifier does not trust either; it reads the workflow reference and the first-run id from artifacts whose signatures it just checked, never from caller-supplied strings.
+
+`workflow verify` then composes the three checks and reports on separate axes. Path, authority, and loop findings never summarize one another, in text or in `--format json`. Undeclared graph cycles and empty evidence fail closed.
+
+Attribution is by admissibility, never by label. A node admits an action when its executor matches the signed actor, or a capability the verified mandate carried, and its `allowed_tools` covers the signed action label. Exactly one admitting node is the only case that earns `checked`, and a recorded node label is not consulted there at all. A runtime cannot relabel work the declaration already places. A label may only pick within an already admissible set, which caps that attempt at `captured`. A label naming a node that cannot admit the action is reported rather than used as a tiebreak.
+
+Two shortcuts would have reported a clean run for a dirty one, and both are now regression tests. Dropping an action no node's `allowed_tools` covers would hide an out-of-scope tool, so such an action stays attributed by executor match and the authority axis still reports it. Accepting a repeated action reference would let one action pay twice against a loop's `budget.max_actions`, which counts unique signed-action references, so duplicates are refused during derivation.
+
+`--strict` is off by default. The spec is explicit that there is no single workflow score, so the pass/fail policy belongs to the caller and the substrate reports the file.
+
+## What it does not do
+
+Automatic checkpoint composition and external workflow-authority trust remain follow-ups. Derivation leaves `pre_existence` asserted; only `verify_workflow_run` grades ordering, and only when a `--proof` is supplied. A run without one can never grade better than `asserted`. The five fail-closed fixes that landed in 0.25.3, the day before, apply here: session close re-verifies the signed root, pre-existence proofs require one checkpoint signing identity, and schema-required `allowed_tools` cannot deserialize as an omitted default.
+
+## Where to go next
+
+- [Workflows guide](/docs/guides/workflows)
+- [session command reference](/docs/cli/session)
+- [Predicate registry](/docs/reference/predicates)
+- [Merkle proofs](/docs/guides/merkle-proofs)
+- [Room sessions](/docs/concepts/room-sessions)
+
+*This entry was written on 11 September 2026 from the 0.26.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-27-the-custody-handshake.mdx
+++ b/docs/content/blog/treeship-0-27-the-custody-handshake.mdx
@@ -1,0 +1,70 @@
+---
+title: "Treeship 0.27: the custody handshake"
+description: "Foreign work handed over A2A or MCP is refused until the other agent proves live key control, and the handoff receipt records that it did."
+date: 2026-09-02
+written: 2026-09-11
+category: release
+release: "0.27.0"
+systems: [cli, a2a, mcp, claude-code, claude-code-plugin, codex, cursor, hermes, openclaw, kimi, perplexity, grok-bot]
+tags: [handoffs, identity, verifier, sessions, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.27: the custody handshake
+
+## What shipped
+
+Treeship 0.27 makes the bridges fail closed. Work that arrives from another agent over A2A or MCP is refused until the sender proves it controls its key right now, and the handoff receipt records that the check happened. Integrations that pass `fromAgent` to `onTaskReceived` without calling `admitTask` first now throw.
+
+The receipt side is `treeship attest handoff --verified <presentation> --challenge <nonce>`. It re-runs the core presentation verifier and, only on a clean live verdict, signs a `custody` block. `treeship verify` then grades the block as `custody: live` or `asserted`.
+
+The rest of the release:
+
+- `--close-loop <session_id>` signs the session's `receipt.json` digest into the handoff statement; a session the machine cannot find is refused.
+- `--custody-reason same_computer` records the shared-keystore case as what it is.
+- `@treeship/a2a` mints the receiver-signed `custody: live` handoff after `admitTask` passes and returns it as `handoffId`; the opt-out path never gets one.
+- `treeship_attest_handoff` in `@treeship/mcp` takes `verified` and `challenge`.
+- Every harness skill teaches the same four-step gate: the universal skill, the Hermes, OpenClaw, Kimi and Perplexity skills, the Claude Code, Codex and Cursor notes, a new `treeship-handshake` skill in the Claude Code plugin, and the Grok Bot skill.
+- `--format json` carries the grade as `checks[].custody.live`.
+- Every handoff the CLI could mint failed chain linkage; that is fixed.
+
+## Why it matters
+
+Until this release, A2A attested after the fact. A receipt URL in task metadata told you a receipt existed, and fetching a URL and calling it verified is structural at best. The actor string on a handoff was asserted until someone checked a card against a pinned issuer. The commands to do that check, `present --challenge` and `verify-presentation --challenge`, have existed since 0.17, but nothing refused to do the work when they failed.
+
+The agent-to-agent spec lays out five checks that must hold on this machine, against this ship's pins, before an inbound task runs: the issuer is pinned with `trust add --kind cert_issuer`, the presentation verifies, the challenge you minted was answered live, the staple is fresh, and the mandate names you as `--to`. Any failure means do not run. 0.27 wires those checks into the place where work is accepted, and makes the weak form visible: a handoff without a live verify is `asserted` custody, and `verify` says so.
+
+The chain-linkage bug hid in plain sight. `attest handoff` records `--artifacts[0]` as the storage parent, but handoff/v1 has no `parentId`, so `verify` reported "claims parent (none)" and `chain_linkage_ok: false` on correctly-signed evidence. The signed `artifacts` list is the edge, the same shape as receipt.v1's `subject.artifactId`, and the walk now reads it.
+
+## How it works
+
+```bash
+# receiver mints a nonce; sender answers it
+treeship present agent://sender --challenge <nonce>
+# receiver verifies, then records the verify in the handoff
+treeship attest handoff --from agent://sender --to agent://receiver --artifacts art_… \
+  --verified ./presentation.json --challenge <nonce> --close-loop <session_id>
+treeship verify last --format json
+```
+
+The `custody` block carries the sha256 of the exact presentation bytes, the nonce this ship minted, the card id, the verifier, and the time. A failing presentation refuses to mint rather than downgrading quietly. A presentation for one agent cannot certify a handoff `--from` another. `--verified` without `--challenge` is a parser error, and `--custody-reason` conflicts with `--verified`.
+
+`verify` grades the block itself rather than echoing it. `custody: live` appears only when the block carries the digest and the nonce a live check produces. A `live` without them, an unknown grade, and no block at all each print as `asserted` with the reason. Canonical bytes of every existing handoff are unchanged.
+
+`--close-loop` binds sealed-session evidence to the handoff, so a receiver can require a closed session as policy. Evidence never upgrades custody: a sealed session proves what the sender did, not who the sender is.
+
+In `@treeship/a2a`, `admitTask` runs the gate and the bridge then mints the handoff on the receiver's key. `handoff` envelopes are validated on parse. In `@treeship/mcp`, the same gate is one tool call with `verified` and `challenge`. Each harness skill states the four steps: mint the nonce, verify the presentation, refuse on any failure, record the verify.
+
+## What it does not do
+
+The handshake proves who is live, what card they hold, and that this ship chose to trust their issuer. It does not prove the sender's task result is true; ground truth of the work is still `wrap` and the session on each side. Grok Bot approvals, slice 3b of the A2A spec, are blocked: the decision is visible only in Grok's app UI, so the packaged skill states the boundary instead of recording an approval nobody observed. `--custody-reason same_computer` records a shared keystore honestly; it does not make that handoff `live`.
+
+## Where to go next
+
+- [The agent handshake](/docs/concepts/agent-handshake)
+- [Handoffs guide](/docs/guides/handoffs)
+- [attest command reference](/docs/cli/attest)
+- [@treeship/a2a](/docs/integrations/a2a) and [@treeship/mcp](/docs/integrations/mcp)
+- [A2A makes agents interoperable](/blog/a2a-treeship-the-trust-layer-for-agent-to-agent), the earlier post on the bridge
+
+*This entry was written on 11 September 2026 from the 0.27.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-31-2-sealed-packages-verify-signatures.mdx
+++ b/docs/content/blog/treeship-0-31-2-sealed-packages-verify-signatures.mdx
@@ -1,0 +1,68 @@
+---
+title: "Treeship 0.31.2: sealed packages now verify their signatures"
+description: "package verify checked the Merkle tree and nothing under it. It now verifies every artifact's Ed25519 envelope, session close seals unchained work, and the MCP bridge reports failures."
+date: 2026-09-10
+written: 2026-09-11
+category: security
+release: "0.31.2"
+systems: [cli, mcp, verifiable-intent, commerce-agents]
+tags: [verifier, receipts, sessions, security-advisory, trust-roots, security]
+readTime: "5 min read"
+---
+
+# Treeship 0.31.2: sealed packages now verify their signatures
+
+## What shipped
+
+Treeship 0.31.2 fixes three findings from an internal security review of 0.31.1, published as advisory TS-2026-002. The headline is AUD-31: through 0.31.1, `treeship package verify` checked that a `.treeship` package was internally consistent and stopped there. It never verified an artifact's Ed25519 signature and never required the envelope to exist. A receipt whose sealed set was rewritten to an invented `art_` id, with the tree recomputed to match, verified with exit 0 and a green verdict.
+
+A package now carries the signed DSSE envelope of every sealed artifact under `artifacts/` and the signing public keys in `keys.json`. `package verify` checks each envelope against those keys. A fabricated id, an edited byte, a reordered chain, a missing envelope, or an unknown key fails with a nonzero exit.
+
+- AUD-32: `session close` seals every artifact signed in the workspace during the session, not only those reachable along the parent chain, and marks loose ones `unchained: true`.
+- AUD-33: the MCP bridge writes `[treeship] <what> failed: <reason>` to stderr on every signing failure, and under `TREESHIP_STRICT=1` fails the tool call.
+- New verify rows: `signature:<id>`, `chain_linkage`, `signer_trust`, `envelopes`, and `chain_completeness`.
+- `--structural` reads a pre-0.31.2 package with a verdict that says signatures were not checked.
+- `attest action` prints a hint when a session is active and no `--parent` was given.
+- Core: `verify_package_with_options`, `verify_package_structural`, `PackageKeys`.
+- Docs: the Verifiable Intent page now says "shipped against the v0.1 draft".
+
+## Why it matters
+
+A `.treeship` package is the artifact Treeship tells a stranger to verify. The verifier guide had always said the package proved structure and a bundle proved signatures, and `treeship verify <id>` did perform real DSSE verification. But the package verdict line did not say so, and the format made a signature check impossible from the file alone. A green verdict on a package was a weaker claim than it looked.
+
+AUD-32 compounded it. An `attest action` signed without `--parent`, or onto a parent off the sealed path, was signed and stored but absent from the package, while `package verify` reported it clean. Three such actions in one session left one in the receipt. AUD-33 meant a tool call that was never recorded looked, to the caller, like one that was. The bridge caught the failure, returned `undefined`, and printed nothing unless `TREESHIP_DEBUG=1`.
+
+The advisory rates AUD-31 and AUD-32 high and AUD-33 medium. The fix shipped in the release after discovery, and no field exploitation was observed.
+
+## How it works
+
+```bash
+treeship package verify <package>.treeship
+treeship package verify <package>.treeship --strict
+treeship package verify <package>.treeship --structural
+treeship trust add <key_id> ed25519:<pk> --kind cert_issuer
+treeship attest action --parent <id>
+```
+
+For each sealed artifact, `package verify` verifies the envelope's Ed25519 signature against `keys.json`, then re-derives the content-addressed id and the digest column from the signed bytes. That is the `signature:<id>` row: the id in the receipt must equal the id computed from what was signed. `chain_linkage` checks that every chained artifact names the previous one as `parentId` inside the signature, so a reordered chain fails even if each envelope is valid. `envelopes` fails when a package carries no envelopes, which is every package built before 0.31.2.
+
+`signer_trust` reports whether the signing keys are pinned trust roots. Unpinned, it warns and prints the exact `treeship trust add` command; under `--strict` it fails. The package names its keys; it cannot vouch for them.
+
+`session close` now seals unchained artifacts after the chain and reports them as `sealed_unchained` in JSON, with a warning and a hint in text. `package verify` surfaces them as `chain_completeness`, so a verifier can tell a linked step from a loose one.
+
+If you accepted a package on a green verdict, re-run `package verify` with 0.31.2. A pre-0.31.2 package fails at `envelopes`; its artifacts can still be verified from a bundle or the hub with `treeship verify <id>` after pinning the producer's key. Ask producers to re-close sessions that matter. A scripted reproduction ships beside the advisory at `docs/security/audit-2026-09-repro.sh`.
+
+## What it does not do
+
+An unchained receipt is now sealed, but its order is the producer's unsigned claim, and `chain_completeness` says so. `signer_trust` is a warning until the verifier pins the key; the package cannot make that decision for them. `TREESHIP_STRICT=1` is opt-in; without it the bridge reports the failure and proceeds. `--structural` is the only way to read a package from before 0.31.2, and its verdict says signatures were not checked.
+
+One rough edge in 0.31.2 itself: the release smoke caught `signer_trust` warning on the producer's own machine that its own signing key was not a pinned root, and `session report` summarised every fresh session as `warn`. The fix, verifying against the pinned roots plus this ship's keystore keys as `session_host` roots, landed on main after the release and is unreleased as of this writing. A stranger's machine still warns until they pin, which is the point.
+
+## Where to go next
+
+- [Verify a package](/docs/commerce/verify-a-package): the verifier guide, including key pinning.
+- [`treeship package`](/docs/cli/package) and [`treeship trust`](/docs/cli/trust): CLI reference.
+- [MCP bridge](/docs/integrations/mcp): `TREESHIP_STRICT` and the bridge's failure reporting.
+- [Treeship 0.7: session receipts you can verify offline](/blog/treeship-0-7-session-receipts): where the package format began, and why it only proved structure.
+
+*This entry was written on 11 September 2026 from the 0.31.2 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-31-verifiable-intent.mdx
+++ b/docs/content/blog/treeship-0-31-verifiable-intent.mdx
@@ -1,0 +1,67 @@
+---
+title: "Treeship 0.31: Verifiable Intent credentials, shipped"
+description: "treeship vi implements the Verifiable Intent v0.1 draft, signs the Layer 3 pair with a Treeship receipt-chain attestation inside, and interoperates with the reference SDK both ways in CI."
+date: 2026-09-08
+written: 2026-09-11
+category: release
+release: "0.31.0"
+systems: [verifiable-intent, commerce-agents, python-sdk, cli]
+tags: [approvals, receipts, keystore, verifier, docs, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.31: Verifiable Intent credentials, shipped
+
+## What shipped
+
+Treeship 0.31 ships `treeship vi`, an independent implementation of the Verifiable Intent v0.1 draft, the credential standard for agent commerce maintained by Mastercard and co-developed with Google. It lives in `treeship-core::vi` with a CLI on top, and it interoperates with the reference SDK in both directions, tested in CI. It is not endorsed by, and does not speak for, the standard's maintainers.
+
+The four commands cover the agent's side of the credential chain:
+
+- `vi keygen` mints the agent's P-256 key, sealed by the ship keystore, and prints the JWK a wallet binds under `cnf`.
+- `vi check` asks whether a purchase fits a Layer 2 mandate, without signing anything.
+- `vi attest` signs the Layer 3 pair, L3a for the payment network and L3b for the merchant, as key-bound SD-JWTs with `sd_hash` over recipient-specific L2 presentations and `transaction_id == checkout_hash`, refusing anything outside the mandate before signing.
+- `vi verify` runs the reference verifier's checks plus the Treeship attestation and, with `--local`, the chain it names.
+
+The spec's optional `agent_attestation` claim carries a `treeship.receipt-chain.v1` value: a ship-signed statement, stored as an artifact chained onto the head, naming the session, chain head, Merkle checkpoint, approval use, mandate digest and transaction. On the commerce side, `TreeshipApprovalMixin` sets `treeship_last_approval` to `proven`, `unproven`, or `None` on the executor after every apply, and a new docs page, `/commerce/verify-a-package`, walks the counterparty through `keys export`, `trust add`, `bundle import`, and `verify`.
+
+0.31.1 followed the same day with QA fixes for the commerce integration. `order_placed` no longer forks the chain off the hand-off receipt; the order chains onto the recorder's head and names the hand-off in `meta.handoff`. `session close` lists signed artifacts that branch off the sealed chain as `unsealed_branches`. The demos run on a clean machine, the Python SDK warns once when the CLI is on another release line, and the quickstarts start with `treeship init --config .treeship/config.json`.
+
+## Why it matters
+
+Verifiable Intent defines a three-layer chain from the user's mandate to the transaction. An issuer signs L1 for the user, the user's wallet signs L2 delegating bounded authority to one agent key, and in autonomous mode the agent signs the L3 pair. The chain proves the agent was authorized. It says nothing about what the agent did between receiving the mandate and handing the cart to checkout.
+
+That gap is where Treeship plugs in, using the field the spec already provides. Before 0.31 this was a design: the April post described it, and the `packages/vi` types from that era targeted a pre-v0.1 draft and were never wired. They are retired. The code lives in `packages/core/src/vi/`, proven against the reference implementation rather than against itself.
+
+## How it works
+
+```bash
+treeship vi keygen --label shopping-agent
+treeship vi check --mandate l2.sdjwt --merchant merchant-uuid-1 --item BAB86345 --amount 27999 --currency USD
+treeship vi attest --mandate l2.sdjwt --checkout-jwt checkout.jwt \
+  --merchant merchant-uuid-1 --item BAB86345 --amount 27999 --currency USD \
+  --aud-network https://www.mastercard.com --aud-merchant https://tennis-warehouse.com \
+  --iss https://agent.example.com --out ./vi-out
+treeship vi verify --mandate l2.sdjwt --l3a vi-out/l3a.sdjwt --l3b vi-out/l3b.sdjwt \
+  --l2-payment vi-out/l2-payment.sdjwt --l2-checkout vi-out/l2-checkout.sdjwt --local --require-attestation
+```
+
+`keygen` seals the private scalar with the keystore's machine key, the same AES-256-GCM construction that protects the Ed25519 keys, and never prints it. `check` runs the eight registered constraint types with the reference checker's semantics and exits 1 on a violation. `attest` checks the request against the mandate first; if it is outside, nothing is signed and nothing is written. Each L3 half is bound to the L2 by an `sd_hash` over exactly the part of the L2 that recipient is shown, and the halves are bound to each other by `transaction_id == checkout_hash`.
+
+The attestation is an ordinary receipt: a `treeship/action/v1` statement with action `vi.l3.attested`, signed with the ship's Ed25519 key, chained onto the previous head inside the signature via `parentId`, and it becomes the new head. Its signed fields are `session`, `chain_head`, `chain_length`, `checkpoint`, `approval_use`, `mandate_digest` and `transaction_id`. The claim embeds the envelope and the signing public key, so any Ed25519 library confirms the signature without Treeship. The L3 credential itself stays signed with the agent's P-256 key as the spec requires; Treeship adds evidence underneath it.
+
+`verify` runs the reference verifier's checks, then the attestation. A verifier that does not know the scheme ignores the claim, as the spec requires. The interop suite in `tests/vi-interop` asserts that the reference's `verify_chain` and `check_constraints` do exactly that, that Treeship verifies what the reference issues, and that one edited byte fails on both.
+
+## What it does not do
+
+This implements the v0.1 draft, which is not final; claim shapes may move when the standard does. Not in scope: multi-pair L2 mandates, network-side cumulative budget and occurrence counting, and immediate mode, which has no L3. `vi verify` does not decide whether the attestation's signing key is one you trust; it prints the key and pinning is yours. And the attestation proves the credential was minted at the end of a specific signed sequence, not that the sequence was wise.
+
+## Where to go next
+
+- [treeship vi reference](/docs/cli/vi)
+- [Verifiable Intent integration](/docs/integrations/verifiable-intent)
+- [Verify a session package](/docs/commerce/verify-a-package)
+- [commerce-agents integration](/docs/integrations/commerce-agents)
+- [Verifiable Intent: how Treeship becomes the agent's proof of work](/blog/verifiable-intent-treeship-agent-attestation), the design-era post this supersedes
+
+*This entry was written on 11 September 2026 from the 0.31.0 and 0.31.1 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-7-session-receipts.mdx
+++ b/docs/content/blog/treeship-0-7-session-receipts.mdx
@@ -1,0 +1,66 @@
+---
+title: "Treeship 0.7: session receipts you can verify offline"
+description: "A closed session now becomes a .treeship package with a Merkle root, a static verifier page, a public hub URL, and A2A middleware."
+date: 2026-04-15
+written: 2026-09-11
+category: release
+release: "0.7.2"
+systems: [cli, hub, a2a, mcp, python-sdk]
+tags: [receipts, sessions, merkle, hub, handoffs, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.7: session receipts you can verify offline
+
+## What shipped
+
+Treeship 0.7 introduced the Session Receipt. When a session closes, the CLI composes a deterministic receipt over everything the session recorded and writes it as a `.treeship` package under `.treeship/sessions/`. The package holds `receipt.json`, `merkle.json`, `render.json`, a per-artifact inclusion proof, and a static `preview.html`. The receipt carries a Merkle root over the session's artifacts.
+
+Three point releases built the surface out between 9 April and 15 April. 0.7.0 shipped the package, the hub endpoints, and the `@treeship/a2a` middleware. 0.7.1 fixed findings from a Codex adversarial review. 0.7.2 made `preview.html` a self-contained verifier and wired MCP tool calls into the session timeline.
+
+- `treeship package inspect` and `treeship package verify` read a package offline; no hub is required.
+- `treeship session report` uploads a closed receipt to the hub and prints its permanent public URL.
+- `treeship session event` appends structured events to the active session; the MCP bridge, A2A bridge, and SDKs use it.
+- `@treeship/mcp` emits an `agent.called_tool` event after each tool call, and failed tool calls are now audited.
+- `treeship declare` writes `.treeship/declaration.json` with `bounded_actions`, `forbidden`, and `escalation_required`.
+- `TREESHIP_MODEL`, `TREESHIP_TOKENS_IN`, `TREESHIP_TOKENS_OUT`, and `TREESHIP_COST_USD` capture model and token usage into the receipt when set before `treeship wrap`.
+- The daemon detects sensitive file reads by tracking atime, and emits `agent.read_file` with `capture_confidence: "inferred"`.
+- Python: `Treeship.session_report(session_id=None)` returns the receipt URL, agent count, and event count.
+
+## Why it matters
+
+Before 0.7, a session was a chain of individual artifacts. Handing that to someone meant handing them a set of files and a verification procedure. Now the unit of exchange is one package. It can be sent as an attachment, opened in a browser with no network, or fetched from a permanent URL.
+
+The failure this closed was the read gap. Prior releases could see writes but not reads, so an agent opening `.env`, a `.pem` file, or `.ssh/*` was invisible. The daemon now walks dotfiles at the project root and one level into `.aws`, `.ssh`, `.gnupg`, `.docker`, and `.kube`, and records a read event when atime advances on a file matching an `on: access` rule.
+
+## How it works
+
+```bash
+treeship session close
+treeship package verify .treeship/sessions/<id>.treeship
+treeship session report
+treeship hub open
+```
+
+`session close` composes Session Receipt v1. 0.7.1 changed it to delete `session.json` before composing, so a late daemon event cannot land in the log but miss the receipt. The Merkle root is the full 256-bit SHA-256 value; 0.7.0 stored a truncated 64-bit prefix, and the changelog says receipts from before 0.7.1 should be regenerated.
+
+`package verify` recomputes the Merkle root from the listed artifacts, verifies each inclusion proof, and checks timeline ordering. `preview.html` runs the same checks client-side through Web Crypto, with zero network calls, so a reader can open the file air-gapped. Its verdict language is deliberate: "Merkle structure verified", not "Verified". Empty states are grey "not captured", and green only appears for things the session measured.
+
+`session report` uploads with `PUT /v1/receipt/{session_id}`, DPoP-authenticated. The hub takes atomic first-write ownership, so a second dock cannot overwrite the `dock_id`, and receipts are write-once; a byte-identical replay is accepted for retry safety. `GET /v1/receipt/{session_id}` is public with no auth and serves the raw receipt JSON with an immutable cache header. `hub open` mints a short-lived share token bound to the dock and opens a browser URL that needs no private key on the client.
+
+For A2A, `TreeshipA2AMiddleware` hooks `onTaskReceived` for an awaited intent, `onTaskCompleted` for a chained receipt, `onHandoff`, and `decorateArtifact`. `verifyReceipt` and `verifyArtifact` run pre-delegation trust checks. The extension URI is `treeship.dev/extensions/attestation/v1`, and the package has zero runtime dependencies and never throws.
+
+## What it does not do
+
+`package verify` in 0.7 proves structure: the root recomputes, the proofs hold, the timeline is ordered. It does not check the Ed25519 signature on each artifact inside the package, and the package does not carry those envelopes. That gap stayed the design until 0.31.2. Sensitive file reads are inferred from atime, and the event says so in `capture_confidence`. The declaration compares declared against actual tool usage and flags unauthorized calls; it does not block them. Token and cost fields are only as honest as the environment variables the caller sets.
+
+## Where to go next
+
+- [Session receipts](/docs/concepts/session-receipts): what a receipt contains and what its root covers.
+- [`treeship session`](/docs/cli/session) and [`treeship package`](/docs/cli/package): CLI reference.
+- [Receipt format](/docs/reference/receipt-format): field-by-field reference.
+- [A2A integration](/docs/integrations/a2a): the middleware and AgentCard helpers.
+- [A2A and Treeship](/blog/a2a-treeship-the-trust-layer-for-agent-to-agent): the post that shipped with 0.7.0.
+- [Treeship 0.31.2: sealed packages now verify their signatures](/blog/treeship-0-31-2-sealed-packages-verify-signatures): the day `package verify` started checking signatures.
+
+*This entry was written on 11 September 2026 from the 0.7.0, 0.7.1 and 0.7.2 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-8-zero-to-receipt.mdx
+++ b/docs/content/blog/treeship-0-8-zero-to-receipt.mdx
@@ -1,0 +1,68 @@
+---
+title: "Treeship 0.8: zero to receipt in under 90 seconds"
+description: "treeship add instruments the agent frameworks already on your machine, quickstart walks to a first receipt, and agents get an identity certificate."
+date: 2026-04-18
+written: 2026-09-11
+category: release
+release: "0.8.0"
+systems: [cli, claude-code, cursor, hermes, openclaw, mcp, hub]
+tags: [identity, sessions, receipts, hub, templates, release]
+readTime: "4 min read"
+---
+
+# Treeship 0.8: zero to receipt in under 90 seconds
+
+## What shipped
+
+Treeship 0.8.0 is about the first ten minutes. `treeship add` detects the agent frameworks installed on the machine, Claude Code, Cursor, Cline, Hermes, and OpenClaw, and instruments each one. `treeship quickstart` is a guided interactive setup that goes from nothing to a verified receipt in under 90 seconds. A one-line installer at treeship.dev/setup installs the CLI, initializes a project, and runs `treeship add`.
+
+The release also gave agents an identity of their own and gave operators a way to watch a session while it runs.
+
+- `treeship agent register` produces an Agent Identity Certificate as a `.agent` package with a `certificate.html`.
+- `treeship session status --watch` opens a live terminal TUI showing agents, events, security, and verification progress.
+- `treeship declare` creates `.treeship/declaration.json` with the tool authorization scope; receipts now show declared against actual usage and flag unauthorized calls.
+- `treeship session event` appends structured events, used by the MCP and A2A bridges.
+- `TREESHIP_PROVIDER` records provider attribution: `anthropic`, `openrouter`, or `bedrock`.
+- Integration packages for Claude Code, Hermes, and OpenClaw ship under `integrations/`, with skill files and MCP configs, plus a universal `TREESHIP.md` for any agent that reads markdown instructions.
+- `preview.html` verifies Merkle structure on its own through Web Crypto, and gained a three-panel narrative, agent cards, timeline grouping, retry detection, approval gates, and a print stylesheet.
+
+## Why it matters
+
+Before 0.8, setting up Treeship meant reading docs, editing framework config by hand, and knowing which commands to run in which order. Each framework had its own file to touch. A new user could install the CLI and still have no receipt an hour later.
+
+Now the CLI does the detection. Error messages tell the user which command fixes the problem. `treeship init` prints the Ship ID, the Key ID, and the next step. `treeship wrap` without an active session warns and says how to start one. `session close` opens `preview.html` in the browser on macOS and Linux, so the first receipt is something the user sees, not a file path.
+
+## How it works
+
+```bash
+treeship quickstart
+treeship add
+treeship agent register
+treeship declare
+treeship session status --watch
+treeship session close
+```
+
+`quickstart` runs the steps interactively. `add` looks for each supported framework and writes its integration: skill files and MCP config that point the agent at `@treeship/mcp`. The MCP bridge now emits session events, so every tool call appears in the receipt timeline, and a failed tool call is audited rather than vanishing from the trail.
+
+`agent register` signs a certificate for a named agent. The name is sanitized to alphanumeric characters, dashes, and underscores, which closed a path traversal found in review. The `.agent` package includes `certificate.html` so the certificate is readable without tooling.
+
+`declare` writes the authorization scope. When the session closes, the receipt compares the declared scope against the tools the session actually called. A call outside the scope is flagged in the receipt.
+
+`session status --watch` renders the live TUI. Every event field is sanitized before display, which closed a terminal escape injection, and string truncation is UTF-8 safe. A raw mode guard restores the terminal on every exit path.
+
+On the hub side, the device code now displays all 16 characters and the hub accepts an 8-character prefix for older clients. `device_code` is redacted from access logs and validated before any database lookup. The hub reads `DATABASE_PATH` for SQLite persistence, caps session id length, rate limits, and returns consistent JSON errors. Receipts are write-once with atomic first-write ownership and a 10 MB upload limit. The changelog counts more than 15 findings across four rounds of Codex adversarial review, all addressed.
+
+## What it does not do
+
+The declaration flags unauthorized tool calls in the receipt. It does not stop them. `TREESHIP_COST_USD` and the `cost_usd` field were removed: cost is a consumer concern for dashboards and billing tools, and receipts store verifiable token usage only. `preview.html` reports "Merkle structure verified", not "Verified", because it checks structure and nothing about the truth of each event. Framework detection covers the five frameworks named above; anything else gets `TREESHIP.md` and manual wiring.
+
+## Where to go next
+
+- [Quickstart](/docs/guides/quickstart) and [First run](/docs/guides/first-run): the guided path this release created.
+- [`treeship add`](/docs/cli/add): CLI reference for framework detection.
+- [Agent identity](/docs/concepts/agent-identity): what an Agent Identity Certificate asserts.
+- [`treeship session`](/docs/cli/session): `status --watch`, `event`, and `close`.
+- [Treeship 0.7: session receipts you can verify offline](/blog/treeship-0-7-session-receipts): the package this onboarding leads to.
+
+*This entry was written on 11 September 2026 from the 0.8.0 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-9-10-approval-authority.mdx
+++ b/docs/content/blog/treeship-0-9-10-approval-authority.mdx
@@ -39,11 +39,13 @@ Other additions across the two versions:
 ## How it works
 
 ```bash
-treeship journal list
-treeship journal inspect
+treeship approval uses <grant-id>
+treeship approval journal
 treeship package inspect <pkg>
 treeship verify <path> --strict
 ```
+
+At 0.9.9 the journal commands were `treeship journal list` and `treeship journal inspect`; they have since moved under `treeship approval`, which is what the block above shows.
 
 At attest time the CLI calls `journal::reserve_use`, which in 0.9.10 runs `check_replay` and derives `use_number` inside `with_lock`, stamping the number from the count observed at lock-acquire time.
 

--- a/docs/content/blog/treeship-0-9-10-approval-authority.mdx
+++ b/docs/content/blog/treeship-0-9-10-approval-authority.mdx
@@ -1,0 +1,72 @@
+---
+title: "Treeship 0.9.10: approval authority"
+description: "Grants define authority, uses prove consumption, an append-only journal enforces replay, and packages carry the evidence. The 0.9.10 patch closes the bypasses an adversarial review found."
+date: 2026-04-30
+written: 2026-09-11
+category: release
+release: "0.9.10"
+systems: [hub, codex, cli]
+tags: [approvals, verifier, receipts, hub, docs, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.9.10: approval authority
+
+## What shipped
+
+Treeship 0.9.9 makes temporary authority a trust object of its own. A human approves an agent for a bounded action. The agent consumes that approval at attest time. An offline verifier replays the chain on any machine. Where a signed Hub checkpoint is embedded, the same verify run can attest to non-replay across machines. The framing every part shares: grants define authority, uses prove consumption, the journal enforces replay, packages carry evidence, checkpoints make evidence portable, Hub signatures extend evidence across machines.
+
+The headline mechanism is consume-before-action. When an action carries an approval grant, the attest path appends a `treeship/approval-use/v1` record to the local Approval Use Journal before the action runs. A crash mid-action can leave a recorded use without an artifact. It cannot leave an artifact without a recorded use.
+
+0.9.10 is a patch release. A targeted Codex adversarial review of 0.9.9 found four trust-bypass paths in the new approval-evidence surface, and 0.9.10 closes them. Verifiers on 0.9.9 should upgrade.
+
+Other additions across the two versions:
+
+- Schemas `treeship/approval-use/v1`, `treeship/approval-revocation/v1`, and `treeship/journal-checkpoint/v1`, each with a `previous_record_digest` chain link and a `record_digest`.
+- The journal at `<config>/journals/approval-use/`, where records are truth and the `by_grant` and `by_nonce` indexes are cache rebuilt on startup.
+- `treeship journal list` and `treeship journal inspect`, both read-only.
+- `approvals/uses/` and `approvals/checkpoints/` exported into the `.treeship` package.
+- An Approval Authority panel and Decision Cards v0 in `treeship package inspect`.
+- In 0.9.10, three new verify rows: `approval-use-action-binding`, `approval-use-nonce-binding`, and `approval-use-chain-continuity`; the old `approval-use-integrity` row is renamed `approval-use-record-digest`.
+- `docs/release-adversarial/README.md` makes the review cadence policy: trust-semantics releases get a targeted adversarial pass, bump-only releases do not.
+
+## Why it matters
+
+0.9.6 scoped approvals and checked scope statelessly, but a spent grant looked the same as a fresh one. The verifier could only catch a replay inside one package. With a journal, a second use of a `max_uses=1` grant is refused at attest time on the same workspace, and the use record travels with the package so a recipient can check it without the originating machine.
+
+0.9.10 matters because 0.9.9 overclaimed. Its `reserve_in_journal` ran the replay check outside the lock, so two parallel `treeship attest` calls against a `max_uses=1` grant could both pass and both write. The package never shipped action envelopes, so the verifier resolved uses by `(grant_id, nonce_digest)` alone and never checked that the action pointed at the use. Each use's `nonce_digest` was read verbatim and never compared to `nonce_digest(grant.nonce)`. And the `previous_record_digest` chain was never walked, so a consistently rewritten chain passed every per-record check.
+
+## How it works
+
+```bash
+treeship journal list
+treeship journal inspect
+treeship package inspect <pkg>
+treeship verify <path> --strict
+```
+
+At attest time the CLI calls `journal::reserve_use`, which in 0.9.10 runs `check_replay` and derives `use_number` inside `with_lock`, stamping the number from the count observed at lock-acquire time.
+
+At session close, every consuming action envelope is written to `pkg_dir/artifacts/<artifact_id>.json` and the uses and checkpoints are exported under `approvals/`. Verify then emits four replay rows. `replay-package-local` fails on duplicate uses inside the package. `replay-local-journal` passes when `use_number` stays within `max_uses` in the workspace journal, fails when it exceeds, and warns when no journal is present. `replay-included-checkpoint` recomputes each embedded checkpoint's `record_digest`. `replay-hub-org` passes only under a four-gate rule: at least one checkpoint declares `kind: hub-org`, every required Hub field is populated, the Ed25519 signature verifies against the embedded public key, and every embedded `use_id` appears in `covered_use_ids`. Anything short is a warning by default and a failure under `--strict`.
+
+The 0.9.10 rows sit beside those. `approval-use-action-binding` passes only when every consuming action's `meta.approval_use_id` resolves to a use in the bundle and the action's `approval_nonce` hashes to that use's `nonce_digest`. Before any field is trusted, the envelope's content address must equal the filename stem, so a forged unsigned action dropped into `artifacts/` is rejected. `approval-use-nonce-binding` recomputes `nonce_digest(grant.nonce)` from the signed grant and compares. `approval-use-chain-continuity` requires one genesis record, no forks, no cycles, and every record reachable from genesis.
+
+The honesty rule holds throughout: a row passes only when the matching evidence is present and verified, fails only when present and failed, and is absent when the package carries no such evidence. A 0.9.9 package under 0.9.10 reads `not asserted by package` on the action-binding row. Under `--strict` that fails, which is the intended upgrade signal.
+
+## What it does not do
+
+- The Hub server that signs checkpoints is out of scope. Until a Hub signs, `replay-hub-org` reads `not checked (no Hub checkpoint in package)` everywhere.
+- Trusted-key pinning is deferred. The signature verifies against the public key embedded in the checkpoint, so an attacker who controls a checkpoint can declare any key.
+- No runtime enforcement. Treeship records consumption; refusing to run a spent or out-of-scope action is the deferred AgentGate layer.
+- The revocation schema is wired, but the runtime revocation flow is deferred. Mobile and desktop approval apps are deferred.
+- Known follow-ups: duplicate `grant_id` entries silently last-wins in the nonce-binding map, and 3-cycle and self-loop chain shapes lack pinned tests.
+
+## Where to go next
+
+- [Approval authority](/docs/concepts/approval-authority)
+- [Approval use journal](/docs/concepts/approval-use-journal)
+- [Replay levels](/docs/guides/replay-levels)
+- [CLI: verify](/docs/cli/verify)
+- [Treeship 0.9.6: the trust fabric](/blog/treeship-0-9-6-the-trust-fabric)
+
+*This entry was written on 11 September 2026 from the 0.9.9 and 0.9.10 changelogs and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-9-10-approval-authority.mdx
+++ b/docs/content/blog/treeship-0-9-10-approval-authority.mdx
@@ -42,7 +42,7 @@ Other additions across the two versions:
 treeship approval uses <grant-id>
 treeship approval journal
 treeship package inspect <pkg>
-treeship verify <path> --strict
+treeship package verify <pkg> --strict
 ```
 
 At 0.9.9 the journal commands were `treeship journal list` and `treeship journal inspect`; they have since moved under `treeship approval`, which is what the block above shows.

--- a/docs/content/blog/treeship-0-9-6-the-trust-fabric.mdx
+++ b/docs/content/blog/treeship-0-9-6-the-trust-fabric.mdx
@@ -1,0 +1,72 @@
+---
+title: "Treeship 0.9.6: the trust fabric"
+description: "Three-layer file capture, tool usage checked against the agent certificate, and scoped approvals. A receipt can now say whether the agent stayed inside its bounds."
+date: 2026-04-27
+written: 2026-09-11
+category: release
+release: "0.9.6"
+systems: [mcp, codex, claude-code-plugin]
+tags: [approvals, receipts, sessions, verifier, redaction, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.9.6: the trust fabric
+
+## What shipped
+
+Treeship 0.9.6 lets a receipt answer a second question. 0.9.5 could prove a receipt was signed and unchanged. It could not say whether the agent stayed inside its bounds. A session could attest that the agent called Read 14 times while nobody checked whether Read was on its authorized tool list. And `files_written` could quietly omit anything that escaped the captured tool channel: a `sed -i` inside a Bash command, a build output, a manual edit.
+
+0.9.6 closes both holes with a capture, normalize, verify chain. Every file the agent touches is captured by at least one of three layers: the hook, the MCP bridge, or git reconciliation at session close. Every tool call is normalized through canonical aliases so the verifier can compare claimed authorization against actual usage. When capture itself was incomplete, the receipt now says so instead of truncating silently.
+
+The release also tightens approvals. A 0.9.5 approval carried only a nonce, so an approval for `deploy.production` could authorize `deploy.staging` and verify still printed `single-use enforced`. 0.9.6 adds an `ApprovalScope` that signs who, what, where, and how many times into the grant.
+
+Other additions:
+
+- `treeship attest approval` gains `--allowed-actor`, `--allowed-action`, `--allowed-subject`, `--max-uses`, and `--unscoped`; each `--allowed-*` flag is repeatable.
+- `treeship attest action --subject <URI>` aliases `--content-uri` so an action binds to the same subject the approval names.
+- MCP-routed `agent.called_tool` events promote into typed file and process events stamped `meta.source = "mcp"`.
+- The receipt's `tool_usage` block carries `declared` and `actual`, and the verifier diffs them through `TOOL_ALIASES`.
+- `proofs.event_log_skipped` records how many malformed event-log lines were skipped, instead of composing an empty session.
+- The Claude Code plugin emits an `agent.decision` event at session start carrying `meta.model`.
+- `treeship add codex` installs an MCP block in `~/.codex/config.toml`.
+- The MCP bridge sanitizer no longer passes `command` or `cmd` into receipts, so inline Bearer tokens and cloud credentials stay out of `meta.tool_input`.
+
+## Why it matters
+
+Before this release, the verifier confirmed a nonce matched and stopped there. The binding was real, but the same nonce could be replayed across unlimited actions and across different actions entirely. Meanwhile an agent that changed files through a shell command left no trace in `files_written`. An audit reader could confirm the signature and still not know what the agent did, or whether it was allowed to do it.
+
+Now the grant states its bounds, verify checks them statelessly, and the receipt commits every file change it can find before the Merkle root is sealed. A reader can answer "did this agent stay inside its bounds" with the same confidence they already had for "was this signature valid."
+
+## How it works
+
+```bash
+treeship attest approval --allowed-subject env://prod --allowed-action deploy.production --max-uses 1
+treeship attest action --subject env://prod
+treeship verify <path>
+```
+
+The first command mints a scoped grant. Without any `--allowed-*` flag or `--max-uses`, and without `--unscoped`, the CLI refuses to mint. Bearer approvals are opt-in now. The second command attests an action against the same subject. Verify then prints three separate rows instead of one: `approval binding` says the nonce matched a signed approval, and that is a cryptographic claim only. `approval scope` says actor, action, and subject matched the scope, or warns that the approval is unscoped and proves binding only. `replay check` always warns that the check is package-local and no global ledger was consulted.
+
+Scope checks run first-violation-wins: actor, then action, then subject, then the scope's own `valid_until`. A wrong-actor failure is never masked by a wrong-action one. If two actions in the same bundle claim the same nonce, the second is rejected as a package-local replay.
+
+On the capture side, the Claude Code hook calls `treeship session event` for every tool use and stamps `meta.source = "session-event-cli"`. The MCP bridge's generic `agent.called_tool` events are inspected at receipt composition, and a known tool name plus path becomes an `AgentReadFile`, `AgentWroteFile`, or `AgentExecutedCommand` event. At session close, git reconciliation runs `git diff HEAD --name-status`, `git diff <since>..HEAD --name-status`, and `git ls-files --others --exclude-standard`, dedupes against writes already captured, and appends synthetic `AgentWroteFile` events to `events.jsonl` before the root is sealed. Rename and copy entries record the destination path. Treeship's own bookkeeping under `.treeship/sessions/*` and similar paths is filtered out; user-authored files like `config.yaml` and `policy.yaml` are kept.
+
+Cross-verification builds `actual` only from events whose `meta.source` is `hook`, `mcp`, `shell-wrap`, `session-event-cli`, or absent. Events from `git-reconcile` and `daemon-atime` are Treeship's backstops, not the agent calling tools, so they never inflate `actual` against the certificate. Aliases map `read_file`, `write_file`, `bash`, and `web_fetch` to `Read`, `Write`, `Bash`, and `WebFetch`, so a Claude session is not flagged for every authorized call.
+
+## What it does not do
+
+- `--max-uses` is signed into the grant for future ledger enforcement. Verify reports replay posture honestly and does not claim global single-use.
+- The replay check is package-local. Two packages can each consume the same nonce and neither verifier will know.
+- Git reconciliation is fail-open. If the directory is not a git repo, git is missing, or a git command errors, the receipt is still produced without backstop events.
+- Nothing here enforces scope at runtime. Treeship records and verifies; it does not refuse to run an action.
+- No keystore format change and no SDK API breakage. `tool_usage` was already on 0.9.5 receipts; this release makes `actual` useful.
+
+## Where to go next
+
+- [Trust fabric](/docs/concepts/trust-fabric)
+- [Cross-verification](/docs/concepts/cross-verification)
+- [Approvals guide](/docs/guides/approvals)
+- [CLI: attest](/docs/cli/attest)
+- [Approval nonces and why a single field prevents an entire attack class](/blog/approval-nonces-and-why-a-single-field-prevents-an-entire-attack-class)
+
+*This entry was written on 11 September 2026 from the 0.9.6 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-9-6-the-trust-fabric.mdx
+++ b/docs/content/blog/treeship-0-9-6-the-trust-fabric.mdx
@@ -33,7 +33,7 @@ Other additions:
 
 ## Why it matters
 
-Before this release, the verifier confirmed a nonce matched and stopped there. The binding was real, but the same nonce could be replayed across unlimited actions and across different actions entirely. Meanwhile an agent that changed files through a shell command left no trace in `files_written`. An audit reader could confirm the signature and still not know what the agent did, or whether it was allowed to do it.
+Before this release, the verifier confirmed a nonce matched and stopped there. The same nonce could be replayed across unlimited actions, and across different actions entirely. Meanwhile an agent that changed files through a shell command left no trace in `files_written`. An audit reader could confirm the signature and still not know what the agent did, or whether it was allowed to do it.
 
 Now the grant states its bounds, verify checks them statelessly, and the receipt commits every file change it can find before the Merkle root is sealed. A reader can answer "did this agent stay inside its bounds" with the same confidence they already had for "was this signature valid."
 
@@ -47,9 +47,9 @@ treeship verify <path>
 
 The first command mints a scoped grant. Without any `--allowed-*` flag or `--max-uses`, and without `--unscoped`, the CLI refuses to mint. Bearer approvals are opt-in now. The second command attests an action against the same subject. Verify then prints three separate rows instead of one: `approval binding` says the nonce matched a signed approval, and that is a cryptographic claim only. `approval scope` says actor, action, and subject matched the scope, or warns that the approval is unscoped and proves binding only. `replay check` always warns that the check is package-local and no global ledger was consulted.
 
-Scope checks run first-violation-wins: actor, then action, then subject, then the scope's own `valid_until`. A wrong-actor failure is never masked by a wrong-action one. If two actions in the same bundle claim the same nonce, the second is rejected as a package-local replay.
+If two actions in the same bundle claim the same nonce, the second is rejected as a package-local replay.
 
-On the capture side, the Claude Code hook calls `treeship session event` for every tool use and stamps `meta.source = "session-event-cli"`. The MCP bridge's generic `agent.called_tool` events are inspected at receipt composition, and a known tool name plus path becomes an `AgentReadFile`, `AgentWroteFile`, or `AgentExecutedCommand` event. At session close, git reconciliation runs `git diff HEAD --name-status`, `git diff <since>..HEAD --name-status`, and `git ls-files --others --exclude-standard`, dedupes against writes already captured, and appends synthetic `AgentWroteFile` events to `events.jsonl` before the root is sealed. Rename and copy entries record the destination path. Treeship's own bookkeeping under `.treeship/sessions/*` and similar paths is filtered out; user-authored files like `config.yaml` and `policy.yaml` are kept.
+On the capture side, the Claude Code hook calls `treeship session event` for every tool use and stamps `meta.source = "session-event-cli"`. The MCP bridge's generic `agent.called_tool` events are inspected at receipt composition, and a known tool name plus path becomes an `AgentReadFile`, `AgentWroteFile`, or `AgentExecutedCommand` event. At session close, git reconciliation runs `git diff HEAD --name-status`, `git diff <since>..HEAD --name-status`, and `git ls-files --others --exclude-standard`, dedupes against writes already captured, and appends synthetic `AgentWroteFile` events to `events.jsonl` before the root is sealed.
 
 Cross-verification builds `actual` only from events whose `meta.source` is `hook`, `mcp`, `shell-wrap`, `session-event-cli`, or absent. Events from `git-reconcile` and `daemon-atime` are Treeship's backstops, not the agent calling tools, so they never inflate `actual` against the certificate. Aliases map `read_file`, `write_file`, `bash`, and `web_fetch` to `Read`, `Write`, `Bash`, and `WebFetch`, so a Claude session is not flagged for every authorized call.
 
@@ -59,7 +59,7 @@ Cross-verification builds `actual` only from events whose `meta.source` is `hook
 - The replay check is package-local. Two packages can each consume the same nonce and neither verifier will know.
 - Git reconciliation is fail-open. If the directory is not a git repo, git is missing, or a git command errors, the receipt is still produced without backstop events.
 - Nothing here enforces scope at runtime. Treeship records and verifies; it does not refuse to run an action.
-- No keystore format change and no SDK API breakage. `tool_usage` was already on 0.9.5 receipts; this release makes `actual` useful.
+- No keystore format change and no SDK API breakage.
 
 ## Where to go next
 

--- a/docs/content/blog/treeship-0-9-the-claude-code-plugin.mdx
+++ b/docs/content/blog/treeship-0-9-the-claude-code-plugin.mdx
@@ -1,0 +1,64 @@
+---
+title: "Treeship 0.9: the official Claude Code plugin"
+description: "Two commands install a plugin whose hooks record every Claude Code session into a sealed receipt. TREESHIP.md tells the agent exactly what is captured."
+date: 2026-04-21
+written: 2026-09-11
+category: integration
+release: "0.9.4"
+systems: [claude-code, claude-code-plugin, mcp]
+tags: [sessions, docs, redaction, keystore, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.9: the official Claude Code plugin
+
+## What shipped
+
+Treeship 0.9.3 and 0.9.4 gave Claude Code a plugin that records sessions without being asked. The plugin lives at `integrations/claude-code-plugin/`, mounts `@treeship/mcp` through `npx -y`, and wires three hooks: SessionStart, SessionEnd, and PostToolUse. The hooks are deterministic; no model prompt decides whether a session gets recorded. 0.9.4 added a marketplace so anyone can install it with two commands.
+
+0.9.3 also answered the trust question an agent asks before it will attach an MCP server. `treeship add` now drops a `TREESHIP.md` into the project root that says what is captured, what is not, and when data leaves the machine.
+
+- Three skills ship with the plugin: `treeship-session`, `treeship-verify`, and `treeship-report`, for the moments that need agent judgment.
+- `treeship session status --check` prints nothing and exits `0` if a session is active, `1` if not, so hook scripts can gate on it.
+- `treeship session event` is race-safe across processes through an advisory sidecar `.lock` file created mode `0o600`.
+- `.claude-plugin/marketplace.json` at the repo root turns the monorepo into a Zerker Labs plugin marketplace.
+- The keystore migration error now includes a diagnosis and a copy-pasteable recovery path.
+- The SessionStart hook reports failures back to Claude Code as `additionalContext` instead of exiting silently.
+
+## Why it matters
+
+Claude Code's built-in tools, Read, Write, Edit, Bash, Grep, and Glob, bypass MCP. Without a PostToolUse hook they never reach the receipt timeline. The plugin closes that gap so the record covers what the agent actually ran, not only the calls that went through the bridge.
+
+Two failures drove the point releases. Before 0.9.3, Claude Code would refuse to attach `@treeship/mcp` because nothing in context explained what it captured. And concurrent hook invocations each derived `sequence_no` from a stale snapshot of the event log, assigning duplicate sequence numbers and silently breaking Merkle chain ordering. 0.9.4 then fixed the SessionStart hook, which had redirected stderr to `/dev/null` and exited `0` on any error. A broken keystore meant no recording and no signal, which the changelog calls the worst possible failure mode.
+
+## How it works
+
+```bash
+claude plugin marketplace add zerkerlabs/treeship
+claude plugin install treeship@treeship
+treeship add
+treeship session status --check
+treeship package verify .treeship/sessions/<id>.treeship
+```
+
+The plugin installs to `~/.claude/plugins/cache/treeship/treeship/<version>/`. Each Claude Code session then fires the hooks: SessionStart opens a Treeship session, PostToolUse appends a `session event` per tool call, and SessionEnd closes it. Sealed receipts land in `.treeship/sessions/<id>.treeship`, and `treeship package verify` passes its integrity checks. The changelog records an end-to-end run on a fresh scratch project.
+
+`session event` takes an exclusive advisory lock, `flock(2)` on Unix and `LockFileEx` on Windows, in a 500 ms bounded retry loop before re-deriving `sequence_no` from the on-disk JSONL line count. After 500 ms of contention the append falls through with a stderr warning rather than freezing the agent. A regression test spawns 16 racing writers and asserts unique sequence numbers. 0.9.4 tightened the lock file's permissions through `fchmod` on the open descriptor, closing a TOCTOU between a metadata read and a path-based chmod.
+
+`TREESHIP.md` is embedded in the CLI binary at compile time, so the drop works offline and never fetches over the network. It is organized by attestation type and enumerates every field the bridge writes, each cross-referenced against `bridges/mcp/src/client.ts` and `attest.ts`. The bridge records the tool name, a SHA-256 digest of the arguments, a SHA-256 digest of the output, the exit code, and duration. It does not capture file contents, env values, or secrets. Data leaves the machine only on `treeship session report`, `hub push`, or `auto_push: true`. `treeship add` no longer edits CLAUDE.md or `.cursorrules` for trust purposes; one file carries the trust block for every agent.
+
+`post-tool-use.sh` parses the hook payload with `jq`, then `python3`, then `node`. The earlier regex pulled the wrong `tool_name` when `tool_input` itself contained that string.
+
+## What it does not do
+
+Hooks fail open. A missing CLI or a missing `.treeship/` directory makes the plugin a silent no-op, by design. `payload.error_message` carries the raw `Error.message` on thrown errors, so treat it like a logged stack trace if your tools can leak in error text. The `session event` append is O(N) in the on-disk event count; the changelog deferred a counter sidecar from 0.9.3 to 0.9.4 and then to 0.9.5. Platform support is macOS and Linux only, and `npm install -g treeship` now fails loudly on Windows; a native binary was planned for 0.10.0. Submission to Anthropic's official marketplace remains a separate track.
+
+## Where to go next
+
+- [Claude Code integration](/docs/integrations/claude-code): plugin install and hook behavior.
+- [MCP bridge](/docs/integrations/mcp): what `@treeship/mcp` records per tool call.
+- [`treeship add`](/docs/cli/add) and [`treeship session`](/docs/cli/session): CLI reference for `add`, `status --check`, and `event`.
+- [Secrets and redaction](/docs/concepts/secrets-and-redaction): what stays on the machine.
+- [MCP bridge agent attestation](/blog/mcp-bridge-agent-attestation): the bridge the plugin mounts.
+
+*This entry was written on 11 September 2026 from the 0.9.3 and 0.9.4 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/treeship-0-9-verify-anywhere.mdx
+++ b/docs/content/blog/treeship-0-9-verify-anywhere.mdx
@@ -1,0 +1,69 @@
+---
+title: "Treeship 0.9: verify a receipt anywhere it lands"
+description: "treeship verify takes a URL, a package, or an id and cross-checks against an Agent Certificate. The same checks ship as WASM for Node, Deno, edge runtimes, and browsers."
+date: 2026-04-20
+written: 2026-09-11
+category: release
+release: "0.9.2"
+systems: [cli, wasm-verifier, typescript-sdk, a2a, mcp]
+tags: [verifier, receipts, identity, release-engineering, release]
+readTime: "5 min read"
+---
+
+# Treeship 0.9: verify a receipt anywhere it lands
+
+## What shipped
+
+Treeship 0.9.0 through 0.9.2 made verification portable. `treeship verify` now accepts three target shapes: an HTTPS URL fetched as receipt JSON, a path to a local `.treeship` or `.agent` package, or a local artifact id. A new `--certificate` flag cross-verifies a receipt against an Agent Certificate. The Rust core then compiled to WebAssembly and published as `@treeship/core-wasm`, with a zero-dependency `@treeship/verify` package on top.
+
+0.9.0 shipped the CLI surface and schema fields on 18 April. 0.9.1 the same day was a partial publish, and 0.9.2 on 20 April realigned every package. More on that below.
+
+- Exit codes on `verify`: `0` success, `1` verification failed, `2` cross-verification failed, `3` network or filesystem error.
+- `schema_version` on Session Receipts and Agent Certificates. New documents emit `"1"`; a missing field is read as `"0"` and verified under existing rules.
+- `session.ship_id`, parsed from the manifest's `actor` URI when it starts with `ship://`.
+- `treeship_core::artifacts` with five DSSE-signed command schemas: `KillCommand`, `ApprovalDecision`, `MandateUpdate`, `BudgetUpdate`, `TerminateSession`.
+- `@treeship/core-wasm` at 167 KB gzipped, exporting `verify_receipt`, `verify_certificate`, and `cross_verify` alongside the envelope and Merkle primitives.
+- `@treeship/sdk` gains in-process `verifyReceipt`, `verifyCertificate`, and `crossVerify`; `@treeship/a2a` `verifyReceipt` now performs cryptographic verification.
+- Runtime support for Node.js 18+, Deno, browser bundlers, Vercel Edge, Cloudflare Workers, and AWS Lambda, with harnesses under `tests/runtime-acceptance/`.
+- A legacy fixture suite at `packages/core/tests/legacy_receipt_fixtures.rs` keeps 0.7.2 and 0.8.0 receipts verifying.
+
+## Why it matters
+
+Before 0.9, verifying a receipt meant having the CLI installed and the artifact in local storage. A dashboard, an edge function, or an agent deciding whether to accept a handoff had to shell out to a subprocess or settle for a structural summary. `@treeship/a2a` `verifyReceipt` was network-only before this release.
+
+Cross-verification answers a question nobody could ask before: did this session stay inside what the agent was allowed to do? A receipt lists the tools called. A certificate lists the tools authorized. `--certificate` checks the two against each other.
+
+## How it works
+
+```bash
+treeship verify https://<hub>/v1/receipt/<session_id>
+treeship verify .treeship/sessions/<id>.treeship
+treeship verify <artifact-id>
+treeship verify <receipt> --certificate <path-or-url>
+```
+
+The URL and path forms go through a new external path and produce the full checkmark-style output. A bare artifact id, including `last`, falls through to the original local-storage verify unchanged. Both runtimes share one implementation: `treeship_core::verify::verify_receipt_json_checks` recomputes the Merkle root, verifies inclusion proofs, checks the leaf count, timeline ordering, and chain linkage. The CLI and the WASM build produce the same result on the same input.
+
+Cross-verification is `cross_verify_receipt_and_certificate(receipt, certificate, now_rfc3339)`, returning a `CrossVerifyResult`. It rolls up three checks: the ship ids match, the certificate is valid at the supplied time, and every tool the session called is authorized. The result lists authorized, unauthorized, and never-called tools. The explicit `now` argument keeps it deterministic for tests and edge callers. `treeship_core::agent::verify_certificate` checks the certificate's Ed25519 signature against its embedded public key.
+
+In JavaScript, `@treeship/verify` depends only on `@treeship/core-wasm` and needs WebAssembly plus `fetch`. The WASM exports take JSON in and return JSON out, with an error shape on malformed input instead of a panic. Dependents pin `@treeship/core-wasm` to the exact release version, no caret, so the schema-rules parity cannot drift.
+
+## The 0.9.1 publish
+
+0.9.1 reached crates.io and PyPI cleanly, and the `treeship` wrapper and platform binaries reached npm. `@treeship/core-wasm` and `@treeship/verify` did not: new package names on the `@treeship` scope needed a one-time bootstrap publish, and the workflow's `continue-on-error` let the failure pass silently. The failure cascaded to `@treeship/sdk`, `@treeship/mcp`, and `@treeship/a2a`. The changelog is blunt: do not install 0.9.1 npm packages, and do not roll back to it.
+
+0.9.2 is byte-for-byte the same work with a different version string. The workflow now fails on any publish error, pre-flights every expected package on the scope, and polls each registry for the published version within 30 seconds.
+
+## What it does not do
+
+The command artifact schemas ship as primitives only; CLI surfaces that issue `KillCommand` or `TerminateSession` were deferred to 0.10.0, along with approval-loop hub endpoints, `--require-approval` on `wrap`, and the treeship.dev/verify drag-and-drop page. `schema_version` `"1"` and `"0"` select the same ruleset in 0.9; the field is informational until a future version moves it inside the signed payload. There is no subprocess fallback for the WASM path; a runtime without WebAssembly must use the legacy `verify(id)` form. Stateful operations, attest, session, dock, and agent register, still run through the subprocess. Edge deploys and cold-start measurements were code-complete but run out-of-band, and the planned adversarial review of the WASM surface was scheduled for before 0.10.0.
+
+## Where to go next
+
+- [`treeship verify`](/docs/cli/verify): every target shape and the exit codes.
+- [Cross-verification](/docs/concepts/cross-verification): receipt against certificate.
+- [`@treeship/verify`](/docs/sdk/verify) and [Edge runtime](/docs/guides/edge-runtime): running the checks outside the CLI.
+- [Schema](/docs/reference/schema): `schema_version` semantics and CLI-to-WASM parity.
+- [From subprocess to WASM](/blog/from-subprocess-to-wasm-eliminating-the-subprocess-attack-surface): why the migration mattered for security.
+
+*This entry was written on 11 September 2026 from the 0.9.0, 0.9.1 and 0.9.2 changelog and the code as released, and is filed under the release date.*

--- a/docs/content/blog/verifiable-intent-treeship-agent-attestation.mdx
+++ b/docs/content/blog/verifiable-intent-treeship-agent-attestation.mdx
@@ -8,6 +8,8 @@ category: integration
 systems: ["verifiable-intent"]
 ---
 
+> **Update (2026-09-08, 0.31):** `treeship vi` shipped, an implementation of the Verifiable Intent v0.1 draft with interop against the reference SDK. The current account is [Treeship 0.31: Verifiable Intent, implemented](/blog/treeship-0-31-verifiable-intent); this post is the design-era one and stays for the record.
+>
 > **Update (2026-07):** The signed attestation, mandate binding, and scope cross-check described here ship today. Any reference to zero-knowledge proofs of policy or spend-limit compliance is the experimental ZK layer, which is excluded from release binaries and being rebuilt statement-first (the selective-disclosure presentation surface is designed, not yet shipped). See the [ZK verification spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md).
 >
 > **Further update (2026-08-18, v0.24):** one half of that has since shipped.

--- a/docs/content/blog/verifiable-intent-treeship-agent-attestation.mdx
+++ b/docs/content/blog/verifiable-intent-treeship-agent-attestation.mdx
@@ -4,6 +4,8 @@ description: "Agent attestation in Verifiable Intent credentials: how Treeship p
 date: 2026-04-04
 tags: ["verifiable-intent", "commerce", "mastercard", "zk"]
 readTime: "6 min read"
+category: integration
+systems: ["verifiable-intent"]
 ---
 
 > **Update (2026-07):** The signed attestation, mandate binding, and scope cross-check described here ship today. Any reference to zero-knowledge proofs of policy or spend-limit compliance is the experimental ZK layer, which is excluded from release binaries and being rebuilt statement-first (the selective-disclosure presentation surface is designed, not yet shipped). See the [ZK verification spec](https://github.com/zerkerlabs/treeship/blob/main/docs/specs/private-verification.md).

--- a/docs/content/blog/verify-any-agent-in-five-minutes.mdx
+++ b/docs/content/blog/verify-any-agent-in-five-minutes.mdx
@@ -4,6 +4,8 @@ description: "A complete worked example, from installing the CLI to a stranger v
 date: 2026-07-07
 tags: ["tutorial", "getting-started", "verification", "handshake"]
 readTime: "8 min read"
+category: guide
+systems: ["cli"]
 ---
 
 Most tools ship with a "hello world." Treeship's is a handshake: by the end of this post, a person who has never met you will verify, on their own machine, that an agent you control is who it claims to be and did what it says it did. No shared server they have to trust, no account, one key.

--- a/docs/content/blog/warrants-not-approvals.mdx
+++ b/docs/content/blog/warrants-not-approvals.mdx
@@ -4,6 +4,8 @@ description: "Most authorization systems for AI agents share a subtle flaw: appr
 date: 2026-03-27
 tags: ["security", "authorization", "cryptography", "agents"]
 readTime: "8 min read"
+category: security
+systems: []
 ---
 
 > **Implementation status (updated 2026-08-18, v0.24).** All four properties

--- a/docs/content/blog/what-farcaster-can-be.mdx
+++ b/docs/content/blog/what-farcaster-can-be.mdx
@@ -4,6 +4,8 @@ description: "We've gotten very good at building agents and very bad at building
 date: 2026-07-01
 tags: ["agents", "infrastructure"]
 readTime: "6 min read"
+category: perspective
+systems: ["zerker-gateway"]
 ---
 
 A few months ago I was staring at a docker-compose file with six services in it, each one calling out to some agent or tool, each one with its own idea of how credentials should be passed in, and none of them logging anything useful when a call failed. I knew which agent had run, but I had no idea what it had actually done, how long it took, or whether the token I'd handed it was still good. That's the normal state of things right now. We've gotten very good at building agents and very bad at building the plumbing between them.

--- a/docs/content/blog/why-agent-actions-need-receipts.mdx
+++ b/docs/content/blog/why-agent-actions-need-receipts.mdx
@@ -4,6 +4,8 @@ description: "When a human takes an action, there's context: intent, memory, acc
 date: 2025-07-14
 tags: ["agents", "trust"]
 readTime: "8 min read"
+category: perspective
+systems: []
 ---
 
 When a human takes an action, there's context: intent, memory, accountability. When an agent takes an action, there's just a log line. That asymmetry is the problem Treeship solves.

--- a/docs/content/blog/why-we-chose-rust-for-the-trust-layer.mdx
+++ b/docs/content/blog/why-we-chose-rust-for-the-trust-layer.mdx
@@ -4,6 +4,8 @@ description: "The ZK proof ecosystem is Rust-first and Rust-only in any producti
 date: 2025-12-02
 tags: ["rust", "engineering"]
 readTime: "9 min read"
+category: engineering
+systems: []
 ---
 
 The ZK proof ecosystem is Rust-first and Rust-only in any production-ready form. But that's not the only reason. Here's the complete case for Rust as the foundation of cryptographic agent infrastructure.

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -12,6 +12,179 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+- **`signer_trust` trusts the ship's own keys.** On 0.31.2 the row warned on the producer's own machine that its own signing key was not a pinned trust root, and `session report` summarised every fresh session as `warn`; the release smoke caught it. `package verify` and `session report` now verify against the pinned roots plus this ship's keystore keys (as `session_host` roots). A stranger's machine still warns until they pin, which is the point.
+
+## 0.31.2 (2026-09-10)
+
+- **`package verify` checks signatures (audit 2026-09 AUD-31, P1; advisory [TS-2026-002](docs/security/TS-2026-002.md)).** Through 0.31.1 the command verified the Merkle tree and nothing under it: a receipt whose sealed set was rewritten to an invented `art_` id, with the tree recomputed, verified with exit 0. A `.treeship` package now carries the signed DSSE envelope of every sealed artifact under `artifacts/` and the signing public keys in `keys.json`, and `package verify` verifies each envelope's Ed25519 signature against those keys, re-derives the content-addressed id and digest from the signed bytes (`signature:<id>`), checks that every chained artifact names the previous one as parent inside the signature (`chain_linkage`), and reports whether the signing keys are pinned trust roots (`signer_trust`, a warning with the exact `treeship trust add` command; a failure under `--strict`). A fabricated id, an edited byte, a reordered chain, or a missing key fails with a nonzero exit. Packages built before 0.31.2 carry no envelopes and fail at a new `envelopes` row; `--structural` reads their structure and approvals with a verdict that says signatures were not checked. Core: `verify_package_with_options`, `verify_package_structural`, `PackageKeys`.
+- **`session close` seals unchained artifacts (AUD-32, P1; QA TS-002b).** An `attest action` signed without `--parent`, or onto a parent off the sealed path, was absent from the package while `package verify` reported it clean; three such actions in one session left one in the receipt. Every artifact signed in the workspace during the session is now sealed, after the chain, and marked `unchained: true` in the receipt so a verifier can tell a linked step from a loose one; the close output lists them (`sealed_unchained` in JSON, a warning and hint in text) and `package verify` reports them as `chain_completeness`. `attest action` prints a hint when a session is active and no `--parent` was given.
+- **The MCP bridge reports signing failures (AUD-33, P2).** A failed `attest`, `session event` or `session start` inside the bridge was caught and dropped, so a tool call with no receipt looked like one that was never recorded. The bridge now writes `[treeship] <what> failed: <reason>` to stderr on every failure and, under `TREESHIP_STRICT=1`, fails the tool call instead of proceeding unrecorded.
+- **Docs: the Verifiable Intent page says which draft.** "Shipped in 0.31" is qualified as shipped against the v0.1 draft, the wording the CLI uses (QA TS-007). The commerce quickstarts start from `git clone` of the reference (QA TS-008).
+
+## 0.31.1 (2026-09-08)
+
+- **treeship-commerce: the order receipt no longer forks the chain (QA TS-002, P0).** `order_placed` signed the host's order onto the hand-off receipt. The checkout result, which also follows the hand-off, became a branch off the path the session seals, so it was signed, verifiable on its own, and absent from the package, while `package verify` reported a clean package. The order now chains onto the recorder's head and names the hand-off in `meta.handoff`; `attest_at_handoff` does the same. A test asserts every receipt a recorder writes is on the sealed chain.
+- **`session close` names unsealed branches (QA TS-002).** Signed artifacts whose parent is on the sealed chain but which are not on it themselves are listed in the close output (`unsealed_branches` in JSON, a warning in text) instead of vanishing silently.
+- **The demos run on a clean machine (QA TS-001, TS-004).** `demo` and `demo_merchant` construct the SDK with `bot_mode=True`, so the CLI is resolved (PATH, cache, then the matching release) rather than assumed; a missing workspace or CLI prints a one-line remedy instead of a traceback; a session a previous run left open is closed with a summary that says so, so a second run works.
+- **The SDK warns when the CLI is on another release line (QA TS-003).** Once per client, on the first call: `treeship --version` against the SDK's own version, a `RuntimeWarning` naming both and the upgrade command.
+- **Quickstarts use the project-local init (QA TS-006).** `treeship init --config .treeship/config.json` in every commerce quickstart. Bare `treeship init` refuses when a global workspace already exists and the current directory is not it (that guard predates 0.31; it was the first command in the quickstarts that was wrong).
+- **`bootstrap.py` docstring matches `bootstrap_cli` (QA TS-005):** the entry point prints the binary path, or the JSON result with `--json`.
+
+## 0.31.0 (2026-09-08)
+
+- **`treeship vi`: Verifiable Intent credentials, shipped.** An independent implementation of the Verifiable Intent v0.1 draft (verifiableintent.dev, Mastercard-maintained, Google co-developed) in `treeship-core::vi`, with a CLI: `vi keygen` mints the agent's P-256 key (sealed by the ship keystore) and prints the JWK a wallet binds under `cnf`; `vi check` asks whether a purchase fits a Layer 2 mandate; `vi attest` signs the Layer 3 pair (L3a for the payment network, L3b for the merchant) as key-bound SD-JWTs with `sd_hash` over recipient-specific L2 presentations and `transaction_id == checkout_hash`, refusing anything outside the mandate before signing; `vi verify` runs the reference verifier's checks plus the Treeship attestation and, with `--local`, the chain it names. The spec's optional `agent_attestation` claim carries a `treeship.receipt-chain.v1` value: a ship-signed statement, stored as an artifact chained onto the head, naming the session, chain head, Merkle checkpoint, approval use, mandate digest and transaction. Interop is tested both ways against the reference SDK in CI (`tests/vi-interop`): the reference's `verify_chain` and `check_constraints` accept what treeship signs and ignore the claim as the spec requires; treeship verifies what the reference issues; one edited byte fails on both. `packages/vi` (April 2026 types against a pre-v0.1 draft, never wired) is retired; the code lives in `packages/core/src/vi/`. The eight registered constraint types are checked with the reference checker's semantics. Not in scope: multi-pair L2 mandates, network-side cumulative budget and occurrence counting.
+
+- **treeship-commerce: the approval verdict next to the tool outcome.** `TreeshipApprovalMixin` now sets `treeship_last_approval` (`proven`, `unproven`, or `None`) on the executor after every apply, so a host can print or log what the intent receipt says about the grant beside what the tool did. `demo_merchant` uses it: the replay row reads `error, approval unproven` in the default run (the journal refused a second use before anything was signed; the mock backend then refused the apply as already applied) instead of a bare `error` that let the backend take credit for the journal's refusal. Under `--enforce` the row is unchanged, `blocked:approval`.
+- **Docs: verify a session package**, a page for the person handed a `.treeship` package (`/commerce/verify-a-package`): what each check proves and does not, the counterparty signature flow (`keys export` → `trust add` → `bundle import` → `verify`), and the limits (`anchoring: UNWITNESSED`, `actor proof: asserted`, `--require-authority` on receipts with no mandate). Shopping demo recording added to the integration page and the announcement post.
+
+## 0.30.0 (2026-09-07)
+
+**Upgrade if you build on Anthropic's commerce-agents reference.** The
+customer gets a receipt for exactly the cart that went to checkout, with
+the host's order chained onto it; the `treeship-commerce` Claude Code
+plugin wires every seam with one command; and the sealed package's own
+receipt page now shows the approvals it embeds instead of "No approval
+gates recorded".
+
+### Fixed
+
+- **The sealed package's preview page now shows the approvals it embeds.**
+  `preview.html` read approvals only from the chained artifacts, so a
+  session whose approval was minted, spent once, and exported under
+  `approvals/` (where `package verify` checks it as
+  `replay-local-journal`) rendered "No approval gates recorded". The
+  preview now carries an `approvals-data` block built from the same bundle
+  the verifier reads, and the Approval gates section lists each grant
+  (approver, description, scope, time) with its uses (`use 1/1`, the action
+  and subject that spent it, the consuming artifact). A grant envelope
+  that does not parse is listed by id as unparsed rather than dropped; a
+  use whose grant is not embedded says so. No bundle renders a JSON `null`,
+  never an empty block that would throw in the page's parser.
+
+### Added
+
+- **`treeship-commerce`: a receipt for exactly the cart that went to
+  checkout.** `receipted_backend(backend)` wraps a storefront backend so the
+  reference's `checkout_handoff(session, cart)` also signs a hand-off receipt
+  on the session chain: the cart's digest, item count, subtotal and currency,
+  and a digest of each hosted URL with its seller. The URL is never written;
+  the cart's lines are never written, and a holder of the checkout card can
+  recompute the digest from the card's own payload. `order_placed(receipts,
+  order_ref=, amount=, currency=)` is the host's half: a signed order receipt
+  chained onto the hand-off with the order reference digested. An order
+  without a hand-off says `handoff_recorded: false` instead of inventing a
+  parent. The wrapped backend finds the session's recorder by the reference's
+  own session tag. Seven tests; the shopping demo ends with the hand-off and
+  a chained mock order.
+
+- **`treeship-commerce` Claude Code plugin.** `claude plugin install
+  treeship-commerce@treeship` from the Treeship marketplace, mirroring the
+  reference's own `commerce-builder`: `/add-treeship-receipts [shopping |
+  merchant | both]` reads the project, wraps the executor on its runtime,
+  signs the merchant approval surface or the shopping checkout hand-off,
+  adds the verify step to CI, and writes to the project's decision record;
+  the `treeship-commerce-receipts` skill says what each receipt carries and
+  never carries, the approval scope and replay rule, and per-runtime
+  differences. The plugin runs no code of its own.
+
+## 0.29.0 (2026-09-07)
+
+**Upgrade if you run the merchant side of Anthropic's commerce-agents
+reference.** The operator's approval becomes a signed, scoped, single-use
+grant that the apply's receipt spends exactly once, on all three runtimes,
+with the reference console's loop unchanged. The Python SDK gains
+`attest_action(subject=)`, which scoped approvals need; `treeship-commerce`
+now requires `treeship-sdk>=0.29.0`.
+
+### Added
+
+- **`treeship-commerce`: signed single-use operator approvals on the merchant
+  `apply_change`.** The reference gates `apply_change` on an in-process set the
+  host fills from its y/N; the set leaves no record and cannot refuse a second
+  apply inside the same window. `MerchantApprovals.grant(change_id)` mints a
+  signed Approval Grant scoped to one actor, one action, and
+  `change://<change_id>` with `max_uses=1`; `approved(receipted(
+  MerchantToolExecutor), approvals)` signs the apply's intent receipt with the
+  grant's nonce, so the CLI reserves a use in the Approval Use Journal before
+  it signs. A replay finds the grant spent; a grant for another change is
+  refused by scope, because the action's subject is taken from the call's own
+  arguments and never from the grant. The receipt says `approval: "proven"` or
+  `"unproven"` with the CLI's reason. Recording only by default; `enforce=True`
+  holds an unproven apply in the reference's own held-outcome shape, and the
+  hold is itself a signed refusal. On an SDK without `subject` it warns once
+  and mints nothing. `approving(toolset, approvals)` wraps the Agent SDK
+  `MerchantToolset`'s `host_approve` / `host_clear` in place, so the reference
+  console's y/N loop mints and forgets grants unchanged. Merchant demo
+  `demo_merchant.py` (`--enforce` for the gating mode); twelve tests,
+  including the replay and wrong-change refusals and the merchant side on all
+  three runtimes through `executor_class`.
+
+- **`treeship-commerce`: arguments that are not JSON-native no longer break
+  the tool.** The reference's MCP server hands the executor parsed pydantic
+  models; the argument digest called `json.dumps` on them outside the guarded
+  path and the stage call died inside the recorder. The digest is now total
+  (pydantic v1/v2, dataclasses, sets, bytes, datetimes, Decimal, Enum, paths,
+  and a typed repr for anything else) and equal to the digest of the same
+  arguments as plain dicts, and nothing raised while describing a call can
+  reach the tool.
+
+- **Python SDK: `attest_action(..., subject=)`.** Sets the action's
+  `subject.uri`, the field an approval's `allowed_subjects` scope is matched
+  against. Without it a subject-scoped grant refused every action from the
+  SDK; the CLI has taken `--subject` since the scope check existed.
+
+## 0.28.0 (2026-09-07)
+
+**Upgrade if you build on Anthropic's commerce-agents reference, or use the
+Python SDK.** `treeship-commerce` is a new package, published to PyPI with
+this release, that gives every tool call in the reference a signed receipt
+on all three of its runtimes. The Python SDK gains `session_event()`.
+
+### Added
+
+- **`treeship-commerce`: signed receipts for every tool call in
+  anthropics/commerce-agents.** One method, `BaseToolExecutor.execute`, runs
+  every tool call on the Messages API, the Agent SDK, and Managed Agents;
+  `TreeshipExecutorMixin` overrides it with a signed intent receipt before
+  dispatch (tool, SHA-256 of the canonical arguments, session tag) and a
+  signed result receipt after (`ok` / `blocked` with the gate's name /
+  `error`, result digest, event types, timing), chained from the Treeship
+  session root. A call the provenance gate holds is a signed refusal, not a
+  gap. Never written: the arguments, the fenced result text, or the commerce
+  session id (only the reference's own twelve-hex tag). `receipted(cls,
+  recorder=...)` wires all three runtimes through their `executor_class`;
+  `attach()` refuses an executor that would record nothing. Recording never
+  breaks the tool: a write that fails is counted in `dropped`, a result whose
+  intent is missing says `intent_recorded: false`, and a client without
+  `session_event` (treeship-sdk 0.27.0) skips timeline events with one
+  warning. Fourteen tests on a real ship over the reference's retail mock,
+  including one per runtime; CI runs them against the reviewed commit of the
+  reference. Guide: docs `/commerce/commerce-agents`. (#360, #361)
+
+- **Python SDK: `Treeship.session_event(...)`.** Appends to the active
+  session's timeline; parity with `ship.session.event()` in the TypeScript
+  SDK. Option-like values are refused, integers are checked as integers, and
+  a CLI document without an `event_id` is an error, not an empty result.
+  (#360)
+
+- **`treeship-commerce` publishes to PyPI by trusted publishing** (OIDC, no
+  new token), in lockstep with the SDK; the release installs it back from the
+  registry and imports it before it is considered published. (#362)
+
+### Changed
+
+- `check-feature-inventory.py` matches a `pyproject.toml` name the way it
+  matched `package.json`, so an inventory entry can name a Python package
+  whose directory is not its name. (#360)
+
+### Documentation
+
+- Commerce: the Claude Commerce Agents guide (wiring for each runtime, a real
+  decoded intent and blocked result, verification, the trust boundary), the
+  overview leading with what ships, and the post "You can't have agentic
+  commerce without tamper-proof receipts". Every id in them is from a run
+  with the released CLI. (#361)
+
 ## 0.27.0 (2026-09-02)
 
 **Upgrade if you use `@treeship/a2a` or `@treeship/mcp`.** Foreign work is
@@ -73,6 +246,23 @@ default this release exists to make.
 ## 0.26.0 (2026-09-01)
 
 ### Added
+- **Pure workflow-conformance reducer.** `treeship-core` now validates the
+  minimal `workflow.v1` graph and compares it with already-verified node
+  observations. It reports path deviations, missing terminals, actor/tool
+  authority deviations, bounded-loop breaches, and `checked | captured |
+  asserted` provenance as separate axes. Undeclared graph cycles and empty
+  evidence fail closed. Seven golden reports pin the contract. `workflow.v1`
+  is now a registered predicate whose nested graph runs the same full validator
+  before the generic `attest receipt` path signs it. Real checkpoint ordering
+  can be checked with `verify_workflow_pre_existence`: trusted signatures, both
+  inclusion proofs, leaf position, and consistency must all pass.
+  `treeship session start --workflow-ref art_...` now validates a locally signed
+  declaration before writing any run state and binds the artifact ID inside the
+  signed `session.start` root action. The manifest and composed session receipt
+  mirror the reference, while `verify_first_run_workflow_binding` independently
+  checks the trusted root signature, content-derived run ID, action type, and
+  exact declaration reference. Automatic checkpoint composition, external
+  workflow-authority trust, and CLI conformance verification remain follow-ups.
 
 - **`treeship workflow verify`: one fail-closed path from a signed declaration
   to a conformance report.** The three verification pieces -- declaration
@@ -142,6 +332,14 @@ remained on the broken 0.25.1 while crates.io and PyPI moved to 0.25.2. This
 release fixes the underlying cause and brings every registry back in line.
 
 ### Fixed
+- **Workflow conformance now fails closed at five trust boundaries.** Session
+  close re-verifies the signed root instead of signing a mutable manifest's
+  substituted workflow reference; pre-existence proofs require one checkpoint
+  signing identity rather than composing unrelated trusted logs; loop action
+  budgets count verified action artifacts instead of tool labels; every
+  undeclared observed node produces a deviation, including a one-node run; and
+  schema-required `allowed_tools` can no longer deserialize as an omitted
+  default.
 
 - **`@treeship/core-wasm` was rewritten by whatever `wasm-opt` the build
   machine happened to have.** `wasm-pack` runs `wasm-opt` on the package it
@@ -169,6 +367,14 @@ release fixes the underlying cause and brings every registry back in line.
 - `rust-toolchain.toml` pins `wasm32-unknown-unknown`. This did not cause the
   failure above, but it was the other unpinned input feeding the same
   artifact.
+
+### Documentation
+- **Workflow conformance now has an executable design contract.** Added the
+  missing `docs/specs/workflow-declarations.md` referenced by commitments,
+  rooms, vision, and the v0.11 changelog. Seven golden reports pin valid runs,
+  undeclared edges, missing terminals, loop-cap breaches, asserted edge
+  evidence, declaration pre-existence, and out-of-scope tools before broader
+  CLI wiring.
 
 ## 0.25.2 (2026-08-30)
 
@@ -219,480 +425,6 @@ that verifies in Node.** Those packages could not verify anything at all in
   verifiable; they report `unknown key` until the old keystore is restored.
   All three corrected, and every command in the message is now executed
   verbatim in testing. (#338)
-
-## 0.25.1 (2026-08-21)
-
-**Upgrade if you use the Python SDK or `treeship wrap --format json`.** Two
-SDK entry points could not work at all — not misconfigured, structurally
-unable to succeed — which is the same shape as the bug that forced 0.25.0.
-
-### Fixed
-
-- **`attest_approval` in the Python SDK could not mint an approval.** It
-  forwarded none of the scoping arguments the CLI requires and passed
-  `expires_in` where the CLI takes `expires_at`, so every call that reached the
-  subprocess was rejected. The scoping arguments (`allowed_actions`,
-  `allowed_actors`, `allowed_subjects`, `max_uses`, `unscoped`) are now
-  forwarded, and an unscoped approval must say so explicitly rather than
-  becoming one by omission. (#331)
-- **`treeship wrap --format json` printed nothing parseable.** It emitted the
-  result through a path that returns early in JSON mode, and interleaved the
-  wrapped command's own stdout into the document, so callers got either an
-  empty string or invalid JSON. The result is now emitted as JSON and the child
-  process's stdout is routed to stderr, leaving stdout a single document. (#332)
-- **`treeship attest --expires 1h` signed a timestamp already in the past.**
-  `--expires` takes an absolute RFC 3339 time; a duration parsed to epoch zero
-  and was signed into the artifact, producing an approval born expired with a
-  valid signature. Durations are now refused with a message naming the expected
-  form. (#328)
-- **`treeship init` told a fresh directory it was "already initialized."** The
-  guard tested the resolved config path, which falls back to the global config,
-  so any directory on a machine with a global Treeship config was reported as
-  already set up. It now distinguishes a local workspace from the global
-  fallback. (#333)
-- **`treeship setup --help` promised a verdict the command does not produce.**
-  It documented promoting cards to `Verified`; the code deliberately sets
-  `Active`. (#330)
-- **`release.sh prepare` could not update the npm lockfiles it exists to
-  update.** `npm install --package-lock-only` resolves against the registry, so
-  it failed on the version being released, which is not published yet — the
-  step added to prevent v0.25.0's out-of-sync lockfiles could never run during
-  a release. Prepare now writes the declared range offline and
-  `release.sh refresh-lockfiles` fills in resolved entries after publish. The
-  sync check also covered only four hardcoded packages; it now discovers all
-  ten, which surfaced three runtime-acceptance lockfiles five releases behind.
-
-### Documentation
-
-- Documentation QA pass across 127 pages, plus eight gates that keep the docs
-  and the CLI from drifting apart: internal links, API routes, verify rows,
-  event types, predicates, command names, flags, and option tables. Four of the
-  fixes above were found by those gates. (#321)
-
-## 0.25.0 (2026-08-19)
-
-**Upgrade if you use any npm package. `@treeship/core-wasm@0.24.0` cannot be
-loaded in Node at all, and npm does not allow republishing a version — a new
-release is the only way to fix it.**
-
-### Fixed
-
-- **`@treeship/core-wasm` threw on import in Node.** `WebAssembly.Table.grow():
-  failed to grow table by 4`, reproduced from a clean install on Node 22.20.0
-  and 22.23.1. The module never finished loading, so every export was
-  unreachable — taking down `@treeship/verify` and every SDK method that calls
-  it. `build-npm.sh` ran only `wasm-pack --target bundler`, which emits an
-  import that needs a bundler to resolve. It survived a release because the one
-  consumer anyone exercised was the website, which vendors and bundles the wasm.
-  Now dual-target with an `exports` map routing Node to a nodejs build. (#320)
-- **`treeship session event --format json` exited 0 and printed nothing.** It
-  built the response and passed it to `printer.info`, which returns early in
-  JSON mode. Every SDK wrapper reading `event_id` got `undefined` from an empty
-  document, with a success exit code. (#311)
-- **`treeship present` panicked on a fresh onboard.** `range end index N out of
-  range` — checkpoints load from `~/.treeship/merkle` regardless of `--config`
-  while artifacts come from the scoped store, so the two could describe
-  different histories. Now a typed error naming both sizes. (#313)
-- **`grant show` and `grant list` put a clean checkmark on revoked grants.** A
-  signature stays valid forever; revocation is what makes a grant stop counting.
-  Both commands reported the signature and neither consulted the revocation
-  receipt the CLI had just written. (#314)
-- **`profile` and `history` reported 0 where the answer was "unknown".** An
-  empty result is not a zero. (#302)
-- **The MCP bridge recorded raw error text into signed receipts.** Everything
-  beside it was a digest; an error message routinely contains the thing that
-  failed. Now digested, with raw text behind an explicit opt-in. (#309)
-
-### Added
-
-- **Revocation works end to end.** `treeship grant revoke` mints a signed
-  `grant_revocation.v1`; `verify` honors it locally and from a hub's published
-  list; the hub publishes real revocations over an indexed lookup and states in
-  the response that absence is not evidence; each entry carries `dock_id` and
-  `rekor_index` so a client can check inclusion itself; and
-  `grant show --check-log` walks the dock's consistency chain and re-verifies
-  every link with RFC 6962. Unknown stays a third state throughout — never a
-  quiet pass. (#303, #305, #306, #314, #315, #316, #317)
-- **Linux arm64 binaries**, built *and executed* on a native `ubuntu-24.04-arm`
-  runner so a broken target blocks merge rather than failing on release day.
-  (#318)
-- **`verify` gates on authority** and reports what was granted but never used,
-  so `authority_ok: true` can no longer mean "checked nothing". (#297)
-- **`ship.session.event()` in the TypeScript SDK.** (#203, contributed by
-  @piyushpathakqa)
-
-### Changed
-
-- **Hub `/v1/stats` labels agent counts as claims.** They are derived from
-  `AgentGraph` nodes in uploaded receipts, which the hub does not
-  cryptographically verify. Artifact, dock and session counts are facts about
-  the hub's own state and are unaffected. `claimed_total` is the honest name;
-  the old keys remain for one release. (#308)
-- **The hub indexes on fields derived from the envelope**, never accepted from
-  the caller — so a resolver filters on content rather than an uploader's claim
-  about itself. (#307)
-
-### Known limitations
-
-- `invitation_authority` on a room is **recorded and not enforced**. `verify`
-  does not read it, so a receipt naming `host-only` and an invite minted by a
-  non-host both verify clean. Fail-safe today because nothing trusts the field,
-  but do not treat it as access control.
-- A receipt fetched by URL is verified **structurally only** — Merkle root,
-  inclusion proofs, leaf count, timeline order. Signatures and issuer are not
-  checked from that source; use the local artifact form for those.
-
-## 0.24.0 (2026-08-10)
-
-**Trusted Rooms, end to end — plus three fixes worth upgrading for.**
-
-### Fixed
-
-- **Legitimate receipts no longer report tampering.** Every `receipt.v1`
-  landing mid-chain reported `chain SIGNED LINKAGE BROKEN — possible
-  tampering` against correctly-signed evidence. `mint_session_record` writes
-  the parent as `subject.artifactId`; the linkage check looked only for a
-  top-level `parentId`. Measured on a real store: 4 of 4 receipts affected,
-  9 of 9 actions fine. A false tampering alarm is worse than a noisy check —
-  it teaches operators to ignore the one signal the product exists to give.
-- **Keystores are portable.** `storage_dir`/`keys_dir` were always absolute,
-  so `mv ~/.treeship ~/.treeship.bak` produced a "backup" whose config still
-  pointed at whatever replaced it. Relative paths now resolve against the
-  config's own directory. Absolute paths are untouched.
-- **The Claude Code plugin monitor stopped shouting.** It emitted a line
-  whenever any counter changed, and `events` ticks on essentially every tool
-  call — one working session produced well over a hundred notifications. Now
-  reports state transitions only: two lines for a full session.
-
-### Added
-
-- **`treeship room create` / `status` / `participants`.** Sugar over
-  `treeship session`; a room is a session whose participant set evolves via
-  invitations. `invitation_authority` is carried and signed but not yet
-  enforced — conformance checking is the follow-up.
-- **`room` rides inside the signed receipt.** `RoomInfo` on `SessionManifest`
-  and mirrored into the DSSE-signed `session.v1`, so `invitation_authority`
-  is attested rather than living only in an editable local file.
-- **The room roster is derived, not stored.** `room participants` walks
-  two-signature participant artifacts instead of reading a list from
-  `session.json` — which anyone with write access could edit, and which was
-  silently incomplete whenever the best-effort append was skipped.
-- **Liveness challenge on countersign.** Opt-in `--challenge` /
-  `--challenge-response` proves the joining agent controls its key *now*,
-  not whenever `join` ran. Omitting both countersigns exactly as before.
-- **`treeship session mint-challenge`.** 128 bits from `OsRng`, because the
-  challenge flag shipped without anything to produce a value and the help
-  text suggested a six-character example. Weak nonces are now refused at both
-  ends: a guessable nonce can be pre-signed, and the proof means nothing.
-- **`Custody` on the session receipt.** Records when a *service* signed on an
-  actor's behalf rather than the actor signing for itself. Deliberately a
-  separate axis from `attestation_class`, which grades how evidence was
-  captured; this grades who held the key. Absent means self-custody, so
-  existing receipts are byte-identical.
-- **`execution_identity` on wrapped commands.** Resolved executable path,
-  sha256, argv, cwd, uid/gid. `git` is `git` only until `PATH` says
-  otherwise; two receipts with identical argv and different digests are two
-  different events. Environment **names** only, never values.
-- **A public Go client for the Hub** (`pkg/dpop`, `pkg/hubclient`). DPoP proof
-  signing existed only in Rust, so a Go service had no path to the API.
-  Tested against the real server verifier, not a stub.
-- **The capability index now covers Hub endpoints and core types.** CI fails
-  when a live endpoint belongs to no feature entry, and a generated
-  `capability-map.json` records every reachable surface — 34 CLI commands,
-  22 routes, 109 wire types.
-
-### Documentation
-
-- New concept pages: what a receipt proves (and does not), logs vs receipts,
-  effect receipts, secrets and redaction, authority delta, wrapping real
-  commands. The redaction page documents, with a measured table, which secret
-  shapes the scrubber catches and which it misses.
-
-## Unreleased
-
-### Fixed
-- **Cyclic agent-parent events no longer overflow the stack during session close.**
-  `AgentGraph` depth calculation recursively followed untrusted
-  `parent_agent_instance_id` links and only cached a node after visiting its
-  parent. A self-parent or `A -> B -> A` cycle therefore recursed until the
-  process crashed while composing the receipt. Depth calculation is now
-  iterative, malformed cycles are recorded in `invalid_parent_cycles`, and
-  cyclic nodes retain depth 0 instead of being presented with a fabricated
-  hierarchy.
-- **Workflow conformance now fails closed at five trust boundaries.** Session
-  close re-verifies the signed root instead of signing a mutable manifest's
-  substituted workflow reference; pre-existence proofs require one checkpoint
-  signing identity rather than composing unrelated trusted logs; loop action
-  budgets count verified action artifacts instead of tool labels; every
-  undeclared observed node produces a deviation, including a one-node run; and
-  schema-required `allowed_tools` can no longer deserialize as an omitted
-  default.
-
-### Added
-- **Pure workflow-conformance reducer.** `treeship-core` now validates the
-  minimal `workflow.v1` graph and compares it with already-verified node
-  observations. It reports path deviations, missing terminals, actor/tool
-  authority deviations, bounded-loop breaches, and `checked | captured |
-  asserted` provenance as separate axes. Undeclared graph cycles and empty
-  evidence fail closed. Seven golden reports pin the contract. `workflow.v1`
-  is now a registered predicate whose nested graph runs the same full validator
-  before the generic `attest receipt` path signs it. Real checkpoint ordering
-  can be checked with `verify_workflow_pre_existence`: trusted signatures, both
-  inclusion proofs, leaf position, and consistency must all pass.
-  `treeship session start --workflow-ref art_...` now validates a locally signed
-  declaration before writing any run state and binds the artifact ID inside the
-  signed `session.start` root action. The manifest and composed session receipt
-  mirror the reference, while `verify_first_run_workflow_binding` independently
-  checks the trusted root signature, content-derived run ID, action type, and
-  exact declaration reference. Automatic checkpoint composition, external
-  workflow-authority trust, and CLI conformance verification remain follow-ups.
-- **`RoomInfo` on `SessionManifest`.** Optional `room` field (`room_id`,
-  `host_pubkey`, `invitation_authority`, `workflow_ref`, `checkpoint_cadence`,
-  `participants`) following the schema proposed in
-  `docs/specs/agent-invitations-rooms.md` Phase 2. Purely additive — absent on
-  ordinary sessions and on manifests written before this field existed. No CLI
-  surface yet (`treeship room create/status/participants` is the follow-up);
-  this lands the data model first so the wire format is settled.
-- **`treeship room create/status/participants`.** The CLI surface promised
-  above: `room create` is sugar over `session start` that also populates
-  `RoomInfo` (fresh `room_id`, host pubkey, `--invitation-authority
-  host-only|delegated|open`, `--delegate`, `--workflow-ref`,
-  `--checkpoint-every`); `room status` shows session status plus room fields
-  and errors clearly on a plain (non-room) session; `room participants` lists
-  the room's finalized (two-signature) joins by reading each participant
-  artifact. `treeship session invite/join/countersign` are unchanged except
-  that `countersign` now appends the finalized participant id to
-  `room.participants` when the active session is a room, which is the only
-  way `room participants` has real data to show. `invitation_authority`
-  remains informational-only in this PR — nothing gates any authority
-  decision on it yet. There is no `room close`: plain `treeship session
-  close` already works on a room since a room is just a session.
-
-### Documentation
-- **Workflow conformance now has an executable design contract.** Added the
-  missing `docs/specs/workflow-declarations.md` referenced by commitments,
-  rooms, vision, and the v0.11 changelog. Seven golden reports pin valid runs,
-  undeclared edges, missing terminals, loop-cap breaches, asserted edge
-  evidence, declaration pre-existence, and out-of-scope tools before broader
-  CLI wiring.
-
-## 0.23.0 (2026-08-05)
-
-The emission release. v0.21 and v0.22 built a verifier that could check
-mandates, delegation chains, effect finality, and resolution deadlines — and
-none of it was reachable, because nothing could mint a grant or emit an
-action/v2 receipt. Both halves now exist, so the loop closes:
-
-```
-treeship grant issue --scope 'payments.*' --audience acme --expiry 2027-12-31T23:59:59Z
-treeship grant issue --parent grn_… --scope payments.charge --audience acme --expiry 2027-06-30T00:00:00Z
-treeship attest action --v2 --actor agent://worker --action payments.charge --grant grn_… \
-  --effect-confidence not_verified --finality initiated
-treeship verify last --format json
-```
-
-```json
-"authority":        { "outcome": "unverified", "reasons": ["revocation could not be checked: …"] },
-"delegation_chain": { "hops": 2, "outcome": "holds" },
-"resolution":       { "outcome": "indefinite" },
-"effect":           { "effective_finality": "initiated" }
-```
-
-### Added
-- **`treeship grant issue` / `list` / `show`.** Mint a signed capability grant,
-  or delegate a narrower one with `--parent`. Ids are content-derived
-  (`grn_` + `hex(sha256(canonical))[..16]`), so a parent pointer is a hash
-  commitment to one specific grant rather than a reference to a name anyone
-  could claim. Grants are workspace-scoped, resolved from the active config the
-  same way the approval-use journal is.
-
-  Attenuation is enforced **at mint**, not only at verify: issuing refuses a
-  child that widens scope, outlives its parent, changes audience, or exceeds
-  `max_delegation`, and `delegation_depth` is derived from the parent rather
-  than accepted from the caller. A verifier catching an invalid chain later is
-  the backstop; refusing to create one is the fix, because an invalid chain
-  that exists is one somebody will eventually be asked to trust. Also refuses
-  an expiry already in the past — a grant that can never verify is never
-  minted deliberately.
-
-  `grant show` re-derives the id and re-checks the signature off disk rather
-  than trusting the file, and will open an unsound grant in order to report it
-  as unsound.
-
-- **`treeship attest action --v2`.** Emits a real action/v2 receipt carrying the
-  mandate from a grant (`--grant` or `--grant-file`), an optional effect block
-  (`--effect-confidence`, `--finality`, `--readback`, `--context-snapshot`,
-  `--resolution-deadline`, `--on-deadline`), and runtime identity. Ancestors are
-  walked from `parent_grant_id` and carried inline, so a delegated action still
-  verifies offline with no fetch.
-
-  A root grant leaves `mandate.chain` empty rather than carrying its lone leaf.
-  A one-element chain has no adjacent pair to check, so reporting it as
-  "attenuation holds" would name a check that never ran; `not_claimed` is the
-  honest answer.
-
-### Fixed
-- **`treeship-core` reaches crates.io again.** It did not publish in v0.22.0
-  while npm and PyPI did — `packages/core/src/session/package.rs` embedded a
-  webfont from `design/fonts/`, outside the crate root, and `cargo publish`
-  builds from a tarball containing only files under that root. The include
-  landed after v0.21.0, which is why the previous release was clean. Each crate
-  now vendors the font under its own `assets/fonts/`.
-
-  Two guards, because the version preflight could never have caught this —
-  every version was correct, the crate simply could not be built:
-  `scripts/check-vendored-fonts.py` flags a published crate embedding anything
-  from outside its root, and CI now runs `cargo package -p treeship-core`, the
-  same verify step publish does.
-
-### Notes
-- Revocation is still unchecked, so the authority axis reports `unverified`
-  rather than `pass` and names the layer it could not check. The hub endpoint
-  remains an unsigned, hardcoded-empty stub; reading it would convert an honest
-  "I don't know" into a false "not revoked" for every grant ever issued.
-- Capability grants ship as **beta**, not stable, for that reason.
-
-### Added
-- **`treeship attest action --v2`** — CLI emission of `treeship/action/v2`
-  receipts. Pass `--grant <id>` (workspace store) or `--grant-file <path>`,
-  optionally bind effect (`--effect-confidence`, `--finality`, `--readback`, …)
-  and runtime identity (`--provider`, `--model`, …). `treeship verify` then
-  surfaces authority / effect / runtime on a receipt the CLI itself produced —
-  the half that was verification-only through 0.22.
-
-## 0.22.0 (2026-08-05)
-
-The delegation-and-completion release. v0.21 answered *what was authorized* and
-*what happened*. This one answers the two questions sitting behind those: was
-the authority legitimately delegated, and did the change actually land?
-
-**CLI emission of action/v2 receipts still does not exist.** Everything below is
-verification-side and reachable today only from `treeship-core` and the SDKs; a
-CLI user cannot yet produce a receipt that exercises it. That is the whole of
-0.23.
-
-### Added
-- **Grant chain resolution.** `grant_id` is now content-derived
-  (`grn_` + `hex(sha256(canonical))[..16]`), mirroring `artifact_id`, so an id is
-  a fact rather than a claim. Grants carry a signed `parent_grant_id`, making a
-  parent pointer a hash commitment to one specific grant instead of a reference
-  to a name anyone could also assert. `Mandate.chain` carries ancestors inline
-  so a delegated action still verifies offline, and `resolve_grant_chain`
-  *derives* the order from those signed links rather than trusting the order the
-  carrier supplied — reordering becomes a no-op, truncation surfaces as a missing
-  ancestor, and splicing surfaces as an unreachable extra. Only then does
-  `verify_grant_chain` judge attenuation, on a chain whose shape is already
-  proven.
-- **Authority and delegation on `treeship verify`.** A new authority line reports
-  whether an action was in scope, in window, and not revoked, and a chain line
-  reports `holds` / `widened` / `unresolvable` / `not_claimed`. Both appear in
-  `--format json` as per-check `authority` and `delegation_chain` objects, plus a
-  top-level `authority_ok` a CI gate can test in one field. Without a revocation
-  resolver wired the authority verdict is `unverified`, never `pass`: claiming a
-  grant is live because nobody looked is the false pass this verifier exists to
-  refuse.
-- **`EffectFinality` — lifecycle, separate from evidence.**
-  `NotAttempted / Initiated / Finalized / Failed / Indeterminate`, orthogonal to
-  `EffectConfidence`. Collapsing the two lets a receipt be accurate in every
-  field and false as a composite: a write accepted, acknowledged, assigned an
-  id, served back on read, and never committed. `verify_effect` caps an unbacked
-  `Finalized` exactly as it already caps an unbacked `Verified` — those are the
-  only two claims that assert something definite, so the only two an actor can
-  inflate. `NotAttempted` with a bound `input_hash` is the "no authority moved"
-  receipt, making a timeout an explicit signed negative instead of silence.
-- **Resolution deadlines.** `Resolution { deadline, on_deadline }` and
-  `check_resolution` bound an unresolved effect. An effect that never resolves
-  emits nothing forever, which is worse than a timeout — a timeout at least
-  produces a countable transition. `Indefinite` is reported as its own outcome
-  rather than folded into "resolved", because unresolved-with-no-deadline is the
-  failure shape, not the safe default. `check_resolution` takes `now_unix`
-  explicitly; a verifier that reached for the system clock would give different
-  answers on replay.
-
-### Fixed
-- `ChainResolveError` and `GrantChainError` have real `Display` impls. The CLI
-  was formatting them with `{:?}`, so operators read
-  `AncestorMissing { parent_grant_id: "grn_..." }` — an internal representation,
-  not a diagnosis.
-- The AUD-19 seed test is hermetic. It relied on first-open minting a
-  co-located seed, but `read_or_create_machine_seed` falls back to
-  `~/.treeship/machine_seed` first — which exists on any machine that has run
-  `treeship init`. The test therefore failed for every developer who had
-  actually used the tool while passing on clean CI.
-- `docs-drift` is green again. Two stacked failures: the feature inventory
-  pointed at `packages/core/src/verify.rs`, gone since the module became a
-  directory, and `docs/specs/receipt-system.md` had no row in the specs index.
-  The first masked the second.
-
-### Notes
-- Both new `Effect` fields are optional and skipped when absent, so existing v2
-  receipts keep byte-identical canonical bytes.
-- Known wart, deliberately left: `EffectConfidence` serializes `snake_case`, so
-  a receipt carries `not_verified` while `--format json` reports
-  `not-verified`. Changing it breaks a field emitted since v0.21 and is a
-  decision to make on purpose, not as a side effect of adding a neighbouring
-  one. Documented on `effect_label`.
-- Revocation remains unresolvable by design. The hub endpoint is an unsigned,
-  hardcoded-empty stub; wiring a resolver to it would convert an honest
-  `Unverified` into a false `NotRevoked` for every grant ever issued.
-
-## 0.21.0 (2026-07-21)
-
-The accountability release. Treeship starts answering not just "was this signed?"
-but "what was it authorized to do, what did it actually touch, and how confident
-are we the effect really happened?", with the verdict separating *operational
-confidence* from *cryptographic validity*.
-
-### Added
-- **action/v2 receipt format (verification path).** An additive superset of
-  `action.v1`: the signed payload now carries a per-hop **`mandate`** (the authority
-  an action ran under, grantor, scope, audience, expiry, delegation depth,
-  revocation) and an **`effect`** block (what the action touched, input/output/
-  readback hashes, bytes moved, cost, side effects, context snapshot). Fully optional
-  and backward-compatible; existing v1 artifact IDs are unaffected. This release
-  ships the format, the core types, and verification; CLI emission of v2 receipts is
-  a follow-up.
-- **`effect_confidence`, the honest effect verdict ("the ack is not the act").** An
-  actor declares how confident it is that an action's real-world effect happened
-  (`verified` / `partial` / `ambiguous` / `unknown` / `not_verified`). `verify_effect`
-  reconciles that claim against independent, actor-unmintable evidence (an external
-  `readback`, or a witness a trusted authority vouches for): a `Verified` claim with
-  no such evidence is downgraded, never taken on faith, and the verdict separates
-  operational confidence from cryptographic validity. Honest lesser claims pass
-  through unchanged, the verifier blocks inflation, it does not erase an actor's own
-  hedging.
-- **Runtime identity on action/v2.** Optional `provider` / `model` /
-  `tool_schema_hash` / `system_prompt_hash`, bound into the signed statement, so a
-  verifier holding a pinned expectation can detect a swapped model, an altered tool
-  set, or a changed system prompt after the fact.
-- **Witness map on effects.** Independent corroborating observers per effect. A
-  witness lifts the confidence ceiling only once a `WitnessAuthority` confirms its
-  signature against a trusted, non-actor key observing the same post-state; the
-  default authority trusts nothing, so a bundled witness never inflates a verdict on
-  its own.
-- **Unified verifier in the browser and SDKs.** Resolution and presentation
-  verification moved into `treeship-core` and exposed via WASM + the TS/Python SDKs,
-  so browser and edge verification run the same logic as the CLI.
-- **Memory-provenance binding spine.** Quarantine-gated approvals (a high-privilege
-  action's grant is withheld if a memory-provenance check comes back dirty, and the
-  denial is itself signed), and signed **`blocked.v1`** refusal artifacts that make
-  negative space, what an agent was stopped from doing, and why, first-class
-  evidence.
-
-### Changed
-- **`treeship trust add --kind`** accepts the v0.19 split kinds `cert_issuer`,
-  `hub_org`, and `revoker` alongside the existing ones, closing the pin-exchange gap
-  where a counterparty following the documented flow hit a CLI error.
-- **`treeship verify`** surfaces the action/v2 effect verdict, a `runtime:` line and
-  an `effect:` line on the timeline, and the same verdict in `--json`, kept clearly
-  distinct from the signature check.
-
-### Docs
-- **Full docs truth-sync.** Every documented CLI command, Hub API route, and SDK
-  contract regenerated from code and rewritten to match what v0.20+ actually does,
-  plus CI drift gates (generated command matrix, feature inventory, docs routes) that
-  fail on any code-vs-docs divergence, so a docs lie now requires deliberately
-  overriding a failing check rather than simply forgetting.
 
 ## Older releases
 

--- a/docs/lib/taxonomy.ts
+++ b/docs/lib/taxonomy.ts
@@ -1,0 +1,118 @@
+// The blog's two sorting axes. A post has exactly one category and any number
+// of systems. Both are closed lists so the index, the listing routes and the
+// chips on a post agree, and so a typo in frontmatter fails the build instead
+// of minting a new bucket.
+
+export const CATEGORIES = {
+  release: {
+    label: 'Releases',
+    singular: 'Release',
+    blurb: 'What each version added, in the order it shipped.',
+  },
+  integration: {
+    label: 'Integrations',
+    singular: 'Integration',
+    blurb: 'Treeship inside another system: a harness, a protocol, a product, a standard.',
+  },
+  guide: {
+    label: 'Guides',
+    singular: 'Guide',
+    blurb: 'Worked examples, start to finish, with real ids.',
+  },
+  engineering: {
+    label: 'Engineering',
+    singular: 'Engineering',
+    blurb: 'How the pieces are built and why they are built that way.',
+  },
+  security: {
+    label: 'Security',
+    singular: 'Security',
+    blurb: 'Attack classes, advisories, and what a verifier can and cannot conclude.',
+  },
+  perspective: {
+    label: 'Perspectives',
+    singular: 'Perspective',
+    blurb: 'Where we think this is going.',
+  },
+  announcement: {
+    label: 'Announcements',
+    singular: 'Announcement',
+    blurb: 'Company and project news.',
+  },
+} as const;
+
+export type Category = keyof typeof CATEGORIES;
+export const CATEGORY_ORDER: Category[] = [
+  'release',
+  'integration',
+  'guide',
+  'engineering',
+  'security',
+  'perspective',
+  'announcement',
+];
+
+export type SystemGroup = 'harness' | 'protocol' | 'framework' | 'standard' | 'product' | 'partner' | 'surface';
+
+export const SYSTEM_GROUPS: Record<SystemGroup, string> = {
+  harness: 'Agent harnesses',
+  protocol: 'Protocols',
+  framework: 'Frameworks',
+  standard: 'Standards',
+  product: 'Zerker products',
+  partner: 'Partners',
+  surface: 'Treeship surfaces',
+};
+
+export interface SystemInfo {
+  label: string;
+  vendor?: string;
+  group: SystemGroup;
+  /** Docs path (this site) or an absolute URL. */
+  docs?: string;
+}
+
+export const SYSTEMS: Record<string, SystemInfo> = {
+  'claude-code': { label: 'Claude Code', vendor: 'Anthropic', group: 'harness', docs: '/integrations/claude-code' },
+  codex: { label: 'Codex CLI', vendor: 'OpenAI', group: 'harness', docs: '/integrations/codex' },
+  cursor: { label: 'Cursor', vendor: 'Anysphere', group: 'harness', docs: '/integrations/cursor' },
+  hermes: { label: 'Hermes', vendor: 'Nous Research', group: 'harness', docs: '/integrations/hermes' },
+  openclaw: { label: 'OpenClaw', vendor: 'OpenClaw', group: 'harness', docs: '/integrations/openclaw' },
+  kimi: { label: 'Kimi Code CLI', vendor: 'Moonshot AI', group: 'harness', docs: '/integrations/agent-skills' },
+  perplexity: { label: 'Perplexity Computer', vendor: 'Perplexity', group: 'harness', docs: '/integrations' },
+  'grok-bot': { label: 'Grok Bot', vendor: 'xAI', group: 'harness', docs: '/integrations' },
+  mcp: { label: '@treeship/mcp', vendor: 'Model Context Protocol', group: 'protocol', docs: '/integrations/mcp' },
+  a2a: { label: '@treeship/a2a', vendor: 'Agent2Agent', group: 'protocol', docs: '/integrations/a2a' },
+  'commerce-agents': { label: 'Claude Commerce Agents', vendor: 'Anthropic', group: 'framework', docs: '/commerce/commerce-agents' },
+  langchain: { label: 'LangChain', group: 'framework', docs: '/integrations/langchain' },
+  rig: { label: 'Rig', group: 'framework', docs: 'https://github.com/zerkerlabs/rig-treeship' },
+  'verifiable-intent': { label: 'Verifiable Intent', vendor: 'Mastercard', group: 'standard', docs: '/integrations/verifiable-intent' },
+  'zerker-reason': { label: 'Zerker Reason', vendor: 'Zerker Labs', group: 'product', docs: '/integrations/zerker-reason' },
+  'zerker-gateway': { label: 'Zerker Gateway', vendor: 'Zerker Labs', group: 'product', docs: 'https://docs.zerker.ai' },
+  'memory-providers': { label: 'Memory providers', group: 'product', docs: '/integrations/memory-proofs' },
+  'lobster-cash': { label: 'Lobster Cash', group: 'partner', docs: '/integrations/lobster-cash' },
+  robinhood: { label: 'Robinhood Agentic Trading', vendor: 'Robinhood', group: 'partner', docs: '/integrations/robinhood-agentic-trading' },
+  ninjatech: { label: 'NinjaTech / SuperNinja', vendor: 'NinjaTech AI', group: 'partner', docs: '/integrations/ninjatech' },
+  cli: { label: 'Treeship CLI', group: 'surface', docs: '/cli/overview' },
+  hub: { label: 'Treeship Hub', group: 'surface', docs: '/api/overview' },
+  'python-sdk': { label: 'Python SDK', group: 'surface', docs: '/sdk/python' },
+  'typescript-sdk': { label: 'TypeScript SDK', group: 'surface', docs: '/sdk/typescript' },
+  'wasm-verifier': { label: '@treeship/verify', group: 'surface', docs: '/sdk/verify' },
+  'go-client': { label: 'Go hub client', group: 'surface', docs: '/api/overview' },
+  'claude-code-plugin': { label: 'Claude Code plugin', vendor: 'Anthropic', group: 'harness', docs: '/integrations/claude-code' },
+};
+
+export function isCategory(value: string): value is Category {
+  return value in CATEGORIES;
+}
+
+export function systemInfo(id: string): SystemInfo {
+  const info = SYSTEMS[id];
+  if (!info) throw new Error(`unknown blog system "${id}"; add it to lib/taxonomy.ts`);
+  return info;
+}
+
+/** URL-safe tag slug: lowercase, spaces and slashes to hyphens. */
+export function tagSlug(tag: string): string {
+  return tag.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -19,6 +19,19 @@ export const blog = defineDocs({
       date: z.date().transform((d) => d.toISOString().split('T')[0]).optional(),
       tags: z.array(z.string()).default([]),
       readTime: z.string().optional(),
+      // One category per post; the blog index sorts on it. Vocabulary in
+      // lib/taxonomy.ts. Older posts were assigned one on 2026-09-11.
+      category: z
+        .enum(['release', 'integration', 'guide', 'engineering', 'security', 'perspective', 'announcement'])
+        .default('perspective'),
+      // The external systems the post is about (harness, protocol, product,
+      // standard). Ids from lib/taxonomy.ts SYSTEMS; unknown ids fail the build.
+      systems: z.array(z.string()).default([]),
+      // The Treeship release the post documents, when it documents one.
+      release: z.string().optional(),
+      // For a retrospective entry: the date the words were written, when it
+      // is not the date the post is filed under.
+      written: z.date().transform((d) => d.toISOString().split('T')[0]).optional(),
     }),
   },
 });


### PR DESCRIPTION
Two things, on the docs blog.

## A sorting system
- Every post has one **category** (release, integration, guide, engineering, security, perspective, announcement) and any number of **systems** from a closed registry in `lib/taxonomy.ts` (harnesses, protocols, frameworks, standards, Zerker products, partners, Treeship surfaces), plus its free tags. An unknown system id fails the build.
- The index filters by category and by system, grouped; every filter is a static route with its own URL: `/blog/category/<c>`, `/blog/system/<s>`, `/blog/tag/<t>` (tags noindex). Listings are in the sitemap. Posts show category, systems and tags as chips linking to the listings; JSON-LD carries `articleSection`.
- `/blog/system/<id>` is what the new treeship.dev/integrations page links to as "Posts" for each card, so a system's guide and its posts are one click apart.
- The 28 existing posts are assigned.

## 22 retrospective release entries
One per release or contiguous group from 0.1.0 to 0.31.2, filed under the release date with `written: 2026-09-11` shown beside it and a closing line that says so. Same five sections each: what shipped, why it matters, how it works (commands as released), what it does not do, where to go next. Written from each release's changelog section; every command and flag checked against the CLI; every link resolves. The April Verifiable Intent post gets a note pointing at the 0.31 entry.

Docs build green; internal links, CLI command/flag/option-table and verify-row gates green over the new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)