### PR TITLE
docs: the coverage audit, and what it found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- **`scripts/coverage-audit.py`: what shipped versus what is documented.** Crosses merged PRs, changelog sections, docs integration pages, blog systems and the treeship.dev card data, per system and per release, and lists the PRs a release section does not reflect. It found Buzz, Rig, the SSRF guard, the hub hardening and the plugin's approval recording missing from the changelog; each now has a dated addendum in its section. Docs pages added for Rig and Grok Bot.
 - **`wrap` signs with the actor's own key.** `treeship wrap --actor agent://x` signed with the ship key even when the agent had a registered key pinned under AgentCert, so a key-bound agent's wrapped commands verified as `actor proof: asserted` while its `attest action` receipts were `proven (key-bound)` (QA on 0.31.1). `wrap` now resolves the signer the way `attest action` does.
 - **`session event --type agent.note`.** The MCP bridge and the harness skills have told agents to leave `agent.note` events since 0.10; the CLI refused them as unsupported. The type exists now, `treeship/session-event` `agent.note` with an optional `text` taken from `--meta` (`text` or `note`), and the timeline prints it as `note`.
 - **`signer_trust` trusts the ship's own keys.** On 0.31.2 the row warned on the producer's own machine that its own signing key was not a pinned trust root, and `session report` summarised every fresh session as `warn`; the release smoke caught it. `package verify` and `session report` now verify against the pinned roots plus this ship's keystore keys (as `session_host` roots). A stranger's machine still warns until they pin, which is the point.
@@ -315,6 +316,12 @@ default this release exists to make.
   its golden fixtures, and the `workflow.v1` predicate schema had existed only
   in a local stash since 2026-08-18. They are on main.
 
+### Addendum (2026-09-11)
+
+Recorded after the fact by `scripts/coverage-audit.py`: merged in this release's window, absent from the section above.
+
+- **The Claude Code plugin records the human's answer** (#347). `AskUserQuestion` fell through to the generic tool branch, so the moment an operator authorized an irreversible publish was recorded as a bare `agent.called_tool`. The question and the selected option are now in the timeline, redacted and capped; an approver is never invented.
+
 ## 0.25.3 (2026-08-31)
 
 **Upgrade if you use `@treeship/verify`, `@treeship/sdk`, or any npm package
@@ -548,6 +555,14 @@ release is the only way to fix it.**
   inclusion proofs, leaf count, timeline order. Signatures and issuer are not
   checked from that source; use the local artifact form for those.
 
+### Addendum (2026-09-11)
+
+Recorded after the fact by `scripts/coverage-audit.py`: merged in this release's window, absent from the section above.
+
+- **`rig-treeship` moved into the monorepo** as `packages/rig` and publishes from the release pipeline in lockstep with `treeship-core` (#292; a missing `anchors` field it exposed fixed in #296). Signed receipts for every Rig tool call, in-process, no subprocess. Docs: [Rig](https://docs.treeship.dev/integrations/rig).
+- **SDK receipt-URL fetches are guarded against SSRF** (audit P1-7, #294). `verify()` in the TypeScript SDK and the MCP bridge fetched any URL: no scheme restriction, no private-address check, no redirect limit, no body cap, no timeout. Now: https only, no embedded credentials, literal and resolved private/loopback/link-local addresses refused, redirects refused (a public URL that 302s to a private one bypassed every address check), body and time bounded. Shared vectors in `tests/vectors/ssrf-urls.json`, including the IPv4-mapped loopback form `new URL()` canonicalizes past a dotted-quad check.
+- **Hub: per-IP rate limiting, graceful shutdown, readiness** (audit items 19 and 49, #288). `httprate` keyed on client IP, 600/min globally and 60/min for the public reads; `/healthz` outside the budget. SIGTERM now drains for 20 s with readiness flipped false first; `/readyz` pings the database and is separate from `/healthz`.
+
 ## 0.24.0 (2026-08-10)
 
 **Trusted Rooms, end to end — plus three fixes worth upgrading for.**
@@ -613,6 +628,12 @@ release is the only way to fix it.**
   effect receipts, secrets and redaction, authority delta, wrapping real
   commands. The redaction page documents, with a measured table, which secret
   shapes the scrubber catches and which it misses.
+
+### Addendum (2026-09-11)
+
+Recorded after the fact by `scripts/coverage-audit.py`: merged in this release's window, absent from the section above.
+
+- **Trusted Rooms were built by the Buzz agents.** Fizz, Bumble and Honey on Buzz, Jack Dorsey's social platform, opened #266, #267 and #269, and their testing surfaced the false tampering alarm fixed in #268. See the [Buzz integration page](https://docs.treeship.dev/integrations/buzz).
 
 ## 0.23.0 (2026-08-05)
 

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -12,6 +12,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); ver
 
 ## Unreleased
 
+- **`scripts/coverage-audit.py`: what shipped versus what is documented.** Crosses merged PRs, changelog sections, docs integration pages, blog systems and the treeship.dev card data, per system and per release, and lists the PRs a release section does not reflect. It found Buzz, Rig, the SSRF guard, the hub hardening and the plugin's approval recording missing from the changelog; each now has a dated addendum in its section. Docs pages added for Rig and Grok Bot.
 - **`wrap` signs with the actor's own key.** `treeship wrap --actor agent://x` signed with the ship key even when the agent had a registered key pinned under AgentCert, so a key-bound agent's wrapped commands verified as `actor proof: asserted` while its `attest action` receipts were `proven (key-bound)` (QA on 0.31.1). `wrap` now resolves the signer the way `attest action` does.
 - **`session event --type agent.note`.** The MCP bridge and the harness skills have told agents to leave `agent.note` events since 0.10; the CLI refused them as unsupported. The type exists now, `treeship/session-event` `agent.note` with an optional `text` taken from `--meta` (`text` or `note`), and the timeline prints it as `note`.
 - **`signer_trust` trusts the ship's own keys.** On 0.31.2 the row warned on the producer's own machine that its own signing key was not a pinned trust root, and `session report` summarised every fresh session as `warn`; the release smoke caught it. `package verify` and `session report` now verify against the pinned roots plus this ship's keystore keys (as `session_host` roots). A stranger's machine still warns until they pin, which is the point.
@@ -324,6 +325,12 @@ default this release exists to make.
 - **The recovered workflow conformance verifier.** `workflow_conformance.rs`,
   its golden fixtures, and the `workflow.v1` predicate schema had existed only
   in a local stash since 2026-08-18. They are on main.
+
+### Addendum (2026-09-11)
+
+Recorded after the fact by `scripts/coverage-audit.py`: merged in this release's window, absent from the section above.
+
+- **The Claude Code plugin records the human's answer** (#347). `AskUserQuestion` fell through to the generic tool branch, so the moment an operator authorized an irreversible publish was recorded as a bare `agent.called_tool`. The question and the selected option are now in the timeline, redacted and capped; an approver is never invented.
 
 ## 0.25.3 (2026-08-31)
 

--- a/docs/content/docs/integrations/grok-bot.mdx
+++ b/docs/content/docs/integrations/grok-bot.mdx
@@ -1,0 +1,54 @@
+---
+title: Grok Bot
+description: Agent-to-agent verification on a Grok Bot cloud VM. A packaged skill that refuses work from another agent until it proves live control of a key you trust.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Grok Bot
+
+Grok Bot runs agents on a cloud VM with a durable `/workspace`. The Treeship integration is a bootstrap script, a shim, and a skill written as prose, because Grok skills are prose rather than files. It answers one question: should this Bot act on work that arrived from another agent? It shipped with the custody handshake in [Treeship 0.27](/blog/treeship-0-27-the-custody-handshake).
+
+<Callout type="warn">
+This is not a verification skill in the pstack sense. It does not drive an app until the UI is green. It refuses foreign work until the sender proves live key control, and records that verify on the handoff. The two compose; they are not substitutes.
+</Callout>
+
+## Install
+
+Ask your Bot to run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zerkerlabs/treeship/main/integrations/grok-bot/bootstrap.sh | bash
+```
+
+Then paste [`SKILL.txt`](https://github.com/zerkerlabs/treeship/blob/main/integrations/grok-bot/SKILL.txt) into a saved skill and invoke it with `/`. Optionally add [`routine.txt`](https://github.com/zerkerlabs/treeship/blob/main/integrations/grok-bot/routine.txt) as a weekday routine so a package wipe self-heals. Bootstrap is idempotent: re-running after a wipe restores the same ship key rather than minting a second identity.
+
+Everything goes through the shim, `/workspace/treeship/ts`, never a bare `treeship`. The CLI resolves its ship by walking up from the current directory, and a Bot can end up in any directory; the shim pins `HOME` and `TREESHIP_CONFIG` so the Bot cannot silently adopt whatever ship the walk finds.
+
+## The rule the skill teaches
+
+Foreign work is anything that arrived from another agent. Before any of the actual task:
+
+```bash
+/workspace/treeship/ts session mint-challenge --format json          # you choose the nonce
+# the sender runs: treeship present <their-actor> --challenge <nonce> --format json
+/workspace/treeship/ts verify-presentation <file> --challenge <nonce> --format json
+/workspace/treeship/ts attest handoff --from <their-actor> --to agent://grok \
+  --artifacts <your-intent-artifact> --verified <file> --challenge <nonce> --format json
+```
+
+Never accept a nonce the sender picked. Refuse on any failure. Record the verify on the handoff, so the receipt says `custody: live` and names the file and nonce it verified.
+
+Verification is against your trust roots, with no registry in the loop. Until you pin a peer's ship with `trust add <key_id> <ed25519:…> --kind cert_issuer`, the honest verdict is "internally consistent, issuer not trusted", not "verified".
+
+## What it does not do
+
+- Every Bot on a Grok account shares one computer and one keystore, and Grok's own docs say not to use separate Bots as a security boundary. A receipt proves this account's computer signed it; which Bot did it is `asserted`. Handoffs between Bots on one account are `custody: asserted (same_computer)`. Real verification is with an agent on a different computer.
+- Approvals are not recorded. The decision is visible only in Grok's app UI, so the skill states that boundary instead of recording an approval nobody observed.
+- A receipt proves who acted, under whose key, and that a live challenge was answered. It does not prove the work is correct.
+
+## Where to go next
+
+- [`integrations/grok-bot`](https://github.com/zerkerlabs/treeship/tree/main/integrations/grok-bot): bootstrap, shim, skill and routine
+- [The agent handshake](/docs/concepts/agent-handshake)
+- [Treeship 0.27: the custody handshake](/blog/treeship-0-27-the-custody-handshake)

--- a/docs/content/docs/integrations/index.mdx
+++ b/docs/content/docs/integrations/index.mdx
@@ -40,6 +40,7 @@ One skill file, any agent that reads skills.
 | Integration | What it is |
 |---|---|
 | [Agent Skills](./agent-skills) | Install the Treeship skill on any coding agent — Kimi, Claude, Codex, Cursor, OpenClaw, Hermes. One skill, every agent. |
+| [Grok Bot](./grok-bot) | Agent-to-agent verification on a Grok Bot cloud VM. A packaged skill that refuses work from another agent until it proves live control of a key you trust. |
 | [Install matrix](./install) | One-liner install command per agent, plus the bypass-proof plugin where available. |
 
 ## Frameworks
@@ -50,6 +51,7 @@ Wrap a framework's calls.
 |---|---|
 | [Claude Commerce Agents](./commerce-agents) | Signed, offline-verifiable receipts for every tool call in anthropics/commerce-agents, on all three of its runtimes. |
 | [LangChain](./langchain) | Add Treeship to LangChain agents. Receipts for every chain and tool call. |
+| [Rig](./rig) | Ed25519-signed Treeship receipts for every tool call a Rig agent makes, in-process, with no CLI subprocess. The rig-treeship crate. |
 
 ## Sibling products
 

--- a/docs/content/docs/integrations/rig.mdx
+++ b/docs/content/docs/integrations/rig.mdx
@@ -1,0 +1,57 @@
+---
+title: Rig
+description: Ed25519-signed Treeship receipts for every tool call a Rig agent makes, in-process, with no CLI subprocess. The rig-treeship crate.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+# Rig
+
+[Rig](https://crates.io/crates/rig-core) is a Rust framework for LLM agents. `rig-treeship` wraps any Rig `PortableTool` so that every call it makes leaves a signed, chained, offline-verifiable receipt. Both stacks are Rust, so this is a type-level integration: signing happens in-process with Ed25519 over DSSE envelopes through `treeship-core`, and the compiler checks the seam.
+
+The crate lives in the Treeship monorepo at `packages/rig` (it moved in with [#292](https://github.com/zerkerlabs/treeship/pull/292) in August 2026) and publishes to crates.io in lockstep with every Treeship release, so `rig-treeship` and `treeship-core` always share a version.
+
+```bash
+cargo add rig-treeship
+```
+
+## What it does
+
+```rust
+use std::sync::Arc;
+use rig_treeship::{AttestedExt, TreeshipLedger};
+
+let ledger = Arc::new(TreeshipLedger::open_default("agent://my-agent")?);
+let tool = MyTool.attested(ledger.clone());
+// register `tool` with your runtime exactly like the bare tool
+```
+
+Every call then:
+
+1. hashes the deserialized arguments (SHA-256, compact JSON),
+2. runs the inner tool,
+3. hashes the output, or records the failure as `outcome: "error"`,
+4. signs a `treeship/action/v1` statement carrying both hashes, chained to the previous receipt via `parentId`,
+5. returns the result only after the receipt is stored. An unattested action is treated as no action.
+
+The wrapper is transparent to the model: same name, description and JSON schema. It changes what the agent can prove, not what it can do.
+
+## Verifying
+
+```rust
+let head = ledger.head().unwrap();
+let verified = ledger.verify_chain(&head)?;   // walks parentId back to genesis
+println!("{} receipts verified", verified.length);
+```
+
+`verify_chain` re-derives every artifact id from its PAE bytes, checks each Ed25519 signature, and confirms the stored parent pointer matches the signed `parentId`. Receipts are standard Treeship artifacts on disk, so the CLI applies too: `treeship verify <id>`, and `treeship hub push <id>` for a public URL.
+
+<Callout type="info">
+Arguments and outputs are digested, never stored. A receipt proves which arguments produced which output under which key; it does not carry either.
+</Callout>
+
+## Where to go next
+
+- [`packages/rig`](https://github.com/zerkerlabs/treeship/tree/main/packages/rig): the crate, with `examples/attested_agent.rs` and an interop test against the CLI verifier
+- [rig-treeship on crates.io](https://crates.io/crates/rig-treeship)
+- [`treeship verify`](/docs/cli/verify)

--- a/scripts/coverage-audit.py
+++ b/scripts/coverage-audit.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""What shipped versus what is documented, per system and per release.
+
+Buzz built Trusted Rooms in August 2026 and nothing public ever said so: the
+changelog credited nobody and named no platform, so a log-only scan could not
+find it. This script crosses four sources so that cannot happen quietly again:
+
+  1. merged pull requests (title, branch, merge date)  -> what actually landed
+  2. CHANGELOG.md sections                             -> what we told users
+  3. docs (integration pages) and blog (systems axis)  -> what is explained
+  4. the ecosystem card data on treeship.dev           -> what is presented
+
+Usage:
+  scripts/coverage-audit.py --prs <prs.tsv> [--site ../treeship.dev-repo]
+
+  <prs.tsv> is `gh pr list --state merged --limit 500 --json
+  number,title,mergedAt,headRefName --jq '.[] | "\\(.mergedAt[:10])\\t#\\(.number)
+  \\t\\(.headRefName)\\t\\(.title)"'` (an author column between branch and title
+  is tolerated). Tags come from git.
+
+Output 1, the systems matrix: for every named system in VOCAB, how many PRs
+name it, which release first mentioned it in the changelog, whether a docs
+integration page, blog system id and ecosystem card exist. A system with PRs
+and no changelog mention, or with a changelog mention and no page, is a gap.
+
+Output 2, the release ledger: for every tag, the PRs merged in its window that
+its changelog section does not reflect (no PR number, and fewer than two of
+the title's distinctive words). Heuristic, so read it as a list to check, not
+a verdict.
+
+Exit code is 0; this is a report, not a gate. Add `--strict` to exit 1 when a
+system has PRs but no changelog mention at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# id -> (label, regex over PR title+branch and changelog text, docs page slug or None)
+VOCAB: dict[str, tuple[str, str, str | None]] = {
+    "claude-code": ("Claude Code", r"claude[ -]?code|claude plugin", "claude-code"),
+    "codex": ("Codex", r"\bcodex\b", "codex"),
+    "cursor": ("Cursor", r"\bcursor\b", "cursor"),
+    "hermes": ("Hermes", r"\bhermes\b", "hermes"),
+    "openclaw": ("OpenClaw", r"openclaw", "openclaw"),
+    "kimi": ("Kimi", r"\bkimi\b", "agent-skills"),
+    "cline": ("Cline", r"\bcline\b", None),
+    "goose": ("Goose", r"\bgoose\b", None),
+    "perplexity": ("Perplexity", r"perplexity", None),
+    "grok-bot": ("Grok Bot", r"\bgrok\b", None),
+    "buzz": ("Buzz", r"\bbuzz\b", "buzz"),
+    "mcp": ("MCP bridge", r"\bmcp\b", "mcp"),
+    "a2a": ("A2A bridge", r"\ba2a\b|agent2agent", "a2a"),
+    "commerce-agents": ("Claude Commerce Agents", r"commerce[- ]agents|treeship-commerce|treeship_commerce", "commerce-agents"),
+    "langchain": ("LangChain", r"langchain", "langchain"),
+    "rig": ("Rig", r"\brig\b|rig-treeship", None),
+    "prime": ("Prime Agent / pi", r"\bprime\b|prime-treeship|\bpi agent\b", None),
+    "verifiable-intent": ("Verifiable Intent", r"verifiable intent|\bvi\b|mastercard", "verifiable-intent"),
+    "lobster-cash": ("Lobster Cash", r"lobster", "lobster-cash"),
+    "robinhood": ("Robinhood", r"robinhood", "robinhood-agentic-trading"),
+    "ninjatech": ("NinjaTech", r"ninjatech|superninja|ninja dev", "ninjatech"),
+    "zerker-reason": ("Zerker Reason", r"\breason\b", "zerker-reason"),
+    "zerker-gateway": ("Zerker Gateway", r"\bgateway\b|farcaster", None),
+    "zmem": ("ZMem / memory", r"\bzmem\b|memory[- ]prov|memory proofs", "memory-proofs"),
+    "slancha": ("Slancha", r"slancha|\breplay\.", None),
+    "proofmark": ("Proofmark / X", r"proofmark|\bexhibit\b|x api|twitter", None),
+    "moltbook": ("Moltbook", r"moltbook", None),
+    "witness-ios": ("Witness iOS", r"\bwitness\b", None),
+    "nostr": ("Nostr", r"\bnostr\b", None),
+    "rekor": ("Rekor / Sigstore", r"\brekor\b|sigstore", None),
+    "hub": ("Treeship Hub", r"\bhub\b|\bdock\b", None),
+    "wasm": ("WASM verifier", r"\bwasm\b|core-wasm|@treeship/verify", None),
+    "python-sdk": ("Python SDK", r"python sdk|treeship-sdk|treeship_sdk|pypi", None),
+    "typescript-sdk": ("TypeScript SDK", r"typescript sdk|@treeship/sdk|sdk-ts", None),
+    "go-client": ("Go hub client", r"\bgo client\b|pkg/hubclient|pkg/dpop", None),
+}
+
+STOP = set("""a an the and or of to for in on at by with from into over under as is are was were be been
+add adds added fix fixes fixed feat chore docs doc refactor test tests ci release bump make makes
+now no not new every each per one two v0 treeship cli core hub sdk when where which that this it its
+""".split())
+
+
+def load_tags() -> list[tuple[str, str]]:
+    out = subprocess.run(
+        ["git", "for-each-ref", "--sort=creatordate", "--format=%(creatordate:short)\t%(refname:short)", "refs/tags"],
+        cwd=REPO, capture_output=True, text=True, check=True,
+    ).stdout
+    tags = []
+    for line in out.splitlines():
+        date, name = line.split("\t")
+        if re.fullmatch(r"v\d+\.\d+\.\d+", name):
+            tags.append((date, name[1:]))
+    return tags
+
+
+def load_prs(path: Path) -> list[dict]:
+    prs = []
+    for line in path.read_text().splitlines():
+        parts = line.split("\t")
+        if len(parts) < 4:
+            continue
+        date, num, branch = parts[0], parts[1].lstrip("#"), parts[2]
+        title = parts[-1]
+        prs.append({"date": date, "num": int(num), "branch": branch, "title": title})
+    return sorted(prs, key=lambda p: (p["date"], p["num"]))
+
+
+def changelog_sections() -> dict[str, str]:
+    text = (REPO / "CHANGELOG.md").read_text()
+    sections: dict[str, str] = {}
+    cur = None
+    for line in text.splitlines():
+        m = re.match(r"^## (\d+\.\d+\.\d+|Unreleased)", line)
+        if m:
+            cur = m.group(1)
+            sections[cur] = ""
+        elif cur:
+            sections[cur] += line + "\n"
+    return sections
+
+
+def release_for(date: str, tags: list[tuple[str, str]]) -> str:
+    for tdate, ver in tags:
+        if tdate >= date:
+            return ver
+    return "Unreleased"
+
+
+def blog_systems() -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for f in (REPO / "docs/content/blog").glob("*.mdx"):
+        m = re.search(r"^systems: \[(.*?)\]", f.read_text(), re.M)
+        if not m:
+            continue
+        for s in m.group(1).split(","):
+            s = s.strip().strip('"').strip("'")
+            if s:
+                counts[s] += 1
+    return counts
+
+
+def site_cards(site: Path | None) -> set[str]:
+    if not site:
+        return set()
+    p = site / "data/integrations.json"
+    if not p.exists():
+        return set()
+    data = json.loads(p.read_text())
+    return {i["id"] for g in data["groups"] for i in g["items"]}
+
+
+def words(title: str) -> set[str]:
+    return {w for w in re.findall(r"[a-z0-9_./-]{3,}", title.lower()) if w not in STOP}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--prs", required=True, type=Path)
+    ap.add_argument("--site", type=Path, default=REPO.parent / "treeship.dev-repo")
+    ap.add_argument("--strict", action="store_true")
+    args = ap.parse_args()
+
+    tags = load_tags()
+    prs = load_prs(args.prs)
+    sections = changelog_sections()
+    versions_desc = [v for _, v in reversed(tags)]
+    blog = blog_systems()
+    cards = site_cards(args.site if args.site.exists() else None)
+    docs_pages = {p.stem for p in (REPO / "docs/content/docs/integrations").glob("*.mdx")}
+
+    for pr in prs:
+        pr["release"] = release_for(pr["date"], tags)
+
+    # ---- systems matrix -------------------------------------------------
+    print("SYSTEMS MATRIX  (prs | first changelog release | changelog mentions | docs page | blog posts | site card)")
+    print("-" * 110)
+    gaps = 0
+    for sid, (label, rx, page) in VOCAB.items():
+        pat = re.compile(rx, re.I)
+        pr_hits = [p for p in prs if pat.search(p["title"] + " " + p["branch"])]
+        first = None
+        mentions = 0
+        for ver in versions_desc:
+            n = len(pat.findall(sections.get(ver, "")))
+            if n:
+                mentions += n
+                first = ver
+        has_page = bool(page and page in docs_pages)
+        posts = blog.get(sid, 0)
+        card = sid in cards
+        flags = []
+        if pr_hits and mentions == 0:
+            flags.append("PRs but never in changelog")
+        if (pr_hits or mentions) and not has_page and page is not None:
+            flags.append("no docs page")
+        if (pr_hits or mentions) and posts == 0:
+            flags.append("no blog posts")
+        if (pr_hits or mentions) and not card and sid not in {"hub", "wasm", "rekor", "nostr", "moltbook", "proofmark"}:
+            flags.append("no site card")
+        if flags:
+            gaps += 1
+        print(f"{label:24} {len(pr_hits):3}  {first or '-':8} {mentions:4}   {'page' if has_page else '-':5} {posts:3}   {'card' if card else '-':5}  {'; '.join(flags)}")
+        if pr_hits and (mentions == 0 or not has_page):
+            for p in pr_hits[:6]:
+                print(f"{'':24}   #{p['num']} {p['date']} {p['title'][:70]}")
+
+    # ---- release ledger -------------------------------------------------
+    print()
+    print("RELEASE LEDGER  (PRs merged in each release window that the changelog section does not reflect)")
+    print("-" * 110)
+    by_rel: dict[str, list[dict]] = defaultdict(list)
+    for p in prs:
+        by_rel[p["release"]].append(p)
+    for _, ver in reversed(tags):
+        sec = sections.get(ver, "")
+        window = by_rel.get(ver, [])
+        if not window:
+            continue
+        low = sec.lower()
+        missing = []
+        for p in window:
+            if f"#{p['num']}" in sec:
+                continue
+            w = words(p["title"])
+            hit = sum(1 for x in w if x in low)
+            if hit < 2:
+                missing.append(p)
+        print(f"{ver:8} {len(window):3} PRs, {len(missing):3} not reflected")
+        for p in missing:
+            print(f"           #{p['num']} {p['date']} {p['title'][:80]}")
+
+    if args.strict and gaps:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen-integrations-index.py
+++ b/scripts/gen-integrations-index.py
@@ -40,6 +40,8 @@ CATEGORIES: dict[str, tuple[str, str]] = {
     "agent-skills": ("Skills", "One skill file, any agent that reads skills."),
     "install": ("Skills", ""),
     "langchain": ("Frameworks", "Wrap a framework's calls."),
+    "rig": ("Frameworks", ""),
+    "grok-bot": ("Skills", ""),
     "commerce-agents": ("Frameworks", ""),
     "memory-proofs": ("Sibling products", "Other Zerker systems that emit or consume Treeship evidence."),
     "zerker-reason": ("Sibling products", ""),


### PR DESCRIPTION
Buzz built Trusted Rooms and nothing public said so; a changelog-only scan could not find it. This adds `scripts/coverage-audit.py`, which crosses four sources per system and per release: merged PRs, changelog sections, docs integration pages + blog systems, and the treeship.dev card data. Two outputs: a systems matrix with gap flags, and a release ledger of PRs a section does not reflect.

What it found, each now a dated `### Addendum (2026-09-11)` in its section (original text untouched):
- **0.24.0:** Trusted Rooms were built by the Buzz agents (#266, #267, #269; #268 from their testing).
- **0.25.0:** `rig-treeship` moved into the monorepo (#292); the SDK/MCP `verify()` SSRF guard (#294, audit P1-7); hub per-IP rate limiting, graceful shutdown and `/readyz` (#288).
- **0.26.0:** the Claude Code plugin records the human's `AskUserQuestion` answer (#347).

Also: docs pages for **Rig** (crate in `packages/rig`, on crates.io in lockstep) and **Grok Bot** (bootstrap, shim, prose skill, same-computer custody limits), both of which had code and a site card but no page. Integrations index regenerated; docs changelog mirror regenerated. Link, command and flag gates green.

Site side (zerkerlabs/treeship.dev#94): Rig and Grok Bot cards link to the new pages; the Go hub client gets a card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)