### PR TITLE
release: npm landing wait asks for the exact version, waits fifteen minutes

### DIFF
--- a/.github/scripts/wait-for-npm-version.sh
+++ b/.github/scripts/wait-for-npm-version.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
-# Poll npm's registry for $PKG to report $VERSION, up to 30 times on
-# 10-second intervals (5 minutes total). Used after `npm publish` in the
-# release workflow so a silent publish-but-not-propagated state is caught
-# in CI instead of in user installs. Wide window because npm's registry
-# CDN can lag behind the origin by several minutes during busy periods.
+# Poll npm's registry for $PKG@$VERSION to exist, up to 15 minutes. Used
+# after `npm publish` in the release workflow so a silent
+# publish-but-not-propagated state is caught in CI instead of in user
+# installs.
+#
+# Two things learned on v0.31.4 (2026-09-11), when this script split a
+# release across npm by giving up on @treeship/sdk and then @treeship/mcp:
+#
+#   1. `npm view <pkg> version` reports the `latest` dist-tag, which npm's
+#      CDN updates minutes after the version document itself. Asking for the
+#      exact version (`npm view <pkg>@<version> version`) sees the publish
+#      first, and is the question we actually want answered: is this
+#      version installable.
+#   2. Five minutes is not a wide window on a busy day. Fifteen is; a
+#      publish that is still invisible after that is worth a human.
 #
 # Usage: wait-for-npm-version.sh <pkg> <version>
 
@@ -12,15 +22,16 @@ set -euo pipefail
 PKG="${1:?usage: $0 <pkg> <version>}"
 VERSION="${2:?usage: $0 <pkg> <version>}"
 
-for i in $(seq 1 30); do
-  ACTUAL="$(npm view "$PKG" version 2>/dev/null || true)"
-  if [ "$ACTUAL" = "$VERSION" ]; then
+for i in $(seq 1 90); do
+  EXACT="$(npm view "${PKG}@${VERSION}" version 2>/dev/null || true)"
+  if [ "$EXACT" = "$VERSION" ]; then
     echo "  ✓ $PKG@$VERSION live on npm (attempt $i)"
     exit 0
   fi
-  echo "  ... $PKG reports '$ACTUAL' (want $VERSION), retrying in 10s (attempt $i/30)"
+  LATEST="$(npm view "$PKG" version 2>/dev/null || true)"
+  echo "  ... $PKG@$VERSION not visible yet (latest tag: '${LATEST:-<none>}'), retrying in 10s (attempt $i/90)"
   sleep 10
 done
 
-echo "::error::$PKG did not reach $VERSION on npm after 300s (last seen: ${ACTUAL:-<none>})"
+echo "::error::$PKG@$VERSION did not become visible on npm after 900s (latest tag: ${LATEST:-<none>})"
 exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- **Release: the npm landing wait asks for the exact version and waits fifteen minutes.** `wait-for-npm-version.sh` compared the `latest` dist-tag, which npm's CDN updates minutes after the version itself, and gave up after five; on 0.31.4 it split the release across npm twice. It now asks whether `<pkg>@<version>` is installable, for up to 900 s.
+
 ## 0.31.4 (2026-09-11)
 
 - **The sealed set is under a signature (audit follow-up AUD-34, P1).** An artifact from another session, signed by the same key, could be dropped into a package as an `unchained` entry with the tree recomputed, and every per-artifact row stayed green, `--strict` included. `session close` now seals its `session.v1` record beside the package as `record.json`; that record signs the SHA-256 of `receipt.json` and the session id, so `package verify` gets a `receipt_binding` row that fails when the sealed set was rewritten after the producer closed it. A `session_window` row warns when a sealed artifact's signed timestamp falls outside the session's own window. Under `--strict`, `chain_completeness`, `receipt_binding` and `session_window` are failures. A package built before this release has no record and gets a warning. A producer who re-signs is outside what a signature can catch; that is what checkpoint anchoring is for.


### PR DESCRIPTION
On v0.31.4 the post-publish check gave up on `@treeship/sdk` and then `@treeship/mcp` after 300 s while both were already live: `npm view <pkg> version` reports the `latest` dist-tag, which the CDN updates minutes after the version document. The job aborted each time before publishing the remaining packages, splitting npm. The script now asks for `<pkg>@<version>` and waits up to 900 s. Takes effect from the next tag (a run uses the workflow at its tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)