### PR TITLE
chore: lockfiles for 0.31.4

### DIFF
--- a/bridges/a2a/package-lock.json
+++ b/bridges/a2a/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.3.tgz",
-      "integrity": "sha512-684TV9De8sy04rzgT9314Op7joO33Eu1mrBRG2GqRQFineBksI2hC5HOJEcXSBEfTnkbWJyfNL2qqEGw6wJ9KQ==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.4.tgz",
+      "integrity": "sha512-zGUhVeAEFhREon78/HyrjdfyxD5JnPdlz1/MtmSufiY3gATIq2Fn0bQRb7SdH3ZfAWcg0i6wm83ShsuNL/vQHg==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/bridges/mcp/package-lock.json
+++ b/bridges/mcp/package-lock.json
@@ -891,9 +891,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.3.tgz",
-      "integrity": "sha512-684TV9De8sy04rzgT9314Op7joO33Eu1mrBRG2GqRQFineBksI2hC5HOJEcXSBEfTnkbWJyfNL2qqEGw6wJ9KQ==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.4.tgz",
+      "integrity": "sha512-zGUhVeAEFhREon78/HyrjdfyxD5JnPdlz1/MtmSufiY3gATIq2Fn0bQRb7SdH3ZfAWcg0i6wm83ShsuNL/vQHg==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/sdk-ts/package-lock.json
+++ b/packages/sdk-ts/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.3.tgz",
-      "integrity": "sha512-684TV9De8sy04rzgT9314Op7joO33Eu1mrBRG2GqRQFineBksI2hC5HOJEcXSBEfTnkbWJyfNL2qqEGw6wJ9KQ==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.4.tgz",
+      "integrity": "sha512-zGUhVeAEFhREon78/HyrjdfyxD5JnPdlz1/MtmSufiY3gATIq2Fn0bQRb7SdH3ZfAWcg0i6wm83ShsuNL/vQHg==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {

--- a/packages/verify-js/package-lock.json
+++ b/packages/verify-js/package-lock.json
@@ -834,9 +834,9 @@
       ]
     },
     "node_modules/@treeship/core-wasm": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.3.tgz",
-      "integrity": "sha512-684TV9De8sy04rzgT9314Op7joO33Eu1mrBRG2GqRQFineBksI2hC5HOJEcXSBEfTnkbWJyfNL2qqEGw6wJ9KQ==",
+      "version": "0.31.4",
+      "resolved": "https://registry.npmjs.org/@treeship/core-wasm/-/core-wasm-0.31.4.tgz",
+      "integrity": "sha512-zGUhVeAEFhREon78/HyrjdfyxD5JnPdlz1/MtmSufiY3gATIq2Fn0bQRb7SdH3ZfAWcg0i6wm83ShsuNL/vQHg==",
       "license": "Apache-2.0"
     },
     "node_modules/@types/chai": {


### PR DESCRIPTION
refresh-lockfiles after the npm publish (rerun of publish-npm after a registry propagation timeout on @treeship/sdk).