### PR TITLE
Release v0.31.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Treeship marketplace. Portable, cryptographically signed receipts for AI coding sessions.",
-    "version": "0.31.3"
+    "version": "0.31.4"
   },
   "plugins": [
     {
       "name": "treeship",
       "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"
@@ -22,7 +22,7 @@
     {
       "name": "treeship-commerce",
       "description": "Add Treeship receipts to an anthropics/commerce-agents deployment: every tool call signed on all three runtimes, the merchant's approval as a signed single-use grant, and a receipt for exactly the cart that went to checkout.",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "author": {
         "name": "Zerker Labs",
         "url": "https://treeship.dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.31.4 (2026-09-11)
 
 - **The sealed set is under a signature (audit follow-up AUD-34, P1).** An artifact from another session, signed by the same key, could be dropped into a package as an `unchained` entry with the tree recomputed, and every per-artifact row stayed green, `--strict` included. `session close` now seals its `session.v1` record beside the package as `record.json`; that record signs the SHA-256 of `receipt.json` and the session id, so `package verify` gets a `receipt_binding` row that fails when the sealed set was rewritten after the producer closed it. A `session_window` row warns when a sealed artifact's signed timestamp falls outside the session's own window. Under `--strict`, `chain_completeness`, `receipt_binding` and `session_window` are failures. A package built before this release has no record and gets a warning. A producer who re-signs is outside what a signature can catch; that is what checkpoint anchoring is for.
 - **`package verify` says `signatures-pass`, not `verified`, when no signing key is pinned (AUD-35, P2).** The success line and the JSON `verdict` distinguish `verified` (every signature under a pinned key), `signatures-pass` (signatures verify, signer not pinned here), `structural-pass` and `failed`. `--format json` now carries every check row, the counts, and `signer_pinned`; it carried no rows at all before.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,7 +3160,7 @@ dependencies = [
 
 [[package]]
 name = "rig-treeship"
-version = "0.31.3"
+version = "0.31.4"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-cli"
-version = "0.31.3"
+version = "0.31.4"
 dependencies = [
  "base64",
  "clap",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core"
-version = "0.31.3"
+version = "0.31.4"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "treeship-core-wasm"
-version = "0.31.3"
+version = "0.31.4"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",

--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/a2a",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.3"
+        "@treeship/core-wasm": "0.31.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/bridges/a2a/package.json
+++ b/bridges/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/a2a",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Treeship attestation middleware for A2A (Agent2Agent) servers and clients",
   "license": "Apache-2.0",
   "repository": {
@@ -31,7 +31,7 @@
     }
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.3"
+    "@treeship/core-wasm": "0.31.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/mcp",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@treeship/core-wasm": "0.31.3",
+        "@treeship/core-wasm": "0.31.4",
         "zod": "^3.25.76"
       },
       "bin": {

--- a/bridges/mcp/package.json
+++ b/bridges/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/mcp",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Drop-in Treeship attestation for MCP tool calls",
   "license": "Apache-2.0",
   "repository": {
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@treeship/core-wasm": "0.31.3",
+    "@treeship/core-wasm": "0.31.4",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/docs/content/docs/about/changelog.mdx
+++ b/docs/content/docs/about/changelog.mdx
@@ -10,6 +10,14 @@ The latest Treeship releases are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The canonical source and [complete release history](https://github.com/zerkerlabs/treeship/blob/main/CHANGELOG.md) live in `CHANGELOG.md` at the repo root. Edit that file, not this page.
 
+## 0.31.4 (2026-09-11)
+
+- **The sealed set is under a signature (audit follow-up AUD-34, P1).** An artifact from another session, signed by the same key, could be dropped into a package as an `unchained` entry with the tree recomputed, and every per-artifact row stayed green, `--strict` included. `session close` now seals its `session.v1` record beside the package as `record.json`; that record signs the SHA-256 of `receipt.json` and the session id, so `package verify` gets a `receipt_binding` row that fails when the sealed set was rewritten after the producer closed it. A `session_window` row warns when a sealed artifact's signed timestamp falls outside the session's own window. Under `--strict`, `chain_completeness`, `receipt_binding` and `session_window` are failures. A package built before this release has no record and gets a warning. A producer who re-signs is outside what a signature can catch; that is what checkpoint anchoring is for.
+- **`package verify` says `signatures-pass`, not `verified`, when no signing key is pinned (AUD-35, P2).** The success line and the JSON `verdict` distinguish `verified` (every signature under a pinned key), `signatures-pass` (signatures verify, signer not pinned here), `structural-pass` and `failed`. `--format json` now carries every check row, the counts, and `signer_pinned`; it carried no rows at all before.
+- **`attest action` chains onto the session's head by default (P3).** Every documented quickstart omits `--parent`, so every session's own actions were sealed as `unchained` and `chain_completeness` warned on honest sessions. Inside an active session the parent now defaults to the newest artifact that walks back to the session root; `--no-parent` keeps a receipt deliberately off the chain. `session close` chains onto that head too, instead of whatever `.last` held, so another agent's receipt in the same workspace no longer becomes the session's chained step.
+- **The MCP bridge's `TREESHIP_STRICT=1` reaches the caller (AUD-33 residual).** The client caught every throw from the attestation module; a signing failure under strict now fails the tool call, and a test drives it through `callTool`.
+- **`verify last` on a receipt with an external subject** (`ord_12345`) no longer walks to the subject as if it were a chain parent (FR-4). **`session report` exits nonzero when its own local verify failed** (FR-7). **`session event --help` lists every event type** and says `agent.decision` requires `--model` (FR-9).
+
 ## 0.31.3 (2026-09-11)
 
 - **`scripts/coverage-audit.py`: what shipped versus what is documented.** Crosses merged PRs, changelog sections, docs integration pages, blog systems and the treeship.dev card data, per system and per release, and lists the PRs a release section does not reflect. It found Buzz, Rig, the SSRF guard, the hub hardening and the plugin's approval recording missing from the changelog; each now has a dated addendum in its section. Docs pages added for Rig and Grok Bot.
@@ -331,59 +339,6 @@ default this release exists to make.
 Recorded after the fact by `scripts/coverage-audit.py`: merged in this release's window, absent from the section above.
 
 - **The Claude Code plugin records the human's answer** (#347). `AskUserQuestion` fell through to the generic tool branch, so the moment an operator authorized an irreversible publish was recorded as a bare `agent.called_tool`. The question and the selected option are now in the timeline, redacted and capped; an approver is never invented.
-
-## 0.25.3 (2026-08-31)
-
-**Upgrade if you use `@treeship/verify`, `@treeship/sdk`, or any npm package
-that verifies in Node.** 0.25.2 never reached npm: the gate added in 0.25.2
-caught that the artifact still did not load and refused to publish it, so npm
-remained on the broken 0.25.1 while crates.io and PyPI moved to 0.25.2. This
-release fixes the underlying cause and brings every registry back in line.
-
-### Fixed
-- **Workflow conformance now fails closed at five trust boundaries.** Session
-  close re-verifies the signed root instead of signing a mutable manifest's
-  substituted workflow reference; pre-existence proofs require one checkpoint
-  signing identity rather than composing unrelated trusted logs; loop action
-  budgets count verified action artifacts instead of tool labels; every
-  undeclared observed node produces a deviation, including a one-node run; and
-  schema-required `allowed_tools` can no longer deserialize as an omitted
-  default.
-
-- **`@treeship/core-wasm` was rewritten by whatever `wasm-opt` the build
-  machine happened to have.** `wasm-pack` runs `wasm-opt` on the package it
-  just built whenever binaryen is on `PATH`. The release workflow installed
-  binaryen from apt, which on Ubuntu noble is `108-1` -- a 2022 build
-  predating the `bulk-memory-opt` and `call-indirect-overlong` features the
-  module declares. It lowered the externref table to a non-growable one, so
-  `require()` threw `WebAssembly.Table.grow(): failed to grow table by 4` on
-  first use. A machine with no `wasm-opt`, or a current one, built the same
-  commit correctly, which is why 0.25.0 and 0.25.1 both shipped broken.
-
-  `wasm-pack`'s `wasm-opt` pass is now disabled for `core-wasm`, so the
-  published nodejs artifact is `wasm-bindgen`'s output and nothing else.
-
-### Changed
-
-- The release and CI workflows install a checksummed binaryen 132 tarball
-  instead of an unpinned apt package. `wasm-pack` was already pinned with
-  `cargo install --locked` specifically so the release job would not run
-  whatever a CDN served at job runtime; the tool that rewrites the artifact
-  is now pinned to the same standard.
-- CI installs binaryen at all, which it previously did not. The two pipelines
-  built differently, so every gate ran against an artifact that was never the
-  one published.
-- `rust-toolchain.toml` pins `wasm32-unknown-unknown`. This did not cause the
-  failure above, but it was the other unpinned input feeding the same
-  artifact.
-
-### Documentation
-- **Workflow conformance now has an executable design contract.** Added the
-  missing `docs/specs/workflow-declarations.md` referenced by commitments,
-  rooms, vision, and the v0.11 changelog. Seven golden reports pin valid runs,
-  undeclared edges, missing terminals, loop-cap breaches, asserted edge
-  evidence, declaration pre-existence, and out-of-scope tools before broader
-  CLI wiring.
 
 ## Older releases
 

--- a/integrations/claude-code-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship",
   "description": "Portable, cryptographically signed receipts for everything Claude Code does. Proof that stays true after the session ends.",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/commerce-agents/plugin/.claude-plugin/plugin.json
+++ b/integrations/commerce-agents/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treeship-commerce",
   "description": "Add Treeship receipts to an anthropics/commerce-agents deployment: a signed intent and result for every tool call on all three runtimes, the merchant's approval as a signed single-use grant, and a receipt for exactly the cart that went to checkout. One command, one skill; the plugin runs no code of its own.",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "author": {
     "name": "Zerker Labs",
     "email": "hello@treeship.dev",

--- a/integrations/commerce-agents/pyproject.toml
+++ b/integrations/commerce-agents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-commerce"
-version = "0.31.3"
+version = "0.31.4"
 description = "Signed, offline-verifiable receipts for every tool call in anthropics/commerce-agents, on all three of its runtimes."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/integrations/commerce-agents/treeship_commerce/__init__.py
+++ b/integrations/commerce-agents/treeship_commerce/__init__.py
@@ -45,5 +45,5 @@ __all__ = [
     "receipted_backend",
     "text_digest",
 ]
-__version__ = "0.31.3"
+__version__ = "0.31.4"
 from .vi import attest_at_handoff, vi_check, vi_verify  # noqa: E402

--- a/integrations/openclaw-plugin/openclaw.plugin.json
+++ b/integrations/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "treeship",
   "name": "Treeship Receipts",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "configSchema": {
     "type": "object",
     "properties": {},

--- a/integrations/openclaw-plugin/package.json
+++ b/integrations/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/openclaw-plugin",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Portable, cryptographically signed receipts for every OpenClaw session. Captures every tool call at the Gateway layer — below the agent — so receipts are complete regardless of agent discipline or prompt-injection state.",
   "license": "Apache-2.0",
   "author": {

--- a/npm/@treeship/cli-darwin-arm64/package.json
+++ b/npm/@treeship/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-arm64",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Treeship CLI binary for darwin arm64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-darwin-x64/package.json
+++ b/npm/@treeship/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-darwin-x64",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Treeship CLI binary for darwin x64",
   "os": [
     "darwin"

--- a/npm/@treeship/cli-linux-arm64/package.json
+++ b/npm/@treeship/cli-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-arm64",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Treeship CLI binary for linux arm64",
   "os": [
     "linux"

--- a/npm/@treeship/cli-linux-x64/package.json
+++ b/npm/@treeship/cli-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/cli-linux-x64",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Treeship CLI binary for linux x64",
   "os": [
     "linux"

--- a/npm/treeship/package.json
+++ b/npm/treeship/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeship",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Portable trust receipts for agent workflows",
   "bin": {
     "treeship": "./bin/treeship.js"
@@ -19,10 +19,10 @@
     "linux"
   ],
   "optionalDependencies": {
-    "@treeship/cli-linux-x64": "0.31.3",
-    "@treeship/cli-linux-arm64": "0.31.3",
-    "@treeship/cli-darwin-arm64": "0.31.3",
-    "@treeship/cli-darwin-x64": "0.31.3"
+    "@treeship/cli-linux-x64": "0.31.4",
+    "@treeship/cli-linux-arm64": "0.31.4",
+    "@treeship/cli-darwin-arm64": "0.31.4",
+    "@treeship/cli-darwin-x64": "0.31.4"
   },
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-cli"
-version = "0.31.3"
+version = "0.31.4"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - CLI"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ zk = ["treeship-zk-circom", "treeship-zk-risc0"]  # Circom + RISC Zero ZK proofs
 zk-bonsai = ["treeship-zk-risc0/zk-bonsai"]  # RISC Zero Bonsai hosted proving
 
 [dependencies]
-treeship-core = { version = "0.31.3", path = "../core" }
+treeship-core = { version = "0.31.4", path = "../core" }
 clap = { version = "4", features = ["derive"] }
 serde         = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/core-wasm/Cargo.toml
+++ b/packages/core-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core-wasm"
-version = "0.31.3"
+version = "0.31.4"
 edition = "2021"
 description = "Treeship verification in the browser via WebAssembly"
 license = "Apache-2.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "treeship-core"
-version = "0.31.3"
+version = "0.31.4"
 edition = "2021"
 description = "Portable trust receipts for agent workflows - core library"
 license = "Apache-2.0"

--- a/packages/rig/Cargo.toml
+++ b/packages/rig/Cargo.toml
@@ -4,7 +4,7 @@ name = "rig-treeship"
 # pipeline derives every crate's version from the git tag. This crate exists to
 # wrap `treeship-core`, so "which treeship does this match" is the most useful
 # thing its version can say.
-version = "0.31.3"
+version = "0.31.4"
 edition = "2021"
 # Matches rust-toolchain.toml and clippy.toml. 1.88 was this crate's MSRV as a
 # standalone repo, where a dedicated CI job built against it. In the workspace
@@ -26,7 +26,7 @@ rig = { package = "rig-core", version = "0.41", default-features = false }
 # Path + version: the path keeps the workspace building against the core in
 # this tree (so a breaking change here fails CI in the same commit that makes
 # it), and the version is what `cargo publish` puts in the released manifest.
-treeship-core = { version = "0.31.3", path = "../core" }
+treeship-core = { version = "0.31.4", path = "../core" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "treeship-sdk"
-version = "0.31.3"
+version = "0.31.4"
 description = "Python SDK for Treeship - portable trust receipts for agent workflows"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/sdk",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.3"
+        "@treeship/core-wasm": "0.31.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/sdk",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "TypeScript SDK for Treeship - portable trust receipts for agent workflows",
   "license": "Apache-2.0",
   "repository": {
@@ -35,7 +35,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.3"
+    "@treeship/core-wasm": "0.31.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeship/verify",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeship/verify",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeship/core-wasm": "0.31.3"
+        "@treeship/core-wasm": "0.31.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/verify-js/package.json
+++ b/packages/verify-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeship/verify",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Zero-dependency cryptographic verification for Treeship receipts and certificates. Runs anywhere WASM runs: Node, browser, Vercel Edge, Cloudflare Workers, AWS Lambda.",
   "license": "Apache-2.0",
   "repository": {
@@ -40,7 +40,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@treeship/core-wasm": "0.31.3"
+    "@treeship/core-wasm": "0.31.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/aws-lambda/package-lock.json
+++ b/tests/runtime-acceptance/aws-lambda/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-aws-lambda-acceptance",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "dependencies": {
-        "@treeship/verify": "0.31.3"
+        "@treeship/verify": "0.31.4"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/aws-lambda/package.json
+++ b/tests/runtime-acceptance/aws-lambda/package.json
@@ -1,11 +1,11 @@
 {
   "name": "treeship-aws-lambda-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "private": true,
   "type": "module",
   "main": "dist/handler.js",
   "dependencies": {
-    "@treeship/verify": "0.31.3"
+    "@treeship/verify": "0.31.4"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package-lock.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-cloudflare-worker-acceptance",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "dependencies": {
-        "@treeship/verify": "0.31.3"
+        "@treeship/verify": "0.31.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/cloudflare-worker/package.json
+++ b/tests/runtime-acceptance/cloudflare-worker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-cloudflare-worker-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.31.3"
+    "@treeship/verify": "0.31.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240000.0",

--- a/tests/runtime-acceptance/vercel-edge/package-lock.json
+++ b/tests/runtime-acceptance/vercel-edge/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treeship-vercel-edge-acceptance",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "dependencies": {
-        "@treeship/verify": "0.31.3"
+        "@treeship/verify": "0.31.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/tests/runtime-acceptance/vercel-edge/package.json
+++ b/tests/runtime-acceptance/vercel-edge/package.json
@@ -1,10 +1,10 @@
 {
   "name": "treeship-vercel-edge-acceptance",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@treeship/verify": "0.31.3"
+    "@treeship/verify": "0.31.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Patch: the sealed set is bound to the close record (AUD-34, record.json + receipt_binding + session_window), signatures-pass verdict and JSON rows (AUD-35), attest chains by default with --no-parent, MCP strict path, FR-4/7/9. Lockfile-sync fails by design until the tarballs publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)