### PR TITLE
wrap signs with the actor's own key; session event accepts agent.note (QA on 0.31.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **`wrap` signs with the actor's own key.** `treeship wrap --actor agent://x` signed with the ship key even when the agent had a registered key pinned under AgentCert, so a key-bound agent's wrapped commands verified as `actor proof: asserted` while its `attest action` receipts were `proven (key-bound)` (QA on 0.31.1). `wrap` now resolves the signer the way `attest action` does.
+- **`session event --type agent.note`.** The MCP bridge and the harness skills have told agents to leave `agent.note` events since 0.10; the CLI refused them as unsupported. The type exists now, `treeship/session-event` `agent.note` with an optional `text` taken from `--meta` (`text` or `note`), and the timeline prints it as `note`.
 - **`signer_trust` trusts the ship's own keys.** On 0.31.2 the row warned on the producer's own machine that its own signing key was not a pinned trust root, and `session report` summarised every fresh session as `warn`; the release smoke caught it. `package verify` and `session report` now verify against the pinned roots plus this ship's keystore keys (as `session_host` roots). A stranger's machine still warns until they pin, which is the point.
 
 ## 0.31.2 (2026-09-10)

--- a/bridges/mcp/src/server.ts
+++ b/bridges/mcp/src/server.ts
@@ -77,7 +77,7 @@ server.registerTool(
   {
     title: 'Append a session event',
     description:
-      'Append a structured event to the active Treeship session. Use type=agent.note for free-form notes the agent wants on the receipt timeline.',
+      'Append a structured event to the active Treeship session. Use type=agent.note for free-form notes the agent wants on the receipt timeline; put the note in meta.text.',
     inputSchema: {
       type: z.string().describe('Event type, e.g. agent.note, agent.decision, agent.handoff'),
       tool: z.string().optional().describe('Tool name, when applicable'),

--- a/docs/content/docs/concepts/session-receipts.mdx
+++ b/docs/content/docs/concepts/session-receipts.mdx
@@ -104,7 +104,7 @@ A chronologically ordered list of every event emitted during the session. Event 
 - `agent.called_tool`, `agent.read_file`, `agent.wrote_file`
 - `agent.opened_port`, `agent.connected_network`
 - `agent.started_process`, `agent.completed_process`
-- `agent.decision`
+- `agent.decision`, `agent.note`
 
 Every event carries W3C Trace Context fields (`trace_id`, `span_id`, `parent_span_id`), agent identity fields (`agent_id`, `agent_instance_id`, `agent_name`, `agent_role`), host identity, and a monotonic sequence number.
 

--- a/packages/cli/src/commands/session.rs
+++ b/packages/cli/src/commands/session.rs
@@ -1028,6 +1028,10 @@ pub fn watch(_config: Option<&str>, _printer: &Printer) -> Result<(), Box<dyn st
                         format!("{} {}ms", status, duration_ms.unwrap_or(0)),
                     )
                 }
+                EventType::AgentNote { text } => (
+                    "note".to_string(),
+                    trunc(text.as_deref().unwrap_or_default(), 60),
+                ),
                 EventType::AgentDecision {
                     model, provider, ..
                 } => {
@@ -1909,6 +1913,17 @@ pub fn event(
     let trace_id = generate_trace_id();
     let a_name = agent_name.unwrap_or("external");
 
+    // A note's text rides in --meta as `text` (or `note`); read it before the
+    // type match so the variant can carry it as a field, not only as meta.
+    let meta_text: Option<String> = meta_json
+        .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .and_then(|v| {
+            v.get("text")
+                .or_else(|| v.get("note"))
+                .and_then(|t| t.as_str())
+                .map(str::to_string)
+        });
+
     let et = match event_type {
         "agent.called_tool" => EventType::AgentCalledTool {
             tool_name: tool.unwrap_or("unknown").into(),
@@ -1980,8 +1995,15 @@ pub fn event(
             to_agent_instance_id: destination.unwrap_or("unknown").into(),
             artifacts: artifact_id.map(|id| vec![id.into()]).unwrap_or_default(),
         },
+        // The MCP bridge and the harness skills have told agents to leave
+        // `agent.note` events since 0.10; the CLI refused them as unsupported
+        // (QA on 0.31.1). The note's text rides in `--meta` as `text` (or
+        // `note`), which is how the bridge already passes free-form fields.
+        "agent.note" => EventType::AgentNote {
+            text: meta_text.clone(),
+        },
         other => {
-            return Err(format!("unsupported event type: {other}\n\n  supported: agent.called_tool, agent.wrote_file, agent.read_file, agent.connected_network, agent.completed_process, agent.decision, agent.handoff").into());
+            return Err(format!("unsupported event type: {other}\n\n  supported: agent.called_tool, agent.wrote_file, agent.read_file, agent.connected_network, agent.completed_process, agent.decision, agent.handoff, agent.note").into());
         }
     };
 

--- a/packages/cli/src/commands/wrap.rs
+++ b/packages/cli/src/commands/wrap.rs
@@ -276,7 +276,12 @@ pub fn run(
     stmt.parent_id = parent_id.clone();
     stmt.meta = Some(meta);
 
-    let signer = ctx.keys.default_signer()?;
+    // The same rule as `attest action`: an `agent://` actor whose registered
+    // key is pinned under AgentCert signs with that key, so `verify` reports
+    // `actor proof: proven (key-bound)`. `wrap` signed with the ship key
+    // regardless, so a key-bound agent's wrapped commands stayed `asserted`
+    // while its attested actions were proven (QA on 0.31.1).
+    let signer = crate::commands::attest::resolve_actor_signer(&ctx, &actor_uri)?;
     let pt = payload_type("action");
     let result = sign(&pt, &stmt, signer.as_ref())?;
 

--- a/packages/cli/tests/qa_0_31_1_cli.rs
+++ b/packages/cli/tests/qa_0_31_1_cli.rs
@@ -1,0 +1,189 @@
+//! QA on the published 0.31.1 (two-ship run, 2026-09-09): two findings in
+//! the CLI, pinned here so they cannot come back.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn cli_path() -> &'static str {
+    env!("CARGO_BIN_EXE_treeship")
+}
+
+struct Ws {
+    _tmp: TempDir,
+    root: PathBuf,
+}
+
+impl Ws {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let ws = Self { _tmp: tmp, root };
+        assert!(ws
+            .cmd()
+            .args(["init", "--name", "qa", "--config"])
+            .arg(ws.config())
+            .status()
+            .unwrap()
+            .success());
+        ws
+    }
+    fn config(&self) -> PathBuf {
+        self.root.join(".treeship/config.json")
+    }
+    fn cmd(&self) -> Command {
+        let mut c = Command::new(cli_path());
+        c.env("HOME", &self.root)
+            .env("TREESHIP_ALLOW_INSECURE_KEY_PERMS", "1")
+            .env("TREESHIP_TRUST_ROOTS", self.root.join("trust_roots.json"))
+            .current_dir(&self.root);
+        c
+    }
+    fn json(&self, args: &[&str]) -> Value {
+        let out = self
+            .cmd()
+            .args(args)
+            .args(["--format", "json", "--config"])
+            .arg(self.config())
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            out.status.success(),
+            "{args:?}: {stdout}\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let last = stdout
+            .trim()
+            .rsplit("\n{")
+            .next()
+            .map(|s| {
+                if s.starts_with('{') {
+                    s.to_string()
+                } else {
+                    format!("{{{s}")
+                }
+            })
+            .unwrap();
+        serde_json::from_str(&last).unwrap_or_else(|e| panic!("{e}: {stdout}"))
+    }
+    fn text(&self, args: &[&str]) -> (bool, String) {
+        let out = self
+            .cmd()
+            .args(args)
+            .args(["--config"])
+            .arg(self.config())
+            .output()
+            .unwrap();
+        (
+            out.status.success(),
+            format!(
+                "{}{}",
+                String::from_utf8_lossy(&out.stdout),
+                String::from_utf8_lossy(&out.stderr)
+            ),
+        )
+    }
+}
+
+/// `wrap --actor` signed with the ship key regardless of the actor's own
+/// registered key, so a key-bound agent's wrapped commands were `asserted`
+/// while its `attest action` receipts were `proven (key-bound)`.
+#[test]
+fn wrap_signs_with_the_key_bound_actors_own_key() {
+    let ws = Ws::new();
+    let (ok, out) = ws.text(&["agent", "register", "--name", "qa", "--own-key", "--quiet"]);
+    assert!(ok, "{out}");
+    // Flags go before `--`; anything after it belongs to the wrapped
+    // command. A harness that appends `--format json` after the command sees
+    // the child's output where it expected a receipt, which is by design.
+    let out = ws
+        .cmd()
+        .args([
+            "wrap",
+            "--actor",
+            "agent://qa",
+            "--format",
+            "json",
+            "--config",
+        ])
+        .arg(ws.config())
+        .args(["--", "echo", "hi"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let wrapped: Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("{e}: {}", String::from_utf8_lossy(&out.stdout)));
+    let id = wrapped["artifact_id"].as_str().unwrap().to_string();
+    let (ok, out) = ws.text(&["verify", &id]);
+    assert!(ok, "{out}");
+    assert!(
+        out.contains("proven (key-bound)"),
+        "wrap must sign with the agent's pinned key:\n{out}"
+    );
+    let attested = ws.json(&["attest", "action", "--actor", "agent://qa", "--action", "t"]);
+    let id2 = attested["id"].as_str().unwrap().to_string();
+    let (_, out2) = ws.text(&["verify", &id2]);
+    assert!(out2.contains("proven (key-bound)"), "{out2}");
+}
+
+/// The MCP bridge tells agents to leave `agent.note` events; the CLI refused
+/// them as unsupported.
+#[test]
+fn session_event_accepts_agent_note() {
+    let ws = Ws::new();
+    ws.json(&[
+        "session",
+        "start",
+        "--name",
+        "notes",
+        "--actor",
+        "agent://qa",
+    ]);
+    let ev = ws.json(&[
+        "session",
+        "event",
+        "--type",
+        "agent.note",
+        "--actor",
+        "agent://qa",
+        "--agent-name",
+        "qa",
+        "--meta",
+        r#"{"text":"stopped before the second retry: rate limited"}"#,
+    ]);
+    assert!(
+        ev["event_id"].as_str().unwrap_or("").starts_with("evt_"),
+        "{ev}"
+    );
+    let session_id = ws.json(&["session", "status"])["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let log = std::fs::read_to_string(
+        ws.root
+            .join(".treeship/sessions")
+            .join(&session_id)
+            .join("events.jsonl"),
+    )
+    .unwrap();
+    assert!(log.contains("\"agent.note\""), "{log}");
+    assert!(log.contains("stopped before the second retry"), "{log}");
+    // And it survives into the sealed receipt with its text as the summary.
+    let closed = ws.json(&["session", "close", "--summary", "notes"]);
+    let receipt = std::fs::read_to_string(
+        PathBuf::from(closed["package"].as_str().unwrap()).join("receipt.json"),
+    )
+    .unwrap();
+    assert!(receipt.contains("agent.note"), "{receipt}");
+    assert!(
+        receipt.contains("stopped before the second retry"),
+        "{receipt}"
+    );
+}

--- a/packages/core/src/session/event.rs
+++ b/packages/core/src/session/event.rs
@@ -138,6 +138,16 @@ pub enum EventType {
     // amount into a signed receipt would make old receipts falsely
     // signed when pricing changes. Consumers (dashboards, billing tools)
     // calculate cost from model + tokens + their pricing config.
+    /// A free-form note the agent wants on the timeline: what it was trying
+    /// to do, what it decided not to do, why it stopped. Text only; it makes
+    /// no claim about a model, a tool or a file, and the verifier treats it
+    /// as the agent's own words.
+    #[serde(rename = "agent.note")]
+    AgentNote {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        text: Option<String>,
+    },
+
     #[serde(rename = "agent.decision")]
     AgentDecision {
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/core/src/session/receipt.rs
+++ b/packages/core/src/session/receipt.rs
@@ -968,6 +968,7 @@ fn event_type_label(et: &super::event::EventType) -> String {
         AgentStartedProcess { .. } => "agent.started_process",
         AgentCompletedProcess { .. } => "agent.completed_process",
         AgentDecision { .. } => "agent.decision",
+        AgentNote { .. } => "agent.note",
     }
     .into()
 }
@@ -986,6 +987,7 @@ fn event_summary(et: &super::event::EventType) -> Option<String> {
         } => Some(format!(
             "{from_agent_instance_id} -> {to_agent_instance_id}"
         )),
+        AgentNote { text } => text.clone(),
         AgentCalledTool { tool_name, .. } => Some(format!("Called {tool_name}")),
         AgentReadFile { file_path, .. } => Some(format!("Read {file_path}")),
         AgentWroteFile { file_path, .. } => Some(format!("Wrote {file_path}")),


### PR DESCRIPTION
From the two-ship QA run against the published 0.31.1 (health 78/100). Three "still broken" items; two are bugs, fixed here.

- **`wrap --actor` stayed `asserted` after a key-bound onboard.** `wrap` called `ctx.keys.default_signer()` regardless of the actor; `attest action` went through `resolve_actor_signer`, which signs with the agent's registered key when it is pinned under AgentCert. `wrap` now uses the same resolver. Verified: `agent register --name qa --own-key`, then `wrap --actor agent://qa` verifies `proven (key-bound)`.
- **`session event --type agent.note` unsupported while the MCP bridge tells agents to use it.** Added `EventType::AgentNote { text }` (`agent.note`), parsed from `--meta` `text`/`note`, printed as `note` on the timeline, carried as the event summary in the receipt. Bridge description now says where the text goes. Docs event list updated; the event-types gate is green.
- **`wrap --format json` "not JSON, child stdout prepended".** Does not reproduce against the published 0.31.1 with `--format json` before `--`; the child's stdout goes to stderr and stdout is one document. It reproduces only with the flag after `--`, where it is an argument to the wrapped command. That is what a harness that appends flags hits (my own first test did the same). Not changed; noted in the test.

Tests: `packages/cli/tests/qa_0_31_1_cli.rs`. Changelog under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)